### PR TITLE
Optimize structural tag scoping checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Bumped Rust toolchain from 1.93 to 1.95.
 - **Internal**: Stabilized benchmarks with sized diagnostics fixtures, repeated microbench companions, validation-rendering contract assertions, and deterministic corpus input ordering.
+- **Internal**: Combined validation scoping checks for closing and intermediate tags into a single tag-spec pass.
 - Changed `djls serve` terminal warning output to plain text without decorative separator lines.
 - Improved `djls check --quiet` performance by counting diagnostics without rendering formatted output.
 - **Internal**: Consolidated `djls-project` and `djls-python` into `djls-semantic` as the unified Django semantic model.

--- a/crates/djls-semantic/src/validation/scoping.rs
+++ b/crates/djls-semantic/src/validation/scoping.rs
@@ -182,5 +182,13 @@ pub(crate) fn check_load_libraries_rule(
 }
 
 pub(crate) fn is_closer_or_intermediate(name: &str, tag_specs: &TagSpecs) -> bool {
-    tag_specs.is_closer(name) || tag_specs.is_intermediate(name)
+    tag_specs.values().any(|spec| {
+        spec.end_tag
+            .as_ref()
+            .is_some_and(|end_tag| end_tag.name.as_ref() == name)
+            || spec
+                .intermediate_tags
+                .iter()
+                .any(|tag| tag.name.as_ref() == name)
+    })
 }


### PR DESCRIPTION
## Summary
- Combine validation scoping checks for closing and intermediate tags into a single tag-spec pass
- Avoid the prior attempted `TagIndex` route, which regressed semantic validation benchmarks due to Salsa tracked-struct access overhead in the hot loop
- Add an internal changelog note

## Validation
- `cargo bench -p djls-bench --bench semantic -- --sample-count 10 validate_template`
- `cargo bench -p djls-bench --bench semantic -- --sample-count 10 'validate_all_templates|validate_template\[large'`
- `cargo test -q`
- `just lint`