### PR TITLE
Drop Django 4.2 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ Before pushing, run `just clippy`, `just fmt`, and `just lint`. Never use `cargo
 ## Testing
 **All tests must pass.** If a test fails, it is your responsibility to fix it — even if you didn't cause the failure. Never dismiss failures as "pre-existing" or "unrelated".
 
+## Generated Content
+- Do not edit text inside cog-generated blocks by hand. Update the source of truth, then run `just cog` to regenerate the block.
+
 ## Code Style
 - Use `tower-lsp-server`, not `tower-lsp`; import LSP types via `tower_lsp_server::ls_types`.
 - Use `camino::Utf8Path`/`Utf8PathBuf` as canonical path types. Convert from `std::path` only at API boundaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Removed
 
+- Dropped Django 4.2 from supported versions.
 - Dropped Django 5.1 from supported versions.
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,8 @@ Available recipes:
     clippy *ARGS
     corpus *ARGS
     fmt *ARGS
-    lint          # run pre-commit on all files
+    lint *ARGS    # run pre-commit on all files
+    run *ARGS
     test *ARGS
     testall *ARGS
     dev:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cog.outl(f"![Django Version](https://img.shields.io/badge/django-{'%20%7C%20'.jo
 ]]] -->
 [![PyPI](https://img.shields.io/pypi/v/django-language-server)](https://pypi.org/project/django-language-server/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-language-server)
-![Django Version](https://img.shields.io/badge/django-4.2%20%7C%205.2%20%7C%206.0%20%7C%20main-%2344B78B?labelColor=%23092E20)
+![Django Version](https://img.shields.io/badge/django-5.2%20%7C%206.0%20%7C%20main-%2344B78B?labelColor=%23092E20)
 <!-- [[[end]]] -->
 
 A language server for the Django web framework.

--- a/crates/djls-corpus/manifest.lock
+++ b/crates/djls-corpus/manifest.lock
@@ -199,12 +199,6 @@ tag = "1.5.1"
 ref = "93b601137eaba07924b7258c7d5496fb8a6d48b8"
 
 [[repo]]
-name = "django-4.2"
-url = "https://github.com/django/django.git"
-tag = "4.2.28"
-ref = "20c71f6b91324cf401056c72136c14e0ec2bf7bf"
-
-[[repo]]
 name = "django-5.2"
 url = "https://github.com/django/django.git"
 tag = "5.2.11"

--- a/crates/djls-corpus/manifest.toml
+++ b/crates/djls-corpus/manifest.toml
@@ -168,11 +168,6 @@ ref = "1.5.1"
 
 # https://endoflife.date/django
 [[repo]]
-name = "django-4.2"
-url = "https://github.com/django/django.git"
-ref = "4.2.28"
-
-[[repo]]
 name = "django-5.2"
 url = "https://github.com/django/django.git"
 ref = "5.2.11"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -27,7 +27,7 @@ cog.outl(f"- Python {', '.join(PY_VERSIONS)}")
 cog.outl(f"- Django {', '.join(django_versions)}")
 ]]] -->
 - Python 3.10, 3.11, 3.12, 3.13, 3.14
-- Django 4.2, 5.2, 6.0
+- Django 5.2, 6.0
 <!-- [[[end]]] -->
 
 ## Version numbering

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,12 +22,11 @@ PY_VERSIONS = [PY310, PY311, PY312, PY313, PY314]
 PY_DEFAULT = PY_VERSIONS[0]
 PY_LATEST = PY_VERSIONS[-1]
 
-DJ42 = "4.2"
 DJ52 = "5.2"
 DJ60 = "6.0"
 DJMAIN = "main"
 DJMAIN_MIN_PY = PY312
-DJ_VERSIONS = [DJ42, DJ52, DJ60, DJMAIN]
+DJ_VERSIONS = [DJ52, DJ60, DJMAIN]
 DJ_LTS = [
     version for version in DJ_VERSIONS if version.endswith(".2") and version != DJMAIN
 ]
@@ -158,7 +157,7 @@ def lint(session):
 
 
 @nox.session
-@nox.parametrize("django", [DJ42, DJ52, DJ60, DJMAIN])
+@nox.parametrize("django", [DJ52, DJ60, DJMAIN])
 def analyze_tags(session, django):
     """Analyze Django template tags and generate TagSpec suggestions."""
     if django == DJMAIN:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ classifiers = [
   #         continue
   #     cog.outl(f'  "Framework :: Django :: {display_version(version)}",')
   # ]]] -->
-  "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   # [[[end]]]


### PR DESCRIPTION
## Summary
- Remove Django 4.2 from the supported version matrix
- Regenerate cog-managed supported-version docs and classifiers
- Remove Django 4.2 from the corpus manifest
- Add an agent note to avoid hand-editing cog-generated content

## Verification
- Fetched endoflife.date API: Django 4.2 is EOL as of 2026-04-07 and no longer maintained
- just cog
- just fmt --check
- uv run nox -l