### PR TITLE
Make venv fallback test robust against `VIRTUAL_ENV`

### DIFF
--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -327,10 +327,8 @@ mod tests {
             // Set VIRTUAL_ENV to something known to be invalid, rather than clearing.
             // This prevents the test runner's VIRTUAL_ENV (e.g., from Nox) from interfering.
             let invalid_virtual_env_path = project_dir.path().join("non_existent_virtual_env");
-            let _guard = VirtualEnvGuard::set(
-                "VIRTUAL_ENV",
-                invalid_virtual_env_path.to_str().unwrap(),
-            );
+            let _guard =
+                VirtualEnvGuard::set("VIRTUAL_ENV", invalid_virtual_env_path.to_str().unwrap());
 
             // Provide an invalid explicit path
             let invalid_path = project_dir.path().join("non_existent_venv");
@@ -390,10 +388,8 @@ mod tests {
 
             // Set VIRTUAL_ENV to something known to be invalid to ensure it's ignored.
             let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_proj_found");
-            let _guard = VirtualEnvGuard::set(
-                "VIRTUAL_ENV",
-                invalid_virtual_env_path.to_str().unwrap(),
-            );
+            let _guard =
+                VirtualEnvGuard::set("VIRTUAL_ENV", invalid_virtual_env_path.to_str().unwrap());
 
             let env = PythonEnvironment::new(project_dir.path(), None)
                 .expect("Should find environment in project .venv");
@@ -410,10 +406,8 @@ mod tests {
 
             // Set VIRTUAL_ENV to something known to be invalid to ensure it's ignored.
             let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_priority");
-            let _guard = VirtualEnvGuard::set(
-                "VIRTUAL_ENV",
-                invalid_virtual_env_path.to_str().unwrap(),
-            );
+            let _guard =
+                VirtualEnvGuard::set("VIRTUAL_ENV", invalid_virtual_env_path.to_str().unwrap());
 
             let env =
                 PythonEnvironment::new(project_dir.path(), None).expect("Should find environment");
@@ -428,11 +422,10 @@ mod tests {
             let project_dir = tempdir().unwrap();
 
             // Set VIRTUAL_ENV to something known to be invalid to ensure it's ignored.
-            let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_sys_fallback");
-            let _guard = VirtualEnvGuard::set(
-                "VIRTUAL_ENV",
-                invalid_virtual_env_path.to_str().unwrap(),
-            );
+            let invalid_virtual_env_path =
+                project_dir.path().join("non_existent_venv_sys_fallback");
+            let _guard =
+                VirtualEnvGuard::set("VIRTUAL_ENV", invalid_virtual_env_path.to_str().unwrap());
             // We don't create any venvs in project_dir
 
             // This test assumes `which python` works and points to a standard layout
@@ -458,10 +451,8 @@ mod tests {
 
             // Ensure no explicit path, no project venvs, and set VIRTUAL_ENV to invalid.
             let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_no_python");
-            let _guard = VirtualEnvGuard::set(
-                "VIRTUAL_ENV",
-                invalid_virtual_env_path.to_str().unwrap(),
-            );
+            let _guard =
+                VirtualEnvGuard::set("VIRTUAL_ENV", invalid_virtual_env_path.to_str().unwrap());
 
             // To *ensure* system fallback fails, we'd need to manipulate PATH,
             // which is tricky and platform-dependent. Instead, we test the scenario

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -333,8 +333,13 @@ mod tests {
             let project_dir = tempdir().unwrap();
             let project_venv_prefix = create_mock_venv(&project_dir.path().join(".venv"), None);
 
-            // Clear VIRTUAL_ENV just in case
-            let _guard = VirtualEnvGuard::clear("VIRTUAL_ENV");
+            // Set VIRTUAL_ENV to something known to be invalid, rather than clearing.
+            // This prevents the test runner's VIRTUAL_ENV (e.g., from Nox) from interfering.
+            let invalid_virtual_env_path = project_dir.path().join("non_existent_virtual_env");
+            let _guard = VirtualEnvGuard::set(
+                "VIRTUAL_ENV",
+                invalid_virtual_env_path.to_str().unwrap(),
+            );
 
             // Provide an invalid explicit path
             let invalid_path = project_dir.path().join("non_existent_venv");

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -277,15 +277,6 @@ mod tests {
                     original_value,
                 }
             }
-
-            fn clear(key: &'a str) -> Self {
-                let original_value = env::var(key).ok();
-                env::remove_var(key);
-                Self {
-                    key,
-                    original_value,
-                }
-            }
         }
 
         impl Drop for VirtualEnvGuard<'_> {

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -397,8 +397,12 @@ mod tests {
             let project_dir = tempdir().unwrap();
             let venv_prefix = create_mock_venv(&project_dir.path().join(".venv"), None);
 
-            // Ensure VIRTUAL_ENV is not set
-            let _guard = VirtualEnvGuard::clear("VIRTUAL_ENV");
+            // Set VIRTUAL_ENV to something known to be invalid to ensure it's ignored.
+            let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_proj_found");
+            let _guard = VirtualEnvGuard::set(
+                "VIRTUAL_ENV",
+                invalid_virtual_env_path.to_str().unwrap(),
+            );
 
             let env = PythonEnvironment::new(project_dir.path(), None)
                 .expect("Should find environment in project .venv");
@@ -413,7 +417,12 @@ mod tests {
             let dot_venv_prefix = create_mock_venv(&project_dir.path().join(".venv"), None);
             let _venv_prefix = create_mock_venv(&project_dir.path().join("venv"), None); // Should be ignored if .venv found first
 
-            let _guard = VirtualEnvGuard::clear("VIRTUAL_ENV");
+            // Set VIRTUAL_ENV to something known to be invalid to ensure it's ignored.
+            let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_priority");
+            let _guard = VirtualEnvGuard::set(
+                "VIRTUAL_ENV",
+                invalid_virtual_env_path.to_str().unwrap(),
+            );
 
             let env =
                 PythonEnvironment::new(project_dir.path(), None).expect("Should find environment");
@@ -427,8 +436,12 @@ mod tests {
         fn test_system_python_fallback() {
             let project_dir = tempdir().unwrap();
 
-            // Ensure no explicit path, no VIRTUAL_ENV, no project venvs
-            let _guard = VirtualEnvGuard::clear("VIRTUAL_ENV");
+            // Set VIRTUAL_ENV to something known to be invalid to ensure it's ignored.
+            let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_sys_fallback");
+            let _guard = VirtualEnvGuard::set(
+                "VIRTUAL_ENV",
+                invalid_virtual_env_path.to_str().unwrap(),
+            );
             // We don't create any venvs in project_dir
 
             // This test assumes `which python` works and points to a standard layout
@@ -452,8 +465,12 @@ mod tests {
         fn test_no_python_found() {
             let project_dir = tempdir().unwrap();
 
-            // Ensure no explicit path, no VIRTUAL_ENV, no project venvs
-            let _guard = VirtualEnvGuard::clear("VIRTUAL_ENV");
+            // Ensure no explicit path, no project venvs, and set VIRTUAL_ENV to invalid.
+            let invalid_virtual_env_path = project_dir.path().join("non_existent_venv_no_python");
+            let _guard = VirtualEnvGuard::set(
+                "VIRTUAL_ENV",
+                invalid_virtual_env_path.to_str().unwrap(),
+            );
 
             // To *ensure* system fallback fails, we'd need to manipulate PATH,
             // which is tricky and platform-dependent. Instead, we test the scenario


### PR DESCRIPTION
This change addresses the flaky test `test_explicit_venv_path_invalid_falls_through_to_project_venv` by setting `VIRTUAL_ENV` to a known invalid path during test setup. This ensures the test runner's environment doesn't interfere and the intended fallback logic is consistently verified.

closes #122