### PR TITLE
Assert Sentry partial app reason

### DIFF
--- a/crates/djls-corpus/project-model-profiles.toml
+++ b/crates/djls-corpus/project-model-profiles.toml
@@ -296,7 +296,9 @@ settings_module = "sentry.conf.server"
 extends_files = []
 installed_apps_confidence = "partial"
 templates_confidence = "partial"
-expected_partial_reasons = []
+expected_partial_reasons = [
+  "module `drf_spectacular` was not found in module search paths",
+]
 
 [profile.django_environment.expected]
 local_apps = []

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -3152,6 +3152,7 @@ TEMPLATES = []
             "django.contrib.contenttypes",
             "django.contrib.humanize",
             "django.contrib.messages",
+            "django.contrib.postgres",
             "django.contrib.sites",
             "django.contrib.sessions",
             "django.contrib.staticfiles",


### PR DESCRIPTION
## Summary
- add shared minimal corpus stub coverage for Django's `django.contrib.postgres`
- assert Sentry's unresolved `drf_spectacular` app as a concrete partial reason
- keep Sentry partial rather than adding third-party stubs to force known confidence

## Validation
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`