### PR TITLE
Add template validation file query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - **Internal**: Renamed template library snapshot types and cache APIs around backend-neutral semantic snapshots instead of inspector responses.
 - **Internal**: Hid template library inspector request plumbing behind a semantic snapshot fetch API.
 - **Internal**: Replaced the database inspector handle with a backend-neutral project introspector.
+- **Internal**: Added a semantic `validate_template_file` convenience query for file-level template validation.
 - **Internal**: Unified `djls-corpus` to repo-only format, removing the PyPI package path. All corpus entries are now `[[repo]]` in `manifest.toml`, fetched as git archives. Removed `sha2`, `toml_edit` dependencies and the `add` CLI command.
 - **Internal**: Added license file fetching to `djls-corpus lock`. License text is saved to `crates/djls-corpus/licenses/` for attribution.
 - **Internal**: Replaced manual `AvailableSymbols` cache in `TemplateValidator` with `SymbolIndex`. Symbol availability is now precomputed per `{% load %}` boundary and memoized across revisions, eliminating per-walk rebuilds and hand-rolled invalidation logic.

--- a/crates/djls-db/src/check.rs
+++ b/crates/djls-db/src/check.rs
@@ -32,9 +32,9 @@ impl CheckResult {
 ///
 /// This is the shared orchestration that both the CLI and LSP server
 /// use to drive diagnostics. Under the hood it triggers Salsa-tracked
-/// `parse_template` and `validate_nodelist` queries (cached across calls).
+/// `parse_template` and `validate_template_file` queries (cached across calls).
 pub fn check_file(db: &dyn SemanticDb, file: File) -> CheckResult {
-    let nodelist = djls_templates::parse_template(db, file);
+    djls_semantic::validate_template_file(db, file);
 
     let template_errors: Vec<TemplateError> =
         djls_templates::parse_template::accumulated::<TemplateErrorAccumulator>(db, file)
@@ -42,16 +42,12 @@ pub fn check_file(db: &dyn SemanticDb, file: File) -> CheckResult {
             .map(|acc| acc.0.clone())
             .collect();
 
-    let mut validation_errors: Vec<ValidationError> = Vec::new();
+    let accumulated =
+        djls_semantic::validate_template_file::accumulated::<ValidationErrorAccumulator>(db, file);
 
-    if let Some(nodelist) = nodelist {
-        let accumulated = djls_semantic::validate_nodelist::accumulated::<ValidationErrorAccumulator>(
-            db, nodelist,
-        );
-
-        validation_errors = accumulated.iter().map(|acc| acc.0.clone()).collect();
-        validation_errors.sort_by_key(|e| e.primary_span().map_or(0, Span::start));
-    }
+    let mut validation_errors: Vec<ValidationError> =
+        accumulated.iter().map(|acc| acc.0.clone()).collect();
+    validation_errors.sort_by_key(|e| e.primary_span().map_or(0, Span::start));
 
     CheckResult {
         template_errors,

--- a/crates/djls-ide/src/diagnostics.rs
+++ b/crates/djls-ide/src/diagnostics.rs
@@ -89,6 +89,8 @@ pub fn collect_diagnostics(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_typ
 
     let config = db.diagnostics_config();
 
+    djls_semantic::validate_template_file(db, file);
+
     let template_errors =
         djls_templates::parse_template::accumulated::<TemplateErrorAccumulator>(db, file);
 
@@ -99,16 +101,13 @@ pub fn collect_diagnostics(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_typ
         push_with_severity(diagnostic, &config, &mut diagnostics);
     }
 
-    let nodelist = djls_templates::parse_template(db, file);
-    if let Some(nodelist) = nodelist {
-        let validation_errors = djls_semantic::validate_nodelist::accumulated::<
-            djls_semantic::ValidationErrorAccumulator,
-        >(db, nodelist);
+    let validation_errors = djls_semantic::validate_template_file::accumulated::<
+        djls_semantic::ValidationErrorAccumulator,
+    >(db, file);
 
-        for error_acc in validation_errors {
-            let diagnostic = error_acc.0.as_diagnostic(line_index);
-            push_with_severity(diagnostic, &config, &mut diagnostics);
-        }
+    for error_acc in validation_errors {
+        let diagnostic = error_acc.0.as_diagnostic(line_index);
+        push_with_severity(diagnostic, &config, &mut diagnostics);
     }
 
     diagnostics

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -109,6 +109,20 @@ pub use structure::OpaqueRegions;
 pub use structure::TagIndex;
 pub use validation::TemplateValidator;
 
+/// Validate a Django template file.
+///
+/// This is a semantic convenience entrypoint: parsing still lives in
+/// `djls-templates`, while this function triggers validation for callers that
+/// need Django meaning for a file.
+#[salsa::tracked]
+pub fn validate_template_file(db: &dyn Db, file: djls_source::File) {
+    let Some(nodelist) = djls_templates::parse_template(db, file) else {
+        return;
+    };
+
+    validate_nodelist(db, nodelist);
+}
+
 /// Validate a Django template node list and return validation errors.
 ///
 /// This function builds a `BlockTree` from the parsed node list and, during

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -211,9 +211,7 @@ impl Session {
     /// Warm template caches and semantic diagnostics for the updated file.
     fn handle_file(&self, file: File) {
         if FileKind::from(file.path(&self.db)) == FileKind::Template {
-            if let Some(nodelist) = djls_templates::parse_template(&self.db, file) {
-                djls_semantic::validate_nodelist(&self.db, nodelist);
-            }
+            djls_semantic::validate_template_file(&self.db, file);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `djls_semantic::validate_template_file` as a narrow semantic file-level convenience query
- Keep parsing owned by `djls-templates`; the new query only orchestrates parse -> semantic validation
- Update diagnostics/checking cache warmup call sites to collect validation errors from the file-level semantic query

## Validation
- `cargo test -q`
- `just fmt --check`
- `just clippy --allow-dirty`
- `just lint`

Refs #514