### PR TITLE
Complete ArchiveBox profile site package stubs

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -20,8 +20,9 @@ root = "."
 settings_file = "archivebox/core/settings.py"
 settings_module = "archivebox.core.settings"
 extends_files = []
-installed_apps_confidence = "partial"
+installed_apps_confidence = "known"
 templates_confidence = "partial"
+template_libraries_confidence = "known"
 expected_partial_reasons = [
   "TEMPLATES DIRS contains an unsupported path expression",
 ]
@@ -36,9 +37,12 @@ local_apps = [
   "archivebox.api",
 ]
 site_package_modules = [
+  "admin_data_views",
   "daphne",
   "django.contrib.admin",
   "django_extensions",
+  "django_object_actions",
+  "signal_webhooks",
 ]
 template_dirs = [
   "archivebox/templates/core",

--- a/crates/djls-corpus/src/profiles.rs
+++ b/crates/djls-corpus/src/profiles.rs
@@ -55,6 +55,8 @@ pub struct DjangoEnvironmentProfile {
     pub installed_apps_confidence: Confidence,
     pub templates_confidence: Confidence,
     #[serde(default)]
+    pub template_libraries_confidence: Option<Confidence>,
+    #[serde(default)]
     pub expected: ExpectedFacts,
     #[serde(default)]
     pub expected_partial_reasons: Vec<String>,

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -3118,6 +3118,10 @@ TEMPLATES = []
     fn expected_profile_snapshot_confidence(
         environment: &djls_corpus::DjangoEnvironmentProfile,
     ) -> Confidence {
+        if let Some(confidence) = environment.template_libraries_confidence {
+            return expected_profile_confidence(confidence);
+        }
+
         if environment.installed_apps_confidence == djls_corpus::Confidence::Unknown
             || environment.templates_confidence == djls_corpus::Confidence::Unknown
         {


### PR DESCRIPTION
## Summary

- add missing literal ArchiveBox third-party apps to corpus `site_package_modules`
- mark ArchiveBox installed-app confidence as known while keeping template-dir confidence partial
- add optional `template_libraries_confidence` profile metadata for cases where template dirs and template libraries differ

## Validation

- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`