### PR TITLE
Mark destructive settings list methods partial

### DIFF
--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -952,7 +952,9 @@ fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutat
             };
             Some(ListMutation::Insert { index, value })
         }
-        "update" => Some(ListMutation::Unsupported),
+        "clear" | "pop" | "remove" | "reverse" | "sort" | "update" => {
+            Some(ListMutation::Unsupported)
+        }
         _ => None,
     }
 }
@@ -2363,6 +2365,36 @@ TEMPLATES.update({"APP_DIRS": True})
         assert!(template_reasons[0]
             .message
             .contains("unsupported dynamic mutation"));
+    }
+
+    #[test]
+    fn marks_destructive_settings_list_methods_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["django.contrib.auth", "django.contrib.sites"]
+if not SITE_MULTI:
+    INSTALLED_APPS.remove("django.contrib.sites")
+TEMPLATES = [{"DIRS": []}]
+TEMPLATES.pop()
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        let (apps, app_reasons) = partial_vec(&facts.installed_apps);
+        assert_eq!(apps, ["django.contrib.auth", "django.contrib.sites"]);
+        assert!(app_reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of INSTALLED_APPS")));
+
+        let (templates, template_reasons) = partial_vec(&facts.template_backends);
+        assert_eq!(templates.len(), 1);
+        assert!(template_reasons
+            .iter()
+            .any(|reason| reason.message.contains("unsupported dynamic mutation")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat destructive/reordering settings list methods (`remove`, `pop`, `clear`, `sort`, `reverse`) as unsupported mutations
- preserve deterministic facts already recovered while downgrading confidence
- add focused coverage for nested `INSTALLED_APPS.remove(...)` and `TEMPLATES.pop()`

## Validation
- `cargo test -q -p djls-semantic marks_destructive_settings_list_methods_partial --no-default-features`
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `cargo test -q -p djls-corpus`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`