### PR TITLE
Bump Rust toolchain to 1.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
+- Bumped Rust toolchain from 1.93 to 1.95.
 - Changed `djls serve` terminal warning output to plain text without decorative separator lines.
 - **Internal**: Consolidated `djls-project` and `djls-python` into `djls-semantic` as the unified Django semantic model.
 - **Internal**: Renamed template library snapshot types and cache APIs around backend-neutral semantic snapshots instead of inspector responses.

--- a/crates/djls-corpus/src/lock.rs
+++ b/crates/djls-corpus/src/lock.rs
@@ -60,7 +60,7 @@ pub fn lock_corpus(
     licenses_dir: &Utf8Path,
 ) -> anyhow::Result<(Lockfile, Vec<String>)> {
     let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_mins(1))
         .user_agent("djls-corpus")
         .build()?;
 

--- a/crates/djls-corpus/src/sync.rs
+++ b/crates/djls-corpus/src/sync.rs
@@ -161,7 +161,7 @@ fn sync_repo(
 pub fn sync_corpus(lockfile: &Lockfile, corpus_root: &Utf8Path, prune: bool) -> anyhow::Result<()> {
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(30))
-        .timeout(Duration::from_secs(300))
+        .timeout(Duration::from_mins(5))
         .build()?;
 
     let repos_dir = corpus_root.join("repos");

--- a/crates/djls-semantic/src/project/inspector.rs
+++ b/crates/djls-semantic/src/project/inspector.rs
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_inspector_with_custom_timeout() {
         // Test creation with custom timeout
-        let _inspector = Inspector::with_timeout(Duration::from_secs(120));
+        let _inspector = Inspector::with_timeout(Duration::from_mins(2));
         // Cleanup thread starts automatically
     }
 

--- a/crates/djls-semantic/src/python/models/extract.rs
+++ b/crates/djls-semantic/src/python/models/extract.rs
@@ -259,20 +259,16 @@ fn is_django_model<'a>(bases: impl Iterator<Item = &'a Expr>, aliases: &ImportAl
     for base in bases {
         match base {
             // models.Model / m.Model (where m aliases django.db.models)
-            Expr::Attribute(attr) => {
-                if attr.attr.as_str() == "Model" {
-                    if let Expr::Name(name) = attr.value.as_ref() {
-                        if aliases.module_aliases.contains(name.id.as_str()) {
-                            return true;
-                        }
+            Expr::Attribute(attr) if attr.attr.as_str() == "Model" => {
+                if let Expr::Name(name) = attr.value.as_ref() {
+                    if aliases.module_aliases.contains(name.id.as_str()) {
+                        return true;
                     }
                 }
             }
             // Model / M (where M aliases django.db.models.Model)
-            Expr::Name(name) => {
-                if aliases.class_aliases.contains(name.id.as_str()) {
-                    return true;
-                }
+            Expr::Name(name) if aliases.class_aliases.contains(name.id.as_str()) => {
+                return true;
             }
             _ => {}
         }

--- a/crates/djls-semantic/src/specs/tags.rs
+++ b/crates/djls-semantic/src/specs/tags.rs
@@ -330,13 +330,11 @@ impl TagSpecs {
                                         value,
                                     });
                                 }
-                                ExtractedArgKind::Choice(values) => {
-                                    if !values.is_empty() {
-                                        rule.choice_at_constraints.push(ChoiceAt {
-                                            position: SplitPosition::Forward(pos + 1),
-                                            values,
-                                        });
-                                    }
+                                ExtractedArgKind::Choice(values) if !values.is_empty() => {
+                                    rule.choice_at_constraints.push(ChoiceAt {
+                                        position: SplitPosition::Forward(pos + 1),
+                                        values,
+                                    });
                                 }
                                 _ => {}
                             }

--- a/crates/djls-templates/src/quotes.rs
+++ b/crates/djls-templates/src/quotes.rs
@@ -31,10 +31,8 @@ pub(crate) fn for_each_unquoted(
                 quote = Some(ch);
             }
             _ if quote.is_some() => {}
-            _ if delimiter(ch) => {
-                if cb(idx) {
-                    return;
-                }
+            _ if delimiter(ch) && cb(idx) => {
+                return;
             }
             _ => {}
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.95"


### PR DESCRIPTION
## Summary
- Bump `rust-toolchain.toml` from Rust 1.93 to 1.95
- Apply Rust 1.95 clippy fixes
- Add an Unreleased changelog entry

## Validation
- `cargo test -q`
- `just fmt --check`
- `just clippy --allow-dirty`
- `just lint`

Closes #516