### PR TITLE
Require partial corpus profile reasons

### DIFF
--- a/crates/djls-corpus/src/profiles.rs
+++ b/crates/djls-corpus/src/profiles.rs
@@ -210,7 +210,20 @@ impl DjangoEnvironmentProfile {
             profile_id,
             &format!("Django environment `{}` expected facts", self.root),
         )?;
+        if self.has_partial_confidence() {
+            anyhow::ensure!(
+                !self.expected_partial_reasons.is_empty(),
+                "profile `{profile_id}` Django environment `{}` has partial confidence but no expected partial reasons",
+                self.root
+            );
+        }
         Ok(())
+    }
+
+    fn has_partial_confidence(&self) -> bool {
+        self.installed_apps_confidence == Confidence::Partial
+            || self.templates_confidence == Confidence::Partial
+            || self.template_libraries_confidence == Some(Confidence::Partial)
     }
 }
 
@@ -290,6 +303,38 @@ mod tests {
             gh401.expected_union.local_apps,
             vec!["clientname.app1", "clientname.app2", "clientname.app3"]
         );
+    }
+
+    #[test]
+    fn partial_environment_requires_expected_partial_reasons() {
+        let profiles: ProfileSet = toml::from_str(
+            r#"
+[[profile]]
+id = "partial-without-reasons"
+description = "Partial confidence must explain why."
+source_roots = ["."]
+
+[profile.source]
+kind = "fixture"
+path = "gh401-multisite"
+
+[[profile.django_environment]]
+root = "."
+settings_file = "projects/site1/settings/dev.py"
+settings_module = "projects.site1.settings.dev"
+extends_files = []
+installed_apps_confidence = "partial"
+templates_confidence = "known"
+expected_partial_reasons = []
+"#,
+        )
+        .unwrap();
+
+        let error = profiles.validate().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("has partial confidence but no expected partial reasons"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- validate that partial corpus profile environments include at least one `expected_partial_reasons` entry
- keep known environments allowed to have empty reason lists
- add a negative loader test for a partial environment without reasons

## Validation
- `cargo test -q -p djls-corpus partial_environment_requires_expected_partial_reasons`
- `cargo test -q -p djls-corpus`
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`