### PR TITLE
Fix workspace Cargo scope and corpus sync idempotency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
-default-members = ["crates/djls"]
 
 [workspace.dependencies]
 djls = { path = "crates/djls" }

--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,9 @@ lint *ARGS:
     @just --fmt
     @just nox lint {{ ARGS }}
 
+run *ARGS:
+    cargo run -p djls -- {{ ARGS }}
+
 test *ARGS:
     @just nox test {{ ARGS }}
 

--- a/crates/djls-corpus/src/lib.rs
+++ b/crates/djls-corpus/src/lib.rs
@@ -38,6 +38,7 @@ pub mod manifest;
 pub mod sync;
 
 const CORPUS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/.corpus");
+const LOCKFILE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/manifest.lock");
 
 /// A validated corpus root directory.
 ///
@@ -66,7 +67,13 @@ impl Corpus {
             Self::is_available(),
             "Corpus not synced. Run: cargo run --bin djls-corpus -- sync",
         );
-        Self { _private: () }
+        let corpus = Self { _private: () };
+        let lockfile = lock::Lockfile::load(Utf8Path::new(LOCKFILE_PATH))
+            .expect("Corpus lockfile missing or invalid. Run: just corpus lock");
+        sync::validate_synced_corpus(&lockfile, corpus.root()).unwrap_or_else(|error| {
+            panic!("{error}");
+        });
+        corpus
     }
 
     /// The corpus root directory.

--- a/crates/djls-corpus/src/sync.rs
+++ b/crates/djls-corpus/src/sync.rs
@@ -121,7 +121,7 @@ fn repo_archive_url(repo: &LockedRepo) -> anyhow::Result<String> {
         .and_then(|s| s.split('/').next())
         .unwrap_or_default();
 
-    if host == "gitlab.com" || host.starts_with("gitlab.") {
+    if host == "gitlab.com" {
         let project = base_url
             .rsplit('/')
             .next()
@@ -419,16 +419,6 @@ mod tests {
         assert_eq!(
             url,
             "https://gitlab.com/group/subgroup/project/-/archive/abc123def456/project-abc123def456.tar.gz"
-        );
-    }
-
-    #[test]
-    fn gitlab_self_hosted() {
-        let repo = locked_repo("https://gitlab.example.com/team/project.git");
-        let url = repo_archive_url(&repo).unwrap();
-        assert_eq!(
-            url,
-            "https://gitlab.example.com/team/project/-/archive/abc123def456/project-abc123def456.tar.gz"
         );
     }
 }

--- a/crates/djls-corpus/src/sync.rs
+++ b/crates/djls-corpus/src/sync.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use serde::Deserialize;
 use serde::Serialize;
 
 use crate::archive::extract_tarball;
@@ -23,7 +24,7 @@ const MAX_CONCURRENT_DOWNLOADS: usize = 8;
 const COMPLETE_MARKER: &str = ".complete.json";
 const MAX_TARBALL_BYTES: u64 = 512 * 1024 * 1024;
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct RepoMarker {
     name: String,
     url: String,
@@ -38,8 +39,45 @@ fn write_marker(out_dir: &Utf8Path, value: &impl Serialize) -> anyhow::Result<()
     Ok(())
 }
 
-fn is_synced(out_dir: &Utf8Path) -> bool {
-    out_dir.join(COMPLETE_MARKER).as_std_path().exists()
+impl From<&LockedRepo> for RepoMarker {
+    fn from(repo: &LockedRepo) -> Self {
+        Self {
+            name: repo.name.clone(),
+            url: repo.url.clone(),
+            git_ref: repo.git_ref.clone(),
+            tag: repo.tag.clone(),
+        }
+    }
+}
+
+fn read_marker(out_dir: &Utf8Path) -> anyhow::Result<RepoMarker> {
+    let marker_path = out_dir.join(COMPLETE_MARKER);
+    let content = std::fs::read_to_string(marker_path.as_std_path())?;
+    Ok(serde_json::from_str(&content)?)
+}
+
+fn is_synced(repo: &LockedRepo, out_dir: &Utf8Path) -> bool {
+    read_marker(out_dir).is_ok_and(|marker| marker == RepoMarker::from(repo))
+}
+
+/// Validate that the local corpus checkout matches the lockfile.
+pub fn validate_synced_corpus(lockfile: &Lockfile, corpus_root: &Utf8Path) -> anyhow::Result<()> {
+    let repos_dir = corpus_root.join("repos");
+    let stale: Vec<&str> = lockfile
+        .repos
+        .iter()
+        .filter(|repo| !is_synced(repo, &repos_dir.join(&repo.name)))
+        .map(|repo| repo.name.as_str())
+        .collect();
+
+    if stale.is_empty() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "Corpus is out of sync with manifest.lock for: {}. Run: just corpus sync",
+        stale.join(", ")
+    );
 }
 
 /// Download a tarball to a temp file.
@@ -122,15 +160,7 @@ fn sync_repo(
         tracing::warn!("{w}");
     }
 
-    write_marker(
-        out_dir,
-        &RepoMarker {
-            name: repo.name.clone(),
-            url: repo.url.clone(),
-            git_ref: repo.git_ref.clone(),
-            tag: repo.tag.clone(),
-        },
-    )?;
+    write_marker(out_dir, &RepoMarker::from(repo))?;
 
     Ok(())
 }
@@ -151,9 +181,13 @@ pub fn sync_corpus(lockfile: &Lockfile, corpus_root: &Utf8Path, prune: bool) -> 
         let out_dir = repos_dir.join(&repo.name);
         let short_ref = repo.git_ref.get(..12).unwrap_or(&repo.git_ref);
         let label = format!("{} @ {} ({short_ref})", repo.name, repo.tag);
-        if is_synced(&out_dir) {
+        if is_synced(repo, &out_dir) {
             skipped += 1;
         } else {
+            if out_dir.as_std_path().exists() {
+                tracing::info!(repo = repo.name, "removing stale corpus checkout");
+                std::fs::remove_dir_all(out_dir.as_std_path())?;
+            }
             work.push(SyncItem {
                 repo,
                 out_dir,
@@ -290,6 +324,69 @@ mod tests {
             tag: "main".to_string(),
             git_ref: "abc123def456".to_string(),
         }
+    }
+
+    fn temp_dir() -> (tempfile::TempDir, Utf8PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf8 path");
+        (dir, path)
+    }
+
+    #[test]
+    fn synced_repo_requires_matching_marker() {
+        let repo = locked_repo("https://github.com/owner/project.git");
+        let (_dir, out) = temp_dir();
+        std::fs::create_dir_all(out.as_std_path()).unwrap();
+        write_marker(&out, &RepoMarker::from(&repo)).unwrap();
+
+        assert!(is_synced(&repo, &out));
+    }
+
+    #[test]
+    fn synced_repo_rejects_stale_marker_ref() {
+        let repo = locked_repo("https://github.com/owner/project.git");
+        let mut stale = locked_repo("https://github.com/owner/project.git");
+        stale.git_ref = "old-ref".to_string();
+        let (_dir, out) = temp_dir();
+        std::fs::create_dir_all(out.as_std_path()).unwrap();
+        write_marker(&out, &RepoMarker::from(&stale)).unwrap();
+
+        assert!(!is_synced(&repo, &out));
+    }
+
+    #[test]
+    fn synced_repo_rejects_missing_marker() {
+        let repo = locked_repo("https://github.com/owner/project.git");
+        let (_dir, out) = temp_dir();
+
+        assert!(!is_synced(&repo, &out));
+    }
+
+    #[test]
+    fn validate_synced_corpus_accepts_matching_markers() {
+        let repo = locked_repo("https://github.com/owner/project.git");
+        let lockfile = Lockfile { repos: vec![repo] };
+        let (_dir, root) = temp_dir();
+        let out = root.join("repos/test");
+        std::fs::create_dir_all(out.as_std_path()).unwrap();
+        write_marker(&out, &RepoMarker::from(&lockfile.repos[0])).unwrap();
+
+        validate_synced_corpus(&lockfile, &root).unwrap();
+    }
+
+    #[test]
+    fn validate_synced_corpus_rejects_stale_markers() {
+        let repo = locked_repo("https://github.com/owner/project.git");
+        let lockfile = Lockfile { repos: vec![repo] };
+        let mut stale = locked_repo("https://github.com/owner/project.git");
+        stale.git_ref = "old-ref".to_string();
+        let (_dir, root) = temp_dir();
+        let out = root.join("repos/test");
+        std::fs::create_dir_all(out.as_std_path()).unwrap();
+        write_marker(&out, &RepoMarker::from(&stale)).unwrap();
+
+        let error = validate_synced_corpus(&lockfile, &root).unwrap_err();
+        assert!(error.to_string().contains("test"));
     }
 
     #[test]

--- a/crates/djls-corpus/src/sync.rs
+++ b/crates/djls-corpus/src/sync.rs
@@ -50,14 +50,12 @@ impl From<&LockedRepo> for RepoMarker {
     }
 }
 
-fn read_marker(out_dir: &Utf8Path) -> anyhow::Result<RepoMarker> {
-    let marker_path = out_dir.join(COMPLETE_MARKER);
-    let content = std::fs::read_to_string(marker_path.as_std_path())?;
-    Ok(serde_json::from_str(&content)?)
-}
-
 fn is_synced(repo: &LockedRepo, out_dir: &Utf8Path) -> bool {
-    read_marker(out_dir).is_ok_and(|marker| marker == RepoMarker::from(repo))
+    let marker_path = out_dir.join(COMPLETE_MARKER);
+    std::fs::read_to_string(marker_path.as_std_path())
+        .ok()
+        .and_then(|content| serde_json::from_str::<RepoMarker>(&content).ok())
+        .is_some_and(|marker| marker == RepoMarker::from(repo))
 }
 
 /// Validate that the local corpus checkout matches the lockfile.

--- a/crates/djls-corpus/src/sync.rs
+++ b/crates/djls-corpus/src/sync.rs
@@ -115,8 +115,13 @@ fn download_tarball(
 
 fn repo_archive_url(repo: &LockedRepo) -> anyhow::Result<String> {
     let base_url = repo.url.trim_end_matches(".git");
+    let host = base_url
+        .strip_prefix("https://")
+        .or_else(|| base_url.strip_prefix("http://"))
+        .and_then(|s| s.split('/').next())
+        .unwrap_or_default();
 
-    if is_gitlab_url(base_url) {
+    if host == "gitlab.com" || host.starts_with("gitlab.") {
         let project = base_url
             .rsplit('/')
             .next()
@@ -129,16 +134,6 @@ fn repo_archive_url(repo: &LockedRepo) -> anyhow::Result<String> {
     } else {
         Ok(format!("{base_url}/archive/{}.tar.gz", repo.git_ref))
     }
-}
-
-fn is_gitlab_url(url: &str) -> bool {
-    let host = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
-        .and_then(|s| s.split('/').next())
-        .unwrap_or_default();
-
-    host == "gitlab.com" || host.starts_with("gitlab.")
 }
 
 fn sync_repo(
@@ -435,25 +430,5 @@ mod tests {
             url,
             "https://gitlab.example.com/team/project/-/archive/abc123def456/project-abc123def456.tar.gz"
         );
-    }
-
-    #[test]
-    fn is_gitlab_detects_gitlab_com() {
-        assert!(is_gitlab_url("https://gitlab.com/group/project"));
-    }
-
-    #[test]
-    fn is_gitlab_detects_self_hosted() {
-        assert!(is_gitlab_url("https://gitlab.example.com/team/project"));
-    }
-
-    #[test]
-    fn is_gitlab_rejects_github() {
-        assert!(!is_gitlab_url("https://github.com/owner/project"));
-    }
-
-    #[test]
-    fn is_gitlab_rejects_other() {
-        assert!(!is_gitlab_url("https://codeberg.org/user/project"));
     }
 }

--- a/crates/djls-project/src/resolve.rs
+++ b/crates/djls-project/src/resolve.rs
@@ -665,8 +665,7 @@ class Article(models.Model):
         let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
         assert!(
             module_paths.contains(&"myapp.models.base.abstract"),
-            "should discover nested model files: got {:?}",
-            module_paths
+            "should discover nested model files: got {module_paths:?}"
         );
     }
 
@@ -689,8 +688,7 @@ class Article(models.Model):
         let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
         assert!(
             module_paths.contains(&"myapp.models.base.abstract"),
-            "should discover nested model files: got {:?}",
-            module_paths
+            "should discover nested model files: got {module_paths:?}"
         );
     }
 

--- a/crates/djls-python/src/analysis/rules.rs
+++ b/crates/djls-python/src/analysis/rules.rs
@@ -828,12 +828,12 @@ def do_tag(parser, token):
     #[test]
     fn bare_raise_not_extracted() {
         let c = extract_from_source(
-            r#"
+            r"
 def do_tag(parser, token):
     bits = token.split_contents()
     if len(bits) < 2:
         raise
-"#,
+",
         );
         assert!(c.arg_constraints.is_empty());
     }

--- a/crates/djls-python/src/models/extract.rs
+++ b/crates/djls-python/src/models/extract.rs
@@ -471,10 +471,10 @@ mod tests {
 
     #[test]
     fn simple_model() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     name = models.CharField(max_length=100)
-"#;
+";
         let graph = extract_model_graph(source, "auth.models");
         assert_eq!(graph.len(), 1);
 
@@ -487,12 +487,12 @@ class User(models.Model):
 
     #[test]
     fn direct_model_import() {
-        let source = r#"
+        let source = r"
 from django.db.models import Model
 
 class User(Model):
     name = models.CharField(max_length=100)
-"#;
+";
         let graph = extract_model_graph(source, "auth.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("User").is_some());
@@ -500,12 +500,12 @@ class User(Model):
 
     #[test]
     fn aliased_models_import() {
-        let source = r#"
+        let source = r"
 from django.db import models as m
 
 class User(m.Model):
     name = m.CharField(max_length=100)
-"#;
+";
         let graph = extract_model_graph(source, "auth.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("User").is_some());
@@ -513,12 +513,12 @@ class User(m.Model):
 
     #[test]
     fn aliased_absolute_import() {
-        let source = r#"
+        let source = r"
 import django.db.models as db_models
 
 class User(db_models.Model):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "auth.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("User").is_some());
@@ -526,12 +526,12 @@ class User(db_models.Model):
 
     #[test]
     fn aliased_model_class_import() {
-        let source = r#"
+        let source = r"
 from django.db.models import Model as BaseModel
 
 class User(BaseModel):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "auth.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("User").is_some());
@@ -539,12 +539,12 @@ class User(BaseModel):
 
     #[test]
     fn geodjango_models_import() {
-        let source = r#"
+        let source = r"
 from django.contrib.gis.db import models
 
 class Location(models.Model):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "geo.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("Location").is_some());
@@ -552,12 +552,12 @@ class Location(models.Model):
 
     #[test]
     fn geodjango_aliased_import() {
-        let source = r#"
+        let source = r"
 from django.contrib.gis.db import models as gis
 
 class Location(gis.Model):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "geo.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("Location").is_some());
@@ -565,12 +565,12 @@ class Location(gis.Model):
 
     #[test]
     fn geodjango_model_class_import() {
-        let source = r#"
+        let source = r"
 from django.contrib.gis.db.models import Model as GeoModel
 
 class Location(GeoModel):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "geo.models");
         assert_eq!(graph.len(), 1);
         assert!(graph.get("Location").is_some());
@@ -579,12 +579,12 @@ class Location(GeoModel):
     #[test]
     fn unrelated_alias_not_matched() {
         // foo.Model should NOT be detected as a Django model
-        let source = r#"
+        let source = r"
 import foo
 
 class NotAModel(foo.Model):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
         assert!(graph.is_empty());
     }
@@ -592,25 +592,25 @@ class NotAModel(foo.Model):
     #[test]
     fn unrelated_model_name_not_matched() {
         // A bare name that happens to not be "Model" should not match
-        let source = r#"
+        let source = r"
 from pydantic import BaseModel
 
 class NotDjango(BaseModel):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
         assert!(graph.is_empty());
     }
 
     #[test]
     fn foreign_key() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
 class Order(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-"#;
+";
         let graph = extract_model_graph(source, "shop.models");
 
         let order = graph.get("Order").unwrap();
@@ -662,14 +662,14 @@ class Order(models.Model):
 
     #[test]
     fn all_relation_types() {
-        let source = r#"
+        let source = r"
 class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
 
 class Article(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE)
     tags = models.ManyToManyField(Tag)
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
 
         let profile = graph.get("Profile").unwrap();
@@ -692,18 +692,18 @@ class Article(models.Model):
 
     #[test]
     fn abstract_model() {
-        let source = r#"
+        let source = r"
 class BaseModel(models.Model):
     class Meta:
         abstract = True
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
         assert_eq!(graph.get("BaseModel").unwrap().kind, ModelKind::Abstract);
     }
 
     #[test]
     fn abstract_inheritance() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
@@ -718,7 +718,7 @@ class BaseOrder(models.Model):
 
 class ConcreteOrder(BaseOrder):
     seller = models.ForeignKey(Seller, on_delete=models.CASCADE)
-"#;
+";
         let graph = extract_model_graph(source, "shop.models");
 
         let concrete = graph.get("ConcreteOrder").unwrap();
@@ -729,7 +729,7 @@ class ConcreteOrder(BaseOrder):
             .relations
             .iter()
             .filter_map(|r| r.target_model())
-            .map(|m| m.as_str())
+            .map(super::super::graph::ModelName::as_str)
             .collect();
         assert!(targets.contains(&"User"));
         assert!(targets.contains(&"Seller"));
@@ -783,13 +783,13 @@ class Order(models.Model):
 
     #[test]
     fn default_reverse_name() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
 class Order(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-"#;
+";
         let graph = extract_model_graph(source, "shop.models");
 
         // Default FK reverse name is <model>_set
@@ -824,7 +824,7 @@ class Comment(models.Model):
 
     #[test]
     fn multiple_abstract_parents() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
@@ -845,7 +845,7 @@ class AuditMixin(models.Model):
 
 class Document(TimestampMixin, AuditMixin):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
 
         let doc = graph.get("Document").unwrap();
@@ -855,7 +855,7 @@ class Document(TimestampMixin, AuditMixin):
             .relations
             .iter()
             .filter_map(|r| r.target_model())
-            .map(|m| m.as_str())
+            .map(super::super::graph::ModelName::as_str)
             .collect();
         assert!(targets.contains(&"User"));
         assert!(targets.contains(&"Approver"));
@@ -863,7 +863,7 @@ class Document(TimestampMixin, AuditMixin):
 
     #[test]
     fn concrete_model_inheritance() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
@@ -872,7 +872,7 @@ class Place(models.Model):
 
 class Restaurant(Place):
     owner = models.ForeignKey(User, on_delete=models.CASCADE)
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
 
         let restaurant = graph.get("Restaurant").unwrap();
@@ -886,7 +886,7 @@ class Restaurant(Place):
 
     #[test]
     fn qualified_base_class_inheritance() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
@@ -898,7 +898,7 @@ class BaseOrder(models.Model):
 
 class ConcreteOrder(some_module.BaseOrder):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "shop.models");
 
         let concrete = graph.get("ConcreteOrder").unwrap();
@@ -911,7 +911,7 @@ class ConcreteOrder(some_module.BaseOrder):
 
     #[test]
     fn multi_level_inheritance_chain() {
-        let source = r#"
+        let source = r"
 class User(models.Model):
     pass
 
@@ -927,7 +927,7 @@ class MiddleMixin(BaseMixin):
 
 class Concrete(MiddleMixin):
     pass
-"#;
+";
         let graph = extract_model_graph(source, "app.models");
 
         // MiddleMixin inherits BaseMixin's FK to User
@@ -980,10 +980,10 @@ class TaggedItem(models.Model):
 
     #[test]
     fn generic_foreign_key_defaults() {
-        let source = r#"
+        let source = r"
 class TaggedItem(models.Model):
     content_object = GenericForeignKey()
-"#;
+";
         let graph = extract_model_graph(source, "tagging.models");
 
         let rel = &graph.get("TaggedItem").unwrap().relations[0];
@@ -999,10 +999,10 @@ class TaggedItem(models.Model):
 
     #[test]
     fn generic_foreign_key_keyword_args() {
-        let source = r#"
+        let source = r"
 class ObjectLog(models.Model):
     parent = GenericForeignKey(ct_field='object_type', fk_field='object_id')
-"#;
+";
         let graph = extract_model_graph(source, "logs.models");
 
         let rel = &graph.get("ObjectLog").unwrap().relations[0];
@@ -1058,11 +1058,11 @@ class TaggedItem(GenericMixin):
 
     #[test]
     fn multiple_generic_foreign_keys() {
-        let source = r#"
+        let source = r"
 class Action(models.Model):
     actor = GenericForeignKey('actor_content_type', 'actor_object_id')
     target = GenericForeignKey('target_content_type', 'target_object_id')
-"#;
+";
         let graph = extract_model_graph(source, "activity.models");
 
         let action = graph.get("Action").unwrap();


### PR DESCRIPTION
Added as a convenience to avoid `cargo run -p djls -- <command>..`, but makes all the other cargo commands scoped to just the `djls` package -- meaning only those tests were running.