### PR TITLE
Improve quiet check diagnostics path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Bumped Rust toolchain from 1.93 to 1.95.
 - **Internal**: Stabilized benchmarks with sized diagnostics fixtures, repeated microbench companions, validation-rendering contract assertions, and deterministic corpus input ordering.
 - Changed `djls serve` terminal warning output to plain text without decorative separator lines.
+- Improved `djls check --quiet` performance by counting diagnostics without rendering formatted output.
 - **Internal**: Consolidated `djls-project` and `djls-python` into `djls-semantic` as the unified Django semantic model.
 - **Internal**: Renamed template library snapshot types and cache APIs around backend-neutral semantic snapshots instead of inspector responses.
 - **Internal**: Hid template library inspector request plumbing behind a semantic snapshot fetch API.

--- a/crates/djls-bench/benches/check.rs
+++ b/crates/djls-bench/benches/check.rs
@@ -27,7 +27,7 @@ fn main() {
 
 /// Run `check_file` and capture the source for rendering (mirrors CLI pattern).
 fn run_check(db: &Db, file: djls_source::File) -> FileCheckResult {
-    let source = file.source(db).to_string();
+    let source = file.source(db);
     let path = file.path(db).clone();
     let check = djls_db::check_file(db, file);
 

--- a/crates/djls-db/src/check.rs
+++ b/crates/djls-db/src/check.rs
@@ -7,6 +7,7 @@ use djls_source::Diagnostic;
 use djls_source::DiagnosticRenderer;
 use djls_source::File;
 use djls_source::Severity;
+use djls_source::SourceText;
 use djls_source::Span;
 use djls_templates::TemplateError;
 use djls_templates::TemplateErrorAccumulator;
@@ -47,7 +48,7 @@ pub fn check_file(db: &dyn SemanticDb, file: File) -> CheckResult {
 
     let mut validation_errors: Vec<ValidationError> =
         accumulated.iter().map(|acc| acc.0.clone()).collect();
-    validation_errors.sort_by_key(|e| e.primary_span().map_or(0, Span::start));
+    validation_errors.sort_by_cached_key(|e| e.primary_span().map_or(0, Span::start));
 
     CheckResult {
         template_errors,
@@ -59,7 +60,7 @@ pub fn check_file(db: &dyn SemanticDb, file: File) -> CheckResult {
 /// for rendering. Used by both the CLI and benchmarks.
 pub struct FileCheckResult {
     pub path: Utf8PathBuf,
-    pub source: String,
+    pub source: SourceText,
     pub check: CheckResult,
 }
 
@@ -70,8 +71,25 @@ impl FileCheckResult {
     }
 
     #[must_use]
+    pub fn renderable_diagnostic_count(&self, config: &DiagnosticsConfig) -> usize {
+        self.check
+            .template_errors
+            .iter()
+            .filter(|error| diagnostic_is_enabled(config, error.diagnostic_code()))
+            .count()
+            + self
+                .check
+                .validation_errors
+                .iter()
+                .filter(|error| {
+                    diagnostic_is_enabled(config, error.code()) && error.primary_span().is_some()
+                })
+                .count()
+    }
+
+    #[must_use]
     pub fn render(&self, config: &DiagnosticsConfig, fmt: &DiagnosticRenderer) -> Vec<String> {
-        let mut results = Vec::new();
+        let mut results = Vec::with_capacity(self.renderable_diagnostic_count(config));
         let path = self.path.as_str();
         let source = self.source.as_str();
 
@@ -89,6 +107,10 @@ impl FileCheckResult {
 
         results
     }
+}
+
+fn diagnostic_is_enabled(config: &DiagnosticsConfig, code: &str) -> bool {
+    config.get_severity(code) != djls_conf::DiagnosticSeverity::Off
 }
 
 // `Off` is never reached in practice — both `render_template_error` and

--- a/crates/djls-source/src/lib.rs
+++ b/crates/djls-source/src/lib.rs
@@ -12,6 +12,7 @@ pub use collections::FxDashSet;
 pub use db::Db;
 pub use file::File;
 pub use file::FileKind;
+pub use file::SourceText;
 pub use line::LineIndex;
 pub use path::safe_join;
 pub use path::SafeJoinError;

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -1,4 +1,5 @@
 use std::io::Read as _;
+use std::io::Write as _;
 use std::sync::Arc;
 
 use anyhow::bail;
@@ -128,16 +129,25 @@ impl Command for Check {
         let mut error_count: usize = 0;
         let mut file_count: usize = 0;
 
-        for result in &raw_results {
-            let rendered = result.render(&config, &fmt);
-            if !rendered.is_empty() {
-                file_count += 1;
-                if !quiet {
-                    for output in &rendered {
-                        println!("{output}\n");
-                    }
+        if quiet {
+            for result in &raw_results {
+                let count = result.renderable_diagnostic_count(&config);
+                if count > 0 {
+                    file_count += 1;
+                    error_count += count;
                 }
-                error_count += rendered.len();
+            }
+        } else {
+            let mut stdout = std::io::stdout().lock();
+            for result in &raw_results {
+                let rendered = result.render(&config, &fmt);
+                if !rendered.is_empty() {
+                    file_count += 1;
+                    for output in &rendered {
+                        writeln!(stdout, "{output}\n")?;
+                    }
+                    error_count += rendered.len();
+                }
             }
         }
 
@@ -176,14 +186,21 @@ fn check_stdin(
     let db = DjangoDatabase::new(fs, settings, Some(project_root));
 
     let result = check_file_with_source(&db, &stdin_path);
+    if quiet {
+        return if result.renderable_diagnostic_count(config) > 0 {
+            Ok(Exit::error())
+        } else {
+            Ok(Exit::success())
+        };
+    }
+
     let rendered = result.render(config, fmt);
     if rendered.is_empty() {
         Ok(Exit::success())
-    } else if quiet {
-        Ok(Exit::error())
     } else {
+        let mut stdout = std::io::stdout().lock();
         for output in &rendered {
-            println!("{output}\n");
+            writeln!(stdout, "{output}\n")?;
         }
         let count = rendered.len();
         let word = if count == 1 { "error" } else { "errors" };
@@ -194,7 +211,7 @@ fn check_stdin(
 /// Run `check_file` and capture the source text for later rendering.
 fn check_file_with_source(db: &DjangoDatabase, path: &Utf8Path) -> FileCheckResult {
     let file = db.get_or_create_file(path);
-    let source = file.source(db).to_string();
+    let source = file.source(db);
     let check = djls_db::check_file(db, file);
 
     FileCheckResult {


### PR DESCRIPTION
## Summary
- Count renderable diagnostics directly for `djls check --quiet` instead of formatting annotate-snippets output that will be discarded
- Keep checked file source as shared `SourceText` instead of cloning it into a new `String` for rendering
- Lock stdout once while printing check diagnostics
- Cache validation-error sort keys during check result construction

## Validation
- `cargo test -q`
- `just lint`
- `cargo bench -p djls-bench --bench check -- --sample-count 1 check_batch_fixtures`