### PR TITLE
Add pre-commit hook for djls check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: djls-check
+  name: djls check
+  entry: djls check
+  language: system
+  require_serial: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
+- Added pre-commit hook for running `djls check` on Django template files.
 - **Internal**: Added venv model scanning, workspace model discovery, and Salsa wiring for `compute_model_graph` — the model graph is now populated from both site-packages and workspace `models.py` files with automatic invalidation on edit.
 - Added rg-style file filtering flags to `djls check`: `-g/--glob` for glob patterns, `--no-ignore` to skip ignore files, `-L/--follow` for symlinks, `-d/--max-depth` for recursion depth, `--color always|auto|never`, and `-q/--quiet`.
 - Added `env_file` configuration option for loading environment variables from a `.env` file into the inspector process.

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,0 +1,40 @@
+# pre-commit
+
+django-language-server provides a [pre-commit](https://pre-commit.com/) hook for running `djls check` on Django template files. This also works with [prek](https://github.com/j178/prek), a drop-in replacement for pre-commit written in Rust.
+
+## Prerequisites
+
+The hook uses `language: system`, which means `djls` must be installed and available on your `PATH` before running the hook. See [Installation](installation.md) for installation options.
+
+## Usage
+
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/joshuadavidthomas/django-language-server
+    rev: v6.0.2  # use the latest release tag
+    hooks:
+      - id: djls-check
+```
+
+Currently, `djls check` recognizes `.html`, `.htm`, and `.djhtml` files as templates. Files with other extensions are silently skipped.
+
+!!! note
+
+    Broader template extension support is planned. See [#465](https://github.com/joshuadavidthomas/django-language-server/issues/465) for details.
+
+## Configuration
+
+Pass additional arguments to `djls check` via the `args` option:
+
+```yaml
+repos:
+  - repo: https://github.com/joshuadavidthomas/django-language-server
+    rev: v6.0.2
+    hooks:
+      - id: djls-check
+        args: [--select, "S100,S117", --color, never]
+```
+
+See `djls check --help` for all available options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ version_pattern = "MAJOR.MINOR.PATCH[-TAG[.NUM]]"
   '^version = "{pep440_version}"',
   '^current_version = "{version}"',
 ]
+"docs/pre-commit.md" = [
+  '    rev: v{version}',
+]
 
 [tool.djlint]
 blank_line_after_tag = "endblock,extends,load"


### PR DESCRIPTION
Add a `.pre-commit-hooks.yaml` defining a `djls-check` hook that runs `djls check` on Django template files (`.html`, `.htm`, `.djhtml`).

Uses `language: system`, requiring `djls` to be pre-installed on the user's PATH. This keeps the implementation simple and leaves the door open for a separate mirror repo with automatic binary distribution (like ruff-pre-commit) in the future.

## Usage

```yaml
repos:
  - repo: https://github.com/joshuadavidthomas/django-language-server
    rev: v6.0.2  # use the latest release tag
    hooks:
      - id: djls-check
```

Closes #460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-commit hook for automated validation of Django template files with customizable configuration through command-line arguments.

* **Documentation**
  * Added comprehensive documentation covering installation, configuration, and usage of the new pre-commit hook integration with practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->