### PR TITLE
Make template reference indexing Salsa-correct

### DIFF
--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -17,7 +17,6 @@ pub mod testing;
 pub use db::Db;
 pub use db::ValidationErrorAccumulator;
 pub use errors::ValidationError;
-pub use primitives::Tag;
 pub use primitives::Template;
 pub use primitives::TemplateName;
 pub use project::build_search_paths;

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -17,6 +17,7 @@ pub mod testing;
 pub use db::Db;
 pub use db::ValidationErrorAccumulator;
 pub use errors::ValidationError;
+pub use primitives::Tag;
 pub use primitives::Template;
 pub use primitives::TemplateName;
 pub use project::build_search_paths;

--- a/crates/djls-semantic/src/primitives.rs
+++ b/crates/djls-semantic/src/primitives.rs
@@ -1,8 +1,5 @@
 use camino::Utf8PathBuf;
 use djls_source::File;
-use djls_source::Span;
-use djls_templates::parse_template;
-use djls_templates::Node;
 
 use crate::db::Db as SemanticDb;
 
@@ -16,37 +13,10 @@ impl<'db> Template<'db> {
     pub fn path_buf(&'db self, db: &'db dyn SemanticDb) -> &'db Utf8PathBuf {
         self.file(db).path(db)
     }
-
-    pub fn tags(&self, db: &'db dyn SemanticDb) -> Vec<Tag<'db>> {
-        let file = self.file(db);
-        let Some(nodelist) = parse_template(db, file) else {
-            return Vec::new();
-        };
-
-        nodelist
-            .nodelist(db)
-            .iter()
-            .filter_map(|node| match node {
-                Node::Tag {
-                    name, bits, span, ..
-                } => Some(Tag::new(db, name.clone(), bits.clone(), *span)),
-                _ => None,
-            })
-            .collect()
-    }
 }
 
 #[salsa::interned]
 pub struct TemplateName {
     #[returns(ref)]
     pub name: String,
-}
-
-#[salsa::tracked]
-pub struct Tag<'db> {
-    #[returns(ref)]
-    pub name: String,
-    #[returns(ref)]
-    pub bits: Vec<djls_templates::TagBit>,
-    pub span: Span,
 }

--- a/crates/djls-semantic/src/primitives.rs
+++ b/crates/djls-semantic/src/primitives.rs
@@ -1,5 +1,8 @@
 use camino::Utf8PathBuf;
 use djls_source::File;
+use djls_source::Span;
+use djls_templates::parse_template;
+use djls_templates::Node;
 
 use crate::db::Db as SemanticDb;
 
@@ -15,8 +18,39 @@ impl<'db> Template<'db> {
     }
 }
 
+#[salsa::tracked]
+impl<'db> Template<'db> {
+    #[salsa::tracked(returns(ref))]
+    pub fn tags(self, db: &'db dyn SemanticDb) -> Vec<Tag<'db>> {
+        let file = self.file(db);
+        let Some(nodelist) = parse_template(db, file) else {
+            return Vec::new();
+        };
+
+        nodelist
+            .nodelist(db)
+            .iter()
+            .filter_map(|node| match node {
+                Node::Tag {
+                    name, bits, span, ..
+                } => Some(Tag::new(db, name.clone(), bits.clone(), *span)),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
 #[salsa::interned]
 pub struct TemplateName {
     #[returns(ref)]
     pub name: String,
+}
+
+#[salsa::tracked]
+pub struct Tag<'db> {
+    #[returns(ref)]
+    pub name: String,
+    #[returns(ref)]
+    pub bits: Vec<djls_templates::TagBit>,
+    pub span: Span,
 }

--- a/crates/djls-semantic/src/primitives.rs
+++ b/crates/djls-semantic/src/primitives.rs
@@ -3,6 +3,7 @@ use djls_source::File;
 use djls_source::Span;
 use djls_templates::parse_template;
 use djls_templates::Node;
+use djls_templates::TagBit;
 
 use crate::db::Db as SemanticDb;
 
@@ -16,28 +17,32 @@ impl<'db> Template<'db> {
     pub fn path_buf(&'db self, db: &'db dyn SemanticDb) -> &'db Utf8PathBuf {
         self.file(db).path(db)
     }
+
+    pub fn tags(self, db: &'db dyn SemanticDb) -> &'db [Tag] {
+        template_tags(db, self)
+    }
 }
 
-#[salsa::tracked]
-impl<'db> Template<'db> {
-    #[salsa::tracked(returns(ref))]
-    pub fn tags(self, db: &'db dyn SemanticDb) -> Vec<Tag<'db>> {
-        let file = self.file(db);
-        let Some(nodelist) = parse_template(db, file) else {
-            return Vec::new();
-        };
+// Tags are a cached projection of a template's parsed nodes, not independent
+// Salsa identities. Keep the query boundary here and expose it through
+// `Template::tags` so callers can still ask a template for its tags.
+#[salsa::tracked(returns(ref))]
+fn template_tags(db: &dyn SemanticDb, template: Template<'_>) -> Vec<Tag> {
+    let file = template.file(db);
+    let Some(nodelist) = parse_template(db, file) else {
+        return Vec::new();
+    };
 
-        nodelist
-            .nodelist(db)
-            .iter()
-            .filter_map(|node| match node {
-                Node::Tag {
-                    name, bits, span, ..
-                } => Some(Tag::new(db, name.clone(), bits.clone(), *span)),
-                _ => None,
-            })
-            .collect()
-    }
+    nodelist
+        .nodelist(db)
+        .iter()
+        .filter_map(|node| match node {
+            Node::Tag {
+                name, bits, span, ..
+            } => Some(Tag::new(name.clone(), bits.clone(), *span)),
+            _ => None,
+        })
+        .collect()
 }
 
 #[salsa::interned]
@@ -46,11 +51,31 @@ pub struct TemplateName {
     pub name: String,
 }
 
-#[salsa::tracked]
-pub struct Tag<'db> {
-    #[returns(ref)]
-    pub name: String,
-    #[returns(ref)]
-    pub bits: Vec<djls_templates::TagBit>,
-    pub span: Span,
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Tag {
+    name: String,
+    bits: Vec<TagBit>,
+    span: Span,
+}
+
+impl Tag {
+    #[must_use]
+    pub fn new(name: String, bits: Vec<TagBit>, span: Span) -> Self {
+        Self { name, bits, span }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn bits(&self) -> &[TagBit] {
+        &self.bits
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        self.span
+    }
 }

--- a/crates/djls-semantic/src/resolution.rs
+++ b/crates/djls-semantic/src/resolution.rs
@@ -3,10 +3,11 @@ use djls_source::safe_join;
 use djls_source::File;
 use djls_source::Span;
 use djls_source::Utf8PathClean;
+use djls_templates::parse_template;
+use djls_templates::Node;
 use ignore::WalkBuilder;
 
 pub use crate::db::Db as SemanticDb;
-use crate::primitives::Tag;
 pub use crate::primitives::Template;
 pub use crate::primitives::TemplateName;
 
@@ -117,19 +118,17 @@ pub fn resolve_template<'db>(db: &'db dyn SemanticDb, name: &str) -> ResolveResu
 
 #[salsa::tracked]
 pub struct TemplateReference<'db> {
+    /// Source span of the extends/include tag. Store the parser payload directly
+    /// so reference indexing does not need a separate Salsa identity for tags.
     pub source: Template<'db>,
     pub target: TemplateName<'db>,
-    pub tag: Tag<'db>,
+    pub span: Span,
 }
 
 impl TemplateReference<'_> {
     pub fn source_file(&self, db: &dyn SemanticDb) -> File {
         let template = self.source(db);
         template.file(db)
-    }
-
-    pub fn span(&self, db: &dyn SemanticDb) -> Span {
-        self.tag(db).span(db)
     }
 }
 
@@ -159,22 +158,36 @@ fn template_reference_index(db: &dyn SemanticDb) -> Vec<TemplateReference<'_>> {
     let templates = discover_templates(db);
 
     for template in templates {
-        for tag in template.tags(db) {
-            let tag_name = tag.name(db);
-            if tag_name == "extends" || tag_name == "include" {
-                if let Some(template_name) = tag
-                    .bits(db)
-                    .first()
-                    .and_then(|argument| argument.template_string().quoted_value())
-                {
-                    references.push(TemplateReference::new(
-                        db,
-                        template,
-                        TemplateName::new(db, template_name.to_string()),
-                        tag,
-                    ));
-                }
+        let file = template.file(db);
+        let Some(nodelist) = parse_template(db, file) else {
+            continue;
+        };
+
+        for node in nodelist.nodelist(db) {
+            let Node::Tag {
+                name, bits, span, ..
+            } = node
+            else {
+                continue;
+            };
+
+            if name != "extends" && name != "include" {
+                continue;
             }
+
+            let Some(template_name) = bits
+                .first()
+                .and_then(|argument| argument.template_string().quoted_value())
+            else {
+                continue;
+            };
+
+            references.push(TemplateReference::new(
+                db,
+                template,
+                TemplateName::new(db, template_name.to_string()),
+                *span,
+            ));
         }
     }
 

--- a/crates/djls-semantic/src/resolution.rs
+++ b/crates/djls-semantic/src/resolution.rs
@@ -6,7 +6,6 @@ use djls_source::Utf8PathClean;
 use ignore::WalkBuilder;
 
 pub use crate::db::Db as SemanticDb;
-use crate::primitives::Tag;
 pub use crate::primitives::Template;
 pub use crate::primitives::TemplateName;
 
@@ -119,17 +118,13 @@ pub fn resolve_template<'db>(db: &'db dyn SemanticDb, name: &str) -> ResolveResu
 pub struct TemplateReference<'db> {
     pub source: Template<'db>,
     pub target: TemplateName<'db>,
-    pub tag: Tag<'db>,
+    pub span: Span,
 }
 
 impl TemplateReference<'_> {
     pub fn source_file(&self, db: &dyn SemanticDb) -> File {
         let template = self.source(db);
         template.file(db)
-    }
-
-    pub fn span(&self, db: &dyn SemanticDb) -> Span {
-        self.tag(db).span(db)
     }
 }
 
@@ -160,10 +155,10 @@ fn template_reference_index(db: &dyn SemanticDb) -> Vec<TemplateReference<'_>> {
 
     for template in templates {
         for tag in template.tags(db) {
-            let tag_name = tag.name(db);
+            let tag_name = tag.name();
             if tag_name == "extends" || tag_name == "include" {
                 if let Some(template_name) = tag
-                    .bits(db)
+                    .bits()
                     .first()
                     .and_then(|argument| argument.template_string().quoted_value())
                 {
@@ -171,7 +166,7 @@ fn template_reference_index(db: &dyn SemanticDb) -> Vec<TemplateReference<'_>> {
                         db,
                         template,
                         TemplateName::new(db, template_name.to_string()),
-                        *tag,
+                        tag.span(),
                     ));
                 }
             }

--- a/crates/djls-semantic/src/resolution.rs
+++ b/crates/djls-semantic/src/resolution.rs
@@ -3,11 +3,10 @@ use djls_source::safe_join;
 use djls_source::File;
 use djls_source::Span;
 use djls_source::Utf8PathClean;
-use djls_templates::parse_template;
-use djls_templates::Node;
 use ignore::WalkBuilder;
 
 pub use crate::db::Db as SemanticDb;
+use crate::primitives::Tag;
 pub use crate::primitives::Template;
 pub use crate::primitives::TemplateName;
 
@@ -118,17 +117,19 @@ pub fn resolve_template<'db>(db: &'db dyn SemanticDb, name: &str) -> ResolveResu
 
 #[salsa::tracked]
 pub struct TemplateReference<'db> {
-    /// Source span of the extends/include tag. Store the parser payload directly
-    /// so reference indexing does not need a separate Salsa identity for tags.
     pub source: Template<'db>,
     pub target: TemplateName<'db>,
-    pub span: Span,
+    pub tag: Tag<'db>,
 }
 
 impl TemplateReference<'_> {
     pub fn source_file(&self, db: &dyn SemanticDb) -> File {
         let template = self.source(db);
         template.file(db)
+    }
+
+    pub fn span(&self, db: &dyn SemanticDb) -> Span {
+        self.tag(db).span(db)
     }
 }
 
@@ -158,36 +159,22 @@ fn template_reference_index(db: &dyn SemanticDb) -> Vec<TemplateReference<'_>> {
     let templates = discover_templates(db);
 
     for template in templates {
-        let file = template.file(db);
-        let Some(nodelist) = parse_template(db, file) else {
-            continue;
-        };
-
-        for node in nodelist.nodelist(db) {
-            let Node::Tag {
-                name, bits, span, ..
-            } = node
-            else {
-                continue;
-            };
-
-            if name != "extends" && name != "include" {
-                continue;
+        for tag in template.tags(db) {
+            let tag_name = tag.name(db);
+            if tag_name == "extends" || tag_name == "include" {
+                if let Some(template_name) = tag
+                    .bits(db)
+                    .first()
+                    .and_then(|argument| argument.template_string().quoted_value())
+                {
+                    references.push(TemplateReference::new(
+                        db,
+                        template,
+                        TemplateName::new(db, template_name.to_string()),
+                        *tag,
+                    ));
+                }
             }
-
-            let Some(template_name) = bits
-                .first()
-                .and_then(|argument| argument.template_string().quoted_value())
-            else {
-                continue;
-            };
-
-            references.push(TemplateReference::new(
-                db,
-                template,
-                TemplateName::new(db, template_name.to_string()),
-                *span,
-            ));
         }
     }
 


### PR DESCRIPTION
## Summary
- keep `Template::tags()` as the domain API for asking a template for its tags
- move the Salsa boundary to a private `template_tags` query with `returns(ref)`, matching Ruff/ty and rust-analyzer-style cached projections
- make `Tag` a plain parsed-node projection instead of a tracked identity; `TemplateReference` stores only source, target, and source span

## Verification
- cargo test -q
- just fmt --check
- just clippy --allow-dirty

Refs #539