### PR TITLE
Complete NetBox profile site package stubs

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -158,8 +158,8 @@ root = "."
 settings_file = "netbox/netbox/settings.py"
 settings_module = "netbox.settings"
 extends_files = []
-installed_apps_confidence = "partial"
-templates_confidence = "partial"
+installed_apps_confidence = "known"
+templates_confidence = "known"
 expected_partial_reasons = []
 
 [profile.django_environment.expected]
@@ -174,15 +174,23 @@ local_apps = [
   "utilities",
 ]
 site_package_modules = [
+  "corsheaders",
   "django.contrib.admin",
   "debug_toolbar",
+  "django_htmx",
   "django_filters",
-  "django_tables2",
-]
-unresolved_apps = [
-  "corsheaders",
   "django_prometheus",
+  "django_rq",
+  "django_tables2",
+  "drf_spectacular",
+  "drf_spectacular_sidecar",
+  "mptt",
+  "rest_framework",
+  "social_django",
+  "sorl.thumbnail",
   "strawberry_django",
+  "taggit",
+  "timezone_field",
 ]
 template_dirs = ["netbox/templates"]
 templatetag_modules = [

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -3145,6 +3145,7 @@ TEMPLATES = []
             "django.contrib.sites",
             "django.contrib.sessions",
             "django.contrib.staticfiles",
+            "django.forms",
             "django.templatetags.cache",
             "django.templatetags.i18n",
             "django.templatetags.l10n",


### PR DESCRIPTION
## Summary

- add literal NetBox third-party apps to corpus `site_package_modules`
- remove NetBox unresolved app expectations for dependencies now stubbed in the corpus harness
- add shared `django.forms` fake module and mark NetBox confidence known

## Validation

- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`