### PR TITLE
Run pre-commit in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_COLOR: "1"
+  PYTHONUNBUFFERED: "1"
+  UV_VERSION: "0.4.x"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          version: ${{ env.UV_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-1|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: pre-commit
+        run: |
+          SKIP=no-commit-to-branch \
+          uv run --with pre-commit-uv pre-commit run \
+            --all-files \
+            --show-diff-on-failure \
+            --color always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,27 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          version: ${{ env.UV_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-1|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: pre-commit
+        run: |
+          SKIP=no-commit-to-branch \
+          uv run --with pre-commit-uv pre-commit run \
+            --all-files \
+            --show-diff-on-failure \
+            --color always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,27 +42,3 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
-
-  lint:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          version: ${{ env.UV_VERSION }}
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit/
-          key: pre-commit-1|${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: pre-commit
-        run: |
-          SKIP=no-commit-to-branch \
-          uv run --with pre-commit-uv pre-commit run \
-            --all-files \
-            --show-diff-on-failure \
-            --color always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-byte-order-marker
       - id: check-case-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: check-byte-order-marker
+      - id: fix-byte-order-marker
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: check-symlinks
       - id: check-toml
       - id: check-yaml
+        args: ["--unsafe"] # breaks on .mkdocs.yml otherwise
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,8 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+      - id: no-commit-to-branch
+        args: ["--branch", "main"]
   - repo: https://github.com/backplane/pre-commit-rust-hooks
     rev: v1.1.0
     hooks:


### PR DESCRIPTION
Fixes #61.

Hello, just passed by this promising repo, saw the ❌ on `main`, found #61 and wanted to contribute.

At work, we have some `local` hooks in our pre-commit configuration (which depend on the installed deps on the project), and we run it directly in GitHub Actions similarly to this.
I guess that this could help, if not, feel free to close this PR.

Extra bits:
- Ran `pre-commit autoupdate` (Hello #57)
- Add `no-commit-to-branch` in case you want only to pass by PRs this is quite useful
- "Fix" the `yaml` hook

Have a nice day!

EDIT:
Ah forgot to mention that I don't really know how the `concurrency` thing interacts with this new job