### PR TITLE
Infer pathlib Path constructor paths

### DIFF
--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -1614,7 +1614,11 @@ fn evaluate_path_call(
     }
 
     match call.func.as_ref() {
-        Expr::Name(name) if name.id.as_str() == "Path" => {
+        _ if matches!(
+            dotted_name(call.func.as_ref()).as_deref(),
+            Some("Path" | "pathlib.Path")
+        ) =>
+        {
             let first = call.arguments.args.first()?;
             evaluate_path(first, path_values, settings_file)
         }
@@ -2819,6 +2823,27 @@ import os
 BASE_DIR = Path(__file__).resolve().parent.parent
 INSTALLED_APPS = []
 TEMPLATES = [{"DIRS": [os.path.join(BASE_DIR, "templates")]}]
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert_eq!(known_vec(&backends[0].dirs)[0].path, root.join("templates"));
+    }
+
+    #[test]
+    fn extracts_pathlib_path_template_dirs() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+import pathlib
+
+BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
+INSTALLED_APPS = []
+TEMPLATES = [{"DIRS": [BASE_DIR / "templates"]}]
 "#,
         );
 


### PR DESCRIPTION
## Summary

- infer `pathlib.Path(...)` path expressions the same way as direct `Path(...)` calls
- add focused settings fact coverage for `pathlib.Path(__file__).resolve().parent` template dirs
- keep the rule source-based; no config or runtime path calls are added

## Validation

- `cargo test -q -p djls-semantic extracts_pathlib_path_template_dirs --no-default-features`
- `cargo test -q -p djls-semantic settings_facts --no-default-features`
- `cargo test -q -p djls-semantic synced_corpus_profiles_static_assembly_matches_expected_facts --no-default-features -- --nocapture`
- `just fmt --check`
- `just test -q`
- `cargo clippy -q --all-targets --all-features --benches -- -D warnings`
- `just lint`