### PR TITLE
Document static project model rollout modes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,18 +149,28 @@ Template parsing does not need its own database trait. `parse_template` depends 
 
 ## How Knowledge Gets In
 
-### The Python Inspector
+### Static Project Model and Python Inspector
 
 > [!NOTE]
-> The inspector is planned for replacement with settings fact extraction ([#401](https://github.com/joshuadavidthomas/django-language-server/issues/401)). The goal: parse `settings.py` with the Ruff AST — the same approach used for templatetag extraction — and eliminate the Python subprocess and calling `django.setup()` entirely.
+> The inspector is being replaced by the static project model ([#401](https://github.com/joshuadavidthomas/django-language-server/issues/401)). The rollout keeps the inspector as a transitional fallback until the documented removal gates are met.
 
-The server needs to know what Django has installed: `INSTALLED_APPS`, template directories, templatetag libraries, and the symbols they export. A Python subprocess currently provides this.
+The server needs to know what Django has installed: `INSTALLED_APPS`, template directories, templatetag libraries, and the symbols they export. The preferred path is the static project model:
 
-A small Python program from `crates/djls-semantic/inspector/` ships embedded in the binary as a zipapp. At startup the server writes it to a temp file and runs it against the project's Python interpreter with Django configured. Project introspection queries Django's template engine registry and returns JSON describing template directories, installed libraries, and their symbols.
+- Resolve Python modules from workspace roots, configured `pythonpath`, auto `src/` roots, and site-packages.
+- Parse Django settings with the Ruff AST.
+- Assemble app registry, template dirs, template libraries, builtins, and symbol snapshots without importing Django.
+
+`project_model` controls rollout behavior:
+
+- `auto` builds static facts first and uses known static outputs without starting the inspector. Partial or unknown static facts can fall back to the inspector during the transition.
+- `static` uses only static facts and never starts the inspector. Partial or unknown facts degrade conservatively.
+- `inspector` uses the legacy runtime path first.
+
+A small Python program from `crates/djls-semantic/inspector/` still ships embedded in the binary as a zipapp for fallback. Project introspection queries Django's template engine registry and returns JSON describing template directories, installed libraries, and their symbols.
 
 Startup uses two phases to avoid blocking the editor:
 
-1. A cache check during `initialized`. The server loads a cached inspector response from `~/.cache/djls/inspector/`. The cache key is a SHA-256 hash of the project root, interpreter path, settings module, and PYTHONPATH. If the cache exists (and its `djls_version` matches), the server becomes functional immediately with the cached data.
+1. A cache check during `initialized`. The server can load cached static template-library facts from `~/.cache/djls/static-project-model/template-libraries/` or legacy inspector responses from `~/.cache/djls/inspector/`, depending on `project_model` and fact confidence.
 2. A background task refreshes project data, updates Salsa inputs, and writes a fresh cache. This includes template directories, template libraries, the first-party project file set, extracted validation rules from installed packages, and external model graphs. When a cache was loaded in phase 1, this runs concurrently with normal operation. If no cache existed, the server waits for this to complete before advertising full capabilities.
 
 This means that in the common case (you've opened this project before and the environment hasn't changed), startup is nearly instant — the server just reads a JSON file from disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Added
 
 - Added opt-in whole-document Django template formatting through `djangofmt`.
+- Added `project_model` configuration for choosing static-first, static-only, or inspector-first discovery of template directories, template libraries, and symbols.
 
 ## [6.0.3]
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -50,18 +50,72 @@ If you prefer not to use an env file:
 
 ## Options
 
+### `project_model`
+
+**Default:** `"auto"`
+
+Selects how djls builds Django project facts for template directories, active template tag libraries, builtins, and symbols.
+
+Supported values:
+
+- `"auto"` — Build the static project model first. When static facts are known, djls uses them without starting the Python inspector. When static facts are partial or unknown, djls can fall back to the inspector during the transition period.
+- `"static"` — Use only the static project model. This avoids the Python inspector, `django.setup()`, and runtime imports. If settings are too dynamic to understand statically, djls degrades conservatively and suppresses diagnostics that would risk false positives.
+- `"inspector"` — Use the legacy Python/Django inspector path first. This keeps the runtime behavior used by older releases while the static model rollout continues.
+
+```toml
+[tool.djls]
+project_model = "auto"
+```
+
+Use `"static"` when you want editor behavior that does not run Django. Use `"inspector"` if a dynamic project still needs the runtime fallback while static support catches up.
+
 ### `django_settings_module`
 
 **Default:** `DJANGO_SETTINGS_MODULE` environment variable
 
 Your Django settings module path (e.g., `"myproject.settings"`).
 
-The server uses this to introspect your Django project and provide template tag completions, diagnostics, and navigation. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
+The server uses this to build Django project facts for template tag completions, diagnostics, and navigation. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
 
 **When to configure:**
 
 - Your editor doesn't pass environment variables to LSP servers (e.g., Sublime Text)
 - You need to override the environment variable for a specific workspace
+
+### `django_environments`
+
+**Default:** `[]` (empty list)
+
+Path-scoped Django settings modules for monorepos or workspaces with more than one Django project.
+
+```toml
+[tool.djls]
+pythonpath = ["projects", "apps"]
+
+[[tool.djls.django_environments]]
+root = "projects/site1"
+django_settings_module = "site1.settings.dev"
+
+[[tool.djls.django_environments]]
+root = "projects/site2"
+django_settings_module = "site2.settings.dev"
+```
+
+Use this when one workspace contains multiple Django settings modules and each applies to a different subtree. Static project model facts stay tied to their environment. Completions can use the union of known facts, while diagnostics only use facts that are safe for the template's environment and suppress unsafe absence claims.
+
+### `django_settings_file_patterns`
+
+**Default:** `[]` (empty list)
+
+Glob patterns for discovering Django settings files and mapping them back to module names through the configured module search paths.
+
+```toml
+[tool.djls]
+pythonpath = ["projects", "apps"]
+django_settings_file_patterns = ["projects/*/settings/dev.py"]
+```
+
+Use this for repetitive monorepo layouts where each project follows the same split-settings pattern. Do not configure this together with `django_environments`; explicit environments are clearer when roots do not follow a pattern.
 
 ### `venv_path`
 
@@ -80,7 +134,7 @@ The server needs access to your virtual environment to discover installed Django
 
 **Default:** `[]` (empty list)
 
-Additional directories to add to Python's import search path when the inspector process runs. These paths are added to `PYTHONPATH` alongside the project root and any existing `PYTHONPATH` environment variable.
+Additional directories to add to Python's import search path. Static project model discovery uses these paths as module search roots. The inspector also adds them to `PYTHONPATH` alongside the project root and any existing `PYTHONPATH` environment variable.
 
 **When to configure:**
 
@@ -103,6 +157,9 @@ If no `env_file` is configured, the server looks for a `.env` file in the projec
 
 - Your `.env` file has a non-standard name (e.g., `.env.local`, `.env.development`)
 - Your `.env` file lives in a subdirectory
+
+!!! note
+    `env_file` is only needed by runtime Django settings. In `project_model = "static"`, djls does not execute your settings module, but static extraction may still need `django_settings_module` and `pythonpath` to find the right files.
 
 ### `tagspecs`
 
@@ -171,13 +228,13 @@ Map diagnostic codes or prefixes to severity levels. Supports:
     S108 = "warning" # New
     ```
 
-*Tag Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
+*Tag Scoping (requires [project model facts](../template-validation.md#project-model-availability)):*
 
 - `S108` - Unknown tag (not found in any known library or in the Python environment)
 - `S109` - Unloaded tag (requires `{% load %}` for a specific library)
 - `S110` - Ambiguous unloaded tag (defined in multiple libraries)
 
-*Filter Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
+*Filter Scoping (requires [project model facts](../template-validation.md#project-model-availability)):*
 
 - `S111` - Unknown filter (not found in any known library or in the Python environment)
 - `S112` - Unloaded filter (requires `{% load %}` for a specific library)
@@ -193,11 +250,11 @@ Map diagnostic codes or prefixes to severity levels. Supports:
 
 - `S117` - Tag argument rule violation (e.g., wrong number of arguments, missing required keyword)
 
-*Environment-Aware Resolution (requires [inspector](../template-validation.md#inspector-availability) and [environment scanner](../template-validation.md#environment-scanner)):*
+*Environment-Aware Resolution (requires [project model facts](../template-validation.md#project-model-availability) and [environment scanner](../template-validation.md#environment-scanner)):*
 
 - `S118` - Tag not in `INSTALLED_APPS` (installed package, but Django app not activated)
 - `S119` - Filter not in `INSTALLED_APPS` (installed package, but Django app not activated)
-- `S120` - Unknown template tag library (not found in inspector or environment)
+- `S120` - Unknown template tag library (not found in the project model or Python environment)
 - `S121` - Library not in `INSTALLED_APPS` (installed package, but Django app not activated)
 
 *Extends Validation:*
@@ -295,6 +352,7 @@ Pass configuration through your editor's LSP client using `initializationOptions
 
 ```json
 {
+  "project_model": "auto",
   "django_settings_module": "myproject.settings",
   "venv_path": "/path/to/venv",
   "pythonpath": ["/path/to/shared/libs"],
@@ -320,6 +378,7 @@ If you use `pyproject.toml`, add a `[tool.djls]` section:
 
 ```toml
 [tool.djls]
+project_model = "auto"
 django_settings_module = "myproject.settings"
 venv_path = "/path/to/venv"  # Optional: only if auto-detection fails
 pythonpath = ["/path/to/shared/libs"]  # Optional: additional import paths

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -6,15 +6,28 @@ Django Language Server validates your Django templates as you write them, catchi
 
 Template validation relies on three systems working together:
 
-### Inspector
+### Project Model
 
-The **inspector** is a Python process that introspects your running Django project to discover:
+The **project model** describes the Django facts djls needs for templates:
 
 - Which template tags and filters exist
 - Which libraries they belong to (builtins vs third-party)
 - Which library load-name maps to which module
+- Which template directories Django searches
 
-This gives djls an accurate picture of your project's template tag ecosystem — the same tags Django would see at runtime. The inspector reflects your `INSTALLED_APPS` configuration, so it only reports tags and filters from apps that are actually activated.
+By default, `project_model = "auto"` builds these facts statically from your workspace, `django_settings_module`, `pythonpath`, and available source files. When static facts are known, djls can provide scoped completions and diagnostics without spawning Python or calling `django.setup()`.
+
+During the transition, auto mode can still fall back to the Python inspector when static facts are partial or unknown. You can force one path with [`project_model`](configuration/index.md#project_model):
+
+- `"auto"` — static first, inspector fallback for partial/unknown facts
+- `"static"` — static only, no inspector subprocess
+- `"inspector"` — legacy runtime inspector first
+
+The static model tracks confidence. Known facts enable scoped availability diagnostics. Partial or unknown facts still allow diagnostics backed by positive facts, but suppress absence-based diagnostics unless inspector fallback supplies known facts.
+
+### Inspector
+
+The **inspector** is the legacy Python process that introspects your running Django project. It remains available as a fallback during the static project model rollout.
 
 ### Environment Scanner
 
@@ -34,7 +47,7 @@ The **extraction engine** analyzes Python source code (using static AST analysis
 - **Filter arity** — whether a filter expects an argument (e.g., `{{ value|default:"nothing" }}`)
 - **Expression syntax** — valid operator usage in `{% if %}` / `{% elif %}` expressions
 
-Together, the inspector tells djls *what's active in your project*, the environment scanner tells djls *what's installed*, and extraction tells djls *how to validate usage*.
+Together, the project model tells djls *what's active in your project*, the environment scanner tells djls *what's installed*, and extraction tells djls *how to validate usage*.
 
 ## Three-Layer Resolution
 
@@ -96,7 +109,7 @@ Validates that template filters are available at their point of use, with the sa
 
 Validates that `{% load %}` library names refer to known template tag libraries:
 
-- **S120** — Unknown library (not found in the inspector inventory or the Python environment)
+- **S120** — Unknown library (not found in the project model or the Python environment)
 - **S121** — Library not in `INSTALLED_APPS` (the library exists in an installed package, but its Django app isn't activated)
 
 ### Extends Validation (S122–S123)
@@ -137,25 +150,29 @@ Django templates are deeply dynamic — many things can only be checked at runti
 - **Dynamic tag behavior** — Tags whose validation depends on runtime state
 - **Format strings** — Whether date/time format strings are valid
 
-## Inspector Availability
+## Project Model Availability
 
-The inspector requires a working Django environment (correct `DJANGO_SETTINGS_MODULE`, virtual environment with Django installed, no import errors during Django setup).
+The static project model needs enough source files and configuration to find your Django settings, installed apps, template directories, and templatetag modules. For typical literal or split settings, it can work without a configured Python runtime.
 
-When the inspector is **healthy**:
+When project model facts are **known**:
 
-- Full validation is active — all S108–S121 diagnostics are emitted
+- Scoped tag, filter, and library availability diagnostics can run from project facts
 - Completions are scoped to loaded libraries at cursor position
+- Argument and arity diagnostics run when extraction or built-in specs provide rules
 
-When the inspector is **unavailable** (Django init failed, Python not configured, etc.):
+When project model facts are **partial or unknown**:
 
-- **S108–S113, S118–S121 are suppressed** — Without knowing which tags/filters exist, djls cannot determine if something is unknown, unloaded, or not in `INSTALLED_APPS`
-- **S115–S116 are suppressed** — Filter arity rules come from extraction, which depends on knowing the source modules
-- **S117 is suppressed** — Tag argument rules come from extraction, which depends on the inspector discovering tag source modules
+- **Absence-based diagnostics are suppressed when unsafe** — Without complete project facts, djls avoids claiming that a tag, filter, or library is unknown or missing from `INSTALLED_APPS` (S108, S111, S118, S119, S120, S121)
+- **Positive-fact diagnostics can still run** — Known but unloaded or ambiguous tags and filters can still produce S109, S110, S112, and S113
+- **Known argument rules can still run** — Tag argument diagnostics (S117) run when extraction or built-in specs provide the needed rules
+- **Known arity rules can still run with positive project facts** — Filter arity diagnostics (S115–S116) run when active project facts include known filters and extraction or built-in specs provide the needed rules
 - **S100–S103 still work** — Block structure validation uses built-in tag specs
 - **S114 still works** — Expression syntax validation is purely structural
 - **Completions show all known tags** — Without library scoping, all tags are offered as a fallback
 
 This design avoids false positives when the Python environment isn't available.
+
+In `project_model = "auto"`, the inspector can still fill gaps for partial or unknown static facts. In `project_model = "static"`, djls does not fall back to the inspector.
 
 ## Configuring Diagnostic Severity
 


### PR DESCRIPTION
## Summary

- Document `project_model = "auto" | "static" | "inspector"` and static-first fallback behavior
- Update template validation docs to describe project-model confidence and absence-based diagnostic suppression
- Update architecture notes and changelog for the static project model rollout

## Validation

- `just fmt`
- `just fmt --check`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just test -q`
- `just lint`
- `just clippy`

Stacked on #577.