### PR TITLE
Treat namespace package resolution as known

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -339,11 +339,9 @@ root = "tests/projects/account_only"
 settings_file = "tests/projects/account_only/settings.py"
 settings_module = "tests.projects.account_only.settings"
 extends_files = []
-installed_apps_confidence = "partial"
-templates_confidence = "partial"
-expected_partial_reasons = [
-  "module resolves through a namespace package segment without __init__.py",
-]
+installed_apps_confidence = "known"
+templates_confidence = "known"
+expected_partial_reasons = []
 
 [profile.django_environment.expected]
 installed_apps = [

--- a/crates/djls-semantic/src/project/module_resolver.rs
+++ b/crates/djls-semantic/src/project/module_resolver.rs
@@ -24,7 +24,6 @@ use crate::project::names::PyModuleName;
 
 struct ModuleCandidate {
     module: ResolvedModule,
-    reasons: Vec<Reason>,
 }
 
 #[must_use]
@@ -140,14 +139,8 @@ pub(crate) fn module_name_for_file(
             "module file is outside configured module search paths",
         )]),
         1 => {
-            let (module, search_path) = candidates.into_iter().next().unwrap();
-            let parts = module.as_str().split('.').collect::<Vec<_>>();
-            let reasons = namespace_package_reasons(&parts, &search_path);
-            if reasons.is_empty() {
-                Fact::known(module)
-            } else {
-                Fact::partial(module, reasons)
-            }
+            let (module, _) = candidates.into_iter().next().unwrap();
+            Fact::known(module)
         }
         _ => Fact::ambiguous(
             candidates.into_iter().map(|(module, _)| module).collect(),
@@ -363,14 +356,7 @@ fn resolve_module_fact(
             requested.clone(),
             "module was not found in module search paths",
         )]),
-        1 => {
-            let candidate = candidates.pop().unwrap();
-            if candidate.reasons.is_empty() {
-                Fact::known(candidate.module)
-            } else {
-                Fact::partial(candidate.module, candidate.reasons)
-            }
-        }
+        1 => Fact::known(candidates.pop().unwrap().module),
         _ => Fact::ambiguous(
             candidates
                 .into_iter()
@@ -409,7 +395,6 @@ fn module_candidate(
         return None;
     };
 
-    let reasons = namespace_package_reasons(&parts, &search_path.path);
     Some(ModuleCandidate {
         module: ResolvedModule {
             module: requested.clone(),
@@ -417,28 +402,7 @@ fn module_candidate(
             search_path: search_path.path.clone(),
             location: classify_module_location(&file, project_root),
         },
-        reasons,
     })
-}
-
-#[must_use]
-fn namespace_package_reasons(parts: &[&str], search_path: &Utf8Path) -> Vec<Reason> {
-    let package_segment_count = parts.len().saturating_sub(1);
-    let mut dir = search_path.to_path_buf();
-    let mut reasons = Vec::new();
-
-    for part in parts.iter().take(package_segment_count) {
-        dir.push(part);
-        if dir.is_dir() && !dir.join("__init__.py").is_file() {
-            reasons.push(Reason::path(
-                Field::ResolverModule,
-                dir.clone(),
-                "module resolves through a namespace package segment without __init__.py",
-            ));
-        }
-    }
-
-    reasons
 }
 
 #[must_use]
@@ -565,6 +529,24 @@ mod tests {
     }
 
     #[test]
+    fn resolves_namespace_package_module_name_for_file_as_known() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&project_root.join("src/acme/plugins/blog/apps.py"), "");
+
+        let search_paths = discover_module_search_paths(&project_root, &[], &[]);
+        let fact = module_name_for_file(
+            &project_root.join("src/acme/plugins/blog/apps.py"),
+            search_path_entries(&search_paths),
+        );
+
+        let Fact::Known { value } = fact else {
+            panic!("expected known module for namespace package file, got {fact:?}");
+        };
+        assert_eq!(value, module("acme.plugins.blog.apps"));
+    }
+
+    #[test]
     fn uses_explicit_nested_source_roots() {
         let tmp = tempfile::TempDir::new().unwrap();
         let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
@@ -627,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn namespace_package_resolution_is_partial() {
+    fn namespace_package_resolution_is_known_when_unique() {
         let tmp = tempfile::TempDir::new().unwrap();
         let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         write_file(&project_root.join("src/acme/plugins/blog/apps.py"), "");
@@ -640,16 +622,13 @@ mod tests {
         );
 
         match resolution.resolved {
-            Fact::Partial { value, reasons } => {
+            Fact::Known { value } => {
                 assert_eq!(
                     value.file,
                     project_root.join("src/acme/plugins/blog/apps.py")
                 );
-                assert!(reasons
-                    .iter()
-                    .any(|reason| reason.field == Field::ResolverModule));
             }
-            other => panic!("expected partial namespace package module, got {other:?}"),
+            other => panic!("expected known namespace package module, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

- treat unique PEP 420 namespace-package module resolutions as known instead of partial
- cover both dotted module resolution and file-to-module mapping for namespace package paths
- update the django-allauth corpus profile to known confidence now that its namespace-package settings path no longer downgrades static assembly

## Validation

- `cargo test -q -p djls-semantic namespace_package --no-default-features`
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-semantic module_resolver --no-default-features`
- `cargo test -q -p djls-semantic app_registry --no-default-features`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`