### PR TITLE
Mark nested installed app updates partial

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -20,10 +20,11 @@ root = "."
 settings_file = "archivebox/core/settings.py"
 settings_module = "archivebox.core.settings"
 extends_files = []
-installed_apps_confidence = "known"
+installed_apps_confidence = "partial"
 templates_confidence = "partial"
-template_libraries_confidence = "known"
+template_libraries_confidence = "partial"
 expected_partial_reasons = [
+  "unsupported nested assignment or mutation of INSTALLED_APPS",
   "TEMPLATES DIRS contains an unsupported path expression",
 ]
 
@@ -108,10 +109,11 @@ root = "."
 settings_file = "src/backend/InvenTree/InvenTree/settings.py"
 settings_module = "InvenTree.settings"
 extends_files = []
-installed_apps_confidence = "known"
+installed_apps_confidence = "partial"
 templates_confidence = "partial"
-template_libraries_confidence = "known"
+template_libraries_confidence = "partial"
 expected_partial_reasons = [
+  "unsupported nested assignment or mutation of INSTALLED_APPS",
   "TEMPLATES DIRS contains an unsupported path expression",
 ]
 
@@ -188,9 +190,11 @@ root = "."
 settings_file = "netbox/netbox/settings.py"
 settings_module = "netbox.settings"
 extends_files = []
-installed_apps_confidence = "known"
-templates_confidence = "known"
-expected_partial_reasons = []
+installed_apps_confidence = "partial"
+templates_confidence = "partial"
+expected_partial_reasons = [
+  "unsupported nested assignment or mutation of INSTALLED_APPS",
+]
 
 [profile.django_environment.expected]
 local_apps = [
@@ -249,6 +253,7 @@ installed_apps_confidence = "partial"
 templates_confidence = "known"
 expected_partial_reasons = [
   "module `djangoformsetjs` was not found in module search paths",
+  "unsupported nested assignment or mutation of INSTALLED_APPS",
 ]
 
 [profile.django_environment.expected]

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -121,6 +121,10 @@ impl SettingsExtractionState {
         self.template_backends_import_reasons.extend(reasons);
     }
 
+    fn add_installed_apps_reason(&mut self, reason: Reason) {
+        self.installed_apps_import_reasons.push(reason);
+    }
+
     fn add_files_read(&mut self, files: impl IntoIterator<Item = Utf8PathBuf>) {
         self.files_read.extend(files);
     }
@@ -283,6 +287,18 @@ fn extract_settings_state_inner(
                 file,
             ));
         }
+    }
+
+    if module
+        .body
+        .iter()
+        .any(|stmt| contains_nested_list_mutation(stmt, INSTALLED_APPS))
+    {
+        state.add_installed_apps_reason(reason(
+            Field::SettingsInstalledApps,
+            file,
+            "unsupported nested assignment or mutation of INSTALLED_APPS",
+        ));
     }
 
     state
@@ -778,6 +794,45 @@ fn list_mutation<'a>(stmt: &'a Stmt, target_name: &str) -> Option<ListMutation<'
         Stmt::Expr(expr_stmt) => call_list_mutation(expr_stmt.value.as_ref(), target_name),
         _ => None,
     }
+}
+
+fn contains_nested_list_mutation(stmt: &Stmt, target_name: &str) -> bool {
+    match stmt {
+        Stmt::If(stmt_if) => {
+            body_contains_list_mutation(&stmt_if.body, target_name)
+                || stmt_if
+                    .elif_else_clauses
+                    .iter()
+                    .any(|clause| body_contains_list_mutation(&clause.body, target_name))
+        }
+        Stmt::For(stmt_for) => {
+            body_contains_list_mutation(&stmt_for.body, target_name)
+                || body_contains_list_mutation(&stmt_for.orelse, target_name)
+        }
+        Stmt::While(stmt_while) => {
+            body_contains_list_mutation(&stmt_while.body, target_name)
+                || body_contains_list_mutation(&stmt_while.orelse, target_name)
+        }
+        Stmt::Try(stmt_try) => {
+            body_contains_list_mutation(&stmt_try.body, target_name)
+                || stmt_try.handlers.iter().any(|handler| {
+                    let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    body_contains_list_mutation(&handler.body, target_name)
+                })
+                || body_contains_list_mutation(&stmt_try.orelse, target_name)
+                || body_contains_list_mutation(&stmt_try.finalbody, target_name)
+        }
+        Stmt::With(stmt_with) => body_contains_list_mutation(&stmt_with.body, target_name),
+        _ => false,
+    }
+}
+
+fn body_contains_list_mutation(body: &[Stmt], target_name: &str) -> bool {
+    body.iter().any(|stmt| {
+        assigned_value(stmt, target_name).is_some()
+            || list_mutation(stmt, target_name).is_some()
+            || contains_nested_list_mutation(stmt, target_name)
+    })
 }
 
 fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutation<'a>> {
@@ -2227,6 +2282,30 @@ TEMPLATES.update({"APP_DIRS": True})
         assert!(template_reasons[0]
             .message
             .contains("unsupported dynamic mutation"));
+    }
+
+    #[test]
+    fn marks_nested_installed_apps_updates_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["django.contrib.auth"]
+if ENABLE_DEBUG_TOOLBAR:
+    INSTALLED_APPS = [*INSTALLED_APPS, "debug_toolbar"]
+for plugin in plugins:
+    INSTALLED_APPS.append(plugin)
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        let (apps, reasons) = partial_vec(&facts.installed_apps);
+        assert_eq!(apps, ["django.contrib.auth"]);
+        assert!(reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of INSTALLED_APPS")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect nested `INSTALLED_APPS` assignments and list mutations under module-level compound statements
- keep recovered deterministic app values, but add a partial confidence reason for unsupported nested updates
- update ArchiveBox, InvenTree, NetBox, and Pretix corpus profile expectations for runtime-dependent app updates

## Validation
- `cargo test -q -p djls-semantic marks_nested_installed_apps_updates_partial --no-default-features`
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`