### PR TITLE
Assert installed app partial reasons

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -247,7 +247,9 @@ settings_module = "pretix.settings"
 extends_files = ["src/pretix/_base_settings.py"]
 installed_apps_confidence = "partial"
 templates_confidence = "known"
-expected_partial_reasons = []
+expected_partial_reasons = [
+  "module `djangoformsetjs` was not found in module search paths",
+]
 
 [profile.django_environment.expected]
 local_apps = [

--- a/crates/djls-semantic/src/project/module_resolver.rs
+++ b/crates/djls-semantic/src/project/module_resolver.rs
@@ -354,7 +354,10 @@ fn resolve_module_fact(
         0 => Fact::unknown(vec![Reason::module(
             Field::ResolverModule,
             requested.clone(),
-            "module was not found in module search paths",
+            format!(
+                "module `{}` was not found in module search paths",
+                requested.as_str()
+            ),
         )]),
         1 => Fact::known(candidates.pop().unwrap().module),
         _ => Fact::ambiguous(

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -1714,6 +1714,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::project::facts::InstalledAppFact;
     use crate::project::introspector::ProjectIntrospector;
     use crate::project::names::LibraryName;
     use crate::project::names::PyModuleName;
@@ -2974,7 +2975,13 @@ TEMPLATES = []
             environment.settings_module,
             snapshot.reasons()
         );
-        assert_expected_profile_partial_reasons(profile_id, environment, &dirs, &snapshot);
+        assert_expected_profile_partial_reasons(
+            profile_id,
+            environment,
+            &context.app_registry.installed_apps,
+            &dirs,
+            &snapshot,
+        );
 
         let Some(snapshot) = snapshot.value() else {
             assert!(
@@ -3058,12 +3065,14 @@ TEMPLATES = []
     fn assert_expected_profile_partial_reasons(
         profile_id: &str,
         environment: &djls_corpus::DjangoEnvironmentProfile,
+        installed_apps: &Fact<Vec<InstalledAppFact>>,
         dirs: &Fact<Vec<Utf8PathBuf>>,
         snapshot: &Fact<TemplateLibrarySnapshot>,
     ) {
-        let reason_messages = dirs
+        let reason_messages = installed_apps
             .reasons()
             .iter()
+            .chain(dirs.reasons())
             .chain(snapshot.reasons())
             .map(|reason| reason.message.as_str())
             .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary
- include installed-app fact reasons in corpus profile partial reason assertions
- include the requested module name in unresolved module resolver reasons
- record Pretix's unresolved `djangoformsetjs` app as an expected partial reason

## Validation
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `cargo test -q -p djls-semantic module_resolver --no-default-features`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`