### PR TITLE
Assert corpus profile partial reasons

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -23,7 +23,6 @@ extends_files = []
 installed_apps_confidence = "partial"
 templates_confidence = "partial"
 expected_partial_reasons = [
-  "dynamic if condition controls settings mutation",
   "TEMPLATES DIRS contains an unsupported path expression",
 ]
 
@@ -129,8 +128,6 @@ extends_files = []
 installed_apps_confidence = "partial"
 templates_confidence = "partial"
 expected_partial_reasons = [
-  "dynamic if condition controls settings mutation",
-  "dynamic for loop controls settings mutation",
   "TEMPLATES DIRS contains an unsupported path expression",
 ]
 
@@ -197,10 +194,7 @@ settings_module = "netbox.settings"
 extends_files = []
 installed_apps_confidence = "partial"
 templates_confidence = "partial"
-expected_partial_reasons = [
-  "dynamic if condition controls settings mutation",
-  "dynamic for loop controls settings mutation",
-]
+expected_partial_reasons = []
 
 [profile.django_environment.expected]
 installed_apps = [
@@ -263,11 +257,7 @@ settings_module = "pretix.settings"
 extends_files = ["src/pretix/_base_settings.py"]
 installed_apps_confidence = "partial"
 templates_confidence = "known"
-expected_partial_reasons = [
-  "star import from ._base_settings",
-  "INSTALLED_APPS += ...",
-  "TEMPLATES.insert",
-]
+expected_partial_reasons = []
 
 [profile.django_environment.expected]
 installed_apps = [
@@ -322,9 +312,7 @@ settings_module = "sentry.conf.server"
 extends_files = []
 installed_apps_confidence = "partial"
 templates_confidence = "partial"
-expected_partial_reasons = [
-  "installed apps are assembled dynamically",
-]
+expected_partial_reasons = []
 
 [profile.django_environment.expected]
 installed_apps = []

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -2960,6 +2960,7 @@ TEMPLATES = []
             environment.settings_module,
             snapshot.reasons()
         );
+        assert_expected_profile_partial_reasons(profile_id, environment, &dirs, &snapshot);
 
         let Some(snapshot) = snapshot.value() else {
             assert!(
@@ -2985,6 +2986,30 @@ TEMPLATES = []
             "expected source-root-aware module names for profile `{profile_id}` environment `{}`, got {library_modules:?}",
             environment.settings_module,
         );
+    }
+
+    fn assert_expected_profile_partial_reasons(
+        profile_id: &str,
+        environment: &djls_corpus::DjangoEnvironmentProfile,
+        dirs: &Fact<Vec<Utf8PathBuf>>,
+        snapshot: &Fact<TemplateLibrarySnapshot>,
+    ) {
+        let reason_messages = dirs
+            .reasons()
+            .iter()
+            .chain(snapshot.reasons())
+            .map(|reason| reason.message.as_str())
+            .collect::<Vec<_>>();
+
+        for expected_reason in &environment.expected_partial_reasons {
+            assert!(
+                reason_messages
+                    .iter()
+                    .any(|message| message.contains(expected_reason)),
+                "profile `{profile_id}` environment `{}` expected partial reason `{expected_reason}` in {reason_messages:?}",
+                environment.settings_module,
+            );
+        }
     }
 
     fn expected_profile_template_dirs(


### PR DESCRIPTION
## Summary

- assert each corpus profile `expected_partial_reasons` entry against surfaced static template-dir and template-library snapshot reason messages
- trim stale settings-internal reason snippets from corpus profiles where static assembly no longer emits them

## Validation

- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`