### PR TITLE
Expand static project model corpus profile coverage

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -21,8 +21,11 @@ settings_file = "archivebox/core/settings.py"
 settings_module = "archivebox.core.settings"
 extends_files = []
 installed_apps_confidence = "partial"
-templates_confidence = "known"
-expected_partial_reasons = ["dynamic if condition controls settings mutation"]
+templates_confidence = "partial"
+expected_partial_reasons = [
+  "dynamic if condition controls settings mutation",
+  "TEMPLATES DIRS must be a literal list or tuple",
+]
 
 [profile.django_environment.expected]
 installed_apps = [
@@ -49,7 +52,7 @@ external_apps = [
   "django.contrib.admin",
   "django_extensions",
 ]
-template_dirs = ["archivebox/templates"]
+template_dirs = []
 templatetag_modules = [
   "archivebox.core.templatetags.config_tags",
   "archivebox.core.templatetags.core_tags",
@@ -120,10 +123,11 @@ settings_file = "src/backend/InvenTree/InvenTree/settings.py"
 settings_module = "InvenTree.settings"
 extends_files = []
 installed_apps_confidence = "partial"
-templates_confidence = "known"
+templates_confidence = "partial"
 expected_partial_reasons = [
   "dynamic if condition controls settings mutation",
   "dynamic for loop controls settings mutation",
+  "TEMPLATES DIRS contains an unsupported path expression",
 ]
 
 [profile.django_environment.expected]
@@ -164,7 +168,7 @@ external_apps = [
   "rest_framework",
   "allauth",
 ]
-template_dirs = ["src/backend/InvenTree/templates"]
+template_dirs = []
 templatetag_modules = [
   "generic.templatetags.generic",
   "plugin.templatetags.plugin_extras",
@@ -188,10 +192,11 @@ settings_file = "netbox/netbox/settings.py"
 settings_module = "netbox.settings"
 extends_files = []
 installed_apps_confidence = "partial"
-templates_confidence = "known"
+templates_confidence = "partial"
 expected_partial_reasons = [
   "dynamic if condition controls settings mutation",
   "dynamic for loop controls settings mutation",
+  "TEMPLATES DIRS contains an unsupported path expression",
 ]
 
 [profile.django_environment.expected]
@@ -230,7 +235,7 @@ unresolved_apps = [
   "django_prometheus",
   "strawberry_django",
 ]
-template_dirs = ["netbox/templates"]
+template_dirs = []
 templatetag_modules = [
   "extras.templatetags.dashboard",
   "extras.templatetags.log_levels",
@@ -290,10 +295,7 @@ external_apps = [
   "rest_framework",
   "statici18n",
 ]
-template_dirs = [
-  "src/pretix/base/templates",
-  "src/pretix/control/templates",
-]
+template_dirs = []
 templatetag_modules = [
   "pretix.base.templatetags.rich_text",
   "pretix.control.templatetags.order_overview",
@@ -302,7 +304,7 @@ templatetag_modules = [
 
 [[profile]]
 id = "sentry"
-description = "Large src-layout project where templates are statically visible but installed apps remain dynamic/unknown."
+description = "Large src-layout project where static assembly recovers partial app/template facts from dynamic settings."
 source_roots = ["src", "."]
 django_settings_file_patterns = []
 
@@ -315,15 +317,18 @@ root = "."
 settings_file = "src/sentry/conf/server.py"
 settings_module = "sentry.conf.server"
 extends_files = []
-installed_apps_confidence = "unknown"
-templates_confidence = "known"
-expected_partial_reasons = ["installed apps are assembled dynamically"]
+installed_apps_confidence = "partial"
+templates_confidence = "partial"
+expected_partial_reasons = [
+  "installed apps are assembled dynamically",
+  "TEMPLATES DIRS contains an unsupported path expression",
+]
 
 [profile.django_environment.expected]
 installed_apps = []
 local_apps = []
 external_apps = []
-template_dirs = ["src/sentry/templates"]
+template_dirs = []
 templatetag_modules = [
   "sentry.templatetags.sentry_assets",
   "sentry.templatetags.sentry_helpers",
@@ -344,9 +349,11 @@ root = "tests/projects/account_only"
 settings_file = "tests/projects/account_only/settings.py"
 settings_module = "tests.projects.account_only.settings"
 extends_files = []
-installed_apps_confidence = "known"
-templates_confidence = "known"
-expected_partial_reasons = []
+installed_apps_confidence = "partial"
+templates_confidence = "partial"
+expected_partial_reasons = [
+  "module resolves through a namespace package segment without __init__.py",
+]
 
 [profile.django_environment.expected]
 installed_apps = [

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -2772,7 +2772,7 @@ TEMPLATES = []
         let site_packages = Utf8PathBuf::try_from(tmp.path().join("site-packages")).unwrap();
         write_minimal_django_site_packages(
             &site_packages,
-            &[
+            [
                 "django.contrib.auth",
                 "django.contrib.contenttypes",
                 "django.templatetags.cache",
@@ -2800,6 +2800,43 @@ TEMPLATES = []
                 environment,
                 &all_expected_templatetag_modules,
             );
+        }
+    }
+
+    #[test]
+    fn synced_corpus_profiles_static_assembly_matches_expected_facts() {
+        if !djls_corpus::Corpus::is_available() {
+            return;
+        }
+
+        let corpus = djls_corpus::Corpus::require();
+        let profiles = djls_corpus::project_model_profiles().unwrap();
+        let tmp = TempDir::new().unwrap();
+
+        for profile in profiles
+            .profiles
+            .iter()
+            .filter(|profile| profile.source.kind == djls_corpus::SourceKind::Corpus)
+        {
+            let root = profile.root_path(Some(&corpus)).unwrap();
+            let pythonpath = profile.source_roots.clone();
+            let site_packages =
+                Utf8PathBuf::try_from(tmp.path().join(&profile.id).join("site-packages")).unwrap();
+            let site_package_modules = minimal_profile_site_package_modules(profile);
+            write_minimal_django_site_packages(
+                &site_packages,
+                site_package_modules.iter().map(String::as_str),
+            );
+
+            for environment in &profile.django_environments {
+                assert_profile_environment_static_assembly_contains_expected_facts(
+                    profile.id.as_str(),
+                    &root,
+                    &pythonpath,
+                    &site_packages,
+                    environment,
+                );
+            }
         }
     }
 
@@ -2880,17 +2917,82 @@ TEMPLATES = []
         );
     }
 
+    fn assert_profile_environment_static_assembly_contains_expected_facts(
+        profile_id: &str,
+        root: &Utf8Path,
+        pythonpath: &[String],
+        site_packages: &Utf8PathBuf,
+        environment: &djls_corpus::DjangoEnvironmentProfile,
+    ) {
+        let dirs = assemble_static_template_dirs(
+            root,
+            Some(&environment.settings_module),
+            pythonpath,
+            std::slice::from_ref(site_packages),
+        );
+        assert_eq!(
+            dirs.confidence(),
+            expected_profile_confidence(environment.templates_confidence),
+            "unexpected template dir confidence for profile `{profile_id}` environment `{}`: {:?}",
+            environment.settings_module,
+            dirs.reasons()
+        );
+        if let Some(dirs) = dirs.value() {
+            for expected_dir in expected_profile_configured_template_dirs(root, environment) {
+                assert!(
+                    dirs.contains(&expected_dir),
+                    "profile `{profile_id}` environment `{}` did not include expected template dir `{expected_dir}` in {dirs:?}",
+                    environment.settings_module,
+                );
+            }
+        }
+
+        let snapshot = assemble_static_template_library_snapshot(
+            root,
+            Some(&environment.settings_module),
+            pythonpath,
+            std::slice::from_ref(site_packages),
+        );
+        assert_eq!(
+            snapshot.confidence(),
+            expected_profile_snapshot_confidence(environment),
+            "unexpected template library confidence for profile `{profile_id}` environment `{}`: {:?}",
+            environment.settings_module,
+            snapshot.reasons()
+        );
+
+        let Some(snapshot) = snapshot.value() else {
+            assert!(
+                environment.expected.templatetag_modules.is_empty(),
+                "profile `{profile_id}` environment `{}` expected template tag modules but snapshot is unknown",
+                environment.settings_module,
+            );
+            return;
+        };
+
+        let library_modules = snapshot.libraries.values().collect::<BTreeSet<_>>();
+        for module in &environment.expected.templatetag_modules {
+            assert!(
+                library_modules.contains(module),
+                "profile `{profile_id}` environment `{}` did not include expected library module `{module}`",
+                environment.settings_module,
+            );
+        }
+        assert!(
+            library_modules
+                .iter()
+                .all(|module| !module.starts_with("src.") && !module.starts_with("repos.")),
+            "expected source-root-aware module names for profile `{profile_id}` environment `{}`, got {library_modules:?}",
+            environment.settings_module,
+        );
+    }
+
     fn expected_profile_template_dirs(
         root: &Utf8Path,
         pythonpath: &[String],
         environment: &djls_corpus::DjangoEnvironmentProfile,
     ) -> Vec<Utf8PathBuf> {
-        let mut dirs = environment
-            .expected
-            .template_dirs
-            .iter()
-            .map(|dir| root.join(dir))
-            .collect::<Vec<_>>();
+        let mut dirs = expected_profile_configured_template_dirs(root, environment);
         dirs.extend(
             environment
                 .expected
@@ -2901,6 +3003,18 @@ TEMPLATES = []
         dirs
     }
 
+    fn expected_profile_configured_template_dirs(
+        root: &Utf8Path,
+        environment: &djls_corpus::DjangoEnvironmentProfile,
+    ) -> Vec<Utf8PathBuf> {
+        environment
+            .expected
+            .template_dirs
+            .iter()
+            .map(|dir| root.join(dir))
+            .collect()
+    }
+
     fn expected_profile_confidence(confidence: djls_corpus::Confidence) -> Confidence {
         match confidence {
             djls_corpus::Confidence::Known => Confidence::Known,
@@ -2909,9 +3023,64 @@ TEMPLATES = []
         }
     }
 
-    fn write_minimal_django_site_packages(site_packages: &Utf8Path, modules: &[&str]) {
+    fn expected_profile_snapshot_confidence(
+        environment: &djls_corpus::DjangoEnvironmentProfile,
+    ) -> Confidence {
+        if environment.installed_apps_confidence == djls_corpus::Confidence::Unknown
+            || environment.templates_confidence == djls_corpus::Confidence::Unknown
+        {
+            Confidence::Unknown
+        } else if environment.installed_apps_confidence == djls_corpus::Confidence::Partial
+            || environment.templates_confidence == djls_corpus::Confidence::Partial
+        {
+            Confidence::Partial
+        } else {
+            Confidence::Known
+        }
+    }
+
+    fn minimal_profile_site_package_modules(profile: &djls_corpus::Profile) -> Vec<String> {
+        let mut modules = [
+            "django.contrib.admin",
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "django.contrib.humanize",
+            "django.contrib.messages",
+            "django.contrib.sites",
+            "django.contrib.sessions",
+            "django.contrib.staticfiles",
+            "django.templatetags.cache",
+            "django.templatetags.i18n",
+            "django.templatetags.l10n",
+            "django.templatetags.static",
+            "django.templatetags.tz",
+            "django.template.defaulttags",
+            "django.template.defaultfilters",
+            "django.template.loader_tags",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+
+        modules.extend(
+            profile
+                .django_environments
+                .iter()
+                .flat_map(|environment| &environment.expected.external_apps)
+                .cloned(),
+        );
+
+        modules.into_iter().collect()
+    }
+
+    fn write_minimal_django_site_packages<S>(
+        site_packages: &Utf8Path,
+        modules: impl IntoIterator<Item = S>,
+    ) where
+        S: AsRef<str>,
+    {
         for module in modules {
-            write_minimal_python_module(site_packages, module);
+            write_minimal_python_module(site_packages, module.as_ref());
         }
     }
 
@@ -2936,7 +3105,13 @@ TEMPLATES = []
         let module_path = module.replace('.', "/");
         source_roots
             .iter()
-            .map(|source_root| root.join(source_root).join(&module_path))
+            .map(|source_root| {
+                if source_root == "." {
+                    root.join(&module_path)
+                } else {
+                    root.join(source_root).join(&module_path)
+                }
+            })
             .find(|path| path.join("__init__.py").is_file())
             .map(|path| path.join("templates"))
             .filter(|path| path.is_dir())


### PR DESCRIPTION
## Summary

- Add synced corpus profile coverage for static template-dir and template-library assembly
- Keep GH-401 exact multi-environment assertions while checking broader real corpus profile facts as stable subsets
- Update project-model profile confidence metadata for current partial static behavior in dynamic real projects

## Validation

- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features`
- `cargo test -q -p djls-semantic gh401_profile_static_assembly_matches_profile_environments --no-default-features`
- `cargo test -q -p djls-corpus --no-default-features`
- `cargo test -q -p djls-semantic --no-default-features`
- `just fmt`
- `just fmt --check`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just test -q`
- `just lint`
- `just clippy`

Stacked on #578.