### PR TITLE
Add markdown diagnostic snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -863,6 +863,7 @@ dependencies = [
  "dotenvy",
  "ignore",
  "insta",
+ "pulldown-cmark",
  "ruff_python_ast",
  "ruff_python_parser",
  "rustc-hash",
@@ -1018,7 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1944,7 +1945,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2191,6 +2192,25 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.10.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quinn"
@@ -2601,7 +2621,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2658,7 +2678,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2929,7 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3045,7 +3065,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3454,6 +3474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,7 +3720,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ insta = { version = "1.47", features = ["glob", "yaml"] }
 memchr = "2.8"
 notify = "8.2"
 percent-encoding = "2.3"
+pulldown-cmark = "0.13.3"
 rayon = "1.12"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
 rustc-hash = "2.1"

--- a/crates/djls-semantic/Cargo.toml
+++ b/crates/djls-semantic/Cargo.toml
@@ -31,6 +31,7 @@ which = { workspace = true }
 [dev-dependencies]
 djls-corpus = { workspace = true }
 insta = { workspace = true }
+pulldown-cmark = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/djls-semantic/resources/mdtest/README.md
+++ b/crates/djls-semantic/resources/mdtest/README.md
@@ -1,0 +1,73 @@
+# Markdown diagnostic snapshots
+
+These files are executable examples for Django template diagnostics. They are meant to be easy to read, write, and review.
+
+Run them with:
+
+```bash
+cargo test -p djls-semantic markdown_diagnostic_snapshots -- --nocapture
+```
+
+Update generated snapshots with:
+
+```bash
+DJLS_UPDATE_MDTEST_SNAPSHOTS=1 cargo test -p djls-semantic markdown_diagnostic_snapshots -- --nocapture
+```
+
+## Authoring format
+
+Any Markdown heading can define a scenario when its section contains one Django template code block:
+
+````markdown
+# if
+
+## Invalid
+
+### rejects empty expression
+
+```htmldjango
+{% if %}{% endif %}
+```
+````
+
+Headings without template code blocks are just grouping. Start flat if that is easier, then group later:
+
+````markdown
+# if
+
+## rejects empty expression
+
+```htmldjango
+{% if %}{% endif %}
+```
+````
+
+The runner accepts `htmldjango`, `django`, and `html` fences as template source. It writes snapshots in `snapshot` fences. A scenario with no diagnostics renders as:
+
+```snapshot
+✓ no diagnostics
+```
+
+## Scenario rules
+
+- Use one template code block per scenario.
+- Treat the template code block as terminal for that heading section.
+- Put the generated `snapshot` block directly after the template block.
+- Do not put child headings below a heading after it has a template block.
+- Use `## Valid`, `## Invalid`, and `## Known gaps` when grouping helps readability.
+
+For non-default paths, put a backtick label immediately before the template block:
+
+````markdown
+`templates/example.html`:
+
+```htmldjango
+{% else %}
+```
+````
+
+## Current scope
+
+The mdtest runner uses `pulldown-cmark` for Markdown parsing, but the mdtest format is intentionally small: heading groups, fenced template code blocks, optional file labels, and generated snapshot fences.
+
+Snapshots run against the curated validation fixture in `src/testing.rs`, not a live inspected Django project. That keeps tests deterministic. Long term, we may add fixtures that exercise more real project discovery behavior.

--- a/crates/djls-semantic/resources/mdtest/README.md
+++ b/crates/djls-semantic/resources/mdtest/README.md
@@ -70,4 +70,4 @@ For non-default paths, put a backtick label immediately before the template bloc
 
 The mdtest runner uses `pulldown-cmark` for Markdown parsing, but the mdtest format is intentionally small: heading groups, fenced template code blocks, optional file labels, and generated snapshot fences.
 
-Snapshots run against the curated validation fixture in `src/testing.rs`, not a live inspected Django project. That keeps tests deterministic. Long term, we may add fixtures that exercise more real project discovery behavior.
+Snapshots run against the curated validation fixture in `src/testing.rs`, not a live inspected Django project. That keeps tests deterministic. Scenarios that assert "requires load" mean "requires load in this fixture, where the library is not configured as a template builtin." Long term, we may add fixtures that exercise more real project discovery and settings behavior.

--- a/crates/djls-semantic/resources/mdtest/diagnostics/expressions.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/expressions.md
@@ -1,0 +1,65 @@
+# If expression diagnostics
+
+## if starts with infix operator
+
+```htmldjango
+{% if and x %}{% endif %}
+```
+
+```snapshot
+error[S114]: Not expecting 'and' in this position in if tag.
+ --> test.html:1:1
+  |
+1 | {% if and x %}{% endif %}
+  | ^^^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+## if ends after infix operator
+
+```htmldjango
+{% if x or %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unexpected end of expression in if tag.
+ --> test.html:1:1
+  |
+1 | {% if x or %}{% endif %}
+  | ^^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+## if contains unused token
+
+```htmldjango
+{% if x y %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unused 'y' at end of if expression.
+ --> test.html:1:1
+  |
+1 | {% if x y %}{% endif %}
+  | ^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+## if has no condition
+
+```htmldjango
+{% if %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unexpected end of expression in if tag.
+ --> test.html:1:1
+  |
+1 | {% if %}{% endif %}
+  | ^^^^^^^^
+  |
+  = note: in tag: if
+```

--- a/crates/djls-semantic/resources/mdtest/diagnostics/expressions.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/expressions.md
@@ -1,6 +1,8 @@
-# If expression diagnostics
+# Expression diagnostics
 
-## if starts with infix operator
+## if tag
+
+### starts with infix operator
 
 ```htmldjango
 {% if and x %}{% endif %}
@@ -16,7 +18,7 @@ error[S114]: Not expecting 'and' in this position in if tag.
   = note: in tag: if
 ```
 
-## if ends after infix operator
+### ends after infix operator
 
 ```htmldjango
 {% if x or %}{% endif %}
@@ -32,7 +34,7 @@ error[S114]: Unexpected end of expression in if tag.
   = note: in tag: if
 ```
 
-## if contains unused token
+### contains unused token
 
 ```htmldjango
 {% if x y %}{% endif %}
@@ -48,7 +50,7 @@ error[S114]: Unused 'y' at end of if expression.
   = note: in tag: if
 ```
 
-## if has no condition
+### has no condition
 
 ```htmldjango
 {% if %}{% endif %}

--- a/crates/djls-semantic/resources/mdtest/diagnostics/expressions.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/expressions.md
@@ -65,3 +65,15 @@ error[S114]: Unexpected end of expression in if tag.
   |
   = note: in tag: if
 ```
+
+## Known gaps
+
+### expression validation is only applied to if and elif
+
+```htmldjango
+{% firstof and x %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/diagnostics/extends.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/extends.md
@@ -1,0 +1,31 @@
+# Extends diagnostics
+
+## extends is not first tag
+
+```htmldjango
+{% load i18n %}
+{% extends "base.html" %}
+```
+
+```snapshot
+error[S122]: '{% extends %}' must be the first tag in the template
+ --> test.html:2:1
+  |
+2 | {% extends "base.html" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## multiple extends tags
+
+```htmldjango
+{% extends "base.html" %}
+{% extends "other.html" %}
+```
+
+```snapshot
+error[S123]: '{% extends %}' cannot appear more than once in the same template
+ --> test.html:2:1
+  |
+2 | {% extends "other.html" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/diagnostics/filters.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/filters.md
@@ -1,0 +1,29 @@
+# Filter diagnostics
+
+## filter requires an argument
+
+```htmldjango
+{{ value|default }}
+```
+
+```snapshot
+error[S115]: Filter 'default' requires an argument
+ --> test.html:1:10
+  |
+1 | {{ value|default }}
+  |          ^^^^^^^
+```
+
+## filter does not accept an argument
+
+```htmldjango
+{{ value|upper:"arg" }}
+```
+
+```snapshot
+error[S116]: Filter 'upper' does not accept an argument
+ --> test.html:1:10
+  |
+1 | {{ value|upper:"arg" }}
+  |          ^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
@@ -14,7 +14,7 @@ error[S108]: Unknown tag 'completelymadetuptag'
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
-## tag requires load
+## tag requires load when not configured as a builtin
 
 ```htmldjango
 {% static "before.css" %}
@@ -56,7 +56,7 @@ error[S111]: Unknown filter 'completelymadetupfilter'
   |          ^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
-## filter requires load
+## filter requires load when not configured as a builtin
 
 ```htmldjango
 {{ value|intcomma }}

--- a/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
@@ -1,0 +1,131 @@
+# Scoping diagnostics
+
+## unknown tag
+
+```htmldjango
+{% completelymadetuptag %}
+```
+
+```snapshot
+error[S108]: Unknown tag 'completelymadetuptag'
+ --> test.html:1:1
+  |
+1 | {% completelymadetuptag %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## tag requires load
+
+```htmldjango
+{% static "before.css" %}
+```
+
+```snapshot
+error[S109]: Tag 'static' requires {% load static %}
+ --> test.html:1:1
+  |
+1 | {% static "before.css" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## tag is available from multiple unloaded libraries
+
+```htmldjango
+{% ambiguous_tag %}
+```
+
+```snapshot
+error[S110]: Tag 'ambiguous_tag' is defined in multiple libraries: ["alpha", "beta"]
+ --> test.html:1:1
+  |
+1 | {% ambiguous_tag %}
+  | ^^^^^^^^^^^^^^^^^^^
+```
+
+## unknown filter
+
+```htmldjango
+{{ value|completelymadetupfilter }}
+```
+
+```snapshot
+error[S111]: Unknown filter 'completelymadetupfilter'
+ --> test.html:1:10
+  |
+1 | {{ value|completelymadetupfilter }}
+  |          ^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## filter requires load
+
+```htmldjango
+{{ value|intcomma }}
+```
+
+```snapshot
+error[S112]: Filter 'intcomma' requires {% load humanize %}
+ --> test.html:1:10
+  |
+1 | {{ value|intcomma }}
+  |          ^^^^^^^^
+```
+
+## filter is available from multiple unloaded libraries
+
+```htmldjango
+{{ value|ambiguous_filter }}
+```
+
+```snapshot
+error[S113]: Filter 'ambiguous_filter' is defined in multiple libraries: ["alpha", "beta"]
+ --> test.html:1:10
+  |
+1 | {{ value|ambiguous_filter }}
+  |          ^^^^^^^^^^^^^^^^
+```
+
+## tag library is unknown
+
+```htmldjango
+{% load nonexistent_library %}
+```
+
+```snapshot
+error[S120]: Unknown template tag library 'nonexistent_library'
+ --> test.html:1:1
+  |
+1 | {% load nonexistent_library %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## tag app is not installed
+
+```htmldjango
+{% widget_tag %}
+```
+
+```snapshot
+error[S118]: Tag 'widget_tag' requires 'example.widgets' in INSTALLED_APPS
+ --> test.html:1:1
+  |
+1 | {% widget_tag %}
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: load_name: widgets
+```
+
+## filter app is not installed
+
+```htmldjango
+{{ value|widget_filter }}
+```
+
+```snapshot
+error[S119]: Filter 'widget_filter' requires 'example.widgets' in INSTALLED_APPS
+ --> test.html:1:10
+  |
+1 | {{ value|widget_filter }}
+  |          ^^^^^^^^^^^^^
+  |
+  = note: load_name: widgets
+```

--- a/crates/djls-semantic/resources/mdtest/diagnostics/structural.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/structural.md
@@ -1,0 +1,59 @@
+# Structural diagnostics
+
+## if block is not closed
+
+```htmldjango
+{% if user %}
+  Hello
+```
+
+```snapshot
+error[S100]: Unclosed tag: if
+ --> test.html:1:1
+  |
+1 | {% if user %}
+  | ^^^^^^^^^^^^^
+```
+
+## else outside if
+
+```htmldjango
+{% else %}
+```
+
+```snapshot
+error[S102]: Orphaned tag 'else' - 'if' or 'ifchanged' block
+ --> test.html:1:1
+  |
+1 | {% else %}
+  | ^^^^^^^^^^
+```
+
+## endif outside if
+
+```htmldjango
+{% endif %}
+```
+
+```snapshot
+error[S101]: Unbalanced structure: 'if' missing closing ''
+ --> test.html:1:1
+  |
+1 | {% endif %}
+  | ^^^^^^^^^^^
+```
+
+## closing block name mismatch
+
+```htmldjango
+{% block content %}
+{% endblock sidebar %}
+```
+
+```snapshot
+error[S103]: 'sidebar' does not match 'content'
+ --> test.html:2:1
+  |
+2 | {% endblock sidebar %}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/diagnostics/tag-rules.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/tag-rules.md
@@ -1,0 +1,33 @@
+# Tag argument diagnostics
+
+## tag requires an argument
+
+```htmldjango
+{% one_arg_tag %}
+```
+
+```snapshot
+error[S117]: 'one_arg_tag' takes exactly 1 argument, 0 given
+ --> test.html:1:1
+  |
+1 | {% one_arg_tag %}
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: one_arg_tag
+```
+
+## tag accepts exactly one argument
+
+```htmldjango
+{% one_arg_tag first second %}
+```
+
+```snapshot
+error[S117]: 'one_arg_tag' takes exactly 1 argument, 2 given
+ --> test.html:1:1
+  |
+1 | {% one_arg_tag first second %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: one_arg_tag
+```

--- a/crates/djls-semantic/resources/mdtest/tags/autoescape.md
+++ b/crates/djls-semantic/resources/mdtest/tags/autoescape.md
@@ -1,0 +1,77 @@
+# autoescape
+
+## Valid
+
+### enables autoescaping
+
+```htmldjango
+{% autoescape on %}
+  {{ content }}
+{% endautoescape %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### disables autoescaping
+
+```htmldjango
+{% autoescape off %}
+  {{ content }}
+{% endautoescape %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects missing mode
+
+```htmldjango
+{% autoescape %}{% endautoescape %}
+```
+
+```snapshot
+error[S117]: 'autoescape' takes exactly 1 argument, 0 given
+ --> test.html:1:1
+  |
+1 | {% autoescape %}{% endautoescape %}
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: autoescape
+```
+
+### rejects too many arguments
+
+```htmldjango
+{% autoescape on off extra %}{% endautoescape %}
+```
+
+```snapshot
+error[S117]: 'autoescape' takes exactly 1 argument, 3 given
+ --> test.html:1:1
+  |
+1 | {% autoescape on off extra %}{% endautoescape %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: autoescape
+```
+
+### rejects unknown mode
+
+```htmldjango
+{% autoescape unknown %}{% endautoescape %}
+```
+
+```snapshot
+error[S117]: 'autoescape' argument must be one of 'on', 'off'
+ --> test.html:1:1
+  |
+1 | {% autoescape unknown %}{% endautoescape %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: autoescape
+```

--- a/crates/djls-semantic/resources/mdtest/tags/block.md
+++ b/crates/djls-semantic/resources/mdtest/tags/block.md
@@ -1,0 +1,60 @@
+# block
+
+## Valid
+
+### defines a named block
+
+```htmldjango
+{% block content %}
+  <p>Hello</p>
+{% endblock %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### allows repeated closing block name
+
+```htmldjango
+{% block sidebar %}
+  <nav>Links</nav>
+{% endblock sidebar %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects mismatched closing name
+
+```htmldjango
+{% block header %}
+  <h1>Title</h1>
+{% endblock footer %}
+```
+
+```snapshot
+error[S103]: 'footer' does not match 'header'
+ --> test.html:3:1
+  |
+3 | {% endblock footer %}
+  | ^^^^^^^^^^^^^^^^^^^^^
+```
+
+### reports unclosed block
+
+```htmldjango
+{% block dangling %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: block
+ --> test.html:1:1
+  |
+1 | {% block dangling %}
+  | ^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/cache.md
+++ b/crates/djls-semantic/resources/mdtest/tags/cache.md
@@ -32,7 +32,7 @@
 
 ## Invalid
 
-### requires load before use
+### requires load when cache is not configured as a builtin
 
 ```htmldjango
 {% cache 500 before_load %}

--- a/crates/djls-semantic/resources/mdtest/tags/cache.md
+++ b/crates/djls-semantic/resources/mdtest/tags/cache.md
@@ -1,0 +1,65 @@
+# cache
+
+## Valid
+
+### caches content after load
+
+```htmldjango
+{% load cache %}
+
+{% cache 500 sidebar %}
+  <nav>Expensive sidebar</nav>
+{% endcache %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports vary-on arguments
+
+```htmldjango
+{% load cache %}
+
+{% cache 500 sidebar request.user.username %}
+  <nav>User-specific sidebar</nav>
+{% endcache %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### requires load before use
+
+```htmldjango
+{% cache 500 before_load %}
+  <p>Before load.</p>
+{% endcache %}
+```
+
+```snapshot
+error[S109]: Tag 'cache' requires {% load cache %}
+ --> test.html:1:1
+  |
+1 | {% cache 500 before_load %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+### reports unclosed cache block
+
+```htmldjango
+{% load cache %}
+{% cache 500 broken %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: cache
+ --> test.html:2:1
+  |
+2 | {% cache 500 broken %}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/comment.md
+++ b/crates/djls-semantic/resources/mdtest/tags/comment.md
@@ -1,0 +1,45 @@
+# comment
+
+## Valid
+
+### treats contents as opaque
+
+```htmldjango
+{% comment %}
+  This is ignored by the template engine.
+  {% if broken %}{% endif broken does not matter here %}
+{% endcomment %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### allows an optional note
+
+```htmldjango
+{% comment "Optional note" %}
+  Also ignored.
+{% endcomment %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### reports unclosed comment
+
+```htmldjango
+{% comment %}
+  Never closed.
+```
+
+```snapshot
+error[S100]: Unclosed tag: comment
+ --> test.html:1:1
+  |
+1 | {% comment %}
+  | ^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/csrf_token.md
+++ b/crates/djls-semantic/resources/mdtest/tags/csrf_token.md
@@ -1,0 +1,13 @@
+# csrf_token
+
+## Valid
+
+### renders without arguments
+
+```htmldjango
+{% csrf_token %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/cycle.md
+++ b/crates/djls-semantic/resources/mdtest/tags/cycle.md
@@ -1,0 +1,71 @@
+# cycle
+
+## Valid
+
+### alternates between literal values
+
+```htmldjango
+{% cycle "row1" "row2" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts more than two values
+
+```htmldjango
+{% cycle "a" "b" "c" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### alternates between variables
+
+```htmldjango
+{% cycle var1 var2 var3 %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### assigns the cycle to a variable
+
+```htmldjango
+{% cycle "row1" "row2" as rowcolors %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports silent assignment
+
+```htmldjango
+{% cycle "row1" "row2" "row3" as rowcolors silent %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### requires at least one value
+
+```htmldjango
+{% cycle %}
+```
+
+```snapshot
+error[S117]: 'cycle' requires at least 1 argument
+ --> test.html:1:1
+  |
+1 | {% cycle %}
+  | ^^^^^^^^^^^
+  |
+  = note: in tag: cycle
+```

--- a/crates/djls-semantic/resources/mdtest/tags/debug.md
+++ b/crates/djls-semantic/resources/mdtest/tags/debug.md
@@ -1,0 +1,13 @@
+# debug
+
+## Valid
+
+### renders without arguments
+
+```htmldjango
+{% debug %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/extends.md
+++ b/crates/djls-semantic/resources/mdtest/tags/extends.md
@@ -1,0 +1,45 @@
+# extends
+
+## Valid
+
+### accepts first tag in template
+
+```htmldjango
+{% extends "djls_app/base.html" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects non-first tag
+
+```htmldjango
+{% load i18n %}
+{% extends "base.html" %}
+```
+
+```snapshot
+error[S122]: '{% extends %}' must be the first tag in the template
+ --> test.html:2:1
+  |
+2 | {% extends "base.html" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+### rejects duplicate extends
+
+```htmldjango
+{% extends "base.html" %}
+{% extends "other.html" %}
+```
+
+```snapshot
+error[S123]: '{% extends %}' cannot appear more than once in the same template
+ --> test.html:2:1
+  |
+2 | {% extends "other.html" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/filter.md
+++ b/crates/djls-semantic/resources/mdtest/tags/filter.md
@@ -1,0 +1,44 @@
+# filter
+
+## Valid
+
+### applies one filter to block contents
+
+```htmldjango
+{% filter lower %}
+  THIS WILL BE LOWERCASED
+{% endfilter %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### applies a filter chain to block contents
+
+```htmldjango
+{% filter lower|truncatewords:5 %}
+  This is some text that will be lowered and truncated.
+{% endfilter %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### reports unclosed filter block
+
+```htmldjango
+{% filter upper %}
+  Never closed.
+```
+
+```snapshot
+error[S100]: Unclosed tag: filter
+ --> test.html:1:1
+  |
+1 | {% filter upper %}
+  | ^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/firstof.md
+++ b/crates/djls-semantic/resources/mdtest/tags/firstof.md
@@ -1,0 +1,33 @@
+# firstof
+
+## Valid
+
+### chooses the first truthy variable
+
+```htmldjango
+{% firstof var1 var2 var3 %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports a literal fallback
+
+```htmldjango
+{% firstof var1 var2 "fallback" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### assigns the result to a variable
+
+```htmldjango
+{% firstof var1 var2 as result %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/for.md
+++ b/crates/djls-semantic/resources/mdtest/tags/for.md
@@ -1,0 +1,116 @@
+# for
+
+## Valid
+
+### iterates over a sequence
+
+```htmldjango
+{% for item in items %}
+  {{ item }}
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports empty fallback
+
+```htmldjango
+{% for item in items %}
+  {{ item }}
+{% empty %}
+  <p>No items.</p>
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports tuple unpacking
+
+```htmldjango
+{% for key, value in items.items %}
+  {{ key }}: {{ value }}
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports reversed iteration
+
+```htmldjango
+{% for item in items reversed %}
+  {{ item }}
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects empty outside for
+
+```htmldjango
+{% empty %}
+```
+
+```snapshot
+error[S102]: Orphaned tag 'empty' - 'for' block
+ --> test.html:1:1
+  |
+1 | {% empty %}
+  | ^^^^^^^^^^^
+```
+
+### reports unclosed loop
+
+```htmldjango
+{% for item in items %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: for
+ --> test.html:1:1
+  |
+1 | {% for item in items %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## Known gaps
+
+### currently accepts missing loop variables
+
+```htmldjango
+{% for %}{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### currently accepts missing in keyword and iterable
+
+```htmldjango
+{% for item %}{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### currently accepts missing iterable
+
+```htmldjango
+{% for item in %}{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/i18n.md
+++ b/crates/djls-semantic/resources/mdtest/tags/i18n.md
@@ -94,7 +94,7 @@
 
 ## Invalid
 
-### trans requires load before use
+### trans requires load when i18n is not configured as a builtin
 
 ```htmldjango
 {% trans "Before load" %}

--- a/crates/djls-semantic/resources/mdtest/tags/i18n.md
+++ b/crates/djls-semantic/resources/mdtest/tags/i18n.md
@@ -1,0 +1,125 @@
+# i18n
+
+## Valid
+
+### translates a literal after load
+
+```htmldjango
+{% load i18n %}
+
+{% trans "Hello" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### assigns translated literal to a variable
+
+```htmldjango
+{% load i18n %}
+
+{% trans "Hello" as greeting %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports translate alias
+
+```htmldjango
+{% load i18n %}
+
+{% translate "Hello" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### translates block contents
+
+```htmldjango
+{% load i18n %}
+
+{% blocktrans %}Hello, {{ name }}!{% endblocktrans %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports plural block translation
+
+```htmldjango
+{% load i18n %}
+
+{% blocktrans count counter=items|length %}
+  There is {{ counter }} item.
+{% plural %}
+  There are {{ counter }} items.
+{% endblocktrans %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports blocktranslate alias
+
+```htmldjango
+{% load i18n %}
+
+{% blocktranslate %}Hello, {{ name }}!{% endblocktranslate %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports with bindings in blocktranslate
+
+```htmldjango
+{% load i18n %}
+
+{% blocktranslate with name=user.get_full_name %}
+  Hello, {{ name }}!
+{% endblocktranslate %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### trans requires load before use
+
+```htmldjango
+{% trans "Before load" %}
+```
+
+```snapshot
+error[S109]: Tag 'trans' requires {% load i18n %}
+ --> test.html:1:1
+  |
+1 | {% trans "Before load" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+### reports unclosed blocktrans
+
+```htmldjango
+{% load i18n %}
+{% blocktrans %}
+  Never closed.
+```
+
+```snapshot
+error[S100]: Unclosed tag: blocktrans
+ --> test.html:2:1
+  |
+2 | {% blocktrans %}
+  | ^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/if.md
+++ b/crates/djls-semantic/resources/mdtest/tags/if.md
@@ -1,0 +1,311 @@
+# if
+
+## Valid
+
+### accepts simple truthy expression
+
+```htmldjango
+{% if user.is_authenticated %}
+  <p>Welcome!</p>
+{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports elif and else branches
+
+```htmldjango
+{% if user.is_superuser %}
+  <p>Admin</p>
+{% elif user.is_staff %}
+  <p>Staff</p>
+{% else %}
+  <p>User</p>
+{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts boolean and operator
+
+```htmldjango
+{% if x and y %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts boolean or operator
+
+```htmldjango
+{% if x or y %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts unary not operator
+
+```htmldjango
+{% if not x %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts equality comparison
+
+```htmldjango
+{% if x == y %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts inequality comparison
+
+```htmldjango
+{% if x != y %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts ordering comparisons
+
+```htmldjango
+{% if x > y %}{% endif %}
+{% if x >= y %}{% endif %}
+{% if x < y %}{% endif %}
+{% if x <= y %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts membership operator
+
+```htmldjango
+{% if x in items %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts negated membership operator
+
+```htmldjango
+{% if x not in items %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts identity operator
+
+```htmldjango
+{% if x is None %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts negated identity operator
+
+```htmldjango
+{% if x is not None %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts filters in expressions
+
+```htmldjango
+{% if items|length > 0 %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### honors operator precedence
+
+```htmldjango
+{% if x or y and z %}{% endif %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects expression starting with and
+
+```htmldjango
+{% if and %}{% endif %}
+```
+
+```snapshot
+error[S114]: Not expecting 'and' in this position in if tag.
+ --> test.html:1:1
+  |
+1 | {% if and %}{% endif %}
+  | ^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### rejects expression starting with or
+
+```htmldjango
+{% if or x %}{% endif %}
+```
+
+```snapshot
+error[S114]: Not expecting 'or' in this position in if tag.
+ --> test.html:1:1
+  |
+1 | {% if or x %}{% endif %}
+  | ^^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### rejects expression ending with or
+
+```htmldjango
+{% if x or %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unexpected end of expression in if tag.
+ --> test.html:1:1
+  |
+1 | {% if x or %}{% endif %}
+  | ^^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### rejects expression ending with and
+
+```htmldjango
+{% if x and %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unexpected end of expression in if tag.
+ --> test.html:1:1
+  |
+1 | {% if x and %}{% endif %}
+  | ^^^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### rejects bare not expression
+
+```htmldjango
+{% if not %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unexpected end of expression in if tag.
+ --> test.html:1:1
+  |
+1 | {% if not %}{% endif %}
+  | ^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### rejects adjacent operands
+
+```htmldjango
+{% if x y %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unused 'y' at end of if expression.
+ --> test.html:1:1
+  |
+1 | {% if x y %}{% endif %}
+  | ^^^^^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### rejects empty expression
+
+```htmldjango
+{% if %}{% endif %}
+```
+
+```snapshot
+error[S114]: Unexpected end of expression in if tag.
+ --> test.html:1:1
+  |
+1 | {% if %}{% endif %}
+  | ^^^^^^^^
+  |
+  = note: in tag: if
+```
+
+### reports else outside if
+
+```htmldjango
+{% else %}
+```
+
+```snapshot
+error[S102]: Orphaned tag 'else' - 'if' or 'ifchanged' block
+ --> test.html:1:1
+  |
+1 | {% else %}
+  | ^^^^^^^^^^
+```
+
+### reports elif outside if
+
+```htmldjango
+{% elif orphaned %}
+```
+
+```snapshot
+error[S102]: Orphaned tag 'elif' - 'if' block
+ --> test.html:1:1
+  |
+1 | {% elif orphaned %}
+  | ^^^^^^^^^^^^^^^^^^^
+```
+
+### reports unclosed if
+
+```htmldjango
+{% if unclosed %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: if
+ --> test.html:1:1
+  |
+1 | {% if unclosed %}
+  | ^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/ifchanged.md
+++ b/crates/djls-semantic/resources/mdtest/tags/ifchanged.md
@@ -1,0 +1,47 @@
+# ifchanged
+
+## Valid
+
+### tracks changes in rendered body
+
+```htmldjango
+{% for item in items %}
+  {% ifchanged %}
+    {{ item.category }}
+  {% endifchanged %}
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### tracks changes in explicit values
+
+```htmldjango
+{% for item in items %}
+  {% ifchanged item.category %}
+    <h2>{{ item.category }}</h2>
+  {% endifchanged %}
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports else branch
+
+```htmldjango
+{% for item in items %}
+  {% ifchanged item.category %}
+    <h2>{{ item.category }}</h2>
+  {% else %}
+    <hr>
+  {% endifchanged %}
+{% endfor %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/include.md
+++ b/crates/djls-semantic/resources/mdtest/tags/include.md
@@ -1,0 +1,53 @@
+# include
+
+## Valid
+
+### includes a literal template name
+
+```htmldjango
+{% include "djls_app/header.html" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### passes context variables
+
+```htmldjango
+{% include "djls_app/header.html" with title="Hello" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### limits context to included template
+
+```htmldjango
+{% include "djls_app/header.html" only %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### combines context variables with only
+
+```htmldjango
+{% include "djls_app/header.html" with title="Hello" only %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts a variable template name
+
+```htmldjango
+{% include template_name %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/l10n.md
+++ b/crates/djls-semantic/resources/mdtest/tags/l10n.md
@@ -32,7 +32,7 @@
 
 ## Invalid
 
-### localize requires load before use
+### localize requires load when l10n is not configured as a builtin
 
 ```htmldjango
 {% localize on %}

--- a/crates/djls-semantic/resources/mdtest/tags/l10n.md
+++ b/crates/djls-semantic/resources/mdtest/tags/l10n.md
@@ -1,0 +1,65 @@
+# l10n
+
+## Valid
+
+### enables localization after load
+
+```htmldjango
+{% load l10n %}
+
+{% localize on %}
+  {{ value }}
+{% endlocalize %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### disables localization after load
+
+```htmldjango
+{% load l10n %}
+
+{% localize off %}
+  {{ value }}
+{% endlocalize %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### localize requires load before use
+
+```htmldjango
+{% localize on %}
+  {{ value }}
+{% endlocalize %}
+```
+
+```snapshot
+error[S109]: Tag 'localize' requires {% load l10n %}
+ --> test.html:1:1
+  |
+1 | {% localize on %}
+  | ^^^^^^^^^^^^^^^^^
+```
+
+### reports unclosed localize block
+
+```htmldjango
+{% load l10n %}
+{% localize on %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: localize
+ --> test.html:2:1
+  |
+2 | {% localize on %}
+  | ^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/load.md
+++ b/crates/djls-semantic/resources/mdtest/tags/load.md
@@ -1,0 +1,63 @@
+# load
+
+## Valid
+
+### loads one library
+
+```htmldjango
+{% load static %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### loads multiple libraries
+
+```htmldjango
+{% load static i18n %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### imports a symbol from a library
+
+```htmldjango
+{% load trans from i18n %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects selective import from unknown library
+
+```htmldjango
+{% load static from staticfiles %}
+```
+
+```snapshot
+error[S120]: Unknown template tag library 'staticfiles'
+ --> test.html:1:1
+  |
+1 | {% load static from staticfiles %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+### rejects unknown library
+
+```htmldjango
+{% load nonexistent_library %}
+```
+
+```snapshot
+error[S120]: Unknown template tag library 'nonexistent_library'
+ --> test.html:1:1
+  |
+1 | {% load nonexistent_library %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/lorem.md
+++ b/crates/djls-semantic/resources/mdtest/tags/lorem.md
@@ -1,0 +1,79 @@
+# lorem
+
+## Valid
+
+### renders requested paragraph count
+
+```htmldjango
+{% lorem 3 p random %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects missing arguments
+
+```htmldjango
+{% lorem %}
+```
+
+```snapshot
+error[S117]: 'lorem' takes exactly 3 arguments, 0 given
+ --> test.html:1:1
+  |
+1 | {% lorem %}
+  | ^^^^^^^^^^^
+  |
+  = note: in tag: lorem
+```
+
+### rejects missing output method and randomness
+
+```htmldjango
+{% lorem 3 %}
+```
+
+```snapshot
+error[S117]: 'lorem' takes exactly 3 arguments, 1 given
+ --> test.html:1:1
+  |
+1 | {% lorem 3 %}
+  | ^^^^^^^^^^^^^
+  |
+  = note: in tag: lorem
+```
+
+### rejects missing randomness
+
+```htmldjango
+{% lorem 3 p %}
+```
+
+```snapshot
+error[S117]: 'lorem' takes exactly 3 arguments, 2 given
+ --> test.html:1:1
+  |
+1 | {% lorem 3 p %}
+  | ^^^^^^^^^^^^^^^
+  |
+  = note: in tag: lorem
+```
+
+### rejects too many arguments
+
+```htmldjango
+{% lorem 3 p random extra %}
+```
+
+```snapshot
+error[S117]: 'lorem' takes exactly 3 arguments, 4 given
+ --> test.html:1:1
+  |
+1 | {% lorem 3 p random extra %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: lorem
+```

--- a/crates/djls-semantic/resources/mdtest/tags/now.md
+++ b/crates/djls-semantic/resources/mdtest/tags/now.md
@@ -1,0 +1,57 @@
+# now
+
+## Valid
+
+### renders a date format
+
+```htmldjango
+{% now "Y-m-d" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders a date and time format
+
+```htmldjango
+{% now "jS F Y H:i" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects missing format
+
+```htmldjango
+{% now %}
+```
+
+```snapshot
+error[S117]: 'now' takes exactly 1 argument, 0 given
+ --> test.html:1:1
+  |
+1 | {% now %}
+  | ^^^^^^^^^
+  |
+  = note: in tag: now
+```
+
+### rejects too many arguments
+
+```htmldjango
+{% now "Y" "m" %}
+```
+
+```snapshot
+error[S117]: 'now' takes exactly 1 argument, 2 given
+ --> test.html:1:1
+  |
+1 | {% now "Y" "m" %}
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: now
+```

--- a/crates/djls-semantic/resources/mdtest/tags/regroup.md
+++ b/crates/djls-semantic/resources/mdtest/tags/regroup.md
@@ -1,0 +1,143 @@
+# regroup
+
+## Valid
+
+### groups items by attribute
+
+```htmldjango
+{% regroup items by category as grouped %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### rejects missing arguments
+
+```htmldjango
+{% regroup %}
+```
+
+```snapshot
+error[S117]: 'regroup' takes exactly 5 arguments, 0 given
+ --> test.html:1:1
+  |
+1 | {% regroup %}
+  | ^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### rejects missing by keyword and target
+
+```htmldjango
+{% regroup items %}
+```
+
+```snapshot
+error[S117]: 'regroup' takes exactly 5 arguments, 1 given
+ --> test.html:1:1
+  |
+1 | {% regroup items %}
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### rejects missing regroup attribute and target
+
+```htmldjango
+{% regroup items by %}
+```
+
+```snapshot
+error[S117]: 'regroup' takes exactly 5 arguments, 2 given
+ --> test.html:1:1
+  |
+1 | {% regroup items by %}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### rejects missing as keyword and target variable
+
+```htmldjango
+{% regroup items by category %}
+```
+
+```snapshot
+error[S117]: 'regroup' takes exactly 5 arguments, 3 given
+ --> test.html:1:1
+  |
+1 | {% regroup items by category %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### rejects missing target variable
+
+```htmldjango
+{% regroup items by category as %}
+```
+
+```snapshot
+error[S117]: 'regroup' takes exactly 5 arguments, 4 given
+ --> test.html:1:1
+  |
+1 | {% regroup items by category as %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### rejects too many arguments
+
+```htmldjango
+{% regroup items by category as grouped extra %}
+```
+
+```snapshot
+error[S117]: 'regroup' takes exactly 5 arguments, 6 given
+ --> test.html:1:1
+  |
+1 | {% regroup items by category as grouped extra %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### requires by keyword
+
+```htmldjango
+{% regroup items WRONG category as grouped %}
+```
+
+```snapshot
+error[S117]: 'regroup' expected 'by' at position 2
+ --> test.html:1:1
+  |
+1 | {% regroup items WRONG category as grouped %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```
+
+### requires as keyword
+
+```htmldjango
+{% regroup items by category WRONG grouped %}
+```
+
+```snapshot
+error[S117]: 'regroup' expected 'as' at position 4
+ --> test.html:1:1
+  |
+1 | {% regroup items by category WRONG grouped %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: regroup
+```

--- a/crates/djls-semantic/resources/mdtest/tags/spaceless.md
+++ b/crates/djls-semantic/resources/mdtest/tags/spaceless.md
@@ -1,0 +1,34 @@
+# spaceless
+
+## Valid
+
+### removes whitespace between html tags
+
+```htmldjango
+{% spaceless %}
+  <p>
+    <a href="/">Home</a>
+  </p>
+{% endspaceless %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### reports unclosed spaceless block
+
+```htmldjango
+{% spaceless %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: spaceless
+ --> test.html:1:1
+  |
+1 | {% spaceless %}
+  | ^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/static.md
+++ b/crates/djls-semantic/resources/mdtest/tags/static.md
@@ -1,0 +1,55 @@
+# static
+
+## Valid
+
+### resolves a literal static path after load
+
+```htmldjango
+{% load static %}
+
+{% static "css/style.css" %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### assigns static path to a variable
+
+```htmldjango
+{% load static %}
+
+{% static "css/style.css" as css_url %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts a variable static path
+
+```htmldjango
+{% load static %}
+
+{% static path_var %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### requires load before use
+
+```htmldjango
+{% static "before.css" %}
+```
+
+```snapshot
+error[S109]: Tag 'static' requires {% load static %}
+ --> test.html:1:1
+  |
+1 | {% static "before.css" %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/static.md
+++ b/crates/djls-semantic/resources/mdtest/tags/static.md
@@ -40,7 +40,7 @@
 
 ## Invalid
 
-### requires load before use
+### requires load when static is not configured as a builtin
 
 ```htmldjango
 {% static "before.css" %}

--- a/crates/djls-semantic/resources/mdtest/tags/templatetag.md
+++ b/crates/djls-semantic/resources/mdtest/tags/templatetag.md
@@ -1,0 +1,83 @@
+# templatetag
+
+## Valid
+
+### renders open block delimiter
+
+```htmldjango
+{% templatetag openblock %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders close block delimiter
+
+```htmldjango
+{% templatetag closeblock %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders open variable delimiter
+
+```htmldjango
+{% templatetag openvariable %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders close variable delimiter
+
+```htmldjango
+{% templatetag closevariable %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders open brace
+
+```htmldjango
+{% templatetag openbrace %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders close brace
+
+```htmldjango
+{% templatetag closebrace %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders open comment delimiter
+
+```htmldjango
+{% templatetag opencomment %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### renders close comment delimiter
+
+```htmldjango
+{% templatetag closecomment %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/tz.md
+++ b/crates/djls-semantic/resources/mdtest/tags/tz.md
@@ -1,0 +1,77 @@
+# tz
+
+## Valid
+
+### enables local time after load
+
+```htmldjango
+{% load tz %}
+
+{% localtime on %}
+  {{ value }}
+{% endlocaltime %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### disables local time after load
+
+```htmldjango
+{% load tz %}
+
+{% localtime off %}
+  {{ value }}
+{% endlocaltime %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### activates literal timezone
+
+```htmldjango
+{% load tz %}
+
+{% timezone "Europe/Paris" %}
+  {{ value }}
+{% endtimezone %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### activates variable timezone
+
+```htmldjango
+{% load tz %}
+
+{% timezone user_tz %}
+  {{ value }}
+{% endtimezone %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### reports unclosed timezone block
+
+```htmldjango
+{% load tz %}
+{% timezone "UTC" %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: timezone
+ --> test.html:2:1
+  |
+2 | {% timezone "UTC" %}
+  | ^^^^^^^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/resources/mdtest/tags/url.md
+++ b/crates/djls-semantic/resources/mdtest/tags/url.md
@@ -1,0 +1,71 @@
+# url
+
+## Valid
+
+### reverses a named url
+
+```htmldjango
+{% url 'home' %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### passes positional arguments
+
+```htmldjango
+{% url 'article-detail' article.pk %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### passes keyword arguments
+
+```htmldjango
+{% url 'article-detail' pk=article.pk %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### assigns reversed url to a variable
+
+```htmldjango
+{% url 'home' as home_url %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### accepts a variable view name
+
+```htmldjango
+{% url view_name %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### requires a view name
+
+```htmldjango
+{% url %}
+```
+
+```snapshot
+error[S117]: 'url' requires at least 1 argument
+ --> test.html:1:1
+  |
+1 | {% url %}
+  | ^^^^^^^^^
+  |
+  = note: in tag: url
+```

--- a/crates/djls-semantic/resources/mdtest/tags/verbatim.md
+++ b/crates/djls-semantic/resources/mdtest/tags/verbatim.md
@@ -1,0 +1,28 @@
+# verbatim
+
+## Valid
+
+### treats contents as opaque
+
+```htmldjango
+{% verbatim %}
+  {{ this_is_not_rendered }}
+  {% if this_is_ignored %}{% endif %}
+{% endverbatim %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports named verbatim blocks
+
+```htmldjango
+{% verbatim myblock %}
+  {{ still_literal }}
+{% endverbatim myblock %}
+```
+
+```snapshot
+✓ no diagnostics
+```

--- a/crates/djls-semantic/resources/mdtest/tags/widthratio.md
+++ b/crates/djls-semantic/resources/mdtest/tags/widthratio.md
@@ -1,0 +1,41 @@
+# widthratio
+
+## Valid
+
+### computes a width ratio
+
+```htmldjango
+{% widthratio this_value max_value max_width %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### assigns computed ratio to a variable
+
+```htmldjango
+{% widthratio this_value max_value max_width as ratio %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### requires as keyword in assignment form
+
+```htmldjango
+{% widthratio this_value max_value max_width WRONG ratio %}
+```
+
+```snapshot
+error[S117]: 'widthratio' expected 'as' at position 4
+ --> test.html:1:1
+  |
+1 | {% widthratio this_value max_value max_width WRONG ratio %}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: in tag: widthratio
+```

--- a/crates/djls-semantic/resources/mdtest/tags/with.md
+++ b/crates/djls-semantic/resources/mdtest/tags/with.md
@@ -1,0 +1,56 @@
+# with
+
+## Valid
+
+### binds one keyword value
+
+```htmldjango
+{% with name="World" %}
+  <p>Hello, {{ name }}!</p>
+{% endwith %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### binds multiple keyword values
+
+```htmldjango
+{% with first="Hello" last="World" %}
+  <p>{{ first }} {{ last }}</p>
+{% endwith %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+### supports as assignment syntax
+
+```htmldjango
+{% with items.count as total %}
+  <p>{{ total }} items</p>
+{% endwith %}
+```
+
+```snapshot
+✓ no diagnostics
+```
+
+## Invalid
+
+### reports unclosed with block
+
+```htmldjango
+{% with x=1 %}
+  <p>Never closed.</p>
+```
+
+```snapshot
+error[S100]: Unclosed tag: with
+ --> test.html:1:1
+  |
+1 | {% with x=1 %}
+  | ^^^^^^^^^^^^^^
+```

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -17,14 +18,33 @@ use djls_workspace::FileSystem;
 use djls_workspace::InMemoryFileSystem;
 
 use crate::specs::tags::builtin_tag_specs;
+use crate::ArgumentCountConstraint;
+use crate::ChoiceAt;
+use crate::FilterArity;
 use crate::FilterAritySpecs;
+use crate::Knowledge;
+use crate::LibraryName;
+use crate::LibraryOrigin;
+use crate::PyModuleName;
+use crate::RequiredKeyword;
+use crate::SplitPosition;
+use crate::SymbolDefinition;
+use crate::SymbolKey;
 use crate::TagIndex;
+use crate::TagRule;
+use crate::TagSpec;
 use crate::TagSpecs;
 use crate::TemplateLibraries;
+use crate::TemplateLibrary;
 use crate::TemplateLibrarySnapshot;
+use crate::TemplateSymbol;
+use crate::TemplateSymbolKind;
+use crate::TemplateSymbolName;
 use crate::TemplateSymbolSnapshot;
 use crate::ValidationError;
 use crate::ValidationErrorAccumulator;
+
+mod mdtest;
 
 pub(crate) fn builtin_tag_json(name: &str, module: &str) -> serde_json::Value {
     serde_json::json!({
@@ -394,6 +414,314 @@ pub(crate) fn render_diagnostic_snapshot(
     }
 
     parts.join("\n")
+}
+
+pub(crate) fn snapshot_validate(source: &str) -> String {
+    snapshot_validate_file("test.html", source)
+}
+
+pub(crate) fn snapshot_validate_file(path: &str, source: &str) -> String {
+    render_validate_snapshot(&standard_validation_db(), path, 0, source)
+}
+
+/// Curated validation environment for mdtest snapshots.
+///
+/// This keeps diagnostic snapshots deterministic and easy to author. It is not
+/// a live Django project inspection fixture; add libraries, tags, and filters
+/// here when a scenario needs them.
+pub(crate) fn standard_validation_db() -> TestDatabase {
+    TestDatabase::new()
+        .with_specs(standard_tag_specs())
+        .with_template_libraries(standard_template_libraries())
+        .with_arity_specs(standard_filter_arities())
+}
+
+fn standard_tag_specs() -> TagSpecs {
+    let mut specs = builtin_tag_specs();
+
+    set_tag_rule(
+        &mut specs,
+        "autoescape",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::Exact(2)],
+            choice_at_constraints: vec![ChoiceAt {
+                position: SplitPosition::Forward(1),
+                values: vec!["on".to_string(), "off".to_string()],
+            }],
+            ..TagRule::default()
+        },
+    );
+    set_tag_rule(
+        &mut specs,
+        "cycle",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::Min(2)],
+            ..TagRule::default()
+        },
+    );
+    set_tag_rule(
+        &mut specs,
+        "lorem",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::Exact(4)],
+            ..TagRule::default()
+        },
+    );
+    set_tag_rule(
+        &mut specs,
+        "now",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::Exact(2)],
+            ..TagRule::default()
+        },
+    );
+    set_tag_rule(
+        &mut specs,
+        "regroup",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::Exact(6)],
+            required_keywords: vec![
+                RequiredKeyword {
+                    position: SplitPosition::Forward(2),
+                    value: "by".to_string(),
+                },
+                RequiredKeyword {
+                    position: SplitPosition::Forward(4),
+                    value: "as".to_string(),
+                },
+            ],
+            ..TagRule::default()
+        },
+    );
+    set_tag_rule(
+        &mut specs,
+        "url",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::Min(2)],
+            ..TagRule::default()
+        },
+    );
+    set_tag_rule(
+        &mut specs,
+        "widthratio",
+        TagRule {
+            arg_constraints: vec![ArgumentCountConstraint::OneOf(vec![4, 6])],
+            required_keywords: vec![RequiredKeyword {
+                position: SplitPosition::Forward(4),
+                value: "as".to_string(),
+            }],
+            ..TagRule::default()
+        },
+    );
+
+    specs.insert(
+        "one_arg_tag".to_string(),
+        TagSpec {
+            module: "example.templatetags.custom".into(),
+            end_tag: None,
+            intermediate_tags: Cow::Borrowed(&[]),
+            opaque: false,
+            extracted_rules: Some(TagRule {
+                arg_constraints: vec![ArgumentCountConstraint::Exact(2)],
+                ..TagRule::default()
+            }),
+        },
+    );
+    specs
+}
+
+fn set_tag_rule(specs: &mut TagSpecs, name: &str, rule: TagRule) {
+    if let Some(spec) = specs.get_mut(name) {
+        spec.extracted_rules = Some(rule);
+    }
+}
+
+fn standard_template_libraries() -> TemplateLibraries {
+    let tags = vec![
+        builtin_tag_json("autoescape", default_builtins_module()),
+        builtin_tag_json("block", default_loader_tags_module()),
+        builtin_tag_json("comment", default_builtins_module()),
+        builtin_tag_json("csrf_token", default_builtins_module()),
+        builtin_tag_json("cycle", default_builtins_module()),
+        builtin_tag_json("debug", default_builtins_module()),
+        builtin_tag_json("extends", default_loader_tags_module()),
+        builtin_tag_json("filter", default_builtins_module()),
+        builtin_tag_json("firstof", default_builtins_module()),
+        builtin_tag_json("for", default_builtins_module()),
+        builtin_tag_json("if", default_builtins_module()),
+        builtin_tag_json("ifchanged", default_builtins_module()),
+        builtin_tag_json("include", default_loader_tags_module()),
+        builtin_tag_json("load", default_builtins_module()),
+        builtin_tag_json("lorem", default_builtins_module()),
+        builtin_tag_json("now", default_builtins_module()),
+        builtin_tag_json("one_arg_tag", "example.templatetags.custom"),
+        builtin_tag_json("regroup", default_builtins_module()),
+        builtin_tag_json("spaceless", default_builtins_module()),
+        builtin_tag_json("templatetag", default_builtins_module()),
+        builtin_tag_json("url", default_builtins_module()),
+        builtin_tag_json("verbatim", default_builtins_module()),
+        builtin_tag_json("widthratio", default_builtins_module()),
+        builtin_tag_json("with", default_builtins_module()),
+        library_tag_json("ambiguous_tag", "alpha", "example.alpha.templatetags.alpha"),
+        library_tag_json("ambiguous_tag", "beta", "example.beta.templatetags.beta"),
+        library_tag_json("blocktrans", "i18n", "django.templatetags.i18n"),
+        library_tag_json("blocktranslate", "i18n", "django.templatetags.i18n"),
+        library_tag_json("cache", "cache", "django.templatetags.cache"),
+        library_tag_json("localize", "l10n", "django.templatetags.l10n"),
+        library_tag_json("localtime", "tz", "django.templatetags.tz"),
+        library_tag_json("static", "static", "django.templatetags.static"),
+        library_tag_json("timezone", "tz", "django.templatetags.tz"),
+        library_tag_json("trans", "i18n", "django.templatetags.i18n"),
+        library_tag_json("translate", "i18n", "django.templatetags.i18n"),
+    ];
+    let filters = vec![
+        builtin_filter_json("title", default_filters_module()),
+        builtin_filter_json("lower", default_filters_module()),
+        builtin_filter_json("length", default_filters_module()),
+        builtin_filter_json("default", default_filters_module()),
+        builtin_filter_json("truncatewords", default_filters_module()),
+        builtin_filter_json("date", default_filters_module()),
+        builtin_filter_json("upper", default_filters_module()),
+        library_filter_json(
+            "intcomma",
+            "humanize",
+            "django.contrib.humanize.templatetags.humanize",
+        ),
+        library_filter_json(
+            "ambiguous_filter",
+            "alpha",
+            "example.alpha.templatetags.alpha",
+        ),
+        library_filter_json("ambiguous_filter", "beta", "example.beta.templatetags.beta"),
+    ];
+    let mut libraries = HashMap::new();
+    libraries.insert("cache".to_string(), "django.templatetags.cache".to_string());
+    libraries.insert("i18n".to_string(), "django.templatetags.i18n".to_string());
+    libraries.insert("l10n".to_string(), "django.templatetags.l10n".to_string());
+    libraries.insert("tz".to_string(), "django.templatetags.tz".to_string());
+    libraries.insert(
+        "humanize".to_string(),
+        "django.contrib.humanize.templatetags.humanize".to_string(),
+    );
+    libraries.insert(
+        "static".to_string(),
+        "django.templatetags.static".to_string(),
+    );
+    libraries.insert(
+        "alpha".to_string(),
+        "example.alpha.templatetags.alpha".to_string(),
+    );
+    libraries.insert(
+        "beta".to_string(),
+        "example.beta.templatetags.beta".to_string(),
+    );
+    let builtins = vec![
+        default_builtins_module().to_string(),
+        default_filters_module().to_string(),
+        default_loader_tags_module().to_string(),
+        "example.templatetags.custom".to_string(),
+    ];
+
+    let mut template_libraries = make_template_libraries(&tags, &filters, &libraries, &builtins);
+    add_discovered_widgets_library(&mut template_libraries);
+    template_libraries
+}
+
+fn add_discovered_widgets_library(template_libraries: &mut TemplateLibraries) {
+    template_libraries.discovery_knowledge = Knowledge::Known;
+
+    let name = LibraryName::parse("widgets").unwrap();
+    let app = PyModuleName::parse("example.widgets").unwrap();
+    let module = PyModuleName::parse("example.widgets.templatetags.widgets").unwrap();
+    let origin = LibraryOrigin {
+        app,
+        module: module.clone(),
+        path: Utf8PathBuf::from("/example/widgets/templatetags/widgets.py"),
+    };
+    let mut library = TemplateLibrary::new_discovered(name.clone(), origin);
+    library.merge_symbol(template_symbol(
+        TemplateSymbolKind::Tag,
+        "widget_tag",
+        "example.widgets.templatetags.widgets",
+    ));
+    library.merge_symbol(template_symbol(
+        TemplateSymbolKind::Filter,
+        "widget_filter",
+        "example.widgets.templatetags.widgets",
+    ));
+    template_libraries
+        .loadable
+        .entry(name)
+        .or_default()
+        .push(library);
+}
+
+fn template_symbol(kind: TemplateSymbolKind, name: &str, module: &str) -> TemplateSymbol {
+    TemplateSymbol {
+        kind,
+        name: TemplateSymbolName::parse(name).unwrap(),
+        definition: SymbolDefinition::Module(PyModuleName::parse(module).unwrap()),
+        doc: None,
+    }
+}
+
+fn standard_filter_arities() -> FilterAritySpecs {
+    let mut specs = FilterAritySpecs::new();
+    specs.insert(
+        SymbolKey::filter(default_filters_module(), "title"),
+        FilterArity {
+            expects_arg: false,
+            arg_optional: false,
+        },
+    );
+    specs.insert(
+        SymbolKey::filter(default_filters_module(), "lower"),
+        FilterArity {
+            expects_arg: false,
+            arg_optional: false,
+        },
+    );
+    specs.insert(
+        SymbolKey::filter(default_filters_module(), "upper"),
+        FilterArity {
+            expects_arg: false,
+            arg_optional: false,
+        },
+    );
+    specs.insert(
+        SymbolKey::filter(default_filters_module(), "default"),
+        FilterArity {
+            expects_arg: true,
+            arg_optional: false,
+        },
+    );
+    specs.insert(
+        SymbolKey::filter(default_filters_module(), "truncatewords"),
+        FilterArity {
+            expects_arg: true,
+            arg_optional: false,
+        },
+    );
+    specs.insert(
+        SymbolKey::filter(default_filters_module(), "date"),
+        FilterArity {
+            expects_arg: true,
+            arg_optional: true,
+        },
+    );
+    specs
+}
+
+fn default_builtins_module() -> &'static str {
+    "django.template.defaulttags"
+}
+
+fn default_filters_module() -> &'static str {
+    "django.template.defaultfilters"
+}
+
+fn default_loader_tags_module() -> &'static str {
+    "django.template.loader_tags"
 }
 
 pub(crate) fn render_validate_snapshot(

--- a/crates/djls-semantic/src/testing/mdtest.rs
+++ b/crates/djls-semantic/src/testing/mdtest.rs
@@ -1,0 +1,726 @@
+//! Markdown diagnostic snapshot tests.
+//!
+//! See `resources/mdtest/README.md` for the authoring format.
+
+use std::fmt::Write as _;
+use std::ops::Range;
+use std::path::Path;
+
+use pulldown_cmark::CodeBlockKind;
+use pulldown_cmark::Event;
+use pulldown_cmark::HeadingLevel;
+use pulldown_cmark::Parser as MarkdownParser;
+use pulldown_cmark::Tag;
+use pulldown_cmark::TagEnd;
+
+use super::snapshot_validate;
+use super::snapshot_validate_file;
+
+const UPDATE_ENV: &str = "DJLS_UPDATE_MDTEST_SNAPSHOTS";
+const NO_DIAGNOSTICS_SNAPSHOT: &str = "✓ no diagnostics";
+
+#[derive(Debug)]
+struct Scenario {
+    name: String,
+    file_path: String,
+    source: String,
+    snapshot: Option<String>,
+    snapshot_start: Option<usize>,
+    snapshot_end: Option<usize>,
+    snapshot_insert_at: usize,
+}
+
+impl Scenario {
+    fn render_snapshot(&self) -> String {
+        let rendered = if self.file_path == "test.html" {
+            snapshot_validate(&self.source)
+        } else {
+            snapshot_validate_file(&self.file_path, &self.source)
+        };
+
+        if rendered.trim().is_empty() {
+            NO_DIAGNOSTICS_SNAPSHOT.to_string()
+        } else {
+            rendered
+        }
+    }
+
+    fn snapshot_update(&self, actual: String) -> SnapshotUpdate {
+        if let (Some(start), Some(end)) = (self.snapshot_start, self.snapshot_end) {
+            SnapshotUpdate {
+                start,
+                end,
+                replacement: actual,
+            }
+        } else {
+            SnapshotUpdate {
+                start: self.snapshot_insert_at,
+                end: self.snapshot_insert_at,
+                replacement: format!("\n```snapshot\n{actual}\n```"),
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SnapshotUpdate {
+    start: usize,
+    end: usize,
+    replacement: String,
+}
+
+impl SnapshotUpdate {
+    fn apply_all(markdown: &str, updates: &[Self]) -> String {
+        let lines = markdown.lines().collect::<Vec<_>>();
+        let mut output = String::new();
+        let mut cursor = 0;
+
+        for update in updates {
+            for line in &lines[cursor..update.start] {
+                writeln!(&mut output, "{line}").unwrap();
+            }
+            if !update.replacement.is_empty() {
+                for line in update.replacement.lines() {
+                    writeln!(&mut output, "{line}").unwrap();
+                }
+            }
+            cursor = update.end;
+        }
+
+        for line in &lines[cursor..] {
+            writeln!(&mut output, "{line}").unwrap();
+        }
+
+        output
+    }
+}
+
+#[test]
+fn markdown_diagnostic_snapshots() {
+    MdtestRun::new(Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/mdtest")).run();
+}
+
+struct MdtestRun {
+    root: std::path::PathBuf,
+    update: bool,
+    failures: Vec<String>,
+}
+
+impl MdtestRun {
+    fn new(root: std::path::PathBuf) -> Self {
+        Self {
+            root,
+            update: std::env::var_os(UPDATE_ENV).is_some_and(|value| value != "0"),
+            failures: Vec::new(),
+        }
+    }
+
+    fn run(mut self) {
+        let files = self.files();
+        assert!(!files.is_empty(), "expected at least one mdtest file");
+
+        for path in files {
+            self.run_file(&path);
+        }
+
+        assert!(
+            self.failures.is_empty(),
+            "mdtest failures:\n\n{}",
+            self.failures.join("\n\n")
+        );
+    }
+
+    fn files(&self) -> Vec<std::path::PathBuf> {
+        let mut dirs = vec![self.root.clone()];
+        let mut files = Vec::new();
+
+        while let Some(dir) = dirs.pop() {
+            for entry in std::fs::read_dir(&dir).expect("failed to read mdtest directory") {
+                let path = entry.expect("failed to read mdtest directory entry").path();
+                if path.is_dir() {
+                    dirs.push(path);
+                } else if path.extension().is_some_and(|ext| ext == "md")
+                    && path.file_name().is_none_or(|name| name != "README.md")
+                {
+                    files.push(path);
+                }
+            }
+        }
+
+        files.sort();
+        files
+    }
+
+    fn run_file(&mut self, path: &Path) {
+        let markdown = std::fs::read_to_string(path).expect("failed to read mdtest file");
+        let scenarios = match ScenarioCollector::new(&markdown).collect() {
+            Ok(scenarios) => scenarios,
+            Err(err) => {
+                self.failures
+                    .push(format!("failed to parse {}: {err}", path.display()));
+                return;
+            }
+        };
+
+        if scenarios.is_empty() {
+            self.failures
+                .push(format!("{} did not contain any scenarios", path.display()));
+            return;
+        }
+
+        let mut updates = Vec::new();
+        for scenario in scenarios {
+            let actual = scenario.render_snapshot();
+            if self.update {
+                updates.push(scenario.snapshot_update(actual));
+            } else {
+                self.check_snapshot(path, scenario, &actual);
+            }
+        }
+
+        if self.update {
+            let rewritten_markdown = SnapshotUpdate::apply_all(&markdown, &updates);
+            std::fs::write(path, rewritten_markdown).expect("failed to update mdtest snapshots");
+        }
+    }
+
+    fn check_snapshot(&mut self, path: &Path, scenario: Scenario, actual: &str) {
+        let Some(expected) = scenario.snapshot else {
+            self.failures.push(format!(
+                "mdtest scenario missing snapshot: {} ({}) in {}. Set {UPDATE_ENV}=1 to insert snapshots.",
+                scenario.name,
+                scenario.file_path,
+                path.display(),
+            ));
+            return;
+        };
+
+        if expected.trim_end() != actual.trim_end() {
+            self.failures.push(format!(
+                "mdtest scenario failed: {} ({}) in {}\n\nexpected:\n{}\n\nactual:\n{}\n\nSet {UPDATE_ENV}=1 to update snapshots.",
+                scenario.name,
+                scenario.file_path,
+                path.display(),
+                expected.trim_end(),
+                actual.trim_end(),
+            ));
+        }
+    }
+}
+
+struct ScenarioCollector<'a> {
+    markdown: &'a str,
+    line_starts: Vec<usize>,
+    current: Option<PartialScenario>,
+    scenarios: Vec<Scenario>,
+    pending_file_path: Option<String>,
+    headings: Vec<Heading>,
+    active_heading: Option<ActiveHeading>,
+    active_code_block: Option<ActiveCodeBlock>,
+    active_paragraph: Option<String>,
+}
+
+#[derive(Debug)]
+struct Heading {
+    level: usize,
+    name: String,
+}
+
+#[derive(Debug)]
+struct PartialScenario {
+    name: String,
+    level: usize,
+    file_path: Option<String>,
+    source: Option<String>,
+    snapshot: Option<String>,
+    snapshot_start: Option<usize>,
+    snapshot_end: Option<usize>,
+    snapshot_insert_at: Option<usize>,
+}
+
+#[derive(Debug)]
+struct ActiveHeading {
+    level: usize,
+    name: String,
+}
+
+#[derive(Debug)]
+struct ActiveCodeBlock {
+    language: Option<String>,
+    content: String,
+    content_start: Option<usize>,
+    content_end: Option<usize>,
+}
+
+#[derive(Debug)]
+struct FencedBlock {
+    language: String,
+    content: String,
+    content_start: usize,
+    content_end: usize,
+    fence_end: usize,
+}
+
+impl PartialScenario {
+    fn new(name: String, level: usize) -> Self {
+        Self {
+            name,
+            level,
+            file_path: None,
+            source: None,
+            snapshot: None,
+            snapshot_start: None,
+            snapshot_end: None,
+            snapshot_insert_at: None,
+        }
+    }
+}
+
+impl ActiveCodeBlock {
+    fn new(language: Option<String>) -> Self {
+        Self {
+            language,
+            content: String::new(),
+            content_start: None,
+            content_end: None,
+        }
+    }
+}
+
+impl<'a> ScenarioCollector<'a> {
+    fn new(markdown: &'a str) -> Self {
+        let mut line_starts = vec![0];
+        for (index, byte) in markdown.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(index + 1);
+            }
+        }
+
+        Self {
+            markdown,
+            line_starts,
+            current: None,
+            scenarios: Vec::new(),
+            pending_file_path: None,
+            headings: Vec::new(),
+            active_heading: None,
+            active_code_block: None,
+            active_paragraph: None,
+        }
+    }
+
+    fn collect(mut self) -> Result<Vec<Scenario>, String> {
+        for (event, range) in MarkdownParser::new(self.markdown).into_offset_iter() {
+            match event {
+                Event::Start(Tag::Heading { level, .. }) => {
+                    let level = match level {
+                        HeadingLevel::H1 => 1,
+                        HeadingLevel::H2 => 2,
+                        HeadingLevel::H3 => 3,
+                        HeadingLevel::H4 => 4,
+                        HeadingLevel::H5 => 5,
+                        HeadingLevel::H6 => 6,
+                    };
+                    self.active_heading = Some(ActiveHeading {
+                        level,
+                        name: String::new(),
+                    });
+                }
+                Event::End(TagEnd::Heading(_)) => self.finish_heading()?,
+                Event::Start(Tag::Paragraph) => {
+                    self.active_paragraph = Some(String::new());
+                }
+                Event::End(TagEnd::Paragraph) => {
+                    if let Some(paragraph) = self.active_paragraph.take() {
+                        let trimmed = paragraph.trim();
+                        if let Some(label) = trimmed
+                            .strip_prefix('`')
+                            .and_then(|value| value.strip_suffix("`:"))
+                        {
+                            if !label.is_empty() {
+                                self.pending_file_path = Some(label.to_string());
+                            }
+                        }
+                    }
+                }
+                Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(info))) => {
+                    let language = info.split_whitespace().next().map(str::to_string);
+                    self.active_code_block = Some(ActiveCodeBlock::new(language));
+                }
+                Event::Start(Tag::CodeBlock(CodeBlockKind::Indented)) => {
+                    self.active_code_block = Some(ActiveCodeBlock::new(None));
+                }
+                Event::End(TagEnd::CodeBlock) => self.finish_code_block(range)?,
+                Event::Text(text) => self.push_text(&text, range),
+                Event::Code(text) => self.push_inline_code(&text),
+                _ => {}
+            }
+        }
+
+        self.finish_current()?;
+        Ok(self.scenarios)
+    }
+
+    fn push_text(&mut self, text: &str, range: Range<usize>) {
+        let content_start = self.line_at(range.start);
+        let content_end = self.line_after(range.end);
+        if let Some(code_block) = &mut self.active_code_block {
+            if code_block.content_start.is_none() {
+                code_block.content_start = Some(content_start);
+            }
+            code_block.content_end = Some(content_end);
+            code_block.content.push_str(text);
+        } else if let Some(heading) = &mut self.active_heading {
+            heading.name.push_str(text);
+        } else if let Some(paragraph) = &mut self.active_paragraph {
+            paragraph.push_str(text);
+        }
+    }
+
+    fn push_inline_code(&mut self, text: &str) {
+        if let Some(heading) = &mut self.active_heading {
+            heading.name.push_str(text);
+        } else if let Some(paragraph) = &mut self.active_paragraph {
+            write!(paragraph, "`{text}`").unwrap();
+        }
+    }
+
+    fn finish_heading(&mut self) -> Result<(), String> {
+        let Some(heading) = self.active_heading.take() else {
+            return Ok(());
+        };
+        let name = heading.name.trim();
+        if name.is_empty() {
+            return Ok(());
+        }
+
+        if let Some(current) = &self.current {
+            if current.source.is_some() && heading.level > current.level {
+                return Err(format!(
+                    "scenario '{}' has child heading '{}' after its Django code block",
+                    current.name, name
+                ));
+            }
+        }
+
+        self.finish_current()?;
+        self.headings
+            .retain(|current| current.level < heading.level);
+        self.headings.push(Heading {
+            level: heading.level,
+            name: name.to_string(),
+        });
+        self.current = Some(PartialScenario::new(self.scenario_name(), heading.level));
+        self.pending_file_path = None;
+        Ok(())
+    }
+
+    fn finish_code_block(&mut self, range: Range<usize>) -> Result<(), String> {
+        let Some(code_block) = self.active_code_block.take() else {
+            return Ok(());
+        };
+        let Some(language) = code_block.language else {
+            return Ok(());
+        };
+        if !matches!(
+            language.as_str(),
+            "htmldjango" | "django" | "html" | "snapshot"
+        ) {
+            return Ok(());
+        }
+
+        let closing_fence_line = self.line_at(range.start);
+        let block = FencedBlock {
+            language,
+            content: code_block.content.trim_end_matches('\n').to_string(),
+            content_start: code_block.content_start.unwrap_or(closing_fence_line),
+            content_end: code_block.content_end.unwrap_or(closing_fence_line),
+            fence_end: self.line_after(range.end),
+        };
+
+        match block.language.as_str() {
+            "htmldjango" | "django" | "html" => self.set_source(block),
+            "snapshot" => self.set_snapshot(block),
+            _ => Ok(()),
+        }
+    }
+
+    fn set_source(&mut self, block: FencedBlock) -> Result<(), String> {
+        let current = self.current.as_mut().ok_or_else(|| {
+            "htmldjango code block must appear under a scenario heading".to_string()
+        })?;
+
+        if current.source.is_some() {
+            return Err(format!(
+                "scenario '{}' has more than one htmldjango code block",
+                current.name
+            ));
+        }
+
+        current.source = Some(block.content);
+        current.snapshot_insert_at = Some(block.fence_end);
+        current.file_path = Some(
+            self.pending_file_path
+                .take()
+                .unwrap_or_else(|| "test.html".to_string()),
+        );
+        Ok(())
+    }
+
+    fn set_snapshot(&mut self, block: FencedBlock) -> Result<(), String> {
+        let current = self
+            .current
+            .as_mut()
+            .ok_or_else(|| "snapshot block must appear under a scenario heading".to_string())?;
+
+        if current.snapshot.is_some() {
+            return Err(format!(
+                "scenario '{}' has more than one snapshot block",
+                current.name
+            ));
+        }
+
+        current.snapshot = Some(block.content);
+        current.snapshot_start = Some(block.content_start);
+        current.snapshot_end = Some(block.content_end);
+        Ok(())
+    }
+
+    fn finish_current(&mut self) -> Result<(), String> {
+        let Some(current) = self.current.take() else {
+            return Ok(());
+        };
+
+        match current.source {
+            Some(source) => {
+                self.scenarios.push(Scenario {
+                    name: current.name,
+                    file_path: current.file_path.unwrap_or_else(|| "test.html".to_string()),
+                    source,
+                    snapshot: current.snapshot,
+                    snapshot_start: current.snapshot_start,
+                    snapshot_end: current.snapshot_end,
+                    snapshot_insert_at: current
+                        .snapshot_insert_at
+                        .expect("source block should have an insertion point"),
+                });
+                Ok(())
+            }
+            None if current.snapshot.is_none() => Ok(()),
+            None => Err(format!(
+                "scenario '{}' has a snapshot block but no Django code block",
+                current.name
+            )),
+        }
+    }
+
+    fn scenario_name(&self) -> String {
+        self.headings
+            .iter()
+            .map(|heading| heading.name.as_str())
+            .collect::<Vec<_>>()
+            .join(" / ")
+    }
+
+    fn line_at(&self, byte: usize) -> usize {
+        self.line_starts
+            .partition_point(|line_start| *line_start <= byte)
+            .saturating_sub(1)
+    }
+
+    fn line_after(&self, byte: usize) -> usize {
+        if byte > 0 && self.markdown.as_bytes().get(byte - 1) == Some(&b'\n') {
+            self.line_at(byte)
+        } else {
+            self.line_at(byte) + 1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_heading_path_for_scenario_name() {
+        let markdown = r"# Diagnostics
+
+## else outside if
+
+`templates/test.html`:
+
+```htmldjango
+{% else %}
+```
+
+```snapshot
+error[S102]: Orphaned tag
+```
+";
+
+        let scenarios = ScenarioCollector::new(markdown).collect().unwrap();
+
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(scenarios[0].name, "Diagnostics / else outside if");
+        assert_eq!(scenarios[0].file_path, "templates/test.html");
+        assert_eq!(scenarios[0].source, "{% else %}");
+        assert_eq!(
+            scenarios[0].snapshot.as_deref(),
+            Some("error[S102]: Orphaned tag")
+        );
+        assert_eq!(scenarios[0].snapshot_start, Some(11));
+        assert_eq!(scenarios[0].snapshot_end, Some(12));
+        assert_eq!(scenarios[0].snapshot_insert_at, 9);
+    }
+
+    #[test]
+    fn ignores_group_headings_without_code_blocks() {
+        let markdown = r"# for
+
+## Valid
+
+### iterates over a sequence
+
+```htmldjango
+{% for item in items %}{% endfor %}
+```
+
+## Invalid
+
+### reports empty outside for
+
+```htmldjango
+{% empty %}
+```
+";
+
+        let scenarios = ScenarioCollector::new(markdown).collect().unwrap();
+
+        assert_eq!(scenarios.len(), 2);
+        assert_eq!(scenarios[0].name, "for / Valid / iterates over a sequence");
+        assert_eq!(
+            scenarios[1].name,
+            "for / Invalid / reports empty outside for"
+        );
+    }
+
+    #[test]
+    fn rejects_child_heading_after_source_block() {
+        let markdown = r#"# i18n
+
+## Valid
+
+```htmldjango
+{% load i18n %}
+{% trans "Hello" %}
+```
+
+### translates a literal after load
+
+```htmldjango
+{% load i18n %}
+{% trans "Hello" %}
+```
+"#;
+
+        let error = ScenarioCollector::new(markdown).collect().unwrap_err();
+
+        assert_eq!(
+            error,
+            "scenario 'i18n / Valid' has child heading 'translates a literal after load' after its Django code block"
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_source_blocks_in_one_heading() {
+        let markdown = r#"# i18n
+
+## translates a literal after load
+
+```htmldjango
+{% load i18n %}
+{% trans "Hello" %}
+```
+
+```htmldjango
+{% load i18n %}
+{% trans "Goodbye" %}
+```
+"#;
+
+        let error = ScenarioCollector::new(markdown).collect().unwrap_err();
+
+        assert_eq!(
+            error,
+            "scenario 'i18n / translates a literal after load' has more than one htmldjango code block"
+        );
+    }
+
+    #[test]
+    fn rewrites_snapshot_contents() {
+        let markdown = r"## scenario
+
+```htmldjango
+{% else %}
+```
+
+```snapshot
+old snapshot
+```
+";
+        let rewritten = SnapshotUpdate::apply_all(
+            markdown,
+            &[SnapshotUpdate {
+                start: 7,
+                end: 8,
+                replacement: "new snapshot".to_string(),
+            }],
+        );
+
+        assert_eq!(
+            rewritten,
+            r"## scenario
+
+```htmldjango
+{% else %}
+```
+
+```snapshot
+new snapshot
+```
+"
+        );
+    }
+
+    #[test]
+    fn inserts_missing_snapshot_block() {
+        let markdown = r"## scenario
+
+```htmldjango
+{% else %}
+```
+";
+        let rewritten = SnapshotUpdate::apply_all(
+            markdown,
+            &[SnapshotUpdate {
+                start: 5,
+                end: 5,
+                replacement: "\n```snapshot\nnew snapshot\n```".to_string(),
+            }],
+        );
+
+        assert_eq!(
+            rewritten,
+            r"## scenario
+
+```htmldjango
+{% else %}
+```
+
+```snapshot
+new snapshot
+```
+"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a Markdown diagnostic snapshot harness for `djls-semantic`
- add generated diagnostic suites and per-tag Django template mdtests
- document mdtest authoring and update workflow

## Related issues
- Refs #398
- Refs #400

This lands the Markdown diagnostic snapshot format and mdtest authoring workflow, but does not fully close either issue yet. Follow-up work remains for broader migration and less synthetic scenario setup.

## Validation
- `just fmt --check`
- `cargo test -p djls-semantic -q`
- `cargo clippy -p djls-semantic --all-targets --all-features -- -D warnings`
- `just lint`