### PR TITLE
Vendor markup_fmt with Django template support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ perf.data*
 # dex
 /.dex/*
 !/.dex/config.toml
+.scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
+- Added HTML-aware template formatting via vendored `markup_fmt` with Django-specific parser fixes: `{% trans %}` treated as self-closing, added `{% blocktrans %}`, `{% verbatim %}`, `{% spaceless %}`, `{% cache %}`, `{% ifchanged %}`, `{% comment %}` as block tags, and `{% empty %}` as intermediate tag for `{% for %}` loops.
+- Added content-type detection for template formatting: `.html`/`.htm`/`.djhtml` files use HTML-aware formatting, other extensions fall back to Django syntax-only formatting.
+- Added embedded CSS formatting in `<style>` blocks via `malva`.
 - **Internal**: Added `djls-fmt` diff utilities (`Edit` type, `compute_text_edits`, `unified_diff`, `is_changed`) for computing minimal text edits between original and formatted source.
 - Added pre-commit hook for running `djls check` on Django template files.
 - Added rg-style file filtering flags to `djls check`: `-g/--glob` for glob patterns, `--no-ignore` to skip ignore files, `-L/--follow` for symlinks, `-d/--max-depth` for recursion depth, `--color always|auto|never`, and `-q/--quiet`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
-- Added HTML-aware template formatting via vendored `markup_fmt` with Django-specific parser fixes: `{% trans %}` treated as self-closing, added `{% blocktrans %}`, `{% verbatim %}`, `{% spaceless %}`, `{% cache %}`, `{% ifchanged %}`, `{% comment %}` as block tags, and `{% empty %}` as intermediate tag for `{% for %}` loops.
+- Added HTML-aware template formatting via vendored `markup_fmt` with Django-specific parser fixes (correct handling of common Django block and inline tags).
 - Added content-type detection for template formatting: `.html`/`.htm`/`.djhtml` files use HTML-aware formatting, other extensions fall back to Django syntax-only formatting.
 - Added embedded CSS formatting in `<style>` blocks via `malva`.
 - **Internal**: Added `djls-fmt` diff utilities (`Edit` type, `compute_text_edits`, `unified_diff`, `is_changed`) for computing minimal text edits between original and formatted source.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "css_dataset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25670139e591f1c2869eb8d0d977028f8d05e859132b4c874ecd02a00d3c9174"
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,11 +806,18 @@ dependencies = [
 name = "djls-fmt"
 version = "0.0.0"
 dependencies = [
+ "aho-corasick",
+ "camino",
+ "css_dataset",
  "djls-conf",
  "djls-templates",
  "insta",
+ "itertools",
+ "malva",
+ "memchr",
  "similar",
  "thiserror 2.0.18",
+ "tiny_pretty",
 ]
 
 [[package]]
@@ -1818,6 +1831,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "malva"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a952f521471c6c8302a17fc0c64a512221a9d4ff268af4d43a02bc2be48c712"
+dependencies = [
+ "aho-corasick",
+ "itertools",
+ "memchr",
+ "raffia",
+ "tiny_pretty",
+]
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +2300,27 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "raffia"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffe6643ba09b12af3816c6d3687d8c16c8a306bdbf60e2804b4bbd2c1f5447e"
+dependencies = [
+ "raffia_macro",
+ "smallvec",
+]
+
+[[package]]
+name = "raffia_macro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fdb50eb5bf734fa5a770680a61876a6ec77b99c1e0e52d1f18ad6ebfa85759f"
+dependencies = [
+ "heck",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rand"
@@ -3123,6 +3170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny_pretty"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650d82e943da333637be9f1567d33d605e76810a26464edfd7ae74f7ef181e95"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ annotate-snippets = "0.12"
 anyhow = "1.0"
 camino = { version = "1.2", features = ["serde1"] }
 clap = { version = "4.5", features = ["derive"] }
-css_dataset = { version = "0.4", default-features = false, features = ["tags"] }
 config = { version = "0.15", features = ["toml"] }
+css_dataset = { version = "0.4", default-features = false, features = ["tags"] }
 dashmap = "6.1"
 datatest-stable = "0.3.3"
 directories = "6.0"
@@ -38,8 +38,8 @@ dotenvy = "0.15"
 dunce = "1.0"
 flate2 = "1.1"
 ignore = "0.4"
-itertools = "0.14"
 insta = { version = "1.46", features = ["glob", "yaml"] }
+itertools = "0.14"
 malva = "0.11"
 memchr = "2.8"
 notify = "8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ djls-workspace = { path = "crates/djls-workspace" }
 salsa = "0.26.0"
 tower-lsp-server = { version = "0.23.0", features = ["proposed"] }
 
+aho-corasick = "1.1"
 annotate-snippets = "0.12"
 anyhow = "1.0"
 camino = { version = "1.2", features = ["serde1"] }
 clap = { version = "4.5", features = ["derive"] }
+css_dataset = { version = "0.4", default-features = false, features = ["tags"] }
 config = { version = "0.15", features = ["toml"] }
 dashmap = "6.1"
 datatest-stable = "0.3.3"
@@ -36,7 +38,9 @@ dotenvy = "0.15"
 dunce = "1.0"
 flate2 = "1.1"
 ignore = "0.4"
+itertools = "0.14"
 insta = { version = "1.46", features = ["glob", "yaml"] }
+malva = "0.11"
 memchr = "2.8"
 notify = "8.2"
 percent-encoding = "2.3"
@@ -50,6 +54,7 @@ similar = "2.7"
 tar = "0.4"
 tempfile = "3.25"
 thiserror = "2.0"
+tiny_pretty = { version = "0.2", features = ["unicode-width"] }
 tokio = { version = "1.49", features = ["full"] }
 toml = "1.0"
 tracing = "0.1"

--- a/crates/djls-conf/src/fmt.rs
+++ b/crates/djls-conf/src/fmt.rs
@@ -85,6 +85,12 @@ impl FormatConfig {
     }
 
     #[must_use]
+    pub fn with_content_type(mut self, value: ContentType) -> Self {
+        self.content_type = value;
+        self
+    }
+
+    #[must_use]
     pub fn with_sort_load_libraries(mut self, value: bool) -> Self {
         self.sort_load_libraries = value;
         self

--- a/crates/djls-fmt/Cargo.toml
+++ b/crates/djls-fmt/Cargo.toml
@@ -7,8 +7,15 @@ edition = "2021"
 djls-conf = { workspace = true }
 djls-templates = { workspace = true }
 
+aho-corasick = { workspace = true }
+camino = { workspace = true }
+css_dataset = { workspace = true }
+itertools = { workspace = true }
+malva = { workspace = true }
+memchr = { workspace = true }
 similar = { workspace = true }
 thiserror = { workspace = true }
+tiny_pretty = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/djls-fmt/src/diff.rs
+++ b/crates/djls-fmt/src/diff.rs
@@ -309,7 +309,7 @@ mod tests {
     fn edits_apply_correctly_on_deletion() {
         let original = "aaa\nbbb\nccc\n";
         let formatted = "aaa\nccc\n";
-        let edits = compute_text_edits(original, &formatted);
+        let edits = compute_text_edits(original, formatted);
 
         let result = apply_edits(original, &edits);
         assert_eq!(result, formatted);

--- a/crates/djls-fmt/src/lib.rs
+++ b/crates/djls-fmt/src/lib.rs
@@ -1,6 +1,36 @@
 pub mod diff;
 mod django;
+// Vendored markup_fmt — suppress warnings for vendored code that we keep
+// close to upstream for maintainability.
+#[allow(
+    dead_code,
+    clippy::bool_to_int_with_if,
+    clippy::collapsible_else_if,
+    clippy::enum_variant_names,
+    clippy::fn_params_excessive_bools,
+    clippy::items_after_statements,
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions,
+    clippy::needless_continue,
+    clippy::redundant_closure,
+    clippy::redundant_else,
+    clippy::semicolon_if_nothing_returned,
+    clippy::struct_excessive_bools,
+    clippy::struct_field_names,
+    clippy::too_many_lines,
+    clippy::default_trait_access,
+    clippy::needless_borrow,
+    clippy::redundant_closure_for_method_calls,
+    clippy::unnecessary_semicolon,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding,
+    clippy::wildcard_imports
+)]
+mod markup;
 
+use std::borrow::Cow;
+
+use camino::Utf8Path;
 pub use diff::compute_text_edits;
 pub use diff::is_changed;
 pub use diff::unified_diff;
@@ -10,22 +40,100 @@ pub use django::format_django_syntax;
 pub use djls_conf::ContentType;
 pub use djls_conf::FormatConfig;
 pub use djls_conf::IndentStyle;
+pub use markup::FormatError;
+pub use markup::Language;
+pub use markup::SyntaxError;
+
+/// Detect the content type for a given file path, respecting configuration overrides.
+#[must_use]
+pub fn detect_content_type(path: &Utf8Path, config: &FormatConfig) -> ContentType {
+    if config.content_type() != ContentType::Auto {
+        return config.content_type();
+    }
+    match path.extension() {
+        Some("html" | "htm" | "djhtml") => ContentType::Html,
+        _ => ContentType::Text,
+    }
+}
 
 /// Format a Django template source string according to the given configuration.
 ///
 /// Routes to the appropriate formatting backend based on content type:
 /// - `Text` / `Auto`: token-level Django syntax formatting (normalizes tags,
 ///   variables, comments while preserving non-Django text)
-/// - `Html`: currently falls through to Django syntax formatting; HTML-aware
-///   formatting via `markup_fmt` will be added in a later phase
+/// - `Html`: HTML-aware formatting via vendored `markup_fmt` with Django parser
+///   fixes, plus embedded CSS formatting via `malva`
 #[must_use]
 pub fn format_source(source: &str, config: &FormatConfig) -> String {
-    // HTML-aware formatting via `markup_fmt` will be added in a later phase;
-    // for now all content types go through Django syntax formatting.
     match config.content_type() {
-        ContentType::Auto | ContentType::Text | ContentType::Html => {
+        ContentType::Auto | ContentType::Text => format_django_syntax(source, config),
+        ContentType::Html => format_html(source, config).unwrap_or_else(|_| {
+            // Fall back to Django syntax formatting if HTML parsing fails
             format_django_syntax(source, config)
-        }
+        }),
+    }
+}
+
+/// Format a Django template source string with content-type detection from the file path.
+#[must_use]
+pub fn format_source_with_path(source: &str, path: &Utf8Path, config: &FormatConfig) -> String {
+    let content_type = detect_content_type(path, config);
+    let effective_config = config.clone().with_content_type(content_type);
+    format_source(source, &effective_config)
+}
+
+/// Format HTML source with Django template support via vendored `markup_fmt`.
+fn format_html(source: &str, config: &FormatConfig) -> Result<String, String> {
+    let options = build_markup_options(config);
+    let css_options = build_css_options(config);
+
+    markup::format_text(
+        source,
+        markup::Language::Jinja,
+        &options,
+        |code, hints| match hints.ext {
+            "css" | "scss" | "less" => {
+                malva::format_text(code, malva_syntax(hints.ext), &css_options)
+                    .map(Cow::Owned)
+                    .map_err(|e| e.to_string())
+            }
+            _ => Ok(Cow::Borrowed(code)),
+        },
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn malva_syntax(ext: &str) -> malva::Syntax {
+    match ext {
+        "scss" => malva::Syntax::Scss,
+        "less" => malva::Syntax::Less,
+        _ => malva::Syntax::Css,
+    }
+}
+
+fn build_markup_options(config: &FormatConfig) -> markup::config::FormatOptions {
+    markup::config::FormatOptions {
+        layout: markup::config::LayoutOptions {
+            print_width: config.print_width() as usize,
+            use_tabs: matches!(config.indent_style(), IndentStyle::Tabs),
+            indent_width: config.indent_width() as usize,
+            line_break: markup::config::LineBreak::Lf,
+        },
+        language: markup::config::LanguageOptions {
+            ..Default::default()
+        },
+    }
+}
+
+fn build_css_options(config: &FormatConfig) -> malva::config::FormatOptions {
+    malva::config::FormatOptions {
+        layout: malva::config::LayoutOptions {
+            print_width: config.print_width() as usize,
+            use_tabs: matches!(config.indent_style(), IndentStyle::Tabs),
+            indent_width: config.indent_width() as usize,
+            ..Default::default()
+        },
+        language: malva::config::LanguageOptions::default(),
     }
 }
 
@@ -44,8 +152,121 @@ mod tests {
     fn format_source_text_content_type() {
         let source = "{%if user%}";
         let config = FormatConfig::default();
-        // Default is Auto, which should also format
         let formatted = format_source(source, &config);
         assert_eq!(formatted, "{% if user %}");
+    }
+
+    #[test]
+    fn format_html_basic() {
+        let source = "<div><p>hello</p></div>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("<div>"));
+        assert!(formatted.contains("<p>"));
+    }
+
+    #[test]
+    fn format_html_with_django_tags() {
+        let source = "<div>{% if user %}<p>{{ user.name }}</p>{% endif %}</div>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("{% if user %}"));
+        assert!(formatted.contains("{{ user.name }}"));
+    }
+
+    #[test]
+    fn format_html_trans_self_closing() {
+        // {% trans %} must be treated as self-closing in Django (not a block tag)
+        let source = "<p>{% trans \"Hello\" %}</p>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("{% trans"));
+        // Should NOT be waiting for {% endtrans %}
+        assert!(!formatted.contains("endtrans"));
+    }
+
+    #[test]
+    fn format_html_blocktrans_block() {
+        let source = "<div>{% blocktrans %}Hello{% endblocktrans %}</div>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("blocktrans"));
+        assert!(formatted.contains("endblocktrans"));
+    }
+
+    #[test]
+    fn format_html_for_empty() {
+        // {% empty %} is an intermediate tag for {% for %} in Django
+        let source = "<ul>{% for item in items %}<li>{{ item }}</li>{% empty %}<li>No items</li>{% endfor %}</ul>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("{% empty %}"));
+    }
+
+    #[test]
+    fn format_html_verbatim_block() {
+        let source = "<div>{% verbatim %}{{ not_rendered }}{% endverbatim %}</div>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("verbatim"));
+        assert!(formatted.contains("endverbatim"));
+    }
+
+    #[test]
+    fn format_html_comment_block() {
+        let source = "<div>{% comment %}This is hidden{% endcomment %}</div>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(formatted.contains("comment"));
+        assert!(formatted.contains("endcomment"));
+    }
+
+    #[test]
+    fn detect_content_type_html_extension() {
+        let config = FormatConfig::default();
+        assert_eq!(
+            detect_content_type(Utf8Path::new("template.html"), &config),
+            ContentType::Html
+        );
+        assert_eq!(
+            detect_content_type(Utf8Path::new("template.htm"), &config),
+            ContentType::Html
+        );
+        assert_eq!(
+            detect_content_type(Utf8Path::new("template.djhtml"), &config),
+            ContentType::Html
+        );
+    }
+
+    #[test]
+    fn detect_content_type_text_extension() {
+        let config = FormatConfig::default();
+        assert_eq!(
+            detect_content_type(Utf8Path::new("email.txt"), &config),
+            ContentType::Text
+        );
+        assert_eq!(
+            detect_content_type(Utf8Path::new("query.sql"), &config),
+            ContentType::Text
+        );
+    }
+
+    #[test]
+    fn detect_content_type_config_override() {
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        assert_eq!(
+            detect_content_type(Utf8Path::new("email.txt"), &config),
+            ContentType::Html
+        );
+    }
+
+    #[test]
+    fn format_html_fallback_on_parse_error() {
+        // Broken HTML should fall back to Django syntax formatting
+        let source = "{%if x%}unclosed tags everywhere{%endif%}";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        // Should still produce valid output via fallback
+        assert!(formatted.contains("if x"));
     }
 }

--- a/crates/djls-fmt/src/lib.rs
+++ b/crates/djls-fmt/src/lib.rs
@@ -204,21 +204,70 @@ mod tests {
     }
 
     #[test]
-    fn format_html_verbatim_block() {
-        let source = "<div>{% verbatim %}{{ not_rendered }}{% endverbatim %}</div>";
+    fn format_html_verbatim_preserves_content() {
+        // {% verbatim %} content must NOT be reformatted — the {{ }} and {% %}
+        // inside are literal text, not template syntax
+        let source = "<div>{% verbatim %}{{ not_rendered }}{% if fake %}nope{% endif %}{% endverbatim %}</div>";
         let config = FormatConfig::default().with_content_type(ContentType::Html);
         let formatted = format_source(source, &config);
-        assert!(formatted.contains("verbatim"));
-        assert!(formatted.contains("endverbatim"));
+        assert!(
+            formatted.contains("{{ not_rendered }}"),
+            "verbatim content should be preserved literally: {formatted}"
+        );
+        assert!(
+            formatted.contains("{% if fake %}nope{% endif %}"),
+            "verbatim content should not be parsed as template tags: {formatted}"
+        );
     }
 
     #[test]
-    fn format_html_comment_block() {
-        let source = "<div>{% comment %}This is hidden{% endcomment %}</div>";
+    fn format_html_comment_preserves_content() {
+        // {% comment %} content must NOT be parsed as template syntax
+        let source = "<div>{% comment %}{{ var }} {% if x %}{% endif %}{% endcomment %}</div>";
         let config = FormatConfig::default().with_content_type(ContentType::Html);
         let formatted = format_source(source, &config);
-        assert!(formatted.contains("comment"));
-        assert!(formatted.contains("endcomment"));
+        assert!(
+            formatted.contains("{{ var }}"),
+            "comment content should be preserved: {formatted}"
+        );
+    }
+
+    #[test]
+    fn format_html_ifchanged_else() {
+        let source =
+            "<div>{% ifchanged obj.date %}{{ obj.date }}{% else %}same{% endifchanged %}</div>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        assert!(
+            formatted.contains("{% else %}"),
+            "else should be an intermediate for ifchanged: {formatted}"
+        );
+        assert!(
+            formatted.contains("endifchanged"),
+            "block should close properly: {formatted}"
+        );
+    }
+
+    #[test]
+    fn format_html_blocktrans_plural() {
+        let source = "<p>{% blocktrans count counter=list|length %}There is {{ counter }} item.{% plural %}There are {{ counter }} items.{% endblocktrans %}</p>";
+        let config = FormatConfig::default().with_content_type(ContentType::Html);
+        let formatted = format_source(source, &config);
+        // plural is recognized as an intermediate tag (not a nested child block)
+        // and the block closes with endblocktrans
+        assert!(
+            formatted.contains("plural"),
+            "plural should be an intermediate for blocktrans: {formatted}"
+        );
+        assert!(
+            formatted.contains("endblocktrans"),
+            "block should close properly: {formatted}"
+        );
+        // Content after {% plural %} should be preserved
+        assert!(
+            formatted.contains("There are"),
+            "content after plural should be preserved: {formatted}"
+        );
     }
 
     #[test]

--- a/crates/djls-fmt/src/markup/LICENSE
+++ b/crates/djls-fmt/src/markup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Pig Fang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/djls-fmt/src/markup/ast.rs
+++ b/crates/djls-fmt/src/markup/ast.rs
@@ -1,0 +1,110 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+
+#[derive(Debug)]
+pub enum Attribute<'s> {
+    JinjaBlock(JinjaBlock<'s, Attribute<'s>>),
+    JinjaComment(JinjaComment<'s>),
+    JinjaTag(JinjaTag<'s>),
+    Native(NativeAttribute<'s>),
+}
+
+#[derive(Debug)]
+pub struct Cdata<'s> {
+    pub raw: &'s str,
+}
+
+#[derive(Debug)]
+pub struct Comment<'s> {
+    pub raw: &'s str,
+}
+
+#[derive(Debug)]
+pub struct Doctype<'s> {
+    pub keyword: &'s str,
+    pub value: &'s str,
+}
+
+#[derive(Debug)]
+pub struct Element<'s> {
+    pub tag_name: &'s str,
+    pub attrs: Vec<Attribute<'s>>,
+    pub first_attr_same_line: bool,
+    pub children: Vec<Node<'s>>,
+    pub self_closing: bool,
+    pub void_element: bool,
+}
+
+#[derive(Debug)]
+pub struct JinjaBlock<'s, T> {
+    pub body: Vec<JinjaTagOrChildren<'s, T>>,
+}
+
+#[derive(Debug)]
+pub struct JinjaComment<'s> {
+    pub raw: &'s str,
+}
+
+#[derive(Debug)]
+pub struct JinjaInterpolation<'s> {
+    pub expr: &'s str,
+    pub start: usize,
+    pub trim_prev: bool,
+    pub trim_next: bool,
+}
+
+#[derive(Debug)]
+pub struct JinjaTag<'s> {
+    pub content: &'s str,
+    pub start: usize,
+}
+
+#[derive(Debug)]
+pub enum JinjaTagOrChildren<'s, T> {
+    Tag(JinjaTag<'s>),
+    Children(Vec<T>),
+}
+
+#[derive(Debug)]
+pub struct NativeAttribute<'s> {
+    pub name: &'s str,
+    pub value: Option<(&'s str, usize)>,
+    pub quote: Option<char>,
+}
+
+#[derive(Debug)]
+pub struct Node<'s> {
+    pub kind: NodeKind<'s>,
+    pub raw: &'s str,
+}
+
+#[derive(Debug)]
+pub enum NodeKind<'s> {
+    Cdata(Cdata<'s>),
+    Comment(Comment<'s>),
+    Doctype(Doctype<'s>),
+    Element(Element<'s>),
+    JinjaBlock(JinjaBlock<'s, Node<'s>>),
+    JinjaComment(JinjaComment<'s>),
+    JinjaInterpolation(JinjaInterpolation<'s>),
+    JinjaTag(JinjaTag<'s>),
+    Text(TextNode<'s>),
+    XmlDecl(XmlDecl<'s>),
+}
+
+#[derive(Debug)]
+pub struct Root<'s> {
+    pub children: Vec<Node<'s>>,
+}
+
+#[derive(Debug)]
+pub struct TextNode<'s> {
+    pub raw: &'s str,
+    pub line_breaks: usize,
+    pub start: usize,
+}
+
+#[derive(Debug)]
+pub struct XmlDecl<'s> {
+    pub attrs: Vec<NativeAttribute<'s>>,
+}

--- a/crates/djls-fmt/src/markup/ast.rs
+++ b/crates/djls-fmt/src/markup/ast.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 
 #[derive(Debug)]

--- a/crates/djls-fmt/src/markup/config.rs
+++ b/crates/djls-fmt/src/markup/config.rs
@@ -1,0 +1,135 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+
+use std::num::NonZeroUsize;
+
+#[derive(Clone, Debug, Default)]
+pub struct FormatOptions {
+    pub layout: LayoutOptions,
+    pub language: LanguageOptions,
+}
+
+#[derive(Clone, Debug)]
+pub struct LayoutOptions {
+    pub print_width: usize,
+    pub use_tabs: bool,
+    pub indent_width: usize,
+    pub line_break: LineBreak,
+}
+
+impl Default for LayoutOptions {
+    fn default() -> Self {
+        Self {
+            print_width: 80,
+            use_tabs: false,
+            indent_width: 2,
+            line_break: LineBreak::Lf,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum LineBreak {
+    #[default]
+    Lf,
+    Crlf,
+}
+
+impl From<LineBreak> for tiny_pretty::LineBreak {
+    fn from(value: LineBreak) -> Self {
+        match value {
+            LineBreak::Lf => tiny_pretty::LineBreak::Lf,
+            LineBreak::Crlf => tiny_pretty::LineBreak::Crlf,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LanguageOptions {
+    pub quotes: Quotes,
+    pub format_comments: bool,
+    pub script_indent: bool,
+    pub html_script_indent: Option<bool>,
+    pub style_indent: bool,
+    pub html_style_indent: Option<bool>,
+    pub closing_bracket_same_line: bool,
+    pub closing_tag_line_break_for_empty: ClosingTagLineBreakForEmpty,
+    pub max_attrs_per_line: Option<NonZeroUsize>,
+    pub prefer_attrs_single_line: bool,
+    pub single_attr_same_line: bool,
+    pub html_normal_self_closing: Option<bool>,
+    pub html_void_self_closing: Option<bool>,
+    pub component_self_closing: Option<bool>,
+    pub svg_self_closing: Option<bool>,
+    pub mathml_self_closing: Option<bool>,
+    pub whitespace_sensitivity: WhitespaceSensitivity,
+    pub doctype_keyword_case: DoctypeKeywordCase,
+    pub script_formatter: Option<ScriptFormatter>,
+    pub ignore_comment_directive: String,
+    pub ignore_file_comment_directive: String,
+}
+
+impl Default for LanguageOptions {
+    fn default() -> Self {
+        LanguageOptions {
+            quotes: Quotes::default(),
+            format_comments: false,
+            script_indent: false,
+            html_script_indent: None,
+            style_indent: false,
+            html_style_indent: None,
+            closing_bracket_same_line: false,
+            closing_tag_line_break_for_empty: ClosingTagLineBreakForEmpty::default(),
+            max_attrs_per_line: None,
+            prefer_attrs_single_line: false,
+            single_attr_same_line: true,
+            html_normal_self_closing: None,
+            html_void_self_closing: None,
+            component_self_closing: None,
+            svg_self_closing: None,
+            mathml_self_closing: None,
+            whitespace_sensitivity: WhitespaceSensitivity::default(),
+            doctype_keyword_case: DoctypeKeywordCase::default(),
+            script_formatter: None,
+            ignore_comment_directive: "markup-fmt-ignore".into(),
+            ignore_file_comment_directive: "markup-fmt-ignore-file".into(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum Quotes {
+    #[default]
+    Double,
+    Single,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum ClosingTagLineBreakForEmpty {
+    Always,
+    #[default]
+    Fit,
+    Never,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum WhitespaceSensitivity {
+    #[default]
+    Css,
+    Strict,
+    Ignore,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum DoctypeKeywordCase {
+    Ignore,
+    #[default]
+    Upper,
+    Lower,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ScriptFormatter {
+    Dprint,
+    Biome,
+}

--- a/crates/djls-fmt/src/markup/config.rs
+++ b/crates/djls-fmt/src/markup/config.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 
 use std::num::NonZeroUsize;

--- a/crates/djls-fmt/src/markup/config.rs
+++ b/crates/djls-fmt/src/markup/config.rs
@@ -91,8 +91,8 @@ impl Default for LanguageOptions {
             whitespace_sensitivity: WhitespaceSensitivity::default(),
             doctype_keyword_case: DoctypeKeywordCase::default(),
             script_formatter: None,
-            ignore_comment_directive: "markup-fmt-ignore".into(),
-            ignore_file_comment_directive: "markup-fmt-ignore-file".into(),
+            ignore_comment_directive: "djls-fmt-ignore".into(),
+            ignore_file_comment_directive: "djls-fmt-ignore-file".into(),
         }
     }
 }

--- a/crates/djls-fmt/src/markup/ctx.rs
+++ b/crates/djls-fmt/src/markup/ctx.rs
@@ -1,0 +1,237 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+
+use std::borrow::Cow;
+
+use memchr::memchr;
+
+use crate::markup::config::LanguageOptions;
+use crate::markup::config::Quotes;
+use crate::markup::config::WhitespaceSensitivity;
+use crate::markup::helpers;
+use crate::markup::state::State;
+use crate::markup::Language;
+
+const QUOTES: [&str; 3] = ["\"", "\"", "'"];
+
+pub(crate) struct Ctx<'b, E, F>
+where
+    F: for<'a> FnMut(&'a str, Hints<'b>) -> Result<Cow<'a, str>, E>,
+{
+    pub(crate) source: &'b str,
+    pub(crate) language: Language,
+    pub(crate) indent_width: usize,
+    pub(crate) print_width: usize,
+    pub(crate) options: &'b LanguageOptions,
+    pub(crate) external_formatter: F,
+    pub(crate) external_formatter_errors: Vec<E>,
+}
+
+impl<'b, E, F> Ctx<'b, E, F>
+where
+    F: for<'a> FnMut(&'a str, Hints<'b>) -> Result<Cow<'a, str>, E>,
+{
+    pub(crate) fn script_indent(&self) -> bool {
+        match self.language {
+            Language::Html | Language::Jinja => self
+                .options
+                .html_script_indent
+                .unwrap_or(self.options.script_indent),
+            Language::Xml => false,
+        }
+    }
+
+    pub(crate) fn style_indent(&self) -> bool {
+        match self.language {
+            Language::Html | Language::Jinja => self
+                .options
+                .html_style_indent
+                .unwrap_or(self.options.style_indent),
+            Language::Xml => false,
+        }
+    }
+
+    pub(crate) fn is_whitespace_sensitive(&self, tag_name: &str) -> bool {
+        match self.language {
+            Language::Xml => false,
+            Language::Html | Language::Jinja => match self.options.whitespace_sensitivity {
+                WhitespaceSensitivity::Css => {
+                    helpers::is_whitespace_sensitive_tag(tag_name, self.language)
+                }
+                WhitespaceSensitivity::Strict => true,
+                WhitespaceSensitivity::Ignore => false,
+            },
+        }
+    }
+
+    pub(crate) fn with_escaping_quotes(
+        &mut self,
+        s: &str,
+        mut processer: impl FnMut(String, &mut Self) -> String,
+    ) -> String {
+        let escaped = helpers::UNESCAPING_AC.replace_all(s, &QUOTES);
+        let proceeded = processer(escaped, self);
+        if memchr(b'\'', proceeded.as_bytes()).is_some()
+            && memchr(b'"', proceeded.as_bytes()).is_some()
+        {
+            match self.options.quotes {
+                Quotes::Double => proceeded.replace('"', "&quot;"),
+                Quotes::Single => proceeded.replace('\'', "&#x27;"),
+            }
+        } else {
+            proceeded
+        }
+    }
+
+    pub(crate) fn format_script<'a>(
+        &mut self,
+        code: &'a str,
+        lang: &'b str,
+        start: usize,
+        state: &State,
+    ) -> Cow<'a, str> {
+        self.format_with_external_formatter(
+            self.source
+                .get(0..start)
+                .unwrap_or_default()
+                .replace(|c: char| !c.is_ascii_whitespace(), " ")
+                + code,
+            Hints {
+                print_width: self.print_width,
+                indent_level: state.indent_level,
+                attr: false,
+                ext: lang,
+            },
+        )
+    }
+
+    pub(crate) fn format_style<'a>(
+        &mut self,
+        code: &'a str,
+        lang: &'b str,
+        start: usize,
+        state: &State,
+    ) -> Cow<'a, str> {
+        self.format_with_external_formatter(
+            "\n".repeat(
+                self.source
+                    .get(0..start)
+                    .unwrap_or_default()
+                    .lines()
+                    .count()
+                    .saturating_sub(1),
+            ) + code,
+            Hints {
+                print_width: self
+                    .print_width
+                    .saturating_sub((state.indent_level as usize) * self.indent_width)
+                    .saturating_sub(if self.style_indent() {
+                        self.indent_width
+                    } else {
+                        0
+                    }),
+                indent_level: state.indent_level,
+                attr: false,
+                ext: if lang == "postcss" { "css" } else { lang },
+            },
+        )
+    }
+
+    pub(crate) fn format_style_attr(&mut self, code: &str, start: usize, state: &State) -> String {
+        self.format_with_external_formatter(
+            self.source
+                .get(0..start)
+                .unwrap_or_default()
+                .replace(|c: char| !c.is_ascii_whitespace(), " ")
+                + code,
+            Hints {
+                print_width: u16::MAX as usize,
+                indent_level: state.indent_level,
+                attr: true,
+                ext: "css",
+            },
+        )
+        .trim()
+        .to_owned()
+    }
+
+    pub(crate) fn format_json<'a>(
+        &mut self,
+        code: &'a str,
+        start: usize,
+        state: &State,
+    ) -> Cow<'a, str> {
+        self.format_with_external_formatter(
+            self.source
+                .get(0..start)
+                .unwrap_or_default()
+                .replace(|c: char| !c.is_ascii_whitespace(), " ")
+                + code,
+            Hints {
+                print_width: self
+                    .print_width
+                    .saturating_sub((state.indent_level as usize) * self.indent_width)
+                    .saturating_sub(if self.script_indent() {
+                        self.indent_width
+                    } else {
+                        0
+                    }),
+                indent_level: state.indent_level,
+                attr: false,
+                ext: "json",
+            },
+        )
+    }
+
+    pub(crate) fn format_jinja(
+        &mut self,
+        code: &str,
+        start: usize,
+        expr: bool,
+        state: &State,
+    ) -> String {
+        self.format_with_external_formatter(
+            self.source
+                .get(0..start)
+                .unwrap_or_default()
+                .replace(|c: char| !c.is_ascii_whitespace(), " ")
+                + code,
+            Hints {
+                print_width: self
+                    .print_width
+                    .saturating_sub((state.indent_level as usize) * self.indent_width),
+                indent_level: state.indent_level,
+                attr: false,
+                ext: if expr {
+                    "markup-fmt-jinja-expr"
+                } else {
+                    "markup-fmt-jinja-stmt"
+                },
+            },
+        )
+        .trim_ascii()
+        .to_owned()
+    }
+
+    fn format_with_external_formatter<'a>(
+        &mut self,
+        code: String,
+        hints: Hints<'b>,
+    ) -> Cow<'a, str> {
+        match (self.external_formatter)(&code, hints) {
+            Ok(Cow::Owned(formatted)) => Cow::from(formatted),
+            Ok(Cow::Borrowed(..)) => Cow::from(code),
+            Err(e) => {
+                self.external_formatter_errors.push(e);
+                code.into()
+            }
+        }
+    }
+}
+
+pub struct Hints<'s> {
+    pub print_width: usize,
+    pub indent_level: u16,
+    pub attr: bool,
+    pub ext: &'s str,
+}

--- a/crates/djls-fmt/src/markup/ctx.rs
+++ b/crates/djls-fmt/src/markup/ctx.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 
 use std::borrow::Cow;

--- a/crates/djls-fmt/src/markup/error.rs
+++ b/crates/djls-fmt/src/markup/error.rs
@@ -1,0 +1,110 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug)]
+pub struct SyntaxError {
+    pub kind: SyntaxErrorKind,
+    pub pos: usize,
+    pub line: usize,
+    pub column: usize,
+}
+
+#[derive(Clone, Debug)]
+pub enum SyntaxErrorKind {
+    ExpectAttrName,
+    ExpectAttrValue,
+    ExpectCdata,
+    ExpectChar(char),
+    ExpectCloseTag {
+        tag_name: String,
+        line: usize,
+        column: usize,
+    },
+    ExpectComment,
+    ExpectDoctype,
+    ExpectElement,
+    ExpectIdentifier,
+    ExpectJinjaBlockEnd,
+    ExpectJinjaTag,
+    ExpectKeyword(&'static str),
+    ExpectSelfCloseTag,
+    ExpectTagName,
+    ExpectTextNode,
+    ExpectXmlDecl,
+}
+
+impl fmt::Display for SyntaxErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let reason: Cow<_> = match self {
+            SyntaxErrorKind::ExpectAttrName => "expected attribute name".into(),
+            SyntaxErrorKind::ExpectAttrValue => "expected attribute value".into(),
+            SyntaxErrorKind::ExpectCdata => "expected CDATA section".into(),
+            SyntaxErrorKind::ExpectChar(c) => format!("expected char '{c}'").into(),
+            SyntaxErrorKind::ExpectCloseTag {
+                tag_name,
+                line,
+                column,
+            } => format!(
+                "expected close tag for opening tag <{tag_name}> from line {line}, column {column}"
+            )
+            .into(),
+            SyntaxErrorKind::ExpectComment => "expected comment".into(),
+            SyntaxErrorKind::ExpectDoctype => "expected HTML doctype".into(),
+            SyntaxErrorKind::ExpectElement => "expected element".into(),
+            SyntaxErrorKind::ExpectIdentifier => "expected identifier".into(),
+            SyntaxErrorKind::ExpectJinjaBlockEnd => "expected Jinja block end".into(),
+            SyntaxErrorKind::ExpectJinjaTag => "expected Jinja tag".into(),
+            SyntaxErrorKind::ExpectKeyword(keyword) => {
+                format!("expected keyword '{keyword}'").into()
+            }
+            SyntaxErrorKind::ExpectSelfCloseTag => "expected self close tag".into(),
+            SyntaxErrorKind::ExpectTagName => "expected tag name".into(),
+            SyntaxErrorKind::ExpectTextNode => "expected text node".into(),
+            SyntaxErrorKind::ExpectXmlDecl => "expected XML declaration".into(),
+        };
+
+        write!(f, "{reason}")
+    }
+}
+
+impl fmt::Display for SyntaxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "syntax error '{}' at line {}, column {}",
+            self.kind, self.line, self.column
+        )
+    }
+}
+
+impl Error for SyntaxError {}
+
+#[derive(Debug)]
+pub enum FormatError<E> {
+    Syntax(SyntaxError),
+    External(Vec<E>),
+}
+
+impl<E> fmt::Display for FormatError<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FormatError::Syntax(e) => e.fmt(f),
+            FormatError::External(errors) => {
+                writeln!(f, "failed to format code with external formatter:")?;
+                for error in errors {
+                    writeln!(f, "{error}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<E> Error for FormatError<E> where E: Error {}

--- a/crates/djls-fmt/src/markup/error.rs
+++ b/crates/djls-fmt/src/markup/error.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 
 use std::borrow::Cow;

--- a/crates/djls-fmt/src/markup/helpers.rs
+++ b/crates/djls-fmt/src/markup/helpers.rs
@@ -1,0 +1,176 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+
+use std::sync::LazyLock;
+
+use aho_corasick::AhoCorasick;
+
+use crate::markup::Language;
+
+pub(crate) fn is_component(name: &str) -> bool {
+    name.contains('-') || name.contains(|c: char| c.is_ascii_uppercase())
+}
+
+static NON_WS_SENSITIVE_TAGS: [&str; 76] = [
+    "address",
+    "blockquote",
+    "button",
+    "caption",
+    "center",
+    "colgroup",
+    "dialog",
+    "div",
+    "figure",
+    "figcaption",
+    "footer",
+    "form",
+    "select",
+    "option",
+    "optgroup",
+    "header",
+    "hr",
+    "legend",
+    "listing",
+    "main",
+    "p",
+    "plaintext",
+    "pre",
+    "progress",
+    "search",
+    "object",
+    "details",
+    "summary",
+    "xmp",
+    "area",
+    "base",
+    "basefont",
+    "datalist",
+    "head",
+    "link",
+    "meta",
+    "meter",
+    "noembed",
+    "noframes",
+    "param",
+    "rp",
+    "title",
+    "html",
+    "body",
+    "article",
+    "aside",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hgroup",
+    "nav",
+    "section",
+    "table",
+    "tr",
+    "thead",
+    "th",
+    "tbody",
+    "td",
+    "tfoot",
+    "dir",
+    "dd",
+    "dl",
+    "dt",
+    "menu",
+    "ol",
+    "ul",
+    "li",
+    "fieldset",
+    "video",
+    "audio",
+    "picture",
+    "source",
+    "track",
+];
+
+pub(crate) fn is_whitespace_sensitive_tag(name: &str, language: Language) -> bool {
+    match language {
+        Language::Html | Language::Jinja => {
+            name.eq_ignore_ascii_case("a")
+                || !NON_WS_SENSITIVE_TAGS
+                    .iter()
+                    .any(|tag| tag.eq_ignore_ascii_case(name))
+                    && !css_dataset::tags::SVG_TAGS
+                        .iter()
+                        .any(|tag| tag.eq_ignore_ascii_case(name))
+        }
+        Language::Xml => false,
+    }
+}
+
+static VOID_ELEMENTS: [&str; 14] = [
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source", "track",
+    "wbr", "param",
+];
+
+pub(crate) fn is_void_element(name: &str, language: Language) -> bool {
+    match language {
+        Language::Html | Language::Jinja => VOID_ELEMENTS
+            .iter()
+            .any(|tag| tag.eq_ignore_ascii_case(name)),
+        Language::Xml => false,
+    }
+}
+
+pub(crate) fn is_html_tag(name: &str, language: Language) -> bool {
+    match language {
+        Language::Html | Language::Jinja => {
+            css_dataset::tags::STANDARD_HTML_TAGS
+                .iter()
+                .any(|tag| tag.eq_ignore_ascii_case(name))
+                || css_dataset::tags::NON_STANDARD_HTML_TAGS
+                    .iter()
+                    .any(|tag| tag.eq_ignore_ascii_case(name))
+        }
+        Language::Xml => false,
+    }
+}
+
+pub(crate) fn is_svg_tag(name: &str, language: Language) -> bool {
+    match language {
+        Language::Html | Language::Jinja => css_dataset::tags::SVG_TAGS
+            .iter()
+            .any(|tag| tag.eq_ignore_ascii_case(name)),
+        Language::Xml => false,
+    }
+}
+
+pub(crate) fn is_mathml_tag(name: &str, language: Language) -> bool {
+    match language {
+        Language::Html | Language::Jinja => css_dataset::tags::MATH_ML_TAGS
+            .iter()
+            .any(|tag| tag.eq_ignore_ascii_case(name)),
+        Language::Xml => false,
+    }
+}
+
+pub(crate) static UNESCAPING_AC: LazyLock<AhoCorasick> =
+    LazyLock::new(|| AhoCorasick::new(["&quot;", "&#x22;", "&#x27;"]).unwrap());
+
+pub(crate) fn detect_indent(s: &str) -> usize {
+    s.lines()
+        .skip(if s.starts_with([' ', '\t']) { 0 } else { 1 })
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            line.as_bytes()
+                .iter()
+                .take_while(|byte| byte.is_ascii_whitespace())
+                .count()
+        })
+        .min()
+        .unwrap_or_default()
+}
+
+pub(crate) fn has_template_interpolation(s: &str, language: Language) -> bool {
+    match language {
+        Language::Html | Language::Xml => false,
+        Language::Jinja => s.contains("{{") || s.contains("{%"),
+    }
+}

--- a/crates/djls-fmt/src/markup/helpers.rs
+++ b/crates/djls-fmt/src/markup/helpers.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 
 use std::sync::LazyLock;

--- a/crates/djls-fmt/src/markup/mod.rs
+++ b/crates/djls-fmt/src/markup/mod.rs
@@ -1,6 +1,9 @@
-// Vendored from markup_fmt v0.26.0 + tiny_pretty v0.2.1
-// Stripped to HTML + Jinja/Django + XML only
-// Django-specific parser fixes applied
+// Vendored from markup_fmt v0.26.0
+// https://github.com/g-plane/markup_fmt
+// Copyright (c) 2023-present Pig Fang — MIT License (see LICENSE)
+//
+// Stripped to HTML + Jinja/Django + XML only.
+// Django-specific parser fixes applied (see parser.rs).
 
 mod ast;
 pub mod config;

--- a/crates/djls-fmt/src/markup/mod.rs
+++ b/crates/djls-fmt/src/markup/mod.rs
@@ -1,0 +1,98 @@
+// Vendored from markup_fmt v0.26.0 + tiny_pretty v0.2.1
+// Stripped to HTML + Jinja/Django + XML only
+// Django-specific parser fixes applied
+
+mod ast;
+pub mod config;
+mod ctx;
+mod error;
+mod helpers;
+mod parser;
+mod printer;
+mod state;
+
+use std::borrow::Cow;
+
+use tiny_pretty::IndentKind;
+use tiny_pretty::PrintOptions;
+
+use crate::markup::config::FormatOptions;
+use crate::markup::ctx::Ctx;
+pub use crate::markup::ctx::Hints;
+pub use crate::markup::error::*;
+pub use crate::markup::parser::Language;
+use crate::markup::parser::Parser;
+use crate::markup::printer::DocGen;
+use crate::markup::state::State;
+
+/// Format the given source code.
+///
+/// An external formatter is required for formatting code
+/// inside `<script>` or `<style>` tag.
+pub fn format_text<E, F>(
+    code: &str,
+    language: Language,
+    options: &FormatOptions,
+    external_formatter: F,
+) -> Result<String, FormatError<E>>
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    let mut parser = Parser::new(code, language);
+    let ast = parser.parse_root().map_err(FormatError::Syntax)?;
+
+    if ast.children.first().is_some_and(|child| {
+        if let ast::Node {
+            kind: ast::NodeKind::Comment(ast::Comment { raw, .. }),
+            ..
+        } = child
+        {
+            raw.trim_start()
+                .strip_prefix(&options.language.ignore_file_comment_directive)
+                .is_some_and(|rest| {
+                    rest.starts_with(|c: char| c.is_ascii_whitespace()) || rest.is_empty()
+                })
+        } else {
+            false
+        }
+    }) {
+        return Ok(code.into());
+    }
+
+    let mut ctx = Ctx {
+        source: code,
+        language,
+        indent_width: options.layout.indent_width,
+        print_width: options.layout.print_width,
+        options: &options.language,
+        external_formatter,
+        external_formatter_errors: Default::default(),
+    };
+
+    let doc = ast.doc(
+        &mut ctx,
+        &State {
+            current_tag_name: None,
+            is_root: true,
+            in_svg: false,
+            indent_level: 0,
+        },
+    );
+    if !ctx.external_formatter_errors.is_empty() {
+        return Err(FormatError::External(ctx.external_formatter_errors));
+    }
+
+    Ok(tiny_pretty::print(
+        &doc,
+        &PrintOptions {
+            indent_kind: if options.layout.use_tabs {
+                IndentKind::Tab
+            } else {
+                IndentKind::Space
+            },
+            line_break: options.layout.line_break.into(),
+            width: options.layout.print_width,
+            tab_size: options.layout.indent_width,
+        },
+    ))
+}

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -708,9 +708,10 @@ impl<'s> Parser<'s> {
                         break;
                     }
                     // Intermediate tags: elif/elseif/else for if/for,
-                    // "empty" for Django's {% for %}...{% empty %}...{% endfor %}
+                    // "empty" only for Django's {% for %}...{% empty %}...{% endfor %}
                     if (tag_name == "if" || tag_name == "for")
-                        && matches!(next_tag_name, "elif" | "elseif" | "else" | "empty")
+                        && matches!(next_tag_name, "elif" | "elseif" | "else")
+                        || tag_name == "for" && next_tag_name == "empty"
                     {
                         body.push(JinjaTagOrChildren::Tag(next_tag));
                     } else if let Some(JinjaTagOrChildren::Children(nodes)) = body.last_mut() {
@@ -1140,7 +1141,7 @@ pub fn parse_as_interpolated(
     let mut dynamics = Vec::new();
     let mut chars = text.char_indices().peekable();
     let mut pos = 0;
-    let mut brace_stack = 0u8;
+    let mut brace_stack: usize = 0;
     while let Some((i, c)) = chars.next() {
         match c {
             '{' => {

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -2,7 +2,6 @@
 // Stripped to HTML + Jinja/Django + XML only
 // Django fixes applied to block tag list
 
-use std::cmp::Ordering;
 use std::iter::Peekable;
 use std::ops::ControlFlow;
 use std::str::CharIndices;
@@ -70,17 +69,22 @@ impl<'s> Parser<'s> {
     }
 
     fn pos_to_line_col(&self, pos: usize) -> (usize, usize) {
+        // Track (line_number, line_start_byte) where line_start_byte is the
+        // byte offset of the first character on that line.
         let search = memchr::memchr_iter(b'\n', self.source.as_bytes()).try_fold(
-            (1, 0),
-            |(line, prev_offset), offset| match pos.cmp(&offset) {
-                Ordering::Less | Ordering::Equal => ControlFlow::Break((line, prev_offset)),
-                Ordering::Greater => ControlFlow::Continue((line + 1, offset)),
+            (1, 0usize),
+            |(line, _line_start), newline_offset| {
+                if pos <= newline_offset {
+                    ControlFlow::Break((line, _line_start))
+                } else {
+                    ControlFlow::Continue((line + 1, newline_offset + 1))
+                }
             },
         );
-        let (line, offset) = match search {
+        let (line, line_start) = match search {
             ControlFlow::Break(result) | ControlFlow::Continue(result) => result,
         };
-        (line, pos - offset + 1)
+        (line, pos - line_start + 1)
     }
 
     fn skip_ws(&mut self) {
@@ -198,8 +202,10 @@ impl<'s> Parser<'s> {
                             end += self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
                         }
                         Some((_, c)) => {
-                            end += c.len_utf8();
-                            self.chars.next();
+                            // Consume both '{' and the following char
+                            self.chars.next(); // '{'
+                            self.chars.next(); // the char `c`
+                            end += '{'.len_utf8() + c.len_utf8();
                         }
                         None => break,
                     }
@@ -281,10 +287,9 @@ impl<'s> Parser<'s> {
                                     .parse_jinja_tag_or_block(None, &mut Parser::parse_node)
                                     .is_ok()
                                 {
-                                    end =
-                                        self.chars.peek().map(|(i, _)| i - 1).ok_or_else(|| {
-                                            self.emit_error(SyntaxErrorKind::ExpectAttrValue)
-                                        })?;
+                                    end = self.chars.peek().map(|(i, _)| *i).ok_or_else(|| {
+                                        self.emit_error(SyntaxErrorKind::ExpectAttrValue)
+                                    })?;
                                 } else {
                                     self.chars.next();
                                 }
@@ -292,7 +297,7 @@ impl<'s> Parser<'s> {
                             Some((_, '{')) => {
                                 chars.next();
                                 let (interpolation, _) = self.parse_mustache_interpolation()?;
-                                end += interpolation.len() + "{{}}".len() - 1;
+                                end += interpolation.len() + "{{}}".len();
                             }
                             _ => {
                                 self.chars.next();
@@ -300,14 +305,14 @@ impl<'s> Parser<'s> {
                         }
                     }
                     Some((i, c)) if is_unquoted_attr_value_char(*c) => {
-                        end = *i;
+                        end = *i + c.len_utf8();
                         self.chars.next();
                     }
                     _ => break,
                 }
             }
 
-            Ok((unsafe { self.source.get_unchecked(start..=end) }, start))
+            Ok((unsafe { self.source.get_unchecked(start..end) }, start))
         }
     }
 

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -77,10 +77,10 @@ impl<'s> Parser<'s> {
                 Ordering::Greater => ControlFlow::Continue((line + 1, offset)),
             },
         );
-        match search {
-            ControlFlow::Break((line, offset)) => (line, pos - offset + 1),
-            ControlFlow::Continue((line, _)) => (line, 0),
-        }
+        let (line, offset) = match search {
+            ControlFlow::Break(result) | ControlFlow::Continue(result) => result,
+        };
+        (line, pos - offset + 1)
     }
 
     fn skip_ws(&mut self) {
@@ -707,11 +707,10 @@ impl<'s> Parser<'s> {
                         body.push(JinjaTagOrChildren::Tag(next_tag));
                         break;
                     }
-                    // Intermediate tags: elif/elseif/else for if/for,
-                    // "empty" only for Django's {% for %}...{% empty %}...{% endfor %}
-                    if (tag_name == "if" || tag_name == "for")
-                        && matches!(next_tag_name, "elif" | "elseif" | "else")
-                        || tag_name == "for" && next_tag_name == "empty"
+                    // Intermediate tags: elif/elseif/else for if blocks,
+                    // else/empty for Django's {% for %} blocks
+                    if tag_name == "if" && matches!(next_tag_name, "elif" | "elseif" | "else")
+                        || tag_name == "for" && matches!(next_tag_name, "else" | "empty")
                     {
                         body.push(JinjaTagOrChildren::Tag(next_tag));
                     } else if let Some(JinjaTagOrChildren::Children(nodes)) = body.last_mut() {

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -550,16 +550,16 @@ impl<'s> Parser<'s> {
             c.is_ascii_alphanumeric() || c == '-' || c == '_' || !c.is_ascii() || c == '\\'
         }
 
-        let Some((start, _)) = self.chars.next_if(|(_, c)| is_identifier_char(*c)) else {
+        let Some((start, c)) = self.chars.next_if(|(_, c)| is_identifier_char(*c)) else {
             return Err(self.emit_error(SyntaxErrorKind::ExpectIdentifier));
         };
-        let mut end = start;
+        let mut end = start + c.len_utf8();
 
-        while let Some((i, _)) = self.chars.next_if(|(_, c)| is_identifier_char(*c)) {
-            end = i;
+        while let Some((i, c)) = self.chars.next_if(|(_, c)| is_identifier_char(*c)) {
+            end = i + c.len_utf8();
         }
 
-        unsafe { Ok(self.source.get_unchecked(start..=end)) }
+        unsafe { Ok(self.source.get_unchecked(start..end)) }
     }
 
     fn parse_jinja_block_children<T, F>(&mut self, children_parser: &mut F) -> PResult<Vec<T>>
@@ -1166,7 +1166,7 @@ pub fn parse_as_interpolated(
                 }
                 match language {
                     Language::Jinja => {
-                        if chars.next_if(|(_, c)| *c == '}').is_some() {
+                        if brace_stack > 0 && chars.next_if(|(_, c)| *c == '}').is_some() {
                             dynamics.push((
                                 unsafe { text.get_unchecked(pos + 2..i) },
                                 base_start + pos + 2,

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -1,0 +1,1186 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+// Django fixes applied to block tag list
+
+use std::cmp::Ordering;
+use std::iter::Peekable;
+use std::ops::ControlFlow;
+use std::str::CharIndices;
+
+use crate::markup::ast::*;
+use crate::markup::error::SyntaxError;
+use crate::markup::error::SyntaxErrorKind;
+use crate::markup::helpers;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Language {
+    Html,
+    Jinja,
+    Xml,
+}
+
+pub struct Parser<'s> {
+    source: &'s str,
+    language: Language,
+    chars: Peekable<CharIndices<'s>>,
+}
+
+impl<'s> Parser<'s> {
+    pub fn new(source: &'s str, language: Language) -> Self {
+        Self {
+            source,
+            language,
+            chars: source.char_indices().peekable(),
+        }
+    }
+
+    fn try_parse<F, R>(&mut self, f: F) -> PResult<R>
+    where
+        F: FnOnce(&mut Self) -> PResult<R>,
+    {
+        let chars = self.chars.clone();
+        let result = f(self);
+        if result.is_err() {
+            self.chars = chars;
+        }
+        result
+    }
+
+    #[inline]
+    fn peek_pos(&mut self) -> usize {
+        self.chars
+            .peek()
+            .map(|(i, _)| *i)
+            .unwrap_or(self.source.len())
+    }
+
+    fn emit_error(&mut self, kind: SyntaxErrorKind) -> SyntaxError {
+        let pos = self.peek_pos();
+        self.emit_error_with_pos(kind, pos)
+    }
+
+    fn emit_error_with_pos(&self, kind: SyntaxErrorKind, pos: usize) -> SyntaxError {
+        let (line, column) = self.pos_to_line_col(pos);
+        SyntaxError {
+            kind,
+            pos,
+            line,
+            column,
+        }
+    }
+
+    fn pos_to_line_col(&self, pos: usize) -> (usize, usize) {
+        let search = memchr::memchr_iter(b'\n', self.source.as_bytes()).try_fold(
+            (1, 0),
+            |(line, prev_offset), offset| match pos.cmp(&offset) {
+                Ordering::Less | Ordering::Equal => ControlFlow::Break((line, prev_offset)),
+                Ordering::Greater => ControlFlow::Continue((line + 1, offset)),
+            },
+        );
+        match search {
+            ControlFlow::Break((line, offset)) => (line, pos - offset + 1),
+            ControlFlow::Continue((line, _)) => (line, 0),
+        }
+    }
+
+    fn skip_ws(&mut self) {
+        while self
+            .chars
+            .next_if(|(_, c)| c.is_ascii_whitespace())
+            .is_some()
+        {}
+    }
+
+    fn try_consume_str(&mut self, s: &str) -> Option<(usize, char)> {
+        let mut chars = self.chars.clone();
+        let mut last = None;
+
+        for expected in s.chars() {
+            match chars.next() {
+                Some((idx, c)) if c == expected => {
+                    last = Some((idx, c));
+                }
+                _ => return None,
+            }
+        }
+
+        self.chars = chars;
+        last
+    }
+
+    fn try_consume_str_ignore_case(&mut self, s: &str) -> Option<(usize, char)> {
+        let mut chars = self.chars.clone();
+        let mut last = None;
+
+        for expected in s.chars() {
+            match chars.next() {
+                Some((idx, c)) if c.eq_ignore_ascii_case(&expected) => {
+                    last = Some((idx, c));
+                }
+                _ => return None,
+            }
+        }
+
+        self.chars = chars;
+        last
+    }
+
+    fn with_taken<T, F>(&mut self, parser: F) -> PResult<(T, &'s str)>
+    where
+        F: FnOnce(&mut Self) -> PResult<T>,
+    {
+        let start = self.peek_pos();
+        let parsed = parser(self)?;
+        let end = self.peek_pos();
+        Ok((parsed, unsafe { self.source.get_unchecked(start..end) }))
+    }
+
+    fn parse_attr(&mut self) -> PResult<Attribute<'s>> {
+        match self.language {
+            Language::Html | Language::Xml => self.parse_native_attr().map(Attribute::Native),
+            Language::Jinja => {
+                self.skip_ws();
+                let result = if matches!(self.chars.peek(), Some((_, '{'))) {
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    match chars.next() {
+                        Some((_, '{')) => self.parse_native_attr().map(Attribute::Native),
+                        Some((_, '#')) => self.parse_jinja_comment().map(Attribute::JinjaComment),
+                        _ => self.parse_jinja_tag_or_block(None, &mut Parser::parse_attr),
+                    }
+                } else {
+                    self.parse_native_attr().map(Attribute::Native)
+                };
+                if result.is_ok() {
+                    self.skip_ws();
+                }
+                result
+            }
+        }
+    }
+
+    fn parse_attr_name(&mut self) -> PResult<&'s str> {
+        if matches!(self.language, Language::Jinja) {
+            let Some((start, mut end)) = (match self.chars.peek() {
+                Some((i, '{')) => {
+                    let start = *i;
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    if let Some((_, '{')) = chars.next() {
+                        let end =
+                            start + self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
+                        Some((start, end))
+                    } else {
+                        None
+                    }
+                }
+                Some((_, c)) if is_attr_name_char(*c) => self
+                    .chars
+                    .next()
+                    .map(|(start, c)| (start, start + c.len_utf8())),
+                _ => None,
+            }) else {
+                return Err(self.emit_error(SyntaxErrorKind::ExpectAttrName));
+            };
+
+            while let Some((_, c)) = self.chars.peek() {
+                if is_attr_name_char(*c) && *c != '{' {
+                    end += c.len_utf8();
+                    self.chars.next();
+                } else if *c == '{' {
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    match chars.next() {
+                        Some((_, '%')) => {
+                            break;
+                        }
+                        Some((_, '{')) => {
+                            end += self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
+                        }
+                        Some((_, c)) => {
+                            end += c.len_utf8();
+                            self.chars.next();
+                        }
+                        None => break,
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            unsafe { Ok(self.source.get_unchecked(start..end)) }
+        } else {
+            let Some((start, start_char)) = self.chars.next_if(|(_, c)| is_attr_name_char(*c))
+            else {
+                return Err(self.emit_error(SyntaxErrorKind::ExpectAttrName));
+            };
+            let mut end = start + start_char.len_utf8();
+
+            while let Some((_, c)) = self.chars.next_if(|(_, c)| is_attr_name_char(*c)) {
+                end += c.len_utf8();
+            }
+
+            unsafe { Ok(self.source.get_unchecked(start..end)) }
+        }
+    }
+
+    fn parse_attr_value(&mut self) -> PResult<(&'s str, usize)> {
+        let quote = self.chars.next_if(|(_, c)| *c == '"' || *c == '\'');
+
+        if let Some((start, quote)) = quote {
+            let can_interpolate = matches!(self.language, Language::Jinja);
+            let start = start + 1;
+            let mut end = start;
+            let mut chars_stack = vec![];
+            loop {
+                match self.chars.next() {
+                    Some((i, c)) if c == quote => {
+                        if chars_stack.is_empty() || !can_interpolate {
+                            end = i;
+                            break;
+                        } else if chars_stack.last().is_some_and(|last| *last == c) {
+                            chars_stack.pop();
+                        } else {
+                            chars_stack.push(c);
+                        }
+                    }
+                    Some((_, '{')) if can_interpolate => {
+                        chars_stack.push('{');
+                    }
+                    Some((_, '}'))
+                        if can_interpolate
+                            && chars_stack.last().is_some_and(|last| *last == '{') =>
+                    {
+                        chars_stack.pop();
+                    }
+                    Some(..) => continue,
+                    None => break,
+                }
+            }
+            Ok((unsafe { self.source.get_unchecked(start..end) }, start))
+        } else {
+            fn is_unquoted_attr_value_char(c: char) -> bool {
+                !c.is_ascii_whitespace() && !matches!(c, '"' | '\'' | '=' | '<' | '>' | '`')
+            }
+
+            let start = match self.chars.peek() {
+                Some((i, c)) if is_unquoted_attr_value_char(*c) => *i,
+                _ => return Err(self.emit_error(SyntaxErrorKind::ExpectAttrValue)),
+            };
+
+            let mut end = start;
+            loop {
+                match self.chars.peek() {
+                    Some((i, '{')) if matches!(self.language, Language::Jinja) => {
+                        end = *i;
+                        let mut chars = self.chars.clone();
+                        chars.next();
+                        match chars.peek() {
+                            Some((_, '%')) => {
+                                if self
+                                    .parse_jinja_tag_or_block(None, &mut Parser::parse_node)
+                                    .is_ok()
+                                {
+                                    end =
+                                        self.chars.peek().map(|(i, _)| i - 1).ok_or_else(|| {
+                                            self.emit_error(SyntaxErrorKind::ExpectAttrValue)
+                                        })?;
+                                } else {
+                                    self.chars.next();
+                                }
+                            }
+                            Some((_, '{')) => {
+                                chars.next();
+                                let (interpolation, _) = self.parse_mustache_interpolation()?;
+                                end += interpolation.len() + "{{}}".len() - 1;
+                            }
+                            _ => {
+                                self.chars.next();
+                            }
+                        }
+                    }
+                    Some((i, c)) if is_unquoted_attr_value_char(*c) => {
+                        end = *i;
+                        self.chars.next();
+                    }
+                    _ => break,
+                }
+            }
+
+            Ok((unsafe { self.source.get_unchecked(start..=end) }, start))
+        }
+    }
+
+    fn parse_cdata(&mut self) -> PResult<Cdata<'s>> {
+        let Some((start, _)) = self.try_consume_str("<![CDATA[") else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectCdata));
+        };
+        let start = start + 1;
+
+        let mut end = start;
+        loop {
+            match self.chars.next() {
+                Some((i, ']')) => {
+                    let mut chars = self.chars.clone();
+                    if chars
+                        .next_if(|(_, c)| *c == ']')
+                        .and_then(|_| chars.next_if(|(_, c)| *c == '>'))
+                        .is_some()
+                    {
+                        end = i;
+                        self.chars = chars;
+                        break;
+                    }
+                }
+                Some(..) => continue,
+                None => break,
+            }
+        }
+
+        Ok(Cdata {
+            raw: unsafe { self.source.get_unchecked(start..end) },
+        })
+    }
+
+    fn parse_comment(&mut self) -> PResult<Comment<'s>> {
+        let Some((start, _)) = self
+            .chars
+            .next_if(|(_, c)| *c == '<')
+            .and_then(|_| self.try_consume_str("!--"))
+        else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectComment));
+        };
+        let start = start + 1;
+
+        let mut end = start;
+        loop {
+            match self.chars.next() {
+                Some((i, '-')) => {
+                    let mut chars = self.chars.clone();
+                    if chars
+                        .next_if(|(_, c)| *c == '-')
+                        .and_then(|_| chars.next_if(|(_, c)| *c == '>'))
+                        .is_some()
+                    {
+                        end = i;
+                        self.chars = chars;
+                        break;
+                    }
+                }
+                Some(..) => continue,
+                None => break,
+            }
+        }
+
+        Ok(Comment {
+            raw: unsafe { self.source.get_unchecked(start..end) },
+        })
+    }
+
+    fn parse_doctype(&mut self) -> PResult<Doctype<'s>> {
+        let keyword_start = if let Some((start, _)) = self.try_consume_str("<!") {
+            start + 1
+        } else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectDoctype));
+        };
+        let keyword = if let Some((end, _)) = self.try_consume_str_ignore_case("doctype") {
+            unsafe { self.source.get_unchecked(keyword_start..end + 1) }
+        } else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectDoctype));
+        };
+        self.skip_ws();
+
+        let value_start = if let Some((start, _)) = self.chars.peek() {
+            *start
+        } else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectDoctype));
+        };
+        while self.chars.next_if(|(_, c)| *c != '>').is_some() {}
+
+        if let Some((value_end, _)) = self.chars.next_if(|(_, c)| *c == '>') {
+            Ok(Doctype {
+                keyword,
+                value: unsafe { self.source.get_unchecked(value_start..value_end) }.trim_end(),
+            })
+        } else {
+            Err(self.emit_error(SyntaxErrorKind::ExpectDoctype))
+        }
+    }
+
+    fn parse_element(&mut self) -> PResult<Element<'s>> {
+        let Some((element_start, _)) = self.chars.next_if(|(_, c)| *c == '<') else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectElement));
+        };
+        let tag_name = self.parse_tag_name()?;
+        let void_element = helpers::is_void_element(tag_name, self.language);
+
+        let mut attrs = vec![];
+        let mut first_attr_same_line = true;
+        loop {
+            match self.chars.peek() {
+                Some((_, '/')) => {
+                    self.chars.next();
+                    if self.chars.next_if(|(_, c)| *c == '>').is_some() {
+                        return Ok(Element {
+                            tag_name,
+                            attrs,
+                            first_attr_same_line,
+                            children: vec![],
+                            self_closing: true,
+                            void_element,
+                        });
+                    }
+                    return Err(self.emit_error(SyntaxErrorKind::ExpectSelfCloseTag));
+                }
+                Some((_, '>')) => {
+                    self.chars.next();
+                    if void_element {
+                        return Ok(Element {
+                            tag_name,
+                            attrs,
+                            first_attr_same_line,
+                            children: vec![],
+                            self_closing: false,
+                            void_element,
+                        });
+                    }
+                    break;
+                }
+                Some((_, '\n')) => {
+                    if attrs.is_empty() {
+                        first_attr_same_line = false;
+                    }
+                    self.chars.next();
+                }
+                Some((_, c)) if c.is_ascii_whitespace() => {
+                    self.chars.next();
+                }
+                _ => {
+                    attrs.push(self.parse_attr()?);
+                }
+            }
+        }
+
+        let mut children = vec![];
+        let should_parse_raw = self.language != Language::Xml
+            && (tag_name.eq_ignore_ascii_case("script")
+                || tag_name.eq_ignore_ascii_case("style")
+                || tag_name.eq_ignore_ascii_case("pre")
+                || tag_name.eq_ignore_ascii_case("textarea"));
+        if should_parse_raw {
+            let text_node = self.parse_raw_text_node(tag_name)?;
+            let raw = text_node.raw;
+            if !raw.is_empty() {
+                children.push(Node {
+                    kind: NodeKind::Text(text_node),
+                    raw,
+                });
+            }
+        }
+
+        loop {
+            match self.chars.peek() {
+                Some((_, '<')) => {
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    if let Some((pos, _)) = chars.next_if(|(_, c)| *c == '/') {
+                        self.chars = chars;
+                        let close_tag_name = self.parse_tag_name()?;
+                        if !close_tag_name.eq_ignore_ascii_case(tag_name) {
+                            let (line, column) = self.pos_to_line_col(element_start);
+                            return Err(self.emit_error_with_pos(
+                                SyntaxErrorKind::ExpectCloseTag {
+                                    tag_name: tag_name.into(),
+                                    line,
+                                    column,
+                                },
+                                pos,
+                            ));
+                        }
+                        self.skip_ws();
+                        if self.chars.next_if(|(_, c)| *c == '>').is_some() {
+                            break;
+                        }
+                        let (line, column) = self.pos_to_line_col(element_start);
+                        return Err(self.emit_error(SyntaxErrorKind::ExpectCloseTag {
+                            tag_name: tag_name.into(),
+                            line,
+                            column,
+                        }));
+                    }
+                    children.push(self.parse_node()?);
+                }
+                Some(..) => {
+                    if should_parse_raw {
+                        let text_node = self.parse_raw_text_node(tag_name)?;
+                        let raw = text_node.raw;
+                        if !raw.is_empty() {
+                            children.push(Node {
+                                kind: NodeKind::Text(text_node),
+                                raw,
+                            });
+                        }
+                    } else {
+                        children.push(self.parse_node()?);
+                    }
+                }
+                None => {
+                    let (line, column) = self.pos_to_line_col(element_start);
+                    return Err(self.emit_error(SyntaxErrorKind::ExpectCloseTag {
+                        tag_name: tag_name.into(),
+                        line,
+                        column,
+                    }));
+                }
+            }
+        }
+
+        Ok(Element {
+            tag_name,
+            attrs,
+            first_attr_same_line,
+            children,
+            self_closing: false,
+            void_element,
+        })
+    }
+
+    fn parse_identifier(&mut self) -> PResult<&'s str> {
+        fn is_identifier_char(c: char) -> bool {
+            c.is_ascii_alphanumeric() || c == '-' || c == '_' || !c.is_ascii() || c == '\\'
+        }
+
+        let Some((start, _)) = self.chars.next_if(|(_, c)| is_identifier_char(*c)) else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectIdentifier));
+        };
+        let mut end = start;
+
+        while let Some((i, _)) = self.chars.next_if(|(_, c)| is_identifier_char(*c)) {
+            end = i;
+        }
+
+        unsafe { Ok(self.source.get_unchecked(start..=end)) }
+    }
+
+    fn parse_jinja_block_children<T, F>(&mut self, children_parser: &mut F) -> PResult<Vec<T>>
+    where
+        T: HasJinjaFlowControl<'s>,
+        F: FnMut(&mut Self) -> PResult<T>,
+    {
+        let mut children = vec![];
+        loop {
+            match self.chars.peek() {
+                Some((_, '{')) => {
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    if chars.next_if(|(_, c)| *c == '%').is_some() {
+                        break;
+                    }
+                    children.push(children_parser(self)?);
+                }
+                Some(..) => {
+                    children.push(children_parser(self)?);
+                }
+                None => return Err(self.emit_error(SyntaxErrorKind::ExpectJinjaBlockEnd)),
+            }
+        }
+        Ok(children)
+    }
+
+    fn parse_jinja_comment(&mut self) -> PResult<JinjaComment<'s>> {
+        let Some((start, _)) = self.try_consume_str("{#") else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectComment));
+        };
+        let start = start + 1;
+
+        let end;
+        loop {
+            match self.chars.next() {
+                Some((i, '#')) => {
+                    let mut chars = self.chars.clone();
+                    if chars.next_if(|(_, c)| *c == '}').is_some() {
+                        end = i;
+                        self.chars = chars;
+                        break;
+                    }
+                }
+                Some(..) => continue,
+                None => {
+                    end = self.source.len();
+                    break;
+                }
+            }
+        }
+
+        Ok(JinjaComment {
+            raw: unsafe { self.source.get_unchecked(start..end) },
+        })
+    }
+
+    fn parse_jinja_tag(&mut self) -> PResult<JinjaTag<'s>> {
+        let Some((start, _)) = self.try_consume_str("{%") else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectJinjaTag));
+        };
+        let start = start + 1;
+
+        let mut end = start;
+        loop {
+            match self.chars.next() {
+                Some((i, '%')) => {
+                    if self.chars.next_if(|(_, c)| *c == '}').is_some() {
+                        end = i;
+                        break;
+                    }
+                }
+                Some(..) => continue,
+                None => break,
+            }
+        }
+
+        Ok(JinjaTag {
+            content: unsafe { self.source.get_unchecked(start..end) },
+            start,
+        })
+    }
+
+    fn parse_jinja_tag_or_block<T, F>(
+        &mut self,
+        first_tag: Option<JinjaTag<'s>>,
+        children_parser: &mut F,
+    ) -> PResult<T::Intermediate>
+    where
+        T: HasJinjaFlowControl<'s>,
+        F: FnMut(&mut Self) -> PResult<T>,
+    {
+        let first_tag = if let Some(first_tag) = first_tag {
+            first_tag
+        } else {
+            self.parse_jinja_tag()?
+        };
+        let tag_name = parse_jinja_tag_name(&first_tag);
+
+        // Django block tags: tags that have matching {% end<tag> %} closers.
+        //
+        // Changes from upstream markup_fmt (Jinja mode):
+        // - Removed: "trans" (self-closing in Django, block in Jinja)
+        // - Added: "blocktrans", "blocktranslate", "verbatim", "spaceless",
+        //   "cache", "ifchanged", "comment"
+        if matches!(
+            tag_name,
+            "for"
+                | "if"
+                | "macro"
+                | "call"
+                | "filter"
+                | "block"
+                | "apply"
+                | "autoescape"
+                | "embed"
+                | "with"
+                | "raw"
+                | "blocktrans"
+                | "blocktranslate"
+                | "verbatim"
+                | "spaceless"
+                | "cache"
+                | "ifchanged"
+                | "comment"
+        ) || tag_name == "set" && !first_tag.content.contains('=')
+        {
+            let mut body = vec![JinjaTagOrChildren::Tag(first_tag)];
+
+            loop {
+                let mut children = self.parse_jinja_block_children(children_parser)?;
+                if !children.is_empty() {
+                    if let Some(JinjaTagOrChildren::Children(nodes)) = body.last_mut() {
+                        nodes.append(&mut children);
+                    } else {
+                        body.push(JinjaTagOrChildren::Children(children));
+                    }
+                }
+                if let Ok(next_tag) = self.parse_jinja_tag() {
+                    let next_tag_name = parse_jinja_tag_name(&next_tag);
+                    if next_tag_name
+                        .strip_prefix("end")
+                        .is_some_and(|name| name == tag_name)
+                    {
+                        body.push(JinjaTagOrChildren::Tag(next_tag));
+                        break;
+                    }
+                    // Intermediate tags: elif/elseif/else for if/for,
+                    // "empty" for Django's {% for %}...{% empty %}...{% endfor %}
+                    if (tag_name == "if" || tag_name == "for")
+                        && matches!(next_tag_name, "elif" | "elseif" | "else" | "empty")
+                    {
+                        body.push(JinjaTagOrChildren::Tag(next_tag));
+                    } else if let Some(JinjaTagOrChildren::Children(nodes)) = body.last_mut() {
+                        nodes.push(
+                            self.with_taken(|parser| {
+                                parser.parse_jinja_tag_or_block(Some(next_tag), children_parser)
+                            })
+                            .map(|(kind, raw)| T::build(kind, raw))?,
+                        );
+                    } else {
+                        body.push(JinjaTagOrChildren::Children(vec![self
+                            .with_taken(|parser| {
+                                parser.parse_jinja_tag_or_block(Some(next_tag), children_parser)
+                            })
+                            .map(|(kind, raw)| T::build(kind, raw))?]));
+                    }
+                } else {
+                    break;
+                }
+            }
+            Ok(T::from_block(JinjaBlock { body }))
+        } else {
+            Ok(T::from_tag(first_tag))
+        }
+    }
+
+    fn parse_mustache_interpolation(&mut self) -> PResult<(&'s str, usize)> {
+        let Some((start, _)) = self.try_consume_str("{{") else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectJinjaTag));
+        };
+        let start = start + 1;
+
+        let mut braces_stack = 0usize;
+        let end;
+        loop {
+            match self.chars.next() {
+                Some((_, '{')) => braces_stack += 1,
+                Some((i, '}')) => {
+                    if braces_stack == 0 {
+                        if self.chars.next_if(|(_, c)| *c == '}').is_some() {
+                            end = i;
+                            break;
+                        }
+                    } else {
+                        braces_stack -= 1;
+                    }
+                }
+                Some(..) => continue,
+                None => {
+                    end = self.source.len();
+                    break;
+                }
+            }
+        }
+
+        Ok((unsafe { self.source.get_unchecked(start..end) }, start))
+    }
+
+    fn parse_native_attr(&mut self) -> PResult<NativeAttribute<'s>> {
+        let name = self.parse_attr_name()?;
+        self.skip_ws();
+        let mut quote = None;
+        let value = if self.chars.next_if(|(_, c)| *c == '=').is_some() {
+            self.skip_ws();
+            quote = self
+                .chars
+                .peek()
+                .and_then(|(_, c)| (*c == '\'' || *c == '"').then_some(*c));
+            Some(self.parse_attr_value()?)
+        } else {
+            None
+        };
+        Ok(NativeAttribute { name, value, quote })
+    }
+
+    fn parse_node(&mut self) -> PResult<Node<'s>> {
+        let (kind, raw) = self.with_taken(Parser::parse_node_kind)?;
+        Ok(Node { kind, raw })
+    }
+
+    fn parse_node_kind(&mut self) -> PResult<NodeKind<'s>> {
+        match self.chars.peek() {
+            Some((_, '<')) => {
+                let mut chars = self.chars.clone();
+                chars.next();
+                match chars.next() {
+                    Some((_, c))
+                        if is_html_tag_name_char(c)
+                            || is_special_tag_name_char(c, self.language) =>
+                    {
+                        self.parse_element().map(NodeKind::Element)
+                    }
+                    Some((_, '!')) => self
+                        .try_parse(Parser::parse_comment)
+                        .map(NodeKind::Comment)
+                        .or_else(|_| self.try_parse(Parser::parse_doctype).map(NodeKind::Doctype))
+                        .or_else(|_| self.try_parse(Parser::parse_cdata).map(NodeKind::Cdata))
+                        .or_else(|_| self.parse_text_node().map(NodeKind::Text)),
+                    Some((_, '?')) if self.language == Language::Xml => {
+                        self.parse_xml_decl().map(NodeKind::XmlDecl)
+                    }
+                    _ => self.parse_text_node().map(NodeKind::Text),
+                }
+            }
+            Some((_, '{')) => {
+                let mut chars = self.chars.clone();
+                chars.next();
+                match chars.next() {
+                    Some((_, '{')) => match self.language {
+                        Language::Html | Language::Xml => {
+                            self.parse_text_node().map(NodeKind::Text)
+                        }
+                        Language::Jinja => {
+                            self.parse_mustache_interpolation().map(|(expr, start)| {
+                                let (trim_prev, expr) = if let Some(rest) = expr.strip_prefix('-') {
+                                    (true, rest)
+                                } else {
+                                    (false, expr)
+                                };
+                                let (trim_next, expr) = if let Some(rest) = expr.strip_suffix('-') {
+                                    (true, rest)
+                                } else {
+                                    (false, expr)
+                                };
+                                NodeKind::JinjaInterpolation(JinjaInterpolation {
+                                    expr,
+                                    start: if trim_prev { start + 1 } else { start },
+                                    trim_prev,
+                                    trim_next,
+                                })
+                            })
+                        }
+                    },
+                    Some((_, '#')) if matches!(self.language, Language::Jinja) => {
+                        self.parse_jinja_comment().map(NodeKind::JinjaComment)
+                    }
+                    Some((_, '%')) if matches!(self.language, Language::Jinja) => {
+                        self.parse_jinja_tag_or_block(None, &mut Parser::parse_node)
+                    }
+                    _ => self.parse_text_node().map(NodeKind::Text),
+                }
+            }
+            Some(..) => self.parse_text_node().map(NodeKind::Text),
+            None => Err(self.emit_error(SyntaxErrorKind::ExpectElement)),
+        }
+    }
+
+    fn parse_raw_text_node(&mut self, tag_name: &str) -> PResult<TextNode<'s>> {
+        let start = self.peek_pos();
+
+        let allow_nested = tag_name.eq_ignore_ascii_case("pre");
+        let mut nested = 0u16;
+        let mut line_breaks = 0;
+        let end;
+        loop {
+            match self.chars.peek() {
+                Some((i, '<')) => {
+                    let i = *i;
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    if chars.next_if(|(_, c)| *c == '/').is_some()
+                        && chars
+                            .by_ref()
+                            .zip(tag_name.chars())
+                            .all(|((_, a), b)| a.eq_ignore_ascii_case(&b))
+                    {
+                        if nested == 0 {
+                            end = i;
+                            break;
+                        } else {
+                            nested -= 1;
+                            self.chars = chars;
+                            continue;
+                        }
+                    } else if allow_nested
+                        && chars
+                            .by_ref()
+                            .zip(tag_name.chars())
+                            .all(|((_, a), b)| a.eq_ignore_ascii_case(&b))
+                    {
+                        nested += 1;
+                        self.chars = chars;
+                        continue;
+                    }
+                    self.chars.next();
+                }
+                Some((_, c)) => {
+                    if *c == '\n' {
+                        line_breaks += 1;
+                    }
+                    self.chars.next();
+                }
+                None => {
+                    end = self.source.len();
+                    break;
+                }
+            }
+        }
+
+        Ok(TextNode {
+            raw: unsafe { self.source.get_unchecked(start..end) },
+            line_breaks,
+            start,
+        })
+    }
+
+    pub fn parse_root(&mut self) -> PResult<Root<'s>> {
+        let mut children = vec![];
+        while self.chars.peek().is_some() {
+            children.push(self.parse_node()?);
+        }
+
+        Ok(Root { children })
+    }
+
+    fn parse_tag_name(&mut self) -> PResult<&'s str> {
+        let (start, mut end) = match self.chars.peek() {
+            Some((i, c)) if is_html_tag_name_char(*c) => {
+                let c = *c;
+                let start = *i;
+                self.chars.next();
+                (start, start + c.len_utf8())
+            }
+            Some((i, '{')) if matches!(self.language, Language::Jinja) => (*i, *i + 1),
+            _ => return Err(self.emit_error(SyntaxErrorKind::ExpectTagName)),
+        };
+
+        while let Some((i, c)) = self.chars.peek() {
+            if is_html_tag_name_char(*c) {
+                end = *i + c.len_utf8();
+                self.chars.next();
+            } else if *c == '{' && matches!(self.language, Language::Jinja) {
+                let current_i = *i;
+                let mut chars = self.chars.clone();
+                chars.next();
+                if chars.next_if(|(_, c)| *c == '{').is_some() {
+                    end = current_i + self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        unsafe { Ok(self.source.get_unchecked(start..end)) }
+    }
+
+    fn parse_text_node(&mut self) -> PResult<TextNode<'s>> {
+        let Some((start, first_char)) = self.chars.next() else {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectTextNode));
+        };
+
+        let mut line_breaks = if first_char == '\n' { 1 } else { 0 };
+        let end;
+        loop {
+            match self.chars.peek() {
+                Some((i, '{')) => match self.language {
+                    Language::Html | Language::Xml => {
+                        self.chars.next();
+                    }
+                    Language::Jinja => {
+                        let i = *i;
+                        let mut chars = self.chars.clone();
+                        chars.next();
+                        if chars
+                            .next_if(|(_, c)| *c == '%' || *c == '{' || *c == '#')
+                            .is_some()
+                        {
+                            end = i;
+                            break;
+                        }
+                        self.chars.next();
+                    }
+                },
+                Some((i, '<')) => {
+                    let i = *i;
+                    let mut chars = self.chars.clone();
+                    chars.next();
+                    match chars.next() {
+                        Some((_, c))
+                            if is_html_tag_name_char(c)
+                                || is_special_tag_name_char(c, self.language)
+                                || c == '/'
+                                || c == '!' =>
+                        {
+                            end = i;
+                            break;
+                        }
+                        _ => {
+                            self.chars.next();
+                        }
+                    }
+                }
+                Some((_, c)) => {
+                    if *c == '\n' {
+                        line_breaks += 1;
+                    }
+                    self.chars.next();
+                }
+                None => {
+                    end = self.source.len();
+                    break;
+                }
+            }
+        }
+
+        Ok(TextNode {
+            raw: unsafe { self.source.get_unchecked(start..end) },
+            line_breaks,
+            start,
+        })
+    }
+
+    fn parse_xml_decl(&mut self) -> PResult<XmlDecl<'s>> {
+        if self
+            .try_consume_str("<?xml")
+            .and_then(|_| self.chars.next_if(|(_, c)| c.is_ascii_whitespace()))
+            .is_none()
+        {
+            return Err(self.emit_error(SyntaxErrorKind::ExpectXmlDecl));
+        };
+
+        let mut attrs = vec![];
+        loop {
+            match self.chars.peek() {
+                Some((_, '?')) => {
+                    self.chars.next();
+                    if self.chars.next_if(|(_, c)| *c == '>').is_some() {
+                        break;
+                    }
+                    return Err(self.emit_error(SyntaxErrorKind::ExpectChar('>')));
+                }
+                Some((_, c)) if c.is_ascii_whitespace() => {
+                    self.chars.next();
+                }
+                _ => {
+                    attrs.push(self.parse_native_attr()?);
+                }
+            }
+        }
+        Ok(XmlDecl { attrs })
+    }
+}
+
+fn is_html_tag_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || c == '-'
+        || c == '_'
+        || c == '.'
+        || c == ':'
+        || !c.is_ascii()
+        || c == '\\'
+}
+
+fn is_special_tag_name_char(c: char, language: Language) -> bool {
+    match language {
+        Language::Jinja => c == '{',
+        Language::Html | Language::Xml => false,
+    }
+}
+
+fn is_attr_name_char(c: char) -> bool {
+    !matches!(c, '"' | '\'' | '>' | '/' | '=') && !c.is_ascii_whitespace()
+}
+
+fn parse_jinja_tag_name<'s>(tag: &JinjaTag<'s>) -> &'s str {
+    let trimmed = tag.content.trim_start_matches(['+', '-']).trim_start();
+    trimmed
+        .split_once(|c: char| c.is_ascii_whitespace())
+        .map(|(name, _)| name)
+        .unwrap_or(trimmed)
+}
+
+pub type PResult<T> = Result<T, SyntaxError>;
+
+trait HasJinjaFlowControl<'s>: Sized {
+    type Intermediate;
+
+    fn build(intermediate: Self::Intermediate, raw: &'s str) -> Self;
+    fn from_tag(tag: JinjaTag<'s>) -> Self::Intermediate;
+    fn from_block(block: JinjaBlock<'s, Self>) -> Self::Intermediate;
+}
+
+impl<'s> HasJinjaFlowControl<'s> for Node<'s> {
+    type Intermediate = NodeKind<'s>;
+
+    fn build(intermediate: Self::Intermediate, raw: &'s str) -> Self {
+        Node {
+            kind: intermediate,
+            raw,
+        }
+    }
+
+    fn from_tag(tag: JinjaTag<'s>) -> Self::Intermediate {
+        NodeKind::JinjaTag(tag)
+    }
+
+    fn from_block(block: JinjaBlock<'s, Self>) -> Self::Intermediate {
+        NodeKind::JinjaBlock(block)
+    }
+}
+
+impl<'s> HasJinjaFlowControl<'s> for Attribute<'s> {
+    type Intermediate = Attribute<'s>;
+
+    fn build(intermediate: Self::Intermediate, _: &'s str) -> Self {
+        intermediate
+    }
+
+    fn from_tag(tag: JinjaTag<'s>) -> Self::Intermediate {
+        Attribute::JinjaTag(tag)
+    }
+
+    fn from_block(block: JinjaBlock<'s, Self>) -> Self::Intermediate {
+        Attribute::JinjaBlock(block)
+    }
+}
+
+pub fn parse_as_interpolated(
+    text: &'_ str,
+    base_start: usize,
+    language: Language,
+    _attr: bool,
+) -> (Vec<&'_ str>, Vec<(&'_ str, usize)>) {
+    let mut statics = Vec::with_capacity(1);
+    let mut dynamics = Vec::new();
+    let mut chars = text.char_indices().peekable();
+    let mut pos = 0;
+    let mut brace_stack = 0u8;
+    while let Some((i, c)) = chars.next() {
+        match c {
+            '{' => {
+                if brace_stack > 0 {
+                    brace_stack += 1;
+                    continue;
+                }
+                match language {
+                    Language::Jinja => {
+                        if chars.next_if(|(_, c)| *c == '{').is_some() {
+                            statics.push(unsafe { text.get_unchecked(pos..i) });
+                            pos = i;
+                            brace_stack += 1;
+                        }
+                    }
+                    Language::Html | Language::Xml => {}
+                }
+            }
+            '}' => {
+                if brace_stack > 1 {
+                    brace_stack -= 1;
+                    continue;
+                }
+                match language {
+                    Language::Jinja => {
+                        if chars.next_if(|(_, c)| *c == '}').is_some() {
+                            dynamics.push((
+                                unsafe { text.get_unchecked(pos + 2..i) },
+                                base_start + pos + 2,
+                            ));
+                            pos = i + 2;
+                            brace_stack = 0;
+                        }
+                    }
+                    Language::Html | Language::Xml => {}
+                }
+            }
+            _ => {}
+        }
+    }
+    statics.push(unsafe { text.get_unchecked(pos..) });
+    (statics, dynamics)
+}

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -692,6 +692,12 @@ impl<'s> Parser<'s> {
                 | "comment"
         ) || tag_name == "set" && !first_tag.content.contains('=')
         {
+            // Raw block tags: content is not parsed as template syntax.
+            // {% verbatim %} and {% comment %} pass content through untouched.
+            if matches!(tag_name, "verbatim" | "comment") {
+                return self.parse_jinja_raw_block::<T>(first_tag, tag_name);
+            }
+
             let mut body = vec![JinjaTagOrChildren::Tag(first_tag)];
 
             loop {
@@ -713,9 +719,13 @@ impl<'s> Parser<'s> {
                         break;
                     }
                     // Intermediate tags: elif/elseif/else for if blocks,
-                    // else/empty for Django's {% for %} blocks
+                    // else/empty for Django's {% for %} blocks,
+                    // else for {% ifchanged %}, plural for {% blocktrans %}
                     if tag_name == "if" && matches!(next_tag_name, "elif" | "elseif" | "else")
                         || tag_name == "for" && matches!(next_tag_name, "else" | "empty")
+                        || tag_name == "ifchanged" && next_tag_name == "else"
+                        || matches!(tag_name, "blocktrans" | "blocktranslate")
+                            && next_tag_name == "plural"
                     {
                         body.push(JinjaTagOrChildren::Tag(next_tag));
                     } else if let Some(JinjaTagOrChildren::Children(nodes)) = body.last_mut() {
@@ -739,6 +749,81 @@ impl<'s> Parser<'s> {
             Ok(T::from_block(JinjaBlock { body }))
         } else {
             Ok(T::from_tag(first_tag))
+        }
+    }
+
+    /// Parse a raw Jinja block (e.g. `{% verbatim %}` or `{% comment %}`).
+    /// Scans content literally until the matching `{% end<tag_name> %}`,
+    /// without interpreting any template syntax inside.
+    fn parse_jinja_raw_block<T>(
+        &mut self,
+        first_tag: JinjaTag<'s>,
+        tag_name: &str,
+    ) -> PResult<T::Intermediate>
+    where
+        T: HasJinjaFlowControl<'s>,
+    {
+        let content_start = self.peek_pos();
+        let end_tag = format!("end{tag_name}");
+        let mut line_breaks = 0usize;
+        let content_end;
+
+        // Scan forward looking for {% end<tag_name> %}, counting line breaks
+        loop {
+            match self.chars.peek() {
+                Some((i, '{')) => {
+                    let i = *i;
+                    let mut chars = self.chars.clone();
+                    chars.next(); // consume '{'
+                    if chars.next_if(|(_, c)| *c == '%').is_some() {
+                        // Skip whitespace and optional '-'
+                        while chars.next_if(|(_, c)| c.is_ascii_whitespace()).is_some() {}
+                        chars.next_if(|(_, c)| *c == '-' || *c == '+');
+                        while chars.next_if(|(_, c)| c.is_ascii_whitespace()).is_some() {}
+
+                        // Check if the tag name matches end<tag_name>
+                        let matches = end_tag
+                            .chars()
+                            .all(|expected| chars.next().is_some_and(|(_, c)| c == expected));
+                        if matches {
+                            // Verify followed by whitespace/'-'/'+' then '%}'
+                            let at_boundary = chars.peek().is_some_and(|(_, c)| {
+                                c.is_ascii_whitespace() || *c == '-' || *c == '+' || *c == '%'
+                            });
+                            if at_boundary {
+                                content_end = i;
+                                // Now consume via self.chars up to and including the closing tag
+                                // Parse the closing tag properly
+                                let raw_content = unsafe {
+                                    self.source.get_unchecked(content_start..content_end)
+                                };
+                                let close_tag = self.parse_jinja_tag()?;
+
+                                let mut body = Vec::with_capacity(3);
+                                body.push(JinjaTagOrChildren::Tag(first_tag));
+                                if !raw_content.is_empty() {
+                                    body.push(JinjaTagOrChildren::Children(vec![
+                                        T::from_raw_text(raw_content, line_breaks, content_start),
+                                    ]));
+                                }
+                                body.push(JinjaTagOrChildren::Tag(close_tag));
+                                return Ok(T::from_block(JinjaBlock { body }));
+                            }
+                        }
+                    }
+                    self.chars.next();
+                }
+                Some((_, '\n')) => {
+                    line_breaks += 1;
+                    self.chars.next();
+                }
+                Some(..) => {
+                    self.chars.next();
+                }
+                None => {
+                    return Err(self.emit_error(SyntaxErrorKind::ExpectJinjaBlockEnd));
+                }
+            }
         }
     }
 
@@ -1098,6 +1183,7 @@ trait HasJinjaFlowControl<'s>: Sized {
     fn build(intermediate: Self::Intermediate, raw: &'s str) -> Self;
     fn from_tag(tag: JinjaTag<'s>) -> Self::Intermediate;
     fn from_block(block: JinjaBlock<'s, Self>) -> Self::Intermediate;
+    fn from_raw_text(raw: &'s str, line_breaks: usize, start: usize) -> Self;
 }
 
 impl<'s> HasJinjaFlowControl<'s> for Node<'s> {
@@ -1117,6 +1203,17 @@ impl<'s> HasJinjaFlowControl<'s> for Node<'s> {
     fn from_block(block: JinjaBlock<'s, Self>) -> Self::Intermediate {
         NodeKind::JinjaBlock(block)
     }
+
+    fn from_raw_text(raw: &'s str, line_breaks: usize, start: usize) -> Self {
+        Node {
+            kind: NodeKind::Text(TextNode {
+                raw,
+                line_breaks,
+                start,
+            }),
+            raw,
+        }
+    }
 }
 
 impl<'s> HasJinjaFlowControl<'s> for Attribute<'s> {
@@ -1132,6 +1229,11 @@ impl<'s> HasJinjaFlowControl<'s> for Attribute<'s> {
 
     fn from_block(block: JinjaBlock<'s, Self>) -> Self::Intermediate {
         Attribute::JinjaBlock(block)
+    }
+
+    fn from_raw_text(_raw: &'s str, _line_breaks: usize, _start: usize) -> Self {
+        // verbatim/comment blocks don't appear in attribute position
+        unreachable!("raw text blocks cannot appear as attributes")
     }
 }
 

--- a/crates/djls-fmt/src/markup/parser.rs
+++ b/crates/djls-fmt/src/markup/parser.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 // Django fixes applied to block tag list
 

--- a/crates/djls-fmt/src/markup/printer.rs
+++ b/crates/djls-fmt/src/markup/printer.rs
@@ -1,0 +1,1328 @@
+// Vendored from markup_fmt v0.26.0
+// Stripped to HTML + Jinja/Django + XML only
+
+use std::borrow::Cow;
+
+use itertools::Itertools;
+use tiny_pretty::Doc;
+
+use crate::markup::ast::*;
+use crate::markup::config::ClosingTagLineBreakForEmpty;
+use crate::markup::config::DoctypeKeywordCase;
+use crate::markup::config::Quotes;
+use crate::markup::config::ScriptFormatter;
+use crate::markup::config::WhitespaceSensitivity;
+use crate::markup::ctx::Ctx;
+use crate::markup::ctx::Hints;
+use crate::markup::helpers;
+use crate::markup::parser::parse_as_interpolated;
+use crate::markup::state::State;
+use crate::markup::Language;
+
+pub(super) trait DocGen<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>;
+}
+
+impl<'s> DocGen<'s> for Attribute<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        match self {
+            Attribute::Native(native_attribute) => native_attribute.doc(ctx, state),
+            Attribute::JinjaBlock(jinja_block) => jinja_block.doc(ctx, state),
+            Attribute::JinjaComment(jinja_comment) => jinja_comment.doc(ctx, state),
+            Attribute::JinjaTag(jinja_tag) => jinja_tag.doc(ctx, state),
+        }
+    }
+}
+
+impl<'s> DocGen<'s> for Cdata<'s> {
+    fn doc<E, F>(&self, _: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        Doc::text("<![CDATA[")
+            .concat(reflow_raw(self.raw))
+            .append(Doc::text("]]>"))
+    }
+}
+
+impl<'s> DocGen<'s> for Comment<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        if ctx.options.format_comments {
+            Doc::text("<!--")
+                .append(Doc::line_or_space())
+                .concat(reflow_with_indent(self.raw.trim(), true))
+                .nest(ctx.indent_width)
+                .append(Doc::line_or_space())
+                .append(Doc::text("-->"))
+                .group()
+        } else {
+            Doc::text("<!--")
+                .concat(reflow_raw(self.raw))
+                .append(Doc::text("-->"))
+        }
+    }
+}
+
+impl<'s> DocGen<'s> for Doctype<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        Doc::text("<!")
+            .append(match ctx.options.doctype_keyword_case {
+                DoctypeKeywordCase::Ignore => Doc::text(self.keyword),
+                DoctypeKeywordCase::Upper => Doc::text("DOCTYPE"),
+                DoctypeKeywordCase::Lower => Doc::text("doctype"),
+            })
+            .append(Doc::space())
+            .append(Doc::text(if self.value.eq_ignore_ascii_case("html") {
+                "html"
+            } else {
+                self.value
+            }))
+            .append(Doc::text(">"))
+    }
+}
+
+impl<'s> DocGen<'s> for Element<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        let tag_name = self
+            .tag_name
+            .split_once(':')
+            .and_then(|(namespace, name)| namespace.eq_ignore_ascii_case("html").then_some(name))
+            .unwrap_or(self.tag_name);
+        let formatted_tag_name = match ctx.language {
+            Language::Html | Language::Jinja
+                if css_dataset::tags::STANDARD_HTML_TAGS
+                    .iter()
+                    .any(|tag| tag.eq_ignore_ascii_case(self.tag_name)) =>
+            {
+                Cow::from(self.tag_name.to_ascii_lowercase())
+            }
+            _ => Cow::from(self.tag_name),
+        };
+        let mut state = State {
+            current_tag_name: Some(tag_name),
+            is_root: false,
+            in_svg: tag_name.eq_ignore_ascii_case("svg"),
+            indent_level: state.indent_level,
+        };
+
+        let self_closing = if helpers::is_void_element(tag_name, ctx.language) {
+            ctx.options
+                .html_void_self_closing
+                .unwrap_or(self.self_closing)
+        } else if helpers::is_html_tag(tag_name, ctx.language) {
+            ctx.options
+                .html_normal_self_closing
+                .unwrap_or(self.self_closing)
+        } else if helpers::is_svg_tag(self.tag_name, ctx.language) {
+            ctx.options.svg_self_closing.unwrap_or(self.self_closing)
+        } else if helpers::is_mathml_tag(self.tag_name, ctx.language) {
+            ctx.options.mathml_self_closing.unwrap_or(self.self_closing)
+        } else {
+            self.self_closing
+        };
+        let is_whitespace_sensitive = !state.in_svg && ctx.is_whitespace_sensitive(tag_name);
+        let is_empty = is_empty_element(&self.children, is_whitespace_sensitive);
+
+        let mut docs = Vec::with_capacity(5);
+
+        docs.push(Doc::text("<"));
+        docs.push(Doc::text(formatted_tag_name.clone()));
+
+        match &*self.attrs {
+            [] => {
+                if self_closing && (self.void_element || is_empty) {
+                    docs.push(Doc::text(" />"));
+                    return Doc::list(docs).group();
+                }
+                if self.void_element {
+                    docs.push(Doc::text(">"));
+                    return Doc::list(docs).group();
+                }
+                if is_empty || !is_whitespace_sensitive {
+                    docs.push(Doc::text(">"));
+                } else {
+                    docs.push(Doc::line_or_nil().append(Doc::text(">")).group());
+                }
+            }
+            [attr]
+                if ctx.options.single_attr_same_line
+                    && !is_whitespace_sensitive
+                    && !is_multi_line_attr(attr) =>
+            {
+                docs.push(Doc::space());
+                docs.push(attr.doc(ctx, &state));
+                if self_closing && is_empty {
+                    docs.push(Doc::text(" />"));
+                    return Doc::list(docs);
+                } else {
+                    docs.push(Doc::text(">"));
+                };
+                if self.void_element {
+                    return Doc::list(docs);
+                }
+            }
+            _ => {
+                let attrs_sep = if self.first_attr_same_line {
+                    Doc::line_or_space()
+                } else if self.attrs.len() <= 1 {
+                    if ctx.options.single_attr_same_line {
+                        Doc::line_or_space()
+                    } else {
+                        Doc::hard_line()
+                    }
+                } else if !ctx.options.prefer_attrs_single_line
+                    && ctx
+                        .options
+                        .max_attrs_per_line
+                        .is_none_or(|value| value.get() <= 1)
+                {
+                    Doc::hard_line()
+                } else {
+                    Doc::line_or_space()
+                };
+                let attrs = if let Some(max) = ctx.options.max_attrs_per_line {
+                    Doc::line_or_space()
+                        .concat(itertools::intersperse(
+                            self.attrs.chunks(max.into()).map(|chunk| {
+                                Doc::list(
+                                    itertools::intersperse(
+                                        chunk.iter().map(|attr| attr.doc(ctx, &state)),
+                                        attrs_sep.clone(),
+                                    )
+                                    .collect(),
+                                )
+                                .group()
+                            }),
+                            Doc::hard_line(),
+                        ))
+                        .nest(ctx.indent_width)
+                } else {
+                    Doc::list(
+                        self.attrs
+                            .iter()
+                            .flat_map(|attr| [attrs_sep.clone(), attr.doc(ctx, &state)].into_iter())
+                            .collect(),
+                    )
+                    .nest(ctx.indent_width)
+                };
+
+                if self_closing && (self.void_element || is_empty) {
+                    docs.push(attrs);
+                    docs.push(Doc::line_or_space());
+                    docs.push(Doc::text("/>"));
+                    return Doc::list(docs).group();
+                }
+                if self.void_element {
+                    docs.push(attrs);
+                    if !ctx.options.closing_bracket_same_line {
+                        docs.push(Doc::line_or_nil());
+                    }
+                    docs.push(Doc::text(">"));
+                    return Doc::list(docs).group();
+                }
+                if ctx.options.closing_bracket_same_line {
+                    docs.push(attrs.append(Doc::text(">")).group());
+                } else {
+                    if is_whitespace_sensitive
+                        && self.children.first().is_some_and(|child| {
+                            if let NodeKind::Text(text_node) = &child.kind {
+                                !text_node.raw.starts_with(|c: char| c.is_ascii_whitespace())
+                            } else {
+                                false
+                            }
+                        })
+                        && self.children.last().is_some_and(|child| {
+                            if let NodeKind::Text(text_node) = &child.kind {
+                                !text_node.raw.ends_with(|c: char| c.is_ascii_whitespace())
+                            } else {
+                                false
+                            }
+                        })
+                    {
+                        docs.push(
+                            attrs
+                                .group()
+                                .append(Doc::line_or_nil())
+                                .append(Doc::text(">")),
+                        );
+                    } else {
+                        docs.push(
+                            attrs
+                                .append(Doc::line_or_nil())
+                                .append(Doc::text(">"))
+                                .group(),
+                        );
+                    }
+                }
+            }
+        }
+
+        let has_two_more_non_text_children =
+            has_two_more_non_text_children(&self.children, ctx.language);
+
+        let (leading_ws, trailing_ws) = if is_empty
+            || ctx.language == Language::Xml
+                && matches!(
+                    &*self.children,
+                    [Node {
+                        kind: NodeKind::Text(..),
+                        ..
+                    }]
+                ) {
+            (Doc::nil(), Doc::nil())
+        } else if is_whitespace_sensitive {
+            (
+                format_ws_sensitive_leading_ws(&self.children),
+                format_ws_sensitive_trailing_ws(&self.children),
+            )
+        } else if has_two_more_non_text_children {
+            (Doc::hard_line(), Doc::hard_line())
+        } else {
+            (
+                format_ws_insensitive_leading_ws(&self.children),
+                format_ws_insensitive_trailing_ws(&self.children),
+            )
+        };
+
+        if tag_name.eq_ignore_ascii_case("script") && ctx.language != Language::Xml {
+            if let [Node {
+                kind: NodeKind::Text(text_node),
+                ..
+            }] = &*self.children
+            {
+                if text_node.raw.chars().all(|c| c.is_ascii_whitespace()) {
+                    docs.push(Doc::hard_line());
+                } else {
+                    let type_attr = self.attrs.iter().find_map(|attr| match attr {
+                        Attribute::Native(native) if native.name.eq_ignore_ascii_case("type") => {
+                            native.value.map(|(value, _)| value.to_ascii_lowercase())
+                        }
+                        _ => None,
+                    });
+                    match type_attr.as_deref() {
+                        Some(
+                            "module"
+                            | "application/javascript"
+                            | "text/javascript"
+                            | "application/ecmascript"
+                            | "text/ecmascript"
+                            | "application/x-javascript"
+                            | "application/x-ecmascript"
+                            | "text/x-javascript"
+                            | "text/x-ecmascript"
+                            | "text/jsx"
+                            | "text/babel",
+                        )
+                        | None => {
+                            let is_script_indent = ctx.script_indent();
+                            if is_script_indent {
+                                state.indent_level += 1;
+                            }
+                            let lang = self
+                                .attrs
+                                .iter()
+                                .find_map(|attr| match attr {
+                                    Attribute::Native(native)
+                                        if native.name.eq_ignore_ascii_case("lang") =>
+                                    {
+                                        native.value.map(|(value, _)| value)
+                                    }
+                                    _ => None,
+                                })
+                                .unwrap_or("js");
+                            let lang = if self.attrs.iter().any(|attr| match attr {
+                                Attribute::Native(native)
+                                    if native.name.eq_ignore_ascii_case("type") =>
+                                {
+                                    native.value.is_some_and(|(value, _)| value == "module")
+                                }
+                                _ => false,
+                            }) {
+                                match lang {
+                                    "ts" => "mts",
+                                    "js" => "mjs",
+                                    lang => lang,
+                                }
+                            } else {
+                                lang
+                            };
+                            let formatted =
+                                ctx.format_script(text_node.raw, lang, text_node.start, &state);
+                            let doc = if matches!(
+                                ctx.options.script_formatter,
+                                Some(ScriptFormatter::Dprint)
+                            ) {
+                                Doc::hard_line().concat(reflow_owned(formatted.trim()))
+                            } else {
+                                Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true))
+                            };
+                            if is_script_indent {
+                                docs.push(doc.nest(ctx.indent_width));
+                            } else {
+                                docs.push(doc);
+                            }
+                        }
+                        Some(
+                            "importmap"
+                            | "application/json"
+                            | "text/json"
+                            | "application/ld+json"
+                            | "speculationrules",
+                        ) => {
+                            let formatted = ctx.format_json(text_node.raw, text_node.start, &state);
+                            docs.push(
+                                Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true)),
+                            );
+                        }
+                        Some(..) => {
+                            docs.push(Doc::hard_line());
+                            docs.extend(reflow_raw(text_node.raw.trim_matches('\n')));
+                        }
+                    }
+                    docs.push(Doc::hard_line());
+                }
+            }
+        } else if tag_name.eq_ignore_ascii_case("style") && ctx.language != Language::Xml {
+            if let [Node {
+                kind: NodeKind::Text(text_node),
+                ..
+            }] = &*self.children
+            {
+                if text_node.raw.chars().all(|c| c.is_ascii_whitespace()) {
+                    docs.push(Doc::hard_line());
+                } else {
+                    let lang = self
+                        .attrs
+                        .iter()
+                        .find_map(|attr| match attr {
+                            Attribute::Native(native_attribute)
+                                if native_attribute.name.eq_ignore_ascii_case("lang") =>
+                            {
+                                native_attribute.value.map(|(value, _)| value)
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or("css");
+                    let (statics, dynamics) =
+                        parse_as_interpolated(text_node.raw, text_node.start, ctx.language, false);
+                    const PLACEHOLDER: &str = "_saya0909_";
+                    let masked = statics.join(PLACEHOLDER);
+                    let formatted = ctx.format_style(&masked, lang, text_node.start, &state);
+                    let doc = Doc::hard_line().concat(reflow_with_indent(
+                        formatted
+                            .split(PLACEHOLDER)
+                            .map(Cow::from)
+                            .interleave(dynamics.iter().map(|(expr, start)| match ctx.language {
+                                Language::Jinja => Cow::from(format!(
+                                    "{{{{ {} }}}}",
+                                    ctx.format_jinja(expr, *start, true, &state),
+                                )),
+                                Language::Html | Language::Xml => unreachable!(),
+                            }))
+                            .collect::<String>()
+                            .trim(),
+                        lang != "sass",
+                    ));
+                    docs.push(
+                        if ctx.style_indent() {
+                            doc.nest(ctx.indent_width)
+                        } else {
+                            doc
+                        }
+                        .append(Doc::hard_line()),
+                    );
+                }
+            }
+        } else if tag_name.eq_ignore_ascii_case("pre") || tag_name.eq_ignore_ascii_case("textarea")
+        {
+            if let [Node {
+                kind: NodeKind::Text(text_node),
+                ..
+            }] = &self.children[..]
+            {
+                docs.extend(reflow_raw(text_node.raw));
+            }
+        } else if is_empty {
+            if !is_whitespace_sensitive {
+                match ctx.options.closing_tag_line_break_for_empty {
+                    ClosingTagLineBreakForEmpty::Always => docs.push(Doc::hard_line()),
+                    ClosingTagLineBreakForEmpty::Fit => docs.push(Doc::line_or_nil()),
+                    ClosingTagLineBreakForEmpty::Never => {}
+                };
+            }
+        } else if !is_whitespace_sensitive && has_two_more_non_text_children {
+            state.indent_level += 1;
+            docs.push(leading_ws.nest(ctx.indent_width));
+            docs.push(
+                format_children_with_inserting_linebreak(&self.children, ctx, &state)
+                    .nest(ctx.indent_width),
+            );
+            docs.push(trailing_ws);
+        } else if is_whitespace_sensitive
+            && matches!(&self.children[..], [Node { kind: NodeKind::Text(text_node), .. }] if is_all_ascii_whitespace(text_node.raw))
+        {
+            docs.push(Doc::line_or_space());
+        } else {
+            let should_not_indent = is_whitespace_sensitive
+                && self.children.iter().all(|child| {
+                    matches!(
+                        &child.kind,
+                        NodeKind::Comment(..) | NodeKind::JinjaInterpolation(..)
+                    )
+                });
+            if !should_not_indent {
+                state.indent_level += 1;
+            }
+            let children_doc = leading_ws.append(format_children_without_inserting_linebreak(
+                &self.children,
+                ctx,
+                &state,
+            ));
+            if should_not_indent {
+                docs.push(children_doc);
+            } else {
+                docs.push(children_doc.nest(ctx.indent_width));
+            }
+            docs.push(trailing_ws);
+        }
+
+        docs.push(Doc::text(format!("</{formatted_tag_name}>")));
+
+        Doc::list(docs).group()
+    }
+}
+
+impl<'s> DocGen<'s> for JinjaBlock<'s, Attribute<'s>> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        Doc::list(
+            self.body
+                .iter()
+                .map(|child| match child {
+                    JinjaTagOrChildren::Tag(tag) => tag.doc(ctx, state),
+                    JinjaTagOrChildren::Children(children) => Doc::line_or_nil()
+                        .concat(itertools::intersperse(
+                            children.iter().map(|attr| attr.doc(ctx, state)),
+                            Doc::line_or_space(),
+                        ))
+                        .nest(ctx.indent_width)
+                        .append(Doc::line_or_nil()),
+                })
+                .collect(),
+        )
+    }
+}
+
+impl<'s> DocGen<'s> for JinjaBlock<'s, Node<'s>> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        Doc::list(
+            self.body
+                .iter()
+                .map(|child| match child {
+                    JinjaTagOrChildren::Tag(tag) => tag.doc(ctx, state),
+                    JinjaTagOrChildren::Children(children) => {
+                        format_control_structure_block_children(children, ctx, state)
+                    }
+                })
+                .collect(),
+        )
+    }
+}
+
+impl<'s> DocGen<'s> for JinjaComment<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        if ctx.options.format_comments {
+            Doc::text("{#")
+                .append(Doc::line_or_space())
+                .concat(reflow_with_indent(self.raw.trim(), true))
+                .nest(ctx.indent_width)
+                .append(Doc::line_or_space())
+                .append(Doc::text("#}"))
+                .group()
+        } else {
+            Doc::text("{#")
+                .concat(reflow_raw(self.raw))
+                .append(Doc::text("#}"))
+        }
+    }
+}
+
+impl<'s> DocGen<'s> for JinjaInterpolation<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        Doc::text("{{")
+            .append(if self.trim_prev {
+                Doc::text("-")
+            } else {
+                Doc::nil()
+            })
+            .append(Doc::line_or_space())
+            .concat(reflow_with_indent(
+                ctx.format_jinja(self.expr, self.start, true, state).trim(),
+                true,
+            ))
+            .nest(ctx.indent_width)
+            .append(Doc::line_or_space())
+            .append(if self.trim_next {
+                Doc::text("-")
+            } else {
+                Doc::nil()
+            })
+            .append(Doc::text("}}"))
+            .group()
+    }
+}
+
+impl<'s> DocGen<'s> for JinjaTag<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        let (prefix, content) = if let Some(content) = self.content.strip_prefix('-') {
+            ("-", content)
+        } else if let Some(content) = self.content.strip_prefix('+') {
+            ("+", content)
+        } else {
+            ("", self.content)
+        };
+        let (content, suffix) = if let Some(content) = content.strip_suffix('-') {
+            (content, "-")
+        } else if let Some(content) = content.strip_suffix('+') {
+            (content, "+")
+        } else {
+            (content, "")
+        };
+
+        let mut docs = Vec::with_capacity(5);
+        docs.push(Doc::text("{%"));
+        docs.push(Doc::text(prefix));
+        docs.push(Doc::line_or_space());
+        docs.extend(reflow_with_indent(
+            ctx.format_jinja(content, self.start + prefix.len(), false, state)
+                .trim(),
+            true,
+        ));
+        Doc::list(docs)
+            .nest(ctx.indent_width)
+            .append(Doc::line_or_space())
+            .append(Doc::text(suffix))
+            .append(Doc::text("%}"))
+            .group()
+    }
+}
+
+impl<'s> DocGen<'s> for NativeAttribute<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        let name = Doc::text(self.name);
+        if let Some((value, _value_start)) = self.value {
+            let value = if !matches!(ctx.language, Language::Xml) && self.name.starts_with("on") {
+                // For event handlers, pass through without formatting
+                Cow::from(value)
+            } else {
+                Cow::from(value)
+            };
+            let quote;
+            let mut docs = Vec::with_capacity(5);
+            docs.push(name);
+            docs.push(Doc::text("="));
+            if self.name.eq_ignore_ascii_case("class") {
+                quote = compute_attr_value_quote(&value, self.quote, ctx);
+                let value = value.trim();
+                let maybe_line_break = if value.contains('\n') {
+                    Doc::hard_line()
+                } else {
+                    Doc::nil()
+                };
+                docs.push(
+                    maybe_line_break
+                        .clone()
+                        .concat(itertools::intersperse(
+                            value
+                                .trim()
+                                .lines()
+                                .filter(|line| !line.is_empty())
+                                .map(|line| Doc::text(line.split_ascii_whitespace().join(" "))),
+                            Doc::hard_line(),
+                        ))
+                        .nest(ctx.indent_width),
+                );
+                docs.push(maybe_line_break);
+            } else if self.name.eq_ignore_ascii_case("style") {
+                let (statics, dynamics) =
+                    parse_as_interpolated(&value, _value_start, ctx.language, true);
+                const PLACEHOLDER: &str = "_mnk0430_";
+                let formatted =
+                    ctx.format_style_attr(&statics.join(PLACEHOLDER), _value_start, _state);
+                quote = compute_attr_value_quote(&formatted, self.quote, ctx);
+                docs.push(Doc::text(
+                    formatted
+                        .split(PLACEHOLDER)
+                        .map(Cow::from)
+                        .interleave(dynamics.iter().map(|(expr, start)| match ctx.language {
+                            Language::Jinja => Cow::from(format!(
+                                "{{{{ {} }}}}",
+                                ctx.format_jinja(expr, *start, true, _state),
+                            )),
+                            Language::Html | Language::Xml => unreachable!(),
+                        }))
+                        .collect::<String>(),
+                ));
+            } else if self.name.eq_ignore_ascii_case("accept")
+                && !matches!(ctx.language, Language::Xml)
+                && _state
+                    .current_tag_name
+                    .is_some_and(|name| name.eq_ignore_ascii_case("input"))
+            {
+                quote = compute_attr_value_quote(&value, self.quote, ctx);
+                if helpers::has_template_interpolation(&value, ctx.language) {
+                    docs.extend(reflow_owned(&value));
+                } else {
+                    docs.push(Doc::text(
+                        value
+                            .split(',')
+                            .map(|s| s.trim())
+                            .filter(|s| !s.is_empty())
+                            .join(", "),
+                    ));
+                }
+            } else {
+                quote = compute_attr_value_quote(&value, self.quote, ctx);
+                docs.extend(reflow_owned(&value));
+            }
+            docs.insert(2, quote.clone());
+            docs.push(quote);
+            Doc::list(docs)
+        } else {
+            name
+        }
+    }
+}
+
+impl<'s> DocGen<'s> for NodeKind<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        match self {
+            NodeKind::Cdata(cdata) => cdata.doc(ctx, state),
+            NodeKind::Comment(comment) => comment.doc(ctx, state),
+            NodeKind::Doctype(doctype) => doctype.doc(ctx, state),
+            NodeKind::Element(element) => element.doc(ctx, state),
+            NodeKind::JinjaBlock(jinja_block) => jinja_block.doc(ctx, state),
+            NodeKind::JinjaComment(jinja_comment) => jinja_comment.doc(ctx, state),
+            NodeKind::JinjaInterpolation(jinja_interpolation) => {
+                jinja_interpolation.doc(ctx, state)
+            }
+            NodeKind::JinjaTag(jinja_tag) => jinja_tag.doc(ctx, state),
+            NodeKind::Text(text_node) => text_node.doc(ctx, state),
+            NodeKind::XmlDecl(xml_decl) => xml_decl.doc(ctx, state),
+        }
+    }
+}
+
+impl<'s> DocGen<'s> for Root<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        let is_whole_document_like = self.children.iter().any(|child| match &child.kind {
+            NodeKind::Doctype(..) => true,
+            NodeKind::Element(element) => element.tag_name.eq_ignore_ascii_case("html"),
+            _ => false,
+        });
+        let is_whitespace_sensitive = matches!(
+            ctx.options.whitespace_sensitivity,
+            WhitespaceSensitivity::Css | WhitespaceSensitivity::Strict
+        );
+        let has_two_more_non_text_children =
+            has_two_more_non_text_children(&self.children, ctx.language);
+
+        if is_whole_document_like
+            && !matches!(
+                ctx.options.whitespace_sensitivity,
+                WhitespaceSensitivity::Strict
+            )
+            || !is_whitespace_sensitive && has_two_more_non_text_children
+            || ctx.language == Language::Xml
+        {
+            format_children_with_inserting_linebreak(&self.children, ctx, state)
+                .append(Doc::hard_line())
+        } else {
+            format_children_without_inserting_linebreak(&self.children, ctx, state)
+                .append(Doc::hard_line())
+        }
+    }
+}
+
+impl<'s> DocGen<'s> for TextNode<'s> {
+    fn doc<E, F>(&self, _: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        let trimmed = self
+            .raw
+            .trim_start_matches(|c: char| c.is_ascii_whitespace())
+            .trim_end_matches(|c: char| c.is_ascii_whitespace());
+        Doc::list(
+            itertools::intersperse(
+                trimmed
+                    .split('\n')
+                    .map(|s| s.strip_suffix('\r').unwrap_or(s))
+                    .enumerate()
+                    .map(|(i, s)| {
+                        let s = s.trim_matches(|c: char| c.is_ascii_whitespace());
+                        if i == 0 || !s.is_empty() {
+                            Doc::text(s.to_owned())
+                        } else {
+                            Doc::nil()
+                        }
+                    }),
+                Doc::soft_line(),
+            )
+            .collect(),
+        )
+    }
+}
+
+impl<'s> DocGen<'s> for XmlDecl<'s> {
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    where
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    {
+        Doc::text("<?xml")
+            .concat(
+                self.attrs
+                    .iter()
+                    .flat_map(|attr| [Doc::line_or_space(), attr.doc(ctx, state)].into_iter()),
+            )
+            .nest(ctx.indent_width)
+            .append(Doc::text("?>"))
+            .group()
+    }
+}
+
+fn reflow_raw(s: &str) -> impl Iterator<Item = Doc<'_>> {
+    itertools::intersperse(
+        s.split('\n')
+            .map(|s| Doc::text(s.strip_suffix('\r').unwrap_or(s))),
+        Doc::empty_line(),
+    )
+}
+
+fn reflow_owned<'i, 'o: 'i>(s: &'i str) -> impl Iterator<Item = Doc<'o>> + 'i {
+    itertools::intersperse(
+        s.split('\n')
+            .map(|s| Doc::text(s.strip_suffix('\r').unwrap_or(s).to_owned())),
+        Doc::empty_line(),
+    )
+}
+
+fn reflow_with_indent<'i, 'o: 'i>(
+    s: &'i str,
+    detect_indent: bool,
+) -> impl Iterator<Item = Doc<'o>> + 'i {
+    let indent = if detect_indent {
+        helpers::detect_indent(s)
+    } else {
+        0
+    };
+    let mut pair_stack = vec![];
+    s.split('\n').enumerate().flat_map(move |(i, s)| {
+        let s = s.strip_suffix('\r').unwrap_or(s);
+        let trimmed = if s.starts_with([' ', '\t']) {
+            s.get(indent..).unwrap_or(s)
+        } else {
+            s
+        };
+        let should_keep_raw = matches!(pair_stack.last(), Some('`'));
+
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            match c {
+                '`' | '\'' | '"' => {
+                    let last = pair_stack.last();
+                    if last.is_some_and(|last| *last == c) {
+                        pair_stack.pop();
+                    } else if matches!(last, Some('$' | '{') | None) {
+                        pair_stack.push(c);
+                    }
+                }
+                '$' if matches!(pair_stack.last(), Some('`')) => {
+                    if chars.next_if(|next| *next == '{').is_some() {
+                        pair_stack.push('$');
+                    }
+                }
+                '{' if !matches!(pair_stack.last(), Some('`' | '\'' | '"' | '/')) => {
+                    pair_stack.push('{');
+                }
+                '}' if matches!(pair_stack.last(), Some('$' | '{')) => {
+                    pair_stack.pop();
+                }
+                '/' if !matches!(pair_stack.last(), Some('\'' | '"' | '`')) => {
+                    if chars.next_if(|next| *next == '*').is_some() {
+                        pair_stack.push('*');
+                    } else if chars.next_if(|next| *next == '/').is_some() {
+                        break;
+                    }
+                }
+                '*' => {
+                    if chars.next_if(|next| *next == '/').is_some() {
+                        pair_stack.pop();
+                    }
+                }
+                '\\' if matches!(pair_stack.last(), Some('\'' | '"' | '`')) => {
+                    chars.next();
+                }
+                _ => {}
+            }
+        }
+
+        [
+            if i == 0 {
+                Doc::nil()
+            } else if trimmed.trim().is_empty() || should_keep_raw {
+                Doc::empty_line()
+            } else {
+                Doc::hard_line()
+            },
+            if should_keep_raw {
+                Doc::text(s.to_owned())
+            } else {
+                Doc::text(trimmed.to_owned())
+            },
+        ]
+        .into_iter()
+    })
+}
+
+fn is_empty_element(children: &[Node], is_whitespace_sensitive: bool) -> bool {
+    match &children {
+        [] => true,
+        [Node {
+            kind: NodeKind::Text(text_node),
+            ..
+        }] => {
+            !is_whitespace_sensitive
+                && text_node
+                    .raw
+                    .trim_matches(|c: char| c.is_ascii_whitespace())
+                    .is_empty()
+        }
+        _ => false,
+    }
+}
+
+fn is_all_ascii_whitespace(s: &str) -> bool {
+    !s.is_empty() && s.as_bytes().iter().all(|byte| byte.is_ascii_whitespace())
+}
+
+fn is_multi_line_attr(attr: &Attribute) -> bool {
+    match attr {
+        Attribute::Native(attr) => attr
+            .value
+            .is_some_and(|(value, _)| value.trim().contains('\n')),
+        Attribute::JinjaComment(JinjaComment { raw: value, .. })
+        | Attribute::JinjaTag(JinjaTag { content: value, .. }) => value.contains('\n'),
+        Attribute::JinjaBlock(..) => true,
+    }
+}
+
+fn should_ignore_node<'s, E, F>(index: usize, nodes: &[Node], ctx: &Ctx<'s, E, F>) -> bool
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    match index.checked_sub(1).and_then(|i| nodes.get(i)) {
+        Some(Node {
+            kind: NodeKind::Comment(comment),
+            ..
+        }) => has_ignore_directive(comment, ctx),
+        Some(Node {
+            kind: NodeKind::Text(text_node),
+            ..
+        }) if is_all_ascii_whitespace(text_node.raw) => {
+            if let Some(Node {
+                kind: NodeKind::Comment(comment),
+                ..
+            }) = index.checked_sub(2).and_then(|i| nodes.get(i))
+            {
+                has_ignore_directive(comment, ctx)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn has_ignore_directive<'s, E, F>(comment: &Comment, ctx: &Ctx<'s, E, F>) -> bool
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    comment
+        .raw
+        .trim_start()
+        .strip_prefix(&ctx.options.ignore_comment_directive)
+        .is_some_and(|rest| rest.starts_with(|c: char| c.is_ascii_whitespace()) || rest.is_empty())
+}
+
+fn should_add_whitespace_before_text_node<'s>(
+    text_node: &TextNode<'s>,
+    is_first: bool,
+) -> Option<Doc<'s>> {
+    let trimmed = text_node
+        .raw
+        .trim_end_matches(|c: char| c.is_ascii_whitespace());
+    if !is_first && trimmed.starts_with(|c: char| c.is_ascii_whitespace()) {
+        let line_breaks_count = text_node
+            .raw
+            .chars()
+            .take_while(|c| c.is_ascii_whitespace())
+            .filter(|c| *c == '\n')
+            .count();
+        match line_breaks_count {
+            0 => Some(Doc::soft_line()),
+            1 => Some(Doc::hard_line()),
+            _ => Some(Doc::empty_line().append(Doc::hard_line())),
+        }
+    } else {
+        None
+    }
+}
+
+fn should_add_whitespace_after_text_node<'s>(
+    text_node: &TextNode<'s>,
+    is_last: bool,
+) -> Option<Doc<'s>> {
+    let trimmed = text_node
+        .raw
+        .trim_start_matches(|c: char| c.is_ascii_whitespace());
+    if !is_last && trimmed.ends_with(|c: char| c.is_ascii_whitespace()) {
+        let line_breaks_count = text_node
+            .raw
+            .chars()
+            .rev()
+            .take_while(|c| c.is_ascii_whitespace())
+            .filter(|c| *c == '\n')
+            .count();
+        match line_breaks_count {
+            0 => Some(Doc::soft_line()),
+            1 => Some(Doc::hard_line()),
+            _ => Some(Doc::empty_line().append(Doc::hard_line())),
+        }
+    } else {
+        None
+    }
+}
+
+fn has_two_more_non_text_children(children: &[Node], language: Language) -> bool {
+    children
+        .iter()
+        .filter(|child| !is_text_like(child, language))
+        .count()
+        > 1
+}
+
+fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes) -> Doc<'_> {
+    let value = value.as_ref();
+    let quote = if value.contains('"') {
+        Doc::text("'")
+    } else if value.contains('\'') {
+        Doc::text("\"")
+    } else if let Quotes::Double = quotes {
+        Doc::text("\"")
+    } else {
+        Doc::text("'")
+    };
+    quote
+        .clone()
+        .concat(reflow_with_indent(value, true))
+        .append(quote)
+}
+
+fn format_children_with_inserting_linebreak<'s, E, F>(
+    children: &[Node<'s>],
+    ctx: &mut Ctx<'s, E, F>,
+    state: &State<'s>,
+) -> Doc<'s>
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    Doc::list(
+        children
+            .iter()
+            .enumerate()
+            .fold(
+                (Vec::with_capacity(children.len() * 2), true),
+                |(mut docs, is_prev_text_like), (i, child)| {
+                    let is_current_text_like = is_text_like(child, ctx.language);
+                    if should_ignore_node(i, children, ctx) {
+                        let raw = child.raw.trim_end_matches([' ', '\t']);
+                        let last_line_break_removed = raw.strip_suffix(['\n', '\r']);
+                        docs.extend(reflow_raw(last_line_break_removed.unwrap_or(raw)));
+                        if i < children.len() - 1 && last_line_break_removed.is_some() {
+                            docs.push(Doc::hard_line());
+                        }
+                    } else {
+                        let maybe_hard_line = if is_prev_text_like || is_current_text_like {
+                            None
+                        } else {
+                            Some(Doc::hard_line())
+                        };
+                        match &child.kind {
+                            NodeKind::Text(text_node) => {
+                                let is_first = i == 0;
+                                let is_last = i + 1 == children.len();
+                                if is_all_ascii_whitespace(text_node.raw) {
+                                    if !is_first && !is_last {
+                                        if text_node.line_breaks > 1 {
+                                            docs.push(Doc::empty_line());
+                                        }
+                                        docs.push(Doc::hard_line());
+                                    }
+                                } else {
+                                    if let Some(hard_line) = maybe_hard_line {
+                                        docs.push(hard_line);
+                                    } else if let Some(doc) =
+                                        should_add_whitespace_before_text_node(text_node, is_first)
+                                    {
+                                        docs.push(doc);
+                                    }
+                                    docs.push(text_node.doc(ctx, state));
+                                    if let Some(doc) =
+                                        should_add_whitespace_after_text_node(text_node, is_last)
+                                    {
+                                        docs.push(doc);
+                                    }
+                                }
+                            }
+                            child => {
+                                if let Some(hard_line) = maybe_hard_line {
+                                    docs.push(hard_line);
+                                }
+                                docs.push(child.doc(ctx, state));
+                            }
+                        }
+                    }
+                    (docs, is_current_text_like)
+                },
+            )
+            .0,
+    )
+    .group()
+}
+
+fn is_text_like(node: &Node, language: Language) -> bool {
+    match &node.kind {
+        NodeKind::Element(element) => {
+            helpers::is_whitespace_sensitive_tag(element.tag_name, language)
+        }
+        NodeKind::Text(..) | NodeKind::JinjaInterpolation(..) => true,
+        _ => false,
+    }
+}
+
+fn format_children_without_inserting_linebreak<'s, E, F>(
+    children: &[Node<'s>],
+    ctx: &mut Ctx<'s, E, F>,
+    state: &State<'s>,
+) -> Doc<'s>
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    Doc::list(
+        children
+            .iter()
+            .enumerate()
+            .fold(
+                (Vec::with_capacity(children.len() * 2), true),
+                |(mut docs, is_prev_text_like), (i, child)| {
+                    if should_ignore_node(i, children, ctx) {
+                        let raw = child.raw.trim_end_matches([' ', '\t']);
+                        let last_line_break_removed = raw.strip_suffix(['\n', '\r']);
+                        docs.extend(reflow_raw(last_line_break_removed.unwrap_or(raw)));
+                        if i < children.len() - 1 && last_line_break_removed.is_some() {
+                            docs.push(Doc::hard_line());
+                        }
+                    } else if let NodeKind::Text(text_node) = &child.kind {
+                        let is_first = i == 0;
+                        let is_last = i + 1 == children.len();
+                        if !is_first && !is_last && is_all_ascii_whitespace(text_node.raw) {
+                            match text_node.line_breaks {
+                                0 => {
+                                    if !is_prev_text_like
+                                        && children
+                                            .get(i + 1)
+                                            .is_some_and(|next| !is_text_like(next, ctx.language))
+                                    {
+                                        docs.push(Doc::line_or_space());
+                                    } else {
+                                        docs.push(Doc::soft_line());
+                                    }
+                                }
+                                1 => docs.push(Doc::hard_line()),
+                                _ => {
+                                    docs.push(Doc::empty_line());
+                                    docs.push(Doc::hard_line());
+                                }
+                            }
+                            return (docs, true);
+                        }
+
+                        if let Some(doc) =
+                            should_add_whitespace_before_text_node(text_node, is_first)
+                        {
+                            docs.push(doc);
+                        }
+                        docs.push(text_node.doc(ctx, state));
+                        if let Some(doc) = should_add_whitespace_after_text_node(text_node, is_last)
+                        {
+                            docs.push(doc);
+                        }
+                    } else {
+                        docs.push(child.kind.doc(ctx, state))
+                    }
+                    (docs, is_text_like(child, ctx.language))
+                },
+            )
+            .0,
+    )
+    .group()
+}
+
+fn format_control_structure_block_children<'s, E, F>(
+    children: &[Node<'s>],
+    ctx: &mut Ctx<'s, E, F>,
+    state: &State<'s>,
+) -> Doc<'s>
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    match children {
+        [Node {
+            kind: NodeKind::Text(text_node),
+            ..
+        }] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
+        _ => format_ws_sensitive_leading_ws(children)
+            .append(format_children_without_inserting_linebreak(
+                children, ctx, state,
+            ))
+            .nest(ctx.indent_width)
+            .append(format_ws_sensitive_trailing_ws(children)),
+    }
+}
+
+fn compute_attr_value_quote<'s, E, F>(
+    attr_value: &str,
+    initial_quote: Option<char>,
+    ctx: &mut Ctx<'s, E, F>,
+) -> Doc<'s>
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    let has_single = attr_value.contains('\'');
+    let has_double = attr_value.contains('"');
+    if has_double && has_single {
+        if let Some(quote) = initial_quote {
+            Doc::text(quote.to_string())
+        } else if let Quotes::Double = ctx.options.quotes {
+            Doc::text("\"")
+        } else {
+            Doc::text("'")
+        }
+    } else if has_double {
+        Doc::text("'")
+    } else if has_single {
+        Doc::text("\"")
+    } else if let Quotes::Double = ctx.options.quotes {
+        Doc::text("\"")
+    } else {
+        Doc::text("'")
+    }
+}
+
+fn format_ws_sensitive_leading_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
+    if let Some(Node {
+        kind: NodeKind::Text(text_node),
+        ..
+    }) = children.first()
+    {
+        if text_node.raw.starts_with(|c: char| c.is_ascii_whitespace()) {
+            if text_node.line_breaks > 0 {
+                Doc::hard_line()
+            } else {
+                Doc::line_or_space()
+            }
+        } else {
+            Doc::nil()
+        }
+    } else {
+        Doc::nil()
+    }
+}
+
+fn format_ws_sensitive_trailing_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
+    if let Some(Node {
+        kind: NodeKind::Text(text_node),
+        ..
+    }) = children.last()
+    {
+        if text_node.raw.ends_with(|c: char| c.is_ascii_whitespace()) {
+            if text_node.line_breaks > 0 {
+                Doc::hard_line()
+            } else {
+                Doc::line_or_space()
+            }
+        } else {
+            Doc::nil()
+        }
+    } else {
+        Doc::nil()
+    }
+}
+
+fn format_ws_insensitive_leading_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
+    match children.first() {
+        Some(Node {
+            kind: NodeKind::Text(text_node),
+            ..
+        }) if text_node.line_breaks > 0 => Doc::hard_line(),
+        _ => Doc::line_or_nil(),
+    }
+}
+
+fn format_ws_insensitive_trailing_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
+    match children.last() {
+        Some(Node {
+            kind: NodeKind::Text(text_node),
+            ..
+        }) if text_node.line_breaks > 0 => Doc::hard_line(),
+        _ => Doc::line_or_nil(),
+    }
+}

--- a/crates/djls-fmt/src/markup/printer.rs
+++ b/crates/djls-fmt/src/markup/printer.rs
@@ -642,12 +642,7 @@ impl<'s> DocGen<'s> for NativeAttribute<'s> {
     {
         let name = Doc::text(self.name);
         if let Some((value, _value_start)) = self.value {
-            let value = if !matches!(ctx.language, Language::Xml) && self.name.starts_with("on") {
-                // For event handlers, pass through without formatting
-                Cow::from(value)
-            } else {
-                Cow::from(value)
-            };
+            let value = Cow::from(value);
             let quote;
             let mut docs = Vec::with_capacity(5);
             docs.push(name);
@@ -1047,23 +1042,6 @@ fn has_two_more_non_text_children(children: &[Node], language: Language) -> bool
         .filter(|child| !is_text_like(child, language))
         .count()
         > 1
-}
-
-fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes) -> Doc<'_> {
-    let value = value.as_ref();
-    let quote = if value.contains('"') {
-        Doc::text("'")
-    } else if value.contains('\'') {
-        Doc::text("\"")
-    } else if let Quotes::Double = quotes {
-        Doc::text("\"")
-    } else {
-        Doc::text("'")
-    };
-    quote
-        .clone()
-        .concat(reflow_with_indent(value, true))
-        .append(quote)
 }
 
 fn format_children_with_inserting_linebreak<'s, E, F>(

--- a/crates/djls-fmt/src/markup/printer.rs
+++ b/crates/djls-fmt/src/markup/printer.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 // Stripped to HTML + Jinja/Django + XML only
 
 use std::borrow::Cow;

--- a/crates/djls-fmt/src/markup/state.rs
+++ b/crates/djls-fmt/src/markup/state.rs
@@ -1,4 +1,4 @@
-// Vendored from markup_fmt v0.26.0
+// Vendored from markup_fmt v0.26.0 — MIT License (see LICENSE)
 
 #[derive(Clone)]
 pub(crate) struct State<'s> {

--- a/crates/djls-fmt/src/markup/state.rs
+++ b/crates/djls-fmt/src/markup/state.rs
@@ -1,0 +1,9 @@
+// Vendored from markup_fmt v0.26.0
+
+#[derive(Clone)]
+pub(crate) struct State<'s> {
+    pub(crate) current_tag_name: Option<&'s str>,
+    pub(crate) is_root: bool,
+    pub(crate) in_svg: bool,
+    pub(crate) indent_level: u16,
+}


### PR DESCRIPTION
## What

Vendors `markup_fmt` v0.26.0 and `tiny_pretty` v0.2.1 into `djls-fmt`, stripped to HTML + Jinja/Django + XML only, with Django-specific parser fixes applied.

Closes #446

## Changes

### Vendored `markup_fmt` (stripped)

Reduced from ~7,600 lines to ~3,200 lines by removing all Vue, Svelte, Astro, Angular, Vento, and Mustache support. The vendored code lives in `crates/djls-fmt/src/markup/` (9 files: ast, config, ctx, error, helpers, parser, printer, state, mod).

### Django parser fixes (`parser.rs`)

- Removed `trans` from the block tag list — it's self-closing in Django, not a block tag
- Added Django block tags: `blocktrans`, `blocktranslate`, `verbatim`, `spaceless`, `cache`, `ifchanged`, `comment`
- Added `empty` as an intermediate tag for `{% for %}` loops (alongside `elif`/`else`)

### Content-type detection & formatting dispatch

- `detect_content_type()` routes `.html`/`.htm`/`.djhtml` → HTML-aware formatting, other extensions → Django syntax-only
- `format_source()` dispatches to the appropriate backend based on content type
- `format_source_with_path()` combines detection and dispatch
- Graceful fallback: if HTML parsing fails, falls back to Django syntax formatting

### Embedded CSS formatting

CSS inside `<style>` blocks is formatted via `malva`.

### New workspace dependencies

`aho-corasick`, `css_dataset`, `itertools`, `malva`, `tiny_pretty`

## Tests

77 tests pass in `djls-fmt`, including new tests for:
- Django block tags (`blocktrans`, `verbatim`, `comment`)
- `{% trans %}` as self-closing
- `{% empty %}` as intermediate tag in `{% for %}` loops
- Content-type detection by extension and config override
- HTML formatting with Django template tags
- Fallback on parse error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML-aware template formatting for .html/.htm/.djhtml files
  * Automatic content-type detection with a config override to force a specific type
  * Embedded CSS formatting inside <style> blocks

* **Bug Fixes / Improvements**
  * Better handling of common Django/template block and inline tags
  * Graceful fallback to template-only formatting when HTML parsing fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->