### PR TITLE
add `html-django` language id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added `html-django` as an alternative Language ID for Django templates
+
 ## [5.1.0a2]
 
 ### Added

--- a/crates/djls-server/src/documents.rs
+++ b/crates/djls-server/src/documents.rs
@@ -314,7 +314,7 @@ pub enum LanguageId {
 impl From<&str> for LanguageId {
     fn from(language_id: &str) -> Self {
         match language_id {
-            "htmldjango" => Self::HtmlDjango,
+            "django-html" | "htmldjango" => Self::HtmlDjango,
             "python" => Self::Python,
             _ => Self::Other,
         }


### PR DESCRIPTION
this seems to be the other way Django templates are specified