### PR TITLE
bump rust toolchain to 1.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped Rust toolchain from 1.90 to 1.91.
+
 ## [6.0.0]
 
 ### Changed

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90"
+channel = "1.91"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Rust toolchain to version 1.91, bringing the latest compiler improvements and stability enhancements to the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->