### PR TITLE
fix django block parsing (for now)

### DIFF
--- a/crates/djls-ast/src/snapshots/djls_ast__parser__tests__parse_django_block.snap
+++ b/crates/djls-ast/src/snapshots/djls_ast__parser__tests__parse_django_block.snap
@@ -11,10 +11,3 @@ nodes:
           - user.is_staff
         children:
           - Text: Admin
-          - Django:
-              Tag:
-                kind: Else
-                bits:
-                  - else
-                children:
-                  - Text: User


### PR DESCRIPTION
it's clear i need a rethink of parsing django block tags to nodes, becuase my mental picture of them differs from the actual use of them. E.g. I tend to think of them the same as HTML tags as either "void" tags or ones with end tags and children but not that's not the case at all. Some have intermediate tags (`{% if %}{% else %}{% endif %}`) which is not a huge lift to support, but the mind blowing realization was that it's just convention that the closing tag starts with `end`.

for builtin's, yeah that's it's the case that all of the tags that have opening and closing tags all close with a matching tag that is the initial tag with `end` prefixed. but given the flexibility of the django template engine, a third-party could feasibly use *any* closing tag it wanted. that makes it very hard to build a structured, full-featured AST for a Django template.

maybe that's not really needed for an LSP. but i'll need to come up with *something* eventually.