### PR TITLE
Add static settings context discovery

### DIFF
--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -2,6 +2,7 @@ mod diagnostics;
 mod format;
 mod tagspecs;
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
@@ -64,6 +65,38 @@ pub enum ConfigError {
     PyprojectParse(#[from] toml::de::Error),
     #[error("Failed to serialize extracted pyproject.toml data")]
     PyprojectSerialize(#[from] toml::ser::Error),
+    #[error("Invalid settings_contexts: {0}")]
+    InvalidSettingsContexts(String),
+}
+
+#[derive(Debug, Deserialize, Default, PartialEq, Eq, Clone)]
+pub struct SettingsContextConfig {
+    label: String,
+    module: Option<String>,
+    file: Option<String>,
+}
+
+impl SettingsContextConfig {
+    #[must_use]
+    pub fn label(&self) -> &str {
+        self.label.trim()
+    }
+
+    #[must_use]
+    pub fn module(&self) -> Option<&str> {
+        self.module
+            .as_deref()
+            .map(str::trim)
+            .filter(|module| !module.is_empty())
+    }
+
+    #[must_use]
+    pub fn file(&self) -> Option<&str> {
+        self.file
+            .as_deref()
+            .map(str::trim)
+            .filter(|file| !file.is_empty())
+    }
 }
 
 #[derive(Debug, Deserialize, Default, PartialEq, Clone)]
@@ -72,6 +105,8 @@ pub struct Settings {
     debug: bool,
     venv_path: Option<String>,
     django_settings_module: Option<String>,
+    #[serde(default, rename = "settings_contexts")]
+    contexts: Vec<SettingsContextConfig>,
     #[serde(default)]
     pythonpath: Vec<String>,
     env_file: Option<String>,
@@ -96,6 +131,9 @@ impl Settings {
             settings.django_settings_module = overrides
                 .django_settings_module
                 .or(settings.django_settings_module);
+            if !overrides.contexts.is_empty() {
+                settings.contexts = overrides.contexts;
+            }
             if !overrides.pythonpath.is_empty() {
                 settings.pythonpath = overrides.pythonpath;
             }
@@ -112,7 +150,43 @@ impl Settings {
             }
         }
 
+        settings.validate()?;
         Ok(settings)
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        let mut labels = BTreeSet::new();
+        for context in &self.contexts {
+            let label = context.label();
+            if label.is_empty() {
+                return Err(ConfigError::InvalidSettingsContexts(
+                    "context label cannot be empty".to_string(),
+                ));
+            }
+            if !labels.insert(label.to_string()) {
+                return Err(ConfigError::InvalidSettingsContexts(format!(
+                    "duplicate context label: {label}"
+                )));
+            }
+
+            let has_module = context.module().is_some();
+            let has_file = context.file().is_some();
+            match (has_module, has_file) {
+                (true, false) | (false, true) => {}
+                (true, true) => {
+                    return Err(ConfigError::InvalidSettingsContexts(format!(
+                        "context {label} must use either module or file, not both"
+                    )));
+                }
+                (false, false) => {
+                    return Err(ConfigError::InvalidSettingsContexts(format!(
+                        "context {label} must set module or file"
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn load_from_paths(
@@ -154,7 +228,8 @@ impl Settings {
         );
 
         let config = builder.build()?;
-        let settings = config.try_deserialize()?;
+        let settings: Self = config.try_deserialize()?;
+        settings.validate()?;
         Ok(settings)
     }
 
@@ -171,6 +246,11 @@ impl Settings {
     #[must_use]
     pub fn django_settings_module(&self) -> Option<&str> {
         self.django_settings_module.as_deref()
+    }
+
+    #[must_use]
+    pub fn settings_contexts(&self) -> &[SettingsContextConfig] {
+        &self.contexts
     }
 
     #[must_use]
@@ -220,6 +300,7 @@ mod tests {
                     debug: false,
                     venv_path: None,
                     django_settings_module: None,
+                    contexts: vec![],
                     pythonpath: vec![],
                     env_file: None,
                     tagspecs: TagSpecDef::default(),
@@ -319,6 +400,70 @@ mod tests {
                     env_file: Some(".env.local".to_string()),
                     ..Default::default()
                 }
+            );
+        }
+
+        #[test]
+        fn test_load_settings_contexts_config() {
+            let dir = tempdir().unwrap();
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+[[settings_contexts]]
+label = "site1"
+module = "projects.site1.settings.dev"
+
+[[settings_contexts]]
+label = "site2"
+file = "projects/site2/settings/dev.py"
+"#,
+            )
+            .unwrap();
+
+            let settings = Settings::new(Utf8Path::from_path(dir.path()).unwrap(), None).unwrap();
+            let contexts = settings.settings_contexts();
+
+            assert_eq!(contexts.len(), 2);
+            assert_eq!(contexts[0].label(), "site1");
+            assert_eq!(contexts[0].module(), Some("projects.site1.settings.dev"));
+            assert_eq!(contexts[0].file(), None);
+            assert_eq!(contexts[1].label(), "site2");
+            assert_eq!(contexts[1].module(), None);
+            assert_eq!(contexts[1].file(), Some("projects/site2/settings/dev.py"));
+        }
+
+        #[test]
+        fn test_overrides_replace_settings_contexts() {
+            let dir = tempdir().unwrap();
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+[[settings_contexts]]
+label = "project"
+module = "project.settings"
+"#,
+            )
+            .unwrap();
+
+            let override_settings = Settings {
+                contexts: vec![SettingsContextConfig {
+                    label: "override".to_string(),
+                    module: Some("override.settings".to_string()),
+                    file: None,
+                }],
+                ..Default::default()
+            };
+            let settings = Settings::new(
+                Utf8Path::from_path(dir.path()).unwrap(),
+                Some(override_settings),
+            )
+            .unwrap();
+
+            assert_eq!(settings.settings_contexts().len(), 1);
+            assert_eq!(settings.settings_contexts()[0].label(), "override");
+            assert_eq!(
+                settings.settings_contexts()[0].module(),
+                Some("override.settings")
             );
         }
 
@@ -610,6 +755,53 @@ end_tag = { name = "endblock", optional = false }
             let result = Settings::new(Utf8Path::from_path(dir.path()).unwrap(), None);
             assert!(result.is_err());
             assert!(matches!(result.unwrap_err(), ConfigError::Config(_)));
+        }
+
+        #[test]
+        fn test_rejects_settings_context_with_module_and_file() {
+            let dir = tempdir().unwrap();
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+[[settings_contexts]]
+label = "site"
+module = "project.settings"
+file = "project/settings.py"
+"#,
+            )
+            .unwrap();
+
+            let result = Settings::new(Utf8Path::from_path(dir.path()).unwrap(), None);
+
+            assert!(matches!(
+                result.unwrap_err(),
+                ConfigError::InvalidSettingsContexts(_)
+            ));
+        }
+
+        #[test]
+        fn test_rejects_duplicate_settings_context_labels() {
+            let dir = tempdir().unwrap();
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+[[settings_contexts]]
+label = "site"
+module = "project.settings"
+
+[[settings_contexts]]
+label = "site"
+module = "other.settings"
+"#,
+            )
+            .unwrap();
+
+            let result = Settings::new(Utf8Path::from_path(dir.path()).unwrap(), None);
+
+            assert!(matches!(
+                result.unwrap_err(),
+                ConfigError::InvalidSettingsContexts(_)
+            ));
         }
     }
 }

--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -4,6 +4,7 @@ mod introspector;
 mod names;
 mod python;
 mod resolve;
+mod static_context;
 mod static_model;
 mod static_resolver;
 mod symbols;

--- a/crates/djls-semantic/src/project/input.rs
+++ b/crates/djls-semantic/src/project/input.rs
@@ -377,7 +377,7 @@ pub fn load_env_file(root: &Utf8Path, settings: &Settings) -> Vec<(String, Strin
     }
 }
 
-fn resolve_django_settings(root: &Utf8Path, settings: &Settings) -> Option<String> {
+pub(crate) fn resolve_django_settings(root: &Utf8Path, settings: &Settings) -> Option<String> {
     settings
         .django_settings_module()
         .map(String::from)

--- a/crates/djls-semantic/src/project/static_context.rs
+++ b/crates/djls-semantic/src/project/static_context.rs
@@ -1,0 +1,313 @@
+//! Settings context discovery for the static Django project model.
+//!
+//! This module is intentionally not wired into project validation yet. It turns
+//! legacy `django_settings_module` and the new settings-context config shape
+//! into context-scoped facts that later static settings extraction can consume.
+
+#![allow(
+    dead_code,
+    reason = "Milestone A3 adds settings context discovery before wiring static settings extraction."
+)]
+
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use djls_conf::Settings;
+
+use crate::project::input::resolve_django_settings;
+use crate::project::names::PyModuleName;
+use crate::project::static_model::Fact;
+use crate::project::static_model::Field;
+use crate::project::static_model::ImportRoot;
+use crate::project::static_model::Reason;
+use crate::project::static_model::ReasonSource;
+use crate::project::static_resolver::resolve_file_module;
+use crate::project::static_resolver::resolve_module;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SettingsContextResolution {
+    pub(crate) label: String,
+    pub(crate) settings_module: Fact<PyModuleName>,
+    pub(crate) settings_file: Fact<Utf8PathBuf>,
+}
+
+#[must_use]
+pub(crate) fn discover_settings_contexts(
+    project_root: &Utf8Path,
+    settings: &Settings,
+    import_roots: &[ImportRoot],
+) -> Vec<SettingsContextResolution> {
+    if !settings.settings_contexts().is_empty() {
+        return settings
+            .settings_contexts()
+            .iter()
+            .map(|context| {
+                if let Some(module) = context.module() {
+                    context_from_module(context.label(), module, project_root, import_roots)
+                } else if let Some(file) = context.file() {
+                    context_from_file(context.label(), file, project_root, import_roots)
+                } else {
+                    invalid_context(context.label(), "settings context must set module or file")
+                }
+            })
+            .collect();
+    }
+
+    resolve_django_settings(project_root, settings)
+        .map(|module| context_from_module("default", &module, project_root, import_roots))
+        .into_iter()
+        .collect()
+}
+
+fn context_from_module(
+    label: &str,
+    module: &str,
+    project_root: &Utf8Path,
+    import_roots: &[ImportRoot],
+) -> SettingsContextResolution {
+    let Ok(settings_module) = PyModuleName::parse(module) else {
+        return invalid_context(
+            label,
+            format!("settings context module is not a valid Python module path: {module}"),
+        );
+    };
+
+    let resolution = resolve_module(settings_module.clone(), import_roots, project_root);
+    SettingsContextResolution {
+        label: label.to_string(),
+        settings_module: Fact::known(settings_module),
+        settings_file: resolution.resolved.map(|resolved| resolved.file),
+    }
+}
+
+fn context_from_file(
+    label: &str,
+    file: &str,
+    project_root: &Utf8Path,
+    import_roots: &[ImportRoot],
+) -> SettingsContextResolution {
+    let file = normalize_context_file(project_root, file);
+    let settings_file = if file.is_file() {
+        Fact::known(file.clone())
+    } else {
+        Fact::unknown(vec![Reason::file(
+            Field::SettingsContext,
+            file.clone(),
+            "settings context file does not exist or is not a file",
+        )])
+    };
+    let settings_module = resolve_file_module(&file, import_roots);
+
+    SettingsContextResolution {
+        label: label.to_string(),
+        settings_module,
+        settings_file,
+    }
+}
+
+fn invalid_context(label: &str, message: impl Into<String>) -> SettingsContextResolution {
+    let reason = Reason::new(
+        Field::SettingsContext,
+        ReasonSource::SettingsContext(label.to_string()),
+        message,
+    );
+
+    SettingsContextResolution {
+        label: label.to_string(),
+        settings_module: Fact::unknown(vec![reason.clone()]),
+        settings_file: Fact::unknown(vec![reason]),
+    }
+}
+
+#[must_use]
+fn normalize_context_file(project_root: &Utf8Path, file: &str) -> Utf8PathBuf {
+    let file = Utf8Path::new(file);
+    if file.is_absolute() {
+        file.to_path_buf()
+    } else {
+        project_root.join(file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::project::static_model::ImportRootKind;
+    use crate::project::static_resolver::discover_import_roots;
+
+    fn settings(root: &Utf8Path) -> Settings {
+        Settings::new(root, None).unwrap()
+    }
+
+    fn import_roots(root: &Utf8Path) -> Vec<ImportRoot> {
+        discover_import_roots(root, &[], &[])
+            .value()
+            .cloned()
+            .unwrap()
+    }
+
+    fn write_file(path: &Utf8Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn module(name: &str) -> PyModuleName {
+        PyModuleName::parse(name).unwrap()
+    }
+
+    fn known_module(fact: &Fact<PyModuleName>) -> PyModuleName {
+        let Fact::Known { value } = fact else {
+            panic!("expected known settings module, got {fact:?}");
+        };
+        value.clone()
+    }
+
+    fn known_file(fact: &Fact<Utf8PathBuf>) -> Utf8PathBuf {
+        let Fact::Known { value } = fact else {
+            panic!("expected known settings file, got {fact:?}");
+        };
+        value.clone()
+    }
+
+    #[test]
+    fn legacy_django_settings_module_becomes_default_context() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(&root.join("project/settings.py"), "");
+        write_file(
+            &root.join("djls.toml"),
+            r#"django_settings_module = "project.settings""#,
+        );
+
+        let contexts = discover_settings_contexts(&root, &settings(&root), &import_roots(&root));
+
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(contexts[0].label, "default");
+        assert_eq!(
+            known_module(&contexts[0].settings_module),
+            module("project.settings")
+        );
+        assert_eq!(
+            known_file(&contexts[0].settings_file),
+            root.join("project/settings.py")
+        );
+    }
+
+    #[test]
+    fn explicit_module_contexts_remain_separate() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("projects/__init__.py"), "");
+        write_file(&root.join("projects/site1/__init__.py"), "");
+        write_file(&root.join("projects/site1/settings.py"), "");
+        write_file(&root.join("projects/site2/__init__.py"), "");
+        write_file(&root.join("projects/site2/settings.py"), "");
+        write_file(
+            &root.join("djls.toml"),
+            r#"
+[[settings_contexts]]
+label = "site1"
+module = "projects.site1.settings"
+
+[[settings_contexts]]
+label = "site2"
+module = "projects.site2.settings"
+"#,
+        );
+
+        let contexts = discover_settings_contexts(&root, &settings(&root), &import_roots(&root));
+
+        assert_eq!(contexts.len(), 2);
+        assert_eq!(contexts[0].label, "site1");
+        assert_eq!(
+            known_module(&contexts[0].settings_module),
+            module("projects.site1.settings")
+        );
+        assert_eq!(
+            known_file(&contexts[0].settings_file),
+            root.join("projects/site1/settings.py")
+        );
+        assert_eq!(contexts[1].label, "site2");
+        assert_eq!(
+            known_module(&contexts[1].settings_module),
+            module("projects.site2.settings")
+        );
+        assert_eq!(
+            known_file(&contexts[1].settings_file),
+            root.join("projects/site2/settings.py")
+        );
+    }
+
+    #[test]
+    fn file_context_resolves_module_through_import_roots() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("src/project/__init__.py"), "");
+        write_file(&root.join("src/project/settings/__init__.py"), "");
+        write_file(&root.join("src/project/settings/dev.py"), "");
+        write_file(
+            &root.join("djls.toml"),
+            r#"
+[[settings_contexts]]
+label = "dev"
+file = "src/project/settings/dev.py"
+"#,
+        );
+
+        let roots = import_roots(&root);
+        assert!(roots
+            .iter()
+            .any(|root| root.kind == ImportRootKind::AutoSrc));
+
+        let contexts = discover_settings_contexts(&root, &settings(&root), &roots);
+
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(contexts[0].label, "dev");
+        assert_eq!(
+            known_module(&contexts[0].settings_module),
+            module("project.settings.dev")
+        );
+        assert_eq!(
+            known_file(&contexts[0].settings_file),
+            root.join("src/project/settings/dev.py")
+        );
+    }
+
+    #[test]
+    fn file_context_outside_import_roots_keeps_file_but_unknown_module() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let external_tmp = tempdir().unwrap();
+        let external_root = Utf8PathBuf::try_from(external_tmp.path().to_path_buf()).unwrap();
+        let settings_file = external_root.join("project/settings.py");
+        write_file(&settings_file, "");
+        write_file(
+            &root.join("djls.toml"),
+            &format!(
+                r#"
+[[settings_contexts]]
+label = "external"
+file = "{settings_file}"
+"#,
+            ),
+        );
+
+        let contexts = discover_settings_contexts(&root, &settings(&root), &import_roots(&root));
+
+        assert_eq!(known_file(&contexts[0].settings_file), settings_file);
+        match &contexts[0].settings_module {
+            Fact::Unknown { reasons } => {
+                assert!(reasons
+                    .iter()
+                    .any(|reason| reason.field == Field::ResolverModule));
+            }
+            other => panic!("expected unknown module for file outside import roots, got {other:?}"),
+        }
+    }
+}

--- a/crates/djls-semantic/src/project/static_resolver.rs
+++ b/crates/djls-semantic/src/project/static_resolver.rs
@@ -109,6 +109,55 @@ pub(crate) fn resolve_module(
 }
 
 #[must_use]
+pub(crate) fn resolve_file_module(
+    file: &Utf8Path,
+    import_roots: &[ImportRoot],
+) -> Fact<PyModuleName> {
+    if !file.is_file() {
+        return Fact::unknown(vec![Reason::file(
+            Field::ResolverModule,
+            file,
+            "module file does not exist or is not a file",
+        )]);
+    }
+
+    if file.extension() != Some("py") {
+        return Fact::unknown(vec![Reason::file(
+            Field::ResolverModule,
+            file,
+            "module file is not a Python file",
+        )]);
+    }
+
+    let candidates = module_names_for_file(file, import_roots);
+    match candidates.len() {
+        0 => Fact::unknown(vec![Reason::file(
+            Field::ResolverModule,
+            file,
+            "module file is outside configured import roots",
+        )]),
+        1 => {
+            let (module, import_root) = candidates.into_iter().next().unwrap();
+            let parts = module.as_str().split('.').collect::<Vec<_>>();
+            let reasons = namespace_package_reasons(&parts, &import_root);
+            if reasons.is_empty() {
+                Fact::known(module)
+            } else {
+                Fact::partial(module, reasons)
+            }
+        }
+        _ => Fact::ambiguous(
+            candidates.into_iter().map(|(module, _)| module).collect(),
+            vec![Reason::file(
+                Field::ResolverModule,
+                file,
+                "module file maps to more than one module name",
+            )],
+        ),
+    }
+}
+
+#[must_use]
 pub(crate) fn resolve_relative_import_module(
     current_module: &PyModuleName,
     level: usize,
@@ -175,6 +224,45 @@ fn normalize_import_root(project_root: &Utf8Path, path: &Utf8Path) -> Utf8PathBu
     } else {
         project_root.join(path)
     }
+}
+
+fn module_names_for_file(
+    file: &Utf8Path,
+    import_roots: &[ImportRoot],
+) -> Vec<(PyModuleName, Utf8PathBuf)> {
+    let Some(longest_root_len) = import_roots
+        .iter()
+        .filter(|root| file.starts_with(&root.path))
+        .map(|root| root.path.as_str().len())
+        .max()
+    else {
+        return Vec::new();
+    };
+
+    import_roots
+        .iter()
+        .filter(|root| file.starts_with(&root.path) && root.path.as_str().len() == longest_root_len)
+        .filter_map(|root| {
+            let relative = file.strip_prefix(&root.path).ok()?;
+            module_name_from_relative_file(relative).map(|module| (module, root.path.clone()))
+        })
+        .fold(Vec::new(), |mut candidates, candidate| {
+            if !candidates.iter().any(|(module, _)| module == &candidate.0) {
+                candidates.push(candidate);
+            }
+            candidates
+        })
+}
+
+fn module_name_from_relative_file(relative: &Utf8Path) -> Option<PyModuleName> {
+    if relative.file_name() == Some("__init__.py") {
+        return relative
+            .parent()
+            .filter(|parent| !parent.as_str().is_empty())
+            .and_then(|parent| PyModuleName::from_relative_package(parent).ok());
+    }
+
+    PyModuleName::from_relative_python_module(relative).ok()
 }
 
 fn collect_pth_import_roots(
@@ -435,6 +523,25 @@ mod tests {
 
         assert_eq!(resolved.file, src_root.join("config/settings.py"));
         assert_eq!(resolved.import_root, src_root);
+    }
+
+    #[test]
+    fn resolves_file_module_from_longest_import_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&project_root.join("src/config/__init__.py"), "");
+        write_file(&project_root.join("src/config/settings.py"), "");
+
+        let import_roots = discover_import_roots(&project_root, &[], &[]);
+        let fact = resolve_file_module(
+            &project_root.join("src/config/settings.py"),
+            roots_value(&import_roots),
+        );
+
+        let Fact::Known { value } = fact else {
+            panic!("expected known module for settings file, got {fact:?}");
+        };
+        assert_eq!(value, module("config.settings"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the experimental settings_contexts config shape with label/module/file validation
- preserve django_settings_module as an implicit default static context when explicit contexts are absent
- add static context discovery that resolves module contexts to files and file contexts back to module names through import roots
- extend the native resolver with longest-root file-to-module mapping for src layouts

## Validation
- just fmt --check
- just test -q
- cargo clippy -q --all-targets --all-features --benches -- -D warnings
- just lint