### PR TITLE
Support AppConfig site package stubs

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -108,8 +108,9 @@ root = "."
 settings_file = "src/backend/InvenTree/InvenTree/settings.py"
 settings_module = "InvenTree.settings"
 extends_files = []
-installed_apps_confidence = "partial"
+installed_apps_confidence = "known"
 templates_confidence = "partial"
+template_libraries_confidence = "known"
 expected_partial_reasons = [
   "TEMPLATES DIRS contains an unsupported path expression",
 ]
@@ -131,9 +132,38 @@ local_apps = [
   "InvenTree",
 ]
 site_package_modules = [
-  "django.contrib.admin",
-  "rest_framework",
   "allauth",
+  "allauth.account",
+  "allauth.headless",
+  "allauth.mfa",
+  "allauth.socialaccount",
+  "allauth.usersessions",
+  "anymail",
+  "corsheaders",
+  "dbbackup",
+  "django.contrib.admin",
+  "django_cleanup.apps.CleanupConfig",
+  "django_filters",
+  "django_ical",
+  "django_mailbox",
+  "django_otp",
+  "django_otp.plugins.otp_static",
+  "django_otp.plugins.otp_totp",
+  "django_q",
+  "django_structlog",
+  "djmoney",
+  "djmoney.contrib.exchange",
+  "drf_spectacular",
+  "error_report",
+  "flags",
+  "maintenance_mode",
+  "markdownify",
+  "mptt",
+  "oauth2_provider",
+  "rest_framework",
+  "storages",
+  "taggit",
+  "whitenoise.runserver_nostatic",
 ]
 template_dirs = ["src/backend/InvenTree/templates"]
 templatetag_modules = [

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -3138,6 +3138,7 @@ TEMPLATES = []
     fn minimal_profile_site_package_modules(profile: &djls_corpus::Profile) -> Vec<String> {
         let mut modules = [
             "django.contrib.admin",
+            "django.contrib.admindocs",
             "django.contrib.auth",
             "django.contrib.contenttypes",
             "django.contrib.humanize",
@@ -3182,6 +3183,11 @@ TEMPLATES = []
     }
 
     fn write_minimal_python_module(root: &Utf8Path, module: &str) {
+        if let Some((config_module, class_name)) = app_config_module(module) {
+            write_minimal_app_config_module(root, config_module, class_name);
+            return;
+        }
+
         let mut parts = module.split('.').collect::<Vec<_>>();
         let Some(file_name) = parts.pop() else {
             return;
@@ -3192,6 +3198,37 @@ TEMPLATES = []
             write_file(&dir.join("__init__.py"), "");
         }
         write_file(&dir.join(format!("{file_name}.py")), "");
+    }
+
+    fn app_config_module(module: &str) -> Option<(&str, &str)> {
+        let (config_module, class_name) = module.rsplit_once('.')?;
+        class_name
+            .ends_with("Config")
+            .then_some((config_module, class_name))
+    }
+
+    fn write_minimal_app_config_module(root: &Utf8Path, module: &str, class_name: &str) {
+        let app_name = module.strip_suffix(".apps").unwrap_or(module);
+        let mut parts = module.split('.').collect::<Vec<_>>();
+        let Some(file_name) = parts.pop() else {
+            return;
+        };
+        let mut dir = root.to_path_buf();
+        for part in parts {
+            dir = dir.join(part);
+            write_file(&dir.join("__init__.py"), "");
+        }
+        write_file(
+            &dir.join(format!("{file_name}.py")),
+            &format!(
+                r#"
+from django.apps import AppConfig
+
+class {class_name}(AppConfig):
+    name = "{app_name}"
+"#
+            ),
+        );
     }
 
     fn profile_app_template_dir(


### PR DESCRIPTION
## Summary

- teach the corpus profile harness to write minimal AppConfig classes for `site_package_modules` entries ending in `*Config`
- add literal InvenTree external dependencies to corpus `site_package_modules`
- mark InvenTree installed-app and template-library confidence known while keeping template dirs partial for the dynamic `MEDIA_ROOT` path

## Validation

- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`