### PR TITLE
Normalize LSP document request inputs

### DIFF
--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -14,7 +14,6 @@ use djls_semantic::TemplateSymbol;
 use djls_semantic::TemplateSymbolKind;
 use djls_source::FileKind;
 use djls_source::PositionEncoding;
-use djls_workspace::TextDocument;
 use tower_lsp_server::ls_types;
 
 use crate::snippets::generate_partial_snippet;
@@ -103,7 +102,7 @@ pub struct LineInfo {
 #[must_use]
 #[allow(clippy::too_many_arguments)]
 pub fn handle_completion(
-    document: &TextDocument,
+    source: &str,
     position: ls_types::Position,
     encoding: PositionEncoding,
     file_kind: FileKind,
@@ -117,8 +116,8 @@ pub fn handle_completion(
         return Vec::new();
     }
 
-    // Get line information from document
-    let Some(line_info) = get_line_info(document, position, encoding) else {
+    // Get line information from source
+    let Some(line_info) = get_line_info(source, position, encoding) else {
         return Vec::new();
     };
 
@@ -140,14 +139,13 @@ pub fn handle_completion(
     )
 }
 
-/// Extract line information from document at given position
+/// Extract line information from source at given position
 fn get_line_info(
-    document: &TextDocument,
+    source: &str,
     position: ls_types::Position,
     encoding: PositionEncoding,
 ) -> Option<LineInfo> {
-    let content = document.content();
-    let lines: Vec<&str> = content.lines().collect();
+    let lines: Vec<&str> = source.lines().collect();
 
     let line_index = position.line as usize;
     if line_index >= lines.len() {

--- a/crates/djls-server/src/ext.rs
+++ b/crates/djls-server/src/ext.rs
@@ -1,13 +1,11 @@
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_source::File;
 use djls_source::FileKind;
 use djls_source::LineCol;
 use djls_source::LineIndex;
 use djls_source::Offset;
 use djls_source::PositionEncoding;
 use djls_source::Range;
-use djls_workspace::Db as WorkspaceDb;
 use djls_workspace::DocumentChange;
 use tower_lsp_server::ls_types;
 
@@ -82,17 +80,6 @@ impl TextDocumentContentChangeEventExt for Vec<ls_types::TextDocumentContentChan
                 DocumentChange::new(change.range.map(|r| r.to_source_range()), change.text)
             })
             .collect()
-    }
-}
-
-pub(crate) trait TextDocumentIdentifierExt {
-    fn to_file(&self, db: &mut dyn WorkspaceDb) -> Option<File>;
-}
-
-impl TextDocumentIdentifierExt for ls_types::TextDocumentIdentifier {
-    fn to_file(&self, db: &mut dyn WorkspaceDb) -> Option<File> {
-        let path = self.uri.to_utf8_path_buf()?;
-        Some(db.get_or_create_file(&path))
     }
 }
 

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -14,8 +14,6 @@ use tower_lsp_server::Client;
 use tower_lsp_server::LanguageServer;
 
 use crate::ext::PositionEncodingExt;
-use crate::ext::PositionExt;
-use crate::ext::TextDocumentIdentifierExt;
 use crate::ext::UriExt;
 use crate::logging::LoggingGuard;
 use crate::queue::Queue;
@@ -117,7 +115,7 @@ impl DjangoLanguageServer {
         }
 
         let diagnostics: Vec<ls_types::Diagnostic> = self
-            .with_session_mut(|session| {
+            .with_session(|session| {
                 let db = session.db();
                 let file = db.get_or_create_file(&path);
                 djls_ide::collect_diagnostics(db, file)
@@ -315,32 +313,19 @@ impl LanguageServer for DjangoLanguageServer {
         params: ls_types::CompletionParams,
     ) -> LspResult<Option<ls_types::CompletionResponse>> {
         let response = self
-            .with_session_mut(|session| {
-                let Some(path) = params
-                    .text_document_position
-                    .text_document
-                    .uri
-                    .to_utf8_path_buf()
-                else {
-                    tracing::debug!(
-                        "Skipping non-file URI in completion: {}",
-                        params.text_document_position.text_document.uri.as_str()
-                    );
-                    // TODO(virtual-paths): Support virtual documents with DocumentPath enum
-                    return None;
-                };
-
-                tracing::debug!(
-                    "Completion requested for {} at {:?}",
-                    path,
-                    params.text_document_position.position
-                );
-
-                let document = session.get_document(&path)?;
+            .with_session(|session| {
                 let position = params.text_document_position.position;
                 let encoding = session.client_info().position_encoding();
-                let file_kind = FileKind::from(&path);
+                let file = session.file_for_document_request(
+                    &params.text_document_position.text_document,
+                    "completion",
+                )?;
                 let db = session.db();
+                let path = file.path(db);
+                let source = file.source(db);
+                let file_kind = *source.kind();
+
+                tracing::debug!("Completion requested for {} at {:?}", path, position);
                 let template_libraries = db.project().map(|project| project.template_libraries(db));
 
                 let tag_specs = db.tag_specs();
@@ -350,7 +335,6 @@ impl LanguageServer for DjangoLanguageServer {
                 let available_symbols = if file_kind == FileKind::Template {
                     if let Some(template_libraries) = template_libraries {
                         if template_libraries.active_knowledge == djls_semantic::Knowledge::Known {
-                            let file = db.get_or_create_file(&path);
                             let nodelist = djls_templates::parse_template(db, file);
 
                             nodelist.map(|nl| {
@@ -375,7 +359,7 @@ impl LanguageServer for DjangoLanguageServer {
                 };
 
                 let completions = djls_ide::handle_completion(
-                    &document,
+                    source.as_str(),
                     position,
                     encoding,
                     file_kind,
@@ -405,25 +389,22 @@ impl LanguageServer for DjangoLanguageServer {
             params.text_document.uri
         );
 
-        let diagnostics = if let Some(path) = params.text_document.uri.to_utf8_path_buf() {
-            if FileKind::from(&path) == FileKind::Template {
-                self.with_session_mut(move |session| {
-                    let db = session.db_mut();
-                    let file = db.get_or_create_file(&path);
-                    djls_ide::collect_diagnostics(db, file)
-                })
-                .await
-            } else {
-                vec![]
-            }
-        } else {
-            tracing::debug!(
-                "Skipping non-file URI in diagnostic: {}",
-                params.text_document.uri.as_str()
-            );
-            // TODO(virtual-paths): Support virtual documents with DocumentPath enum
-            vec![]
-        };
+        let diagnostics = self
+            .with_session(|session| {
+                let Some(file) =
+                    session.file_for_document_request(&params.text_document, "diagnostic")
+                else {
+                    return Vec::new();
+                };
+                let db = session.db();
+
+                if *file.source(db).kind() != FileKind::Template {
+                    return Vec::new();
+                }
+
+                djls_ide::collect_diagnostics(db, file)
+            })
+            .await;
 
         Ok(ls_types::DocumentDiagnosticReportResult::Report(
             ls_types::DocumentDiagnosticReport::Full(
@@ -443,15 +424,17 @@ impl LanguageServer for DjangoLanguageServer {
         params: ls_types::FoldingRangeParams,
     ) -> LspResult<Option<Vec<ls_types::FoldingRange>>> {
         let ranges = self
-            .with_session_mut(|session| {
-                let db = session.db_mut();
-                let Some(file) = params.text_document.to_file(db) else {
-                    tracing::debug!(
-                        "Skipping non-file URI in folding ranges: {}",
-                        params.text_document.uri.as_str()
-                    );
+            .with_session(|session| {
+                let Some(file) =
+                    session.file_for_document_request(&params.text_document, "folding")
+                else {
                     return Vec::new();
                 };
+                let db = session.db();
+
+                if *file.source(db).kind() != FileKind::Template {
+                    return Vec::new();
+                }
 
                 djls_ide::collect_folding_ranges(db, file)
             })
@@ -465,20 +448,18 @@ impl LanguageServer for DjangoLanguageServer {
         params: ls_types::GotoDefinitionParams,
     ) -> LspResult<Option<ls_types::GotoDefinitionResponse>> {
         let response = self
-            .with_session_mut(|session| {
-                let encoding = session.client_info().position_encoding();
-                let db = session.db_mut();
-                let file = params
-                    .text_document_position_params
-                    .text_document
-                    .to_file(db)?;
-                let source = file.source(db);
-                let line_index = file.line_index(db);
-                let offset = params.text_document_position_params.position.to_offset(
-                    source.as_str(),
-                    line_index,
-                    encoding,
-                );
+            .with_session(|session| {
+                let (file, offset) = session.position_for_document_request(
+                    &params.text_document_position_params.text_document,
+                    params.text_document_position_params.position,
+                    "goto definition",
+                )?;
+                let db = session.db();
+
+                if *file.source(db).kind() != FileKind::Template {
+                    return None;
+                }
+
                 djls_ide::goto_definition(db, file, offset)
             })
             .await;
@@ -491,17 +472,18 @@ impl LanguageServer for DjangoLanguageServer {
         params: ls_types::ReferenceParams,
     ) -> LspResult<Option<Vec<ls_types::Location>>> {
         let response = self
-            .with_session_mut(|session| {
-                let encoding = session.client_info().position_encoding();
-                let db = session.db_mut();
-                let file = params.text_document_position.text_document.to_file(db)?;
-                let source = file.source(db);
-                let line_index = file.line_index(db);
-                let offset = params.text_document_position.position.to_offset(
-                    source.as_str(),
-                    line_index,
-                    encoding,
-                );
+            .with_session(|session| {
+                let (file, offset) = session.position_for_document_request(
+                    &params.text_document_position.text_document,
+                    params.text_document_position.position,
+                    "references",
+                )?;
+                let db = session.db();
+
+                if *file.source(db).kind() != FileKind::Template {
+                    return None;
+                }
+
                 djls_ide::find_references(db, file, offset)
             })
             .await;

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -8,14 +8,16 @@ use camino::Utf8PathBuf;
 use djls_conf::Settings;
 use djls_db::DjangoDatabase;
 use djls_semantic::ProjectDb;
+use djls_source::Db as SourceDb;
 use djls_source::File;
-use djls_source::FileKind;
+use djls_source::Offset;
 use djls_workspace::TextDocument;
 use djls_workspace::Workspace;
 use tower_lsp_server::ls_types;
 
 use crate::client::ClientInfo;
 use crate::ext::InitializeParamsExt;
+use crate::ext::PositionExt;
 use crate::ext::TextDocumentContentChangeEventExt;
 use crate::ext::TextDocumentItemExt;
 use crate::ext::UriExt;
@@ -116,7 +118,6 @@ impl Session {
     ///
     /// Updates both the workspace buffers and database. Creates the file in
     /// the database or invalidates it if it already exists.
-    /// For template files, immediately triggers parsing and validation.
     pub fn open_document(
         &mut self,
         text_document: &ls_types::TextDocumentItem,
@@ -128,16 +129,13 @@ impl Session {
 
         let kind = text_document.language_id_to_file_kind(self.client_info.client());
 
-        let document = self.workspace.open_document(
+        self.workspace.open_document(
             &mut self.db,
             &path,
             &text_document.text,
             text_document.version,
             kind,
-        )?;
-
-        self.handle_file(document.file());
-        Some(document)
+        )
     }
 
     pub fn save_document(
@@ -149,9 +147,7 @@ impl Session {
             return None;
         };
 
-        let document = self.workspace.save_document(&mut self.db, &path)?;
-        self.handle_file(document.file());
-        Some(document)
+        self.workspace.save_document(&mut self.db, &path)
     }
 
     pub fn update_document(
@@ -164,16 +160,13 @@ impl Session {
             return None;
         };
 
-        let document = self.workspace.update_document(
+        self.workspace.update_document(
             &mut self.db,
             &path,
             changes.to_document_changes(),
             text_document.version,
             self.client_info.position_encoding(),
-        )?;
-
-        self.handle_file(document.file());
-        Some(document)
+        )
     }
 
     /// Close a document.
@@ -199,6 +192,47 @@ impl Session {
         self.workspace.get_document(path)
     }
 
+    /// Resolve an LSP document request to the tracked file for that URI.
+    ///
+    /// Open editor buffers are exposed to Salsa through the workspace overlay,
+    /// so feature code should read current text through [`File::source`]
+    /// instead of reaching back into [`TextDocument`] state.
+    pub(crate) fn file_for_document_request(
+        &self,
+        text_document: &ls_types::TextDocumentIdentifier,
+        request: &str,
+    ) -> Option<File> {
+        let Some(path) = text_document.uri.to_utf8_path_buf() else {
+            tracing::debug!(
+                "Skipping non-file URI in {} request: {}",
+                request,
+                text_document.uri.as_str()
+            );
+            return None;
+        };
+
+        Some(self.db.get_or_create_file(&path))
+    }
+
+    /// Resolve an LSP positioned document request to a tracked file and byte offset.
+    pub(crate) fn position_for_document_request(
+        &self,
+        text_document: &ls_types::TextDocumentIdentifier,
+        position: ls_types::Position,
+        request: &str,
+    ) -> Option<(File, Offset)> {
+        let file = self.file_for_document_request(text_document, request)?;
+        let source = file.source(&self.db);
+        let line_index = file.line_index(&self.db);
+        let offset = position.to_offset(
+            source.as_str(),
+            line_index,
+            self.client_info.position_encoding(),
+        );
+
+        Some((file, offset))
+    }
+
     /// Get all currently open documents.
     pub fn open_documents(&self) -> Vec<TextDocument> {
         self.workspace
@@ -206,13 +240,6 @@ impl Session {
             .iter()
             .map(|(_path, document)| document)
             .collect()
-    }
-
-    /// Warm template caches and semantic diagnostics for the updated file.
-    fn handle_file(&self, file: File) {
-        if FileKind::from(file.path(&self.db)) == FileKind::Template {
-            djls_semantic::validate_template_file(&self.db, file);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- normalize LSP document and positioned request inputs through Session helpers
- make completion consume source text instead of TextDocument directly
- remove eager template validation from document lifecycle updates

## Validation
- just fmt --check
- cargo test -p djls-server -p djls-ide -q
- cargo clippy -p djls-server -p djls-ide --all-targets --all-features -- -D warnings
- just lint