### PR TITLE
fix bug with stdin not triggering template discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `djls check` with no arguments silently reading stdin instead of discovering template files. Stdin is now triggered explicitly by passing `-` as a path.
+
 ## [6.0.1]
 
 ### Added

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -28,8 +28,8 @@ use crate::exit::Exit;
 
 #[derive(Debug, Parser)]
 pub struct Check {
-    /// Files or directories to check. If omitted, discovers template
-    /// directories from the Django project.
+    /// Files or directories to check. Pass `-` to read from stdin. If
+    /// omitted, discovers template directories from the Django project.
     paths: Vec<Utf8PathBuf>,
 
     /// Select specific diagnostic codes to enable (e.g. S100,S101).
@@ -54,7 +54,7 @@ impl Command for Check {
         let config = build_diagnostics_config(&settings, &self.select, &self.ignore);
         let fmt = pick_renderer();
 
-        let reading_stdin = !std::io::stdin().is_terminal() && self.paths.is_empty();
+        let reading_stdin = self.paths.iter().any(|p| p.as_str() == "-");
 
         if reading_stdin {
             return check_stdin(&project_root, &settings, &config, &fmt);

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -135,7 +135,7 @@ fn check_stdin_detects_errors() {
     setup_project(dir.path());
 
     let mut child = Command::new(djls_binary())
-        .args(["check"])
+        .args(["check", "-"])
         .current_dir(dir.path())
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `djls check` no longer implicitly reads from stdin. Piping input now requires explicitly passing "-" as a path argument.

* **Documentation**
  * Updated documentation to clarify stdin usage with the "-" path argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->