### PR TITLE
Add confidence-aware template validation gates

### DIFF
--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -131,12 +131,22 @@ mod tests {
     use crate::testing::builtin_filter_json;
     use crate::testing::builtin_tag_json;
     use crate::testing::collect_errors;
+    use crate::testing::library_filter_json;
     use crate::testing::library_tag_json;
     use crate::testing::make_template_libraries;
     use crate::testing::TestDatabase;
     use crate::FilterArity;
+    use crate::Knowledge;
+    use crate::LibraryName;
+    use crate::LibraryOrigin;
+    use crate::PyModuleName;
+    use crate::SymbolDefinition;
     use crate::SymbolKey;
     use crate::TemplateLibraries;
+    use crate::TemplateLibrary;
+    use crate::TemplateSymbol;
+    use crate::TemplateSymbolKind;
+    use crate::TemplateSymbolName;
     use crate::ValidationError;
 
     fn default_builtins_module() -> &'static str {
@@ -165,6 +175,7 @@ mod tests {
             builtin_filter_json("default", default_filters_module()),
             builtin_filter_json("truncatewords", default_filters_module()),
             builtin_filter_json("date", default_filters_module()),
+            library_filter_json("translate", "i18n", "django.templatetags.i18n"),
         ];
         let mut libraries = HashMap::new();
         libraries.insert("i18n".to_string(), "django.templatetags.i18n".to_string());
@@ -219,6 +230,84 @@ mod tests {
         TestDatabase::new()
             .with_template_libraries(standard_inventory())
             .with_arity_specs(standard_arities())
+    }
+
+    fn partial_active_db() -> TestDatabase {
+        let mut libraries = standard_inventory();
+        libraries.active_knowledge = Knowledge::Partial;
+        TestDatabase::new()
+            .with_template_libraries(libraries)
+            .with_arity_specs(standard_arities())
+    }
+
+    fn discovered_widgets_inventory(active_knowledge: Knowledge) -> TemplateLibraries {
+        let mut libraries = standard_inventory();
+        libraries.active_knowledge = active_knowledge;
+        libraries.discovery_knowledge = Knowledge::Known;
+
+        let name = LibraryName::parse("widgets").unwrap();
+        let app = PyModuleName::parse("example.widgets").unwrap();
+        let module = PyModuleName::parse("example.widgets.templatetags.widgets").unwrap();
+        let origin = LibraryOrigin {
+            app,
+            module: module.clone(),
+            path: Utf8PathBuf::from("/example/widgets/templatetags/widgets.py"),
+        };
+        let mut library = TemplateLibrary::new_discovered(name.clone(), origin);
+        library.merge_symbol(discovered_widget_symbol(
+            TemplateSymbolKind::Tag,
+            "widget_tag",
+            module.as_str(),
+        ));
+        library.merge_symbol(discovered_widget_symbol(
+            TemplateSymbolKind::Filter,
+            "widget_filter",
+            module.as_str(),
+        ));
+
+        libraries.loadable.entry(name).or_default().push(library);
+        libraries
+    }
+
+    fn discovered_widget_symbol(
+        kind: TemplateSymbolKind,
+        name: &str,
+        module: &str,
+    ) -> TemplateSymbol {
+        TemplateSymbol {
+            kind,
+            name: TemplateSymbolName::parse(name).unwrap(),
+            definition: SymbolDefinition::Module(PyModuleName::parse(module).unwrap()),
+            doc: None,
+        }
+    }
+
+    fn ambiguous_filter_inventory() -> TemplateLibraries {
+        let tags = vec![
+            builtin_tag_json("load", default_builtins_module()),
+            library_tag_json("trans", "i18n", "django.templatetags.i18n"),
+        ];
+        let filters = vec![
+            builtin_filter_json("lower", default_filters_module()),
+            library_filter_json("shared", "alpha", "example.alpha.templatetags.alpha"),
+            library_filter_json("shared", "beta", "example.beta.templatetags.beta"),
+        ];
+        let mut libraries = HashMap::new();
+        libraries.insert(
+            "alpha".to_string(),
+            "example.alpha.templatetags.alpha".to_string(),
+        );
+        libraries.insert(
+            "beta".to_string(),
+            "example.beta.templatetags.beta".to_string(),
+        );
+        let builtins = vec![
+            default_builtins_module().to_string(),
+            default_filters_module().to_string(),
+        ];
+        let mut libraries = make_template_libraries(&tags, &filters, &libraries, &builtins);
+        libraries.active_knowledge = Knowledge::Partial;
+        libraries
     }
 
     fn collect_all_errors(db: &TestDatabase, source: &str) -> Vec<ValidationError> {
@@ -409,6 +498,153 @@ mod tests {
                 if tag == "trans" && library == "i18n"),
             "Expected UnloadedTag for trans/i18n, got: {:?}",
             scoping_errors[0]
+        );
+    }
+
+    #[test]
+    fn partial_active_knowledge_keeps_known_unloaded_tag_diagnostic() {
+        let db = partial_active_db();
+        let errors = collect_all_errors(&db, "{% trans \"hello\" %}\n");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UnloadedTag { tag, library, .. }
+                    if tag == "trans" && library == "i18n"
+            )),
+            "Expected partial known active facts to keep S109 for known unloaded tags, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_active_knowledge_keeps_known_unloaded_filter_diagnostic() {
+        let db = partial_active_db();
+        let errors = collect_all_errors(&db, "{{ value|translate }}\n");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UnloadedFilter { filter, library, .. }
+                    if filter == "translate" && library == "i18n"
+            )),
+            "Expected partial known active facts to keep S112 for known unloaded filters, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_active_knowledge_keeps_known_ambiguous_unloaded_filter_diagnostic() {
+        let db = TestDatabase::new()
+            .with_template_libraries(ambiguous_filter_inventory())
+            .with_arity_specs(standard_arities());
+        let errors = collect_all_errors(&db, "{{ value|shared }}\n");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::AmbiguousUnloadedFilter { filter, libraries, .. }
+                    if filter == "shared"
+                        && libraries == &vec!["alpha".to_string(), "beta".to_string()]
+            )),
+            "Expected partial known active facts to keep S113 for ambiguous unloaded filters, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_active_knowledge_suppresses_unknown_tag_and_library() {
+        let db = partial_active_db();
+        let errors = collect_all_errors(
+            &db,
+            concat!(
+                "{% definitely_unknown_tag %}\n",
+                "{{ value|definitely_unknown_filter }}\n",
+                "{% load definitely_unknown_library %}\n",
+            ),
+        );
+
+        assert!(
+            errors.iter().all(|error| !matches!(
+                error,
+                ValidationError::UnknownTag { .. }
+                    | ValidationError::UnknownFilter { .. }
+                    | ValidationError::UnknownLibrary { .. }
+            )),
+            "Expected partial active facts to suppress unsafe unknown diagnostics, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn known_active_knowledge_keeps_not_in_installed_apps_diagnostics() {
+        let db = TestDatabase::new()
+            .with_template_libraries(discovered_widgets_inventory(Knowledge::Known))
+            .with_arity_specs(standard_arities());
+        let errors = collect_all_errors(
+            &db,
+            concat!(
+                "{% widget_tag %}\n",
+                "{{ value|widget_filter }}\n",
+                "{% load widgets %}\n",
+            ),
+        );
+
+        assert!(
+            errors.iter().any(
+                |error| matches!(error, ValidationError::TagNotInInstalledApps { tag, .. }
+                    if tag == "widget_tag")
+            ),
+            "Expected known active facts to keep S118, got: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(
+                |error| matches!(error, ValidationError::FilterNotInInstalledApps { filter, .. }
+                    if filter == "widget_filter")
+            ),
+            "Expected known active facts to keep S119, got: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(
+                |error| matches!(error, ValidationError::LibraryNotInInstalledApps { name, .. }
+                    if name == "widgets")
+            ),
+            "Expected known active facts to keep S121, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_active_knowledge_suppresses_not_in_installed_apps_diagnostics() {
+        let db = TestDatabase::new()
+            .with_template_libraries(discovered_widgets_inventory(Knowledge::Partial))
+            .with_arity_specs(standard_arities());
+        let errors = collect_all_errors(
+            &db,
+            concat!(
+                "{% widget_tag %}\n",
+                "{{ value|widget_filter }}\n",
+                "{% load widgets %}\n",
+            ),
+        );
+
+        assert!(
+            errors.iter().all(|error| !matches!(
+                error,
+                ValidationError::TagNotInInstalledApps { .. }
+                    | ValidationError::FilterNotInInstalledApps { .. }
+                    | ValidationError::LibraryNotInInstalledApps { .. }
+            )),
+            "Expected partial active facts to suppress unsafe not-in-installed-apps diagnostics, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_active_knowledge_keeps_known_filter_arity_diagnostic() {
+        let db = partial_active_db();
+        let errors = collect_all_errors(&db, "{{ value|truncatewords }}\n");
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error, ValidationError::FilterMissingArgument { filter, .. }
+                    if filter == "truncatewords")),
+            "Expected partial known active facts to keep S115 for known filter arity, got: {errors:?}"
         );
     }
 

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -169,10 +169,23 @@ impl TemplateLibrary {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Knowledge {
     Known,
+    Partial,
     Unknown,
 }
 
-#[derive(Serialize, Deserialize)]
+impl Knowledge {
+    #[must_use]
+    pub(crate) fn has_positive_facts(self) -> bool {
+        matches!(self, Self::Known | Self::Partial)
+    }
+
+    #[must_use]
+    pub(crate) fn is_fully_known(self) -> bool {
+        matches!(self, Self::Known)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TemplateLibrarySnapshot {
     pub symbols: Vec<TemplateSymbolSnapshot>,
     pub libraries: BTreeMap<String, String>,
@@ -226,7 +239,7 @@ impl TemplateLibraries {
 
     #[must_use]
     pub fn registration_modules(&self) -> FxHashSet<PyModuleName> {
-        if self.active_knowledge != Knowledge::Known {
+        if !self.active_knowledge.has_positive_facts() {
             return FxHashSet::default();
         }
 
@@ -460,14 +473,30 @@ impl TemplateLibraries {
     }
 
     #[must_use]
-    pub fn apply_active_snapshot(mut self, response: Option<TemplateLibrarySnapshot>) -> Self {
+    pub fn apply_active_snapshot(self, response: Option<TemplateLibrarySnapshot>) -> Self {
+        self.apply_active_snapshot_with_knowledge(response, Knowledge::Known)
+    }
+
+    #[must_use]
+    pub(crate) fn apply_partial_active_snapshot(
+        self,
+        response: Option<TemplateLibrarySnapshot>,
+    ) -> Self {
+        self.apply_active_snapshot_with_knowledge(response, Knowledge::Partial)
+    }
+
+    fn apply_active_snapshot_with_knowledge(
+        mut self,
+        response: Option<TemplateLibrarySnapshot>,
+        knowledge: Knowledge,
+    ) -> Self {
         let Some(response) = response else {
             self.active_knowledge = Knowledge::Unknown;
             self.builtins.clear();
             return self;
         };
 
-        self.active_knowledge = Knowledge::Known;
+        self.active_knowledge = knowledge;
 
         let mut enabled: BTreeMap<LibraryName, PyModuleName> = BTreeMap::new();
         for (name, module) in response.libraries {

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -47,6 +47,7 @@ use super::resolve::find_site_packages;
 use super::resolve::resolve_modules;
 use super::resolve::ResolvedModule;
 use super::settings_facts::extract_settings_facts_for_module;
+use super::symbols::Knowledge;
 use super::symbols::TemplateLibrarySnapshot;
 use super::template_dirs::assemble_template_dirs;
 use super::template_libraries::assemble_template_libraries;
@@ -274,8 +275,21 @@ fn apply_template_library_snapshot(
     project: Project,
     snapshot: TemplateLibrarySnapshot,
 ) -> bool {
+    apply_template_library_snapshot_with_knowledge(db, project, snapshot, Knowledge::Known)
+}
+
+fn apply_template_library_snapshot_with_knowledge(
+    db: &mut dyn ProjectDb,
+    project: Project,
+    snapshot: TemplateLibrarySnapshot,
+    knowledge: Knowledge,
+) -> bool {
     let current = project.template_libraries(db).clone();
-    let next = current.apply_active_snapshot(Some(snapshot));
+    let next = match knowledge {
+        Knowledge::Known => current.apply_active_snapshot(Some(snapshot)),
+        Knowledge::Partial => current.apply_partial_active_snapshot(Some(snapshot)),
+        Knowledge::Unknown => current.apply_active_snapshot(None),
+    };
     if project.template_libraries(db) == &next {
         return false;
     }
@@ -314,11 +328,11 @@ fn apply_static_template_library_snapshot(
     project: Project,
     snapshot: Fact<TemplateLibrarySnapshot>,
 ) -> bool {
-    let Some(snapshot) = usable_static_template_library_snapshot(snapshot) else {
+    let Some((snapshot, knowledge)) = usable_static_template_library_snapshot(snapshot) else {
         return false;
     };
 
-    apply_template_library_snapshot(db, project, snapshot)
+    apply_template_library_snapshot_with_knowledge(db, project, snapshot, knowledge)
 }
 
 fn assemble_static_template_library_snapshot(
@@ -414,10 +428,15 @@ fn assemble_static_project_context(
 
 fn usable_static_template_library_snapshot(
     snapshot: Fact<TemplateLibrarySnapshot>,
-) -> Option<TemplateLibrarySnapshot> {
+) -> Option<(TemplateLibrarySnapshot, Knowledge)> {
     match snapshot {
-        Fact::Known { value } => has_static_template_libraries(&value).then_some(value),
-        Fact::Partial { .. } | Fact::Unknown { .. } | Fact::Ambiguous { .. } => None,
+        Fact::Known { value } => {
+            has_static_template_libraries(&value).then_some((value, Knowledge::Known))
+        }
+        Fact::Partial { value, .. } => {
+            has_static_template_libraries(&value).then_some((value, Knowledge::Partial))
+        }
+        Fact::Unknown { .. } | Fact::Ambiguous { .. } => None,
     }
 }
 
@@ -902,11 +921,16 @@ mod tests {
 
     use super::*;
     use crate::project::introspector::ProjectIntrospector;
+    use crate::project::names::LibraryName;
+    use crate::project::names::PyModuleName;
     use crate::project::symbols::InstalledSymbolOrigin;
     use crate::project::symbols::Knowledge;
     use crate::project::symbols::TemplateLibraries;
     use crate::project::symbols::TemplateSymbolKind;
     use crate::project::symbols::TemplateSymbolSnapshot;
+    use crate::testing::collect_errors;
+    use crate::testing::TestDatabase;
+    use crate::ValidationError;
 
     #[salsa::db]
     struct StaticSnapshotTestDb {
@@ -1959,7 +1983,62 @@ TEMPLATES = []
         assert!(!reasons.is_empty());
         assert!(value.libraries.contains_key("blog_tags"));
         assert!(value.symbols.iter().any(|symbol| symbol.name == "shout"));
-        assert!(usable_static_template_library_snapshot(snapshot).is_none());
+        assert!(matches!(
+            usable_static_template_library_snapshot(snapshot.clone()),
+            Some((_, Knowledge::Partial))
+        ));
+
+        let (mut db, project) =
+            StaticSnapshotTestDb::with_project(root.clone(), Some("project.settings".to_string()));
+        assert!(apply_static_template_library_snapshot(
+            &mut db, project, snapshot,
+        ));
+        let libraries = project.template_libraries(&db);
+        assert_eq!(libraries.active_knowledge, Knowledge::Partial);
+        assert!(libraries
+            .loadable
+            .contains_key(&LibraryName::parse("blog_tags").unwrap()));
+        assert!(libraries
+            .registration_modules()
+            .contains(&PyModuleName::parse("blog.templatetags.blog_tags").unwrap()));
+
+        let validation_db = TestDatabase::new().with_template_libraries(libraries.clone());
+        let errors = collect_errors(
+            &validation_db,
+            "test.html",
+            concat!(
+                "{% shout \"hello\" %}\n",
+                "{{ value|emph }}\n",
+                "{% definitely_unknown_tag %}\n",
+                "{{ value|definitely_unknown_filter }}\n",
+                "{% load definitely_unknown_library %}\n",
+            ),
+        );
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UnloadedTag { tag, library, .. }
+                    if tag == "shout" && library == "blog_tags"
+            )),
+            "Expected static partial active facts to keep known unloaded tag diagnostics, got: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UnloadedFilter { filter, library, .. }
+                    if filter == "emph" && library == "blog_tags"
+            )),
+            "Expected static partial active facts to keep known unloaded filter diagnostics, got: {errors:?}"
+        );
+        assert!(
+            errors.iter().all(|error| !matches!(
+                error,
+                ValidationError::UnknownTag { .. }
+                    | ValidationError::UnknownFilter { .. }
+                    | ValidationError::UnknownLibrary { .. }
+            )),
+            "Expected static partial active facts to suppress unsafe unknown diagnostics, got: {errors:?}"
+        );
     }
 
     #[test]

--- a/crates/djls-semantic/src/validation/filters.rs
+++ b/crates/djls-semantic/src/validation/filters.rs
@@ -14,7 +14,7 @@ pub(crate) fn check_filter_arity_rule(
     arity_specs: &FilterAritySpecs,
     active_knowledge: Knowledge,
 ) {
-    if active_knowledge != Knowledge::Known {
+    if !active_knowledge.has_positive_facts() {
         return;
     }
 

--- a/crates/djls-semantic/src/validation/scoping.rs
+++ b/crates/djls-semantic/src/validation/scoping.rs
@@ -26,7 +26,7 @@ pub(crate) fn check_tag_scoping_rule(
     env_tags: Option<&HashMap<crate::TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>>,
     active_knowledge: Knowledge,
 ) {
-    if active_knowledge != Knowledge::Known {
+    if !active_knowledge.has_positive_facts() {
         return;
     }
 
@@ -35,6 +35,9 @@ pub(crate) fn check_tag_scoping_rule(
     match symbols.check(name) {
         TagAvailability::Available => {}
         TagAvailability::Unknown => {
+            if !active_knowledge.is_fully_known() {
+                return;
+            }
             if let Some(env_tags) = env_tags {
                 if let Ok(key) = crate::TemplateSymbolName::parse(name) {
                     if let Some(env_symbols) = env_tags.get(&key) {
@@ -84,13 +87,16 @@ pub(crate) fn check_filter_scoping_rule(
     env_filters: Option<&HashMap<crate::TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>>,
     active_knowledge: Knowledge,
 ) {
-    if active_knowledge != Knowledge::Known {
+    if !active_knowledge.has_positive_facts() {
         return;
     }
 
     match symbols.check_filter(&filter.name) {
         FilterAvailability::Available => {}
         FilterAvailability::Unknown => {
+            if !active_knowledge.is_fully_known() {
+                return;
+            }
             if let Some(env_filters) = env_filters {
                 if let Ok(key) = crate::TemplateSymbolName::parse(filter.name.as_str()) {
                     if let Some(env_symbols) = env_filters.get(&key) {
@@ -139,7 +145,7 @@ pub(crate) fn check_load_libraries_rule(
     bits: &[TagBit],
     template_libraries: &crate::TemplateLibraries,
 ) {
-    if template_libraries.active_knowledge != Knowledge::Known {
+    if !template_libraries.active_knowledge.has_positive_facts() {
         return;
     }
 
@@ -154,11 +160,15 @@ pub(crate) fn check_load_libraries_rule(
 
     for lib in libs {
         if let Ok(name) = LibraryName::parse(lib.as_str()) {
-            if template_libraries.loadable.contains_key(&name) {
+            if template_libraries.is_enabled_library(&name) {
                 continue;
             }
         } else {
             // Invalid library name string (shouldn't happen given LoadKind parser, but safety first)
+            continue;
+        }
+
+        if !template_libraries.active_knowledge.is_fully_known() {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- add `Knowledge::Partial` for template libraries and apply partial static template snapshots as partial active facts
- allow partial active facts to drive positive diagnostics while suppressing unsafe unknown/not-in-installed-apps diagnostics
- keep registration-module extraction available for known modules in partial snapshots

## Validation
- `cargo test -q -p djls-semantic partial_active_knowledge --no-default-features`
- `cargo test -q -p djls-semantic static_template_snapshot_preserves_partial_known_data --no-default-features`
- `cargo test -q -p djls-semantic --no-default-features`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just fmt --check`
- `just test -q`
- `just lint`
- `just clippy`