### PR TITLE
move LSP serve method to main cli crate and fix shutdown handling

### DIFF
--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -3,17 +3,4 @@ mod queue;
 mod server;
 mod workspace;
 
-use crate::server::DjangoLanguageServer;
-use anyhow::Result;
-use tower_lsp_server::{LspService, Server};
-
-pub async fn serve() -> Result<()> {
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
-
-    let (service, socket) = LspService::build(DjangoLanguageServer::new).finish();
-
-    Server::new(stdin, stdout, socket).serve(service).await;
-
-    Ok(())
-}
+pub use crate::server::DjangoLanguageServer;

--- a/crates/djls-server/src/queue.rs
+++ b/crates/djls-server/src/queue.rs
@@ -105,7 +105,7 @@ impl Queue {
                     }
                 }
             }
-            eprintln!("Queue worker task shutting down.");
+            eprintln!("Queue worker task shutting down");
         });
 
         Self {
@@ -179,7 +179,7 @@ impl Drop for QueueInner {
             // `.ok()` ignores the result, as the receiver might have already
             // terminated if the channel closed naturally or panicked.
             sender.send(()).ok();
-            eprintln!("Sent shutdown signal to queue worker.");
+            eprintln!("Sent shutdown signal to queue worker");
         }
     }
 }

--- a/crates/djls/src/commands.rs
+++ b/crates/djls/src/commands.rs
@@ -1,12 +1,12 @@
 mod serve;
 
 use crate::args::Args;
+use crate::exit::Exit;
 use anyhow::Result;
 use clap::Subcommand;
-use std::process::ExitCode;
 
 pub trait Command {
-    async fn execute(&self, args: &Args) -> Result<ExitCode>;
+    fn execute(&self, args: &Args) -> Result<Exit>;
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/djls/src/commands/serve.rs
+++ b/crates/djls/src/commands/serve.rs
@@ -1,8 +1,10 @@
 use crate::args::Args;
 use crate::commands::Command;
+use crate::exit::Exit;
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use std::process::ExitCode;
+use djls_server::DjangoLanguageServer;
+use tower_lsp_server::{LspService, Server};
 
 #[derive(Debug, Parser)]
 pub struct Serve {
@@ -17,8 +19,29 @@ enum ConnectionType {
 }
 
 impl Command for Serve {
-    async fn execute(&self, _args: &Args) -> Result<ExitCode> {
-        djls_server::serve().await?;
-        Ok(ExitCode::SUCCESS)
+    fn execute(&self, _args: &Args) -> Result<Exit> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let exit_status = runtime.block_on(async {
+            let stdin = tokio::io::stdin();
+            let stdout = tokio::io::stdout();
+
+            let (service, socket) = LspService::build(DjangoLanguageServer::new).finish();
+
+            Server::new(stdin, stdout, socket).serve(service).await;
+
+            // Exit here instead of returning control to the `Cli`, for ... reasons?
+            // If we don't exit here, ~~~ something ~~~ goes on with PyO3 (I assume)
+            // or the Python entrypoint wrapper to indefinitely hang the CLI and keep
+            // the process running
+            Exit::success()
+                .with_message("Server completed successfully")
+                .process_exit()
+        });
+
+        Ok(exit_status)
     }
 }

--- a/crates/djls/src/exit.rs
+++ b/crates/djls/src/exit.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use std::error::Error;
+use std::fmt;
+
+type ExitMessage = Option<String>;
+
+#[derive(Debug)]
+pub(crate) enum ExitStatus {
+    Success,
+    Error,
+}
+
+impl ExitStatus {
+    pub fn as_raw(&self) -> i32 {
+        match self {
+            ExitStatus::Success => 0,
+            ExitStatus::Error => 1,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            ExitStatus::Success => "Command succeeded",
+            ExitStatus::Error => "Command error",
+        }
+    }
+}
+
+impl From<ExitStatus> for i32 {
+    fn from(status: ExitStatus) -> Self {
+        status.as_raw()
+    }
+}
+
+impl fmt::Display for ExitStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = self.as_str();
+        write!(f, "{}", msg)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Exit {
+    status: ExitStatus,
+    message: ExitMessage,
+}
+
+impl Exit {
+    fn new(status: ExitStatus) -> Self {
+        Self {
+            status,
+            message: None,
+        }
+    }
+
+    pub fn success() -> Self {
+        Self::new(ExitStatus::Success)
+    }
+
+    pub fn error() -> Self {
+        Self::new(ExitStatus::Error)
+    }
+
+    pub fn with_message<S: Into<String>>(mut self, message: S) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    pub fn process_exit(self) -> ! {
+        if let Some(message) = self.message {
+            println!("{}", message)
+        }
+        std::process::exit(self.status.as_raw())
+    }
+
+    #[allow(dead_code)]
+    pub fn ok(self) -> Result<()> {
+        match self.status {
+            ExitStatus::Success => Ok(()),
+            _ => Err(self.into()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn as_raw(&self) -> i32 {
+        self.status.as_raw()
+    }
+}
+
+impl fmt::Display for Exit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let status_str = self.status.as_str();
+        match &self.message {
+            Some(msg) => write!(f, "{}: {}", status_str, msg),
+            None => write!(f, "{}", status_str),
+        }
+    }
+}
+
+impl Error for Exit {}

--- a/crates/djls/src/exit.rs
+++ b/crates/djls/src/exit.rs
@@ -5,7 +5,7 @@ use std::fmt;
 type ExitMessage = Option<String>;
 
 #[derive(Debug)]
-pub(crate) enum ExitStatus {
+pub enum ExitStatus {
     Success,
     Error,
 }
@@ -40,7 +40,7 @@ impl fmt::Display for ExitStatus {
 }
 
 #[derive(Debug)]
-pub(crate) struct Exit {
+pub struct Exit {
     status: ExitStatus,
     message: ExitMessage,
 }

--- a/crates/djls/src/main.rs
+++ b/crates/djls/src/main.rs
@@ -1,0 +1,18 @@
+/// Binary interface for local development only.
+///
+/// This binary exists for development and testing with `cargo run`.
+/// The production CLI is distributed through the PyO3 interface in lib.rs.
+mod args;
+mod cli;
+mod commands;
+mod exit;
+
+/// Process CLI args and run the appropriate command.
+fn main() -> anyhow::Result<()> {
+    // Get command line arguments
+    let args: Vec<String> = std::env::args().collect();
+
+    // Call the unified CLI run function
+    cli::run(args)
+}
+

--- a/crates/djls/src/main.rs
+++ b/crates/djls/src/main.rs
@@ -7,12 +7,13 @@ mod cli;
 mod commands;
 mod exit;
 
+use anyhow::Result;
+
 /// Process CLI args and run the appropriate command.
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     // Get command line arguments
     let args: Vec<String> = std::env::args().collect();
 
     // Call the unified CLI run function
     cli::run(args)
 }
-


### PR DESCRIPTION
closes #142 

Okay, this at least fixes the issue with the process not being killed when the editor quits and stdin/stdout is closed. But there's some issues with I assume the unique way we have the Python entrypoint and PyO3 not handing off ... something? The result handling at the end of the cli run method doesn't actually get hit, so you have to process exit in the serve method. Who knows????

This also moves the tokio business just into the serve command, as well as creates some boilerplate for exiting. Could have used an external crate for this -- there are a few -- but it seemed simple enough so I just brought it in.

Still can't handle Ctrl-C quitting the serve command when just running in the terminal, but you can hit enter to force a parse error and crash the thing. I may revisit that later, but since this isn't designed to be run in the terminal maybe a simple log about that not being supported and a note about hitting enter to exit will do fine.