### PR TITLE
Assemble static template libraries and symbols

### DIFF
--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -13,6 +13,7 @@ mod symbols;
 mod sync;
 mod system;
 mod template_dirs;
+mod template_libraries;
 
 pub use crate::project::db::Db;
 pub use crate::project::input::load_env_file;

--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -14,6 +14,7 @@ mod sync;
 mod system;
 mod template_dirs;
 mod template_libraries;
+mod template_symbols;
 
 pub use crate::project::db::Db;
 pub use crate::project::input::load_env_file;

--- a/crates/djls-semantic/src/project/facts.rs
+++ b/crates/djls-semantic/src/project/facts.rs
@@ -348,6 +348,7 @@ pub(crate) enum TemplateLibrarySource {
     AppTemplateTags { app: PyModuleName },
     SettingsLibraries,
     SettingsBuiltins,
+    DjangoDefaultLibrary,
     DjangoDefaultBuiltin,
     Discovered,
     UserOverride,

--- a/crates/djls-semantic/src/project/template_libraries.rs
+++ b/crates/djls-semantic/src/project/template_libraries.rs
@@ -1,0 +1,1165 @@
+//! Static Django template library facts.
+//!
+//! This module assembles loadable template libraries and builtin libraries from
+//! extracted template backend settings plus the static app registry. It models
+//! Django's standard `DjangoTemplates` backend: Django's built-in `{% load %}`
+//! libraries, installed-app `templatetags` packages, `OPTIONS.libraries`,
+//! Django's default builtins, and `OPTIONS.builtins`.
+//!
+//! A8 facts are flattened across Django template backends and do not carry
+//! backend identity yet. For duplicate load names, later flattened backend/app
+//! entries replace earlier entries; explicit `OPTIONS.libraries` entries replace
+//! discovered/default libraries for the same backend, matching Django's
+//! `libraries.update(custom_libraries)` behavior.
+
+#![allow(
+    dead_code,
+    reason = "Milestone A8 adds template library facts before project facts are assembled."
+)]
+
+use std::collections::BTreeMap;
+use std::fs;
+
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use ruff_python_ast::Expr;
+use ruff_python_ast::Stmt;
+
+use crate::project::facts::AppFact;
+use crate::project::facts::Fact;
+use crate::project::facts::Field;
+use crate::project::facts::Reason;
+use crate::project::facts::ReasonSource;
+use crate::project::facts::TemplateBackendFact;
+use crate::project::facts::TemplateLibraryFact;
+use crate::project::facts::TemplateLibrarySource;
+use crate::project::names::LibraryName;
+use crate::project::names::PyModuleName;
+
+const DJANGO_TEMPLATES_BACKEND: &str = "django.template.backends.django.DjangoTemplates";
+
+const DJANGO_DEFAULT_LOADABLE_LIBRARIES: &[(&str, &str)] = &[
+    ("cache", "django.templatetags.cache"),
+    ("i18n", "django.templatetags.i18n"),
+    ("l10n", "django.templatetags.l10n"),
+    ("static", "django.templatetags.static"),
+    ("tz", "django.templatetags.tz"),
+];
+
+const DJANGO_DEFAULT_BUILTINS: &[&str] = &[
+    "django.template.defaulttags",
+    "django.template.defaultfilters",
+    "django.template.loader_tags",
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DuplicatePolicy {
+    Report,
+    SilentOverride,
+}
+
+#[must_use]
+pub(crate) fn assemble_template_libraries(
+    template_backends: &Fact<Vec<TemplateBackendFact>>,
+    app_registry: &Fact<Vec<AppFact>>,
+) -> Fact<Vec<TemplateLibraryFact>> {
+    match template_backends {
+        Fact::Known { value } => {
+            assemble_template_backend_libraries(value, Vec::new(), app_registry)
+        }
+        Fact::Partial { value, reasons } => {
+            assemble_template_backend_libraries(value, reasons.clone(), app_registry)
+        }
+        Fact::Unknown { reasons } | Fact::Ambiguous { reasons, .. } => {
+            Fact::unknown(reasons.clone())
+        }
+    }
+}
+
+fn assemble_template_backend_libraries(
+    backends: &[TemplateBackendFact],
+    mut reasons: Vec<Reason>,
+    app_registry: &Fact<Vec<AppFact>>,
+) -> Fact<Vec<TemplateLibraryFact>> {
+    let mut loadable = BTreeMap::new();
+    let mut builtins = Vec::new();
+
+    for backend in backends {
+        if !is_django_template_backend(backend, &mut reasons) {
+            continue;
+        }
+
+        append_default_loadable_libraries(&mut loadable, &mut reasons);
+        append_app_template_tag_libraries(&mut loadable, &mut reasons, app_registry);
+        append_option_libraries(&mut loadable, &mut reasons, &backend.option_libraries);
+        append_default_builtins(&mut builtins);
+        append_option_builtins(&mut builtins, &mut reasons, &backend.option_builtins);
+    }
+
+    let mut libraries = loadable.into_values().collect::<Vec<_>>();
+    libraries.extend(builtins);
+    known_or_partial(libraries, reasons)
+}
+
+fn is_django_template_backend(backend: &TemplateBackendFact, reasons: &mut Vec<Reason>) -> bool {
+    let Some(backend) = backend.backend.as_deref() else {
+        reasons.push(Reason::new(
+            Field::TemplateLibraries,
+            ReasonSource::Unknown,
+            "TEMPLATES BACKEND is not known; skipped template library assembly for this backend",
+        ));
+        return false;
+    };
+
+    backend == DJANGO_TEMPLATES_BACKEND
+}
+
+fn append_default_loadable_libraries(
+    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+) {
+    for (load_name, module) in DJANGO_DEFAULT_LOADABLE_LIBRARIES {
+        let fact = TemplateLibraryFact {
+            load_name: LibraryName::parse(load_name).expect("Django default library name is valid"),
+            module: PyModuleName::parse(module).expect("Django default library module is valid"),
+            source: TemplateLibrarySource::DjangoDefaultLibrary,
+        };
+        upsert_loadable_library(loadable, reasons, fact, DuplicatePolicy::Report);
+    }
+}
+
+fn append_app_template_tag_libraries(
+    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+    app_registry: &Fact<Vec<AppFact>>,
+) {
+    match app_registry {
+        Fact::Known { value } => push_app_template_tag_libraries(loadable, reasons, value),
+        Fact::Partial {
+            value,
+            reasons: app_reasons,
+        } => {
+            push_app_template_tag_libraries(loadable, reasons, value);
+            extend_unique_reasons(reasons, app_reasons.iter().cloned());
+        }
+        Fact::Unknown {
+            reasons: app_reasons,
+        }
+        | Fact::Ambiguous {
+            reasons: app_reasons,
+            ..
+        } => {
+            extend_unique_reasons(reasons, app_reasons.iter().cloned());
+        }
+    }
+}
+
+fn push_app_template_tag_libraries(
+    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+    apps: &[AppFact],
+) {
+    for app in apps {
+        for fact in discover_app_template_tag_libraries(app, reasons) {
+            upsert_loadable_library(loadable, reasons, fact, DuplicatePolicy::Report);
+        }
+    }
+}
+
+fn discover_app_template_tag_libraries(
+    app: &AppFact,
+    reasons: &mut Vec<Reason>,
+) -> Vec<TemplateLibraryFact> {
+    let templatetags_dir = app.path.join("templatetags");
+    if !templatetags_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut files = Vec::new();
+    collect_python_files(&templatetags_dir, &mut files, reasons);
+    files.sort();
+
+    files
+        .into_iter()
+        .filter_map(|file| app_template_tag_library(app, &templatetags_dir, &file, reasons))
+        .collect()
+}
+
+fn collect_python_files(dir: &Utf8Path, files: &mut Vec<Utf8PathBuf>, reasons: &mut Vec<Reason>) {
+    let Ok(entries) = fs::read_dir(dir.as_std_path()) else {
+        reasons.push(Reason::path(
+            Field::TemplateLibraries,
+            dir,
+            "failed to read templatetags package directory",
+        ));
+        return;
+    };
+
+    let mut paths = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| Utf8PathBuf::try_from(entry.path()).ok())
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    for path in paths {
+        if path.is_dir() {
+            // Django discovers nested libraries through pkgutil.walk_packages(),
+            // which only descends into package directories.
+            if path.join("__init__.py").is_file() {
+                collect_python_files(&path, files, reasons);
+            }
+        } else if path.extension() == Some("py") {
+            files.push(path);
+        }
+    }
+}
+
+fn app_template_tag_library(
+    app: &AppFact,
+    templatetags_dir: &Utf8Path,
+    file: &Utf8Path,
+    reasons: &mut Vec<Reason>,
+) -> Option<TemplateLibraryFact> {
+    let load_name = template_tag_load_name(templatetags_dir, file, reasons)?;
+    if !defines_template_register(file, reasons) {
+        return None;
+    }
+
+    let module = PyModuleName::parse(&format!(
+        "{}.templatetags.{}",
+        app.module.as_str(),
+        load_name.as_str()
+    ))
+    .ok()?;
+
+    Some(TemplateLibraryFact {
+        load_name,
+        module,
+        source: TemplateLibrarySource::AppTemplateTags {
+            app: app.module.clone(),
+        },
+    })
+}
+
+fn template_tag_load_name(
+    templatetags_dir: &Utf8Path,
+    file: &Utf8Path,
+    reasons: &mut Vec<Reason>,
+) -> Option<LibraryName> {
+    let relative = file.strip_prefix(templatetags_dir).ok()?;
+    let module_path = if relative.file_name() == Some("__init__.py") {
+        let parent = relative.parent()?;
+        if parent.as_str().is_empty() {
+            return None;
+        }
+        parent.to_path_buf()
+    } else {
+        relative.with_extension("")
+    };
+
+    let dotted = dotted_path(&module_path);
+    match LibraryName::parse(&dotted) {
+        Ok(load_name) => Some(load_name),
+        Err(error) => {
+            reasons.push(Reason::file(
+                Field::TemplateLibraries,
+                file,
+                format!("template tag module has an invalid load name: {error}"),
+            ));
+            None
+        }
+    }
+}
+
+fn dotted_path(path: &Utf8Path) -> String {
+    path.components()
+        .map(|component| component.as_str())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn defines_template_register(file: &Utf8Path, reasons: &mut Vec<Reason>) -> bool {
+    let source = match fs::read_to_string(file.as_std_path()) {
+        Ok(source) => source,
+        Err(error) => {
+            reasons.push(Reason::file(
+                Field::TemplateLibraries,
+                file,
+                format!("failed to read template tag module: {error}"),
+            ));
+            return false;
+        }
+    };
+
+    let module = match ruff_python_parser::parse_module(&source) {
+        Ok(parsed) => parsed.into_syntax(),
+        Err(error) => {
+            reasons.push(Reason::file(
+                Field::TemplateLibraries,
+                file,
+                format!("failed to parse template tag module: {error}"),
+            ));
+            return false;
+        }
+    };
+
+    module.body.iter().any(stmt_defines_template_register)
+}
+
+fn stmt_defines_template_register(stmt: &Stmt) -> bool {
+    let Some(value) = assigned_value(stmt, "register") else {
+        return false;
+    };
+    is_template_library_call(value)
+}
+
+fn assigned_value<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
+    match stmt {
+        Stmt::Assign(assign) => assign
+            .targets
+            .iter()
+            .any(|target| is_name(target, target_name))
+            .then_some(assign.value.as_ref()),
+        Stmt::AnnAssign(assign) if is_name(assign.target.as_ref(), target_name) => {
+            assign.value.as_deref()
+        }
+        _ => None,
+    }
+}
+
+fn is_name(expr: &Expr, expected: &str) -> bool {
+    matches!(expr, Expr::Name(name) if name.id.as_str() == expected)
+}
+
+fn is_template_library_call(expr: &Expr) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+
+    match call.func.as_ref() {
+        Expr::Name(name) => name.id.as_str() == "Library",
+        Expr::Attribute(attribute) => attribute.attr.as_str() == "Library",
+        _ => false,
+    }
+}
+
+fn append_option_libraries(
+    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+    option_libraries: &Fact<Vec<TemplateLibraryFact>>,
+) {
+    match option_libraries {
+        Fact::Known { value } => push_option_libraries(loadable, reasons, value),
+        Fact::Partial {
+            value,
+            reasons: library_reasons,
+        } => {
+            push_option_libraries(loadable, reasons, value);
+            extend_unique_reasons(reasons, library_reasons.iter().cloned());
+        }
+        Fact::Unknown {
+            reasons: library_reasons,
+        }
+        | Fact::Ambiguous {
+            reasons: library_reasons,
+            ..
+        } => {
+            extend_unique_reasons(reasons, library_reasons.iter().cloned());
+        }
+    }
+}
+
+fn push_option_libraries(
+    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+    libraries: &[TemplateLibraryFact],
+) {
+    for library in libraries {
+        upsert_loadable_library(
+            loadable,
+            reasons,
+            library.clone(),
+            DuplicatePolicy::SilentOverride,
+        );
+    }
+}
+
+fn append_default_builtins(builtins: &mut Vec<TemplateLibraryFact>) {
+    for module in DJANGO_DEFAULT_BUILTINS {
+        push_unique_builtin(
+            builtins,
+            builtin_fact(
+                PyModuleName::parse(module).expect("Django default builtin module is valid"),
+                TemplateLibrarySource::DjangoDefaultBuiltin,
+            ),
+        );
+    }
+}
+
+fn append_option_builtins(
+    builtins: &mut Vec<TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+    option_builtins: &Fact<Vec<PyModuleName>>,
+) {
+    match option_builtins {
+        Fact::Known { value } => push_option_builtins(builtins, value),
+        Fact::Partial {
+            value,
+            reasons: builtin_reasons,
+        } => {
+            push_option_builtins(builtins, value);
+            extend_unique_reasons(reasons, builtin_reasons.iter().cloned());
+        }
+        Fact::Unknown {
+            reasons: builtin_reasons,
+        }
+        | Fact::Ambiguous {
+            reasons: builtin_reasons,
+            ..
+        } => {
+            extend_unique_reasons(reasons, builtin_reasons.iter().cloned());
+        }
+    }
+}
+
+fn push_option_builtins(builtins: &mut Vec<TemplateLibraryFact>, modules: &[PyModuleName]) {
+    for module in modules {
+        push_unique_builtin(
+            builtins,
+            builtin_fact(module.clone(), TemplateLibrarySource::SettingsBuiltins),
+        );
+    }
+}
+
+fn builtin_fact(module: PyModuleName, source: TemplateLibrarySource) -> TemplateLibraryFact {
+    let load_name = module
+        .as_str()
+        .split('.')
+        .next_back()
+        .and_then(|name| LibraryName::parse(name).ok())
+        .expect("builtin module basename is a valid library name");
+    TemplateLibraryFact {
+        load_name,
+        module,
+        source,
+    }
+}
+
+fn push_unique_builtin(builtins: &mut Vec<TemplateLibraryFact>, builtin: TemplateLibraryFact) {
+    if builtins
+        .iter()
+        .any(|existing| existing.module == builtin.module)
+    {
+        return;
+    }
+    builtins.push(builtin);
+}
+
+fn upsert_loadable_library(
+    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
+    reasons: &mut Vec<Reason>,
+    library: TemplateLibraryFact,
+    duplicate_policy: DuplicatePolicy,
+) {
+    if duplicate_policy == DuplicatePolicy::Report {
+        if let Some(existing) = loadable.get(&library.load_name) {
+            if existing.module != library.module {
+                let reason = Reason::module(
+                    Field::TemplateLibraries,
+                    library.module.clone(),
+                    format!(
+                        "template library load name `{}` is provided by both `{}` and `{}`; the later Django discovery entry wins",
+                        library.load_name.as_str(),
+                        existing.module.as_str(),
+                        library.module.as_str(),
+                    ),
+                );
+                if !reasons.contains(&reason) {
+                    reasons.push(reason);
+                }
+            }
+        }
+    }
+
+    loadable.insert(library.load_name.clone(), library);
+}
+
+fn known_or_partial(
+    value: Vec<TemplateLibraryFact>,
+    reasons: Vec<Reason>,
+) -> Fact<Vec<TemplateLibraryFact>> {
+    if reasons.is_empty() {
+        Fact::known(value)
+    } else {
+        Fact::partial(value, reasons)
+    }
+}
+
+fn extend_unique_reasons(reasons: &mut Vec<Reason>, new_reasons: impl Iterator<Item = Reason>) {
+    for reason in new_reasons {
+        if !reasons.contains(&reason) {
+            reasons.push(reason);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use camino::Utf8PathBuf;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::project::app_registry::resolve_app_registry;
+    use crate::project::facts::ModuleSearchPathEntry;
+    use crate::project::facts::TemplateDirFact;
+    use crate::project::facts::TemplateDirSource;
+    use crate::project::module_resolver::discover_module_search_paths;
+    use crate::project::settings_facts::extract_settings_facts;
+
+    fn module(name: &str) -> PyModuleName {
+        PyModuleName::parse(name).unwrap()
+    }
+
+    fn library(name: &str) -> LibraryName {
+        LibraryName::parse(name).unwrap()
+    }
+
+    fn mkdir(path: &Utf8Path) {
+        std::fs::create_dir_all(path).unwrap();
+    }
+
+    fn write_file(path: &Utf8Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            mkdir(parent);
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn search_paths(root: &Utf8Path) -> Vec<ModuleSearchPathEntry> {
+        discover_module_search_paths(root, &[], &[])
+            .value()
+            .unwrap()
+            .clone()
+    }
+
+    fn backend(app_dirs: Fact<bool>) -> TemplateBackendFact {
+        TemplateBackendFact {
+            backend: Some(DJANGO_TEMPLATES_BACKEND.to_string()),
+            dirs: Fact::known(Vec::new()),
+            app_dirs,
+            option_libraries: Fact::known(Vec::new()),
+            option_builtins: Fact::known(Vec::new()),
+        }
+    }
+
+    fn backend_with_options(
+        option_libraries: Fact<Vec<TemplateLibraryFact>>,
+        option_builtins: Fact<Vec<PyModuleName>>,
+    ) -> TemplateBackendFact {
+        TemplateBackendFact {
+            option_libraries,
+            option_builtins,
+            ..backend(Fact::known(false))
+        }
+    }
+
+    fn settings_library(load_name: &str, module_name: &str) -> TemplateLibraryFact {
+        TemplateLibraryFact {
+            load_name: library(load_name),
+            module: module(module_name),
+            source: TemplateLibrarySource::SettingsLibraries,
+        }
+    }
+
+    fn app(root: &Utf8Path, module_name: &str) -> AppFact {
+        AppFact {
+            entry: module_name.to_string(),
+            module: module(module_name),
+            path: root.join(module_name.replace('.', "/")),
+            config: None,
+        }
+    }
+
+    fn write_template_library(root: &Utf8Path, app_module: &str, load_name: &str) {
+        write_file(
+            &root.join(format!(
+                "{}/templatetags/{load_name}.py",
+                app_module.replace('.', "/")
+            )),
+            r"
+from django import template
+
+register = template.Library()
+",
+        );
+    }
+
+    fn known_vec(fact: &Fact<Vec<TemplateLibraryFact>>) -> Vec<TemplateLibraryFact> {
+        match fact {
+            Fact::Known { value } => value.clone(),
+            other => panic!("expected known template libraries, got {other:?}"),
+        }
+    }
+
+    fn partial_vec(
+        fact: &Fact<Vec<TemplateLibraryFact>>,
+    ) -> (Vec<TemplateLibraryFact>, Vec<Reason>) {
+        match fact {
+            Fact::Partial { value, reasons } => (value.clone(), reasons.clone()),
+            other => panic!("expected partial template libraries, got {other:?}"),
+        }
+    }
+
+    fn loadable_map(fact: &Fact<Vec<TemplateLibraryFact>>) -> BTreeMap<String, String> {
+        fact.value()
+            .unwrap()
+            .iter()
+            .filter(|library| {
+                !matches!(
+                    library.source,
+                    TemplateLibrarySource::DjangoDefaultBuiltin
+                        | TemplateLibrarySource::SettingsBuiltins
+                )
+            })
+            .map(|library| {
+                (
+                    library.load_name.as_str().to_string(),
+                    library.module.as_str().to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn builtin_modules(fact: &Fact<Vec<TemplateLibraryFact>>) -> Vec<String> {
+        fact.value()
+            .unwrap()
+            .iter()
+            .filter(|library| {
+                matches!(
+                    library.source,
+                    TemplateLibrarySource::DjangoDefaultBuiltin
+                        | TemplateLibrarySource::SettingsBuiltins
+                )
+            })
+            .map(|library| library.module.as_str().to_string())
+            .collect()
+    }
+
+    fn app_registry_reason() -> Reason {
+        Reason::new(
+            Field::AppsInstalled,
+            ReasonSource::Unknown,
+            "INSTALLED_APPS has an unsupported dynamic entry",
+        )
+    }
+
+    fn option_reason() -> Reason {
+        Reason::new(
+            Field::SettingsTemplateOptions,
+            ReasonSource::Unknown,
+            "TEMPLATES OPTIONS.libraries contains an unsupported value",
+        )
+    }
+
+    #[test]
+    fn adds_django_default_libraries_and_builtins() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(false))]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert_eq!(
+            loadable_map(&facts),
+            BTreeMap::from([
+                ("cache".to_string(), "django.templatetags.cache".to_string(),),
+                ("i18n".to_string(), "django.templatetags.i18n".to_string()),
+                ("l10n".to_string(), "django.templatetags.l10n".to_string()),
+                (
+                    "static".to_string(),
+                    "django.templatetags.static".to_string(),
+                ),
+                ("tz".to_string(), "django.templatetags.tz".to_string()),
+            ])
+        );
+        assert_eq!(
+            builtin_modules(&facts),
+            [
+                "django.template.defaulttags",
+                "django.template.defaultfilters",
+                "django.template.loader_tags",
+            ]
+        );
+    }
+
+    #[test]
+    fn settings_libraries_override_default_load_names_and_append_builtins() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend_with_options(
+                Fact::known(vec![settings_library(
+                    "static",
+                    "project.templatetags.assets",
+                )]),
+                Fact::known(vec![module("project.templatetags.extra_builtins")]),
+            )]),
+            &Fact::known(Vec::new()),
+        );
+
+        let loadable = loadable_map(&facts);
+        assert_eq!(
+            loadable.get("static").map(String::as_str),
+            Some("project.templatetags.assets")
+        );
+        assert_eq!(
+            builtin_modules(&facts),
+            [
+                "django.template.defaulttags",
+                "django.template.defaultfilters",
+                "django.template.loader_tags",
+                "project.templatetags.extra_builtins",
+            ]
+        );
+    }
+
+    #[test]
+    fn discovers_app_templatetags_even_when_app_dirs_is_false() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_template_library(&root, "blog", "blog_tags");
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(false))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        assert_eq!(
+            loadable_map(&facts).get("blog_tags").map(String::as_str),
+            Some("blog.templatetags.blog_tags")
+        );
+    }
+
+    #[test]
+    fn filters_templatetag_modules_without_register() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("blog/templatetags/base.py"),
+            "class Helper: pass\n",
+        );
+        write_template_library(&root, "blog", "real_tags");
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        let loadable = loadable_map(&facts);
+        assert!(!loadable.contains_key("base"));
+        assert_eq!(
+            loadable.get("real_tags").map(String::as_str),
+            Some("blog.templatetags.real_tags")
+        );
+    }
+
+    #[test]
+    fn discovers_nested_templatetag_packages() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("blog/templatetags/nested/__init__.py"),
+            r"
+from django.template import Library
+
+register = Library()
+",
+        );
+        write_file(
+            &root.join("blog/templatetags/nested/deep.py"),
+            r"
+from django import template
+
+register = template.Library()
+",
+        );
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        let loadable = loadable_map(&facts);
+        assert_eq!(
+            loadable.get("nested").map(String::as_str),
+            Some("blog.templatetags.nested")
+        );
+        assert_eq!(
+            loadable.get("nested.deep").map(String::as_str),
+            Some("blog.templatetags.nested.deep")
+        );
+    }
+
+    #[test]
+    fn nested_non_package_directories_are_not_discovered() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("blog/templatetags/not_a_package/deep.py"),
+            r"
+from django import template
+
+register = template.Library()
+",
+        );
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        assert!(!loadable_map(&facts).contains_key("not_a_package.deep"));
+    }
+
+    #[test]
+    fn duplicate_app_load_names_choose_later_app_and_record_reason() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_template_library(&root, "app1", "shared_tags");
+        write_template_library(&root, "app2", "shared_tags");
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::known(vec![app(&root, "app1"), app(&root, "app2")]),
+        );
+
+        let (libraries, reasons) = partial_vec(&facts);
+        let loadable = Fact::known(libraries);
+        assert_eq!(
+            loadable_map(&loadable)
+                .get("shared_tags")
+                .map(String::as_str),
+            Some("app2.templatetags.shared_tags")
+        );
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.message.contains("shared_tags")));
+    }
+
+    #[test]
+    fn app_load_names_can_override_django_defaults_with_reason() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_template_library(&root, "blog", "static");
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        let (libraries, reasons) = partial_vec(&facts);
+        let loadable = Fact::known(libraries);
+        assert_eq!(
+            loadable_map(&loadable).get("static").map(String::as_str),
+            Some("blog.templatetags.static")
+        );
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.message.contains("django.templatetags.static")));
+    }
+
+    #[test]
+    fn partial_app_registry_keeps_known_libraries_and_reasons() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_template_library(&root, "blog", "blog_tags");
+        let reason = app_registry_reason();
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::partial(vec![app(&root, "blog")], vec![reason.clone()]),
+        );
+
+        let (_libraries, reasons) = partial_vec(&facts);
+        assert_eq!(
+            loadable_map(&facts).get("blog_tags").map(String::as_str),
+            Some("blog.templatetags.blog_tags")
+        );
+        assert_eq!(reasons, [reason]);
+    }
+
+    #[test]
+    fn unknown_app_registry_keeps_default_libraries_partial() {
+        let reason = app_registry_reason();
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::unknown(vec![reason.clone()]),
+        );
+
+        let (_libraries, reasons) = partial_vec(&facts);
+        assert_eq!(
+            loadable_map(&facts).get("cache").map(String::as_str),
+            Some("django.templatetags.cache")
+        );
+        assert_eq!(reasons, [reason]);
+    }
+
+    #[test]
+    fn partial_option_libraries_preserve_values_and_reasons() {
+        let reason = option_reason();
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend_with_options(
+                Fact::partial(
+                    vec![settings_library("custom", "project.templatetags.custom")],
+                    vec![reason.clone()],
+                ),
+                Fact::known(Vec::new()),
+            )]),
+            &Fact::known(Vec::new()),
+        );
+
+        let (_libraries, reasons) = partial_vec(&facts);
+        assert_eq!(
+            loadable_map(&facts).get("custom").map(String::as_str),
+            Some("project.templatetags.custom")
+        );
+        assert_eq!(reasons, [reason]);
+    }
+
+    #[test]
+    fn unknown_template_backends_are_unknown_template_libraries() {
+        let reason = Reason::new(
+            Field::SettingsTemplates,
+            ReasonSource::Unknown,
+            "TEMPLATES is not assigned in this settings file",
+        );
+
+        let facts = assemble_template_libraries(
+            &Fact::unknown(vec![reason.clone()]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert_eq!(facts.reasons(), &[reason]);
+        assert!(matches!(facts, Fact::Unknown { .. }));
+    }
+
+    #[test]
+    fn skips_non_django_backends_without_blocking_django_backend() {
+        let mut jinja_backend = backend(Fact::known(false));
+        jinja_backend.backend = Some("django.template.backends.jinja2.Jinja2".to_string());
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![
+                jinja_backend,
+                backend_with_options(
+                    Fact::known(vec![settings_library(
+                        "custom",
+                        "project.templatetags.custom",
+                    )]),
+                    Fact::known(Vec::new()),
+                ),
+            ]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert_eq!(
+            loadable_map(&facts).get("custom").map(String::as_str),
+            Some("project.templatetags.custom")
+        );
+    }
+
+    #[test]
+    fn missing_backend_skips_backend_as_partial() {
+        let mut unknown_backend = backend_with_options(
+            Fact::known(vec![settings_library(
+                "custom",
+                "project.templatetags.custom",
+            )]),
+            Fact::known(Vec::new()),
+        );
+        unknown_backend.backend = None;
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![unknown_backend]),
+            &Fact::known(Vec::new()),
+        );
+
+        let (libraries, reasons) = partial_vec(&facts);
+        assert!(libraries.is_empty());
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.message.contains("BACKEND is not known")));
+    }
+
+    #[test]
+    fn multiple_django_backends_deduplicate_default_builtins() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![
+                backend(Fact::known(false)),
+                backend(Fact::known(false)),
+            ]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert_eq!(
+            builtin_modules(&facts),
+            [
+                "django.template.defaulttags",
+                "django.template.defaultfilters",
+                "django.template.loader_tags",
+            ]
+        );
+    }
+
+    #[test]
+    fn assembles_libraries_from_extracted_settings_and_resolved_apps() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("blog/__init__.py"), "");
+        write_template_library(&root, "blog", "blog_tags");
+        write_file(
+            &root.join("settings.py"),
+            r#"
+INSTALLED_APPS = ["blog"]
+TEMPLATES = [{
+    "BACKEND": "django.template.backends.django.DjangoTemplates",
+    "APP_DIRS": False,
+    "OPTIONS": {
+        "libraries": {"alias": "blog.templatetags.blog_tags"},
+        "builtins": ["blog.templatetags.blog_tags"],
+    },
+}]
+"#,
+        );
+
+        let settings = extract_settings_facts(&root.join("settings.py"));
+        let app_registry =
+            resolve_app_registry(&settings.installed_apps, &root, &search_paths(&root));
+        let facts =
+            assemble_template_libraries(&settings.template_backends, &app_registry.app_registry);
+
+        let loadable = loadable_map(&facts);
+        assert_eq!(
+            loadable.get("blog_tags").map(String::as_str),
+            Some("blog.templatetags.blog_tags")
+        );
+        assert_eq!(
+            loadable.get("alias").map(String::as_str),
+            Some("blog.templatetags.blog_tags")
+        );
+        assert_eq!(
+            builtin_modules(&facts).last().map(String::as_str),
+            Some("blog.templatetags.blog_tags")
+        );
+    }
+
+    #[test]
+    fn uses_app_config_path_when_discovering_templatetags() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("blog/__init__.py"), "");
+        write_file(
+            &root.join("blog/apps.py"),
+            r#"
+from django.apps import AppConfig
+
+class BlogConfig(AppConfig):
+    name = "blog"
+    path = "custom_blog"
+"#,
+        );
+        write_file(
+            &root.join("custom_blog/templatetags/custom_tags.py"),
+            r"
+from django import template
+
+register = template.Library()
+",
+        );
+
+        let app_registry = resolve_app_registry(
+            &Fact::known(vec!["blog.apps.BlogConfig".to_string()]),
+            &root,
+            &search_paths(&root),
+        );
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(false))]),
+            &app_registry.app_registry,
+        );
+
+        assert_eq!(
+            loadable_map(&facts).get("custom_tags").map(String::as_str),
+            Some("blog.templatetags.custom_tags")
+        );
+    }
+
+    #[test]
+    fn settings_builtins_duplicate_default_modules_keep_first_builtin() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend_with_options(
+                Fact::known(Vec::new()),
+                Fact::known(vec![module("django.template.defaulttags")]),
+            )]),
+            &Fact::known(Vec::new()),
+        );
+
+        let libraries = known_vec(&facts);
+        let defaulttags = libraries
+            .iter()
+            .find(|library| library.module == module("django.template.defaulttags"))
+            .unwrap();
+        assert!(matches!(
+            defaulttags.source,
+            TemplateLibrarySource::DjangoDefaultBuiltin
+        ));
+    }
+
+    #[test]
+    fn malformed_templatetag_module_makes_fact_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("blog/templatetags/broken.py"),
+            "from django import template\nregister = template.Library(\n",
+        );
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(false))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        let (_libraries, reasons) = partial_vec(&facts);
+        assert!(reasons
+            .iter()
+            .any(|reason| reason.message.contains("failed to parse")));
+    }
+
+    #[test]
+    fn template_dirs_field_is_not_required_for_library_assembly() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![TemplateBackendFact {
+                backend: Some(DJANGO_TEMPLATES_BACKEND.to_string()),
+                dirs: Fact::partial(
+                    vec![TemplateDirFact {
+                        path: Utf8PathBuf::from("templates"),
+                        source: TemplateDirSource::SettingsDir,
+                    }],
+                    vec![Reason::path(
+                        Field::TemplateDirs,
+                        "templates",
+                        "template dir uncertainty should not affect libraries",
+                    )],
+                ),
+                app_dirs: Fact::unknown(vec![Reason::new(
+                    Field::SettingsTemplates,
+                    ReasonSource::Unknown,
+                    "APP_DIRS is dynamic but irrelevant for libraries",
+                )]),
+                option_libraries: Fact::known(Vec::new()),
+                option_builtins: Fact::known(Vec::new()),
+            }]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert!(matches!(facts, Fact::Known { .. }));
+    }
+}

--- a/crates/djls-semantic/src/project/template_libraries.rs
+++ b/crates/djls-semantic/src/project/template_libraries.rs
@@ -335,24 +335,33 @@ fn stmt_defines_template_register(stmt: &Stmt) -> bool {
         return true;
     }
 
-    // Django's discovery accepts any module with a top-level `register`
-    // attribute. Keep the static filter at the same boundary instead of trying
-    // to prove that the value is specifically a `django.template.Library`.
-    assigned_value(stmt, "register").is_some()
+    match stmt {
+        Stmt::FunctionDef(function) if function.name.as_str() == "register" => true,
+        Stmt::ClassDef(class) if class.name.as_str() == "register" => true,
+        _ => {
+            // Django's discovery accepts any module with a top-level `register`
+            // attribute. Keep the static filter at the same boundary instead of
+            // trying to prove that the value is specifically a
+            // `django.template.Library`.
+            assigned_value(stmt, "register").is_some()
+        }
+    }
 }
 
 fn imported_as_register(stmt: &Stmt) -> bool {
-    let Stmt::ImportFrom(import_from) = stmt else {
-        return false;
-    };
+    match stmt {
+        Stmt::Import(import) => import.names.iter().any(alias_binds_register),
+        Stmt::ImportFrom(import_from) => import_from.names.iter().any(alias_binds_register),
+        _ => false,
+    }
+}
 
-    import_from.names.iter().any(|alias| {
-        alias
-            .asname
-            .as_ref()
-            .map_or(alias.name.as_str(), |asname| asname.as_str())
-            == "register"
-    })
+fn alias_binds_register(alias: &ruff_python_ast::Alias) -> bool {
+    alias
+        .asname
+        .as_ref()
+        .map_or(alias.name.as_str(), |asname| asname.as_str())
+        == "register"
 }
 
 fn assigned_value<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
@@ -793,6 +802,18 @@ register = lib
             &root.join("blog/templatetags/reexported.py"),
             "from .aliased import register\n",
         );
+        write_file(
+            &root.join("blog/templatetags/imported.py"),
+            "import blog.templatetags.aliased as register\n",
+        );
+        write_file(
+            &root.join("blog/templatetags/function.py"),
+            "def register():\n    pass\n",
+        );
+        write_file(
+            &root.join("blog/templatetags/classy.py"),
+            "class register:\n    pass\n",
+        );
 
         let facts = assemble_template_libraries(
             &Fact::known(vec![backend(Fact::known(true))]),
@@ -811,6 +832,18 @@ register = lib
         assert_eq!(
             loadable.get("reexported").map(String::as_str),
             Some("blog.templatetags.reexported")
+        );
+        assert_eq!(
+            loadable.get("imported").map(String::as_str),
+            Some("blog.templatetags.imported")
+        );
+        assert_eq!(
+            loadable.get("function").map(String::as_str),
+            Some("blog.templatetags.function")
+        );
+        assert_eq!(
+            loadable.get("classy").map(String::as_str),
+            Some("blog.templatetags.classy")
         );
     }
 
@@ -1050,7 +1083,7 @@ register = template.Library()
                 "custom",
                 "project.templatetags.custom",
             )]),
-            Fact::known(Vec::new()),
+            Fact::known(vec![module("project.templatetags.custom_builtins")]),
         );
         unknown_backend.backend = None;
 
@@ -1060,9 +1093,15 @@ register = template.Library()
         );
 
         let (_libraries, reasons) = partial_vec(&facts);
+        let loadable = loadable_map(&facts);
         assert_eq!(
-            loadable_map(&facts).get("custom").map(String::as_str),
+            loadable.get("custom").map(String::as_str),
             Some("project.templatetags.custom")
+        );
+        assert!(!loadable.contains_key("cache"));
+        assert_eq!(
+            builtin_modules(&facts),
+            ["project.templatetags.custom_builtins"]
         );
         assert!(reasons
             .iter()
@@ -1088,6 +1127,28 @@ register = template.Library()
         assert_eq!(
             loadable_map(&facts).get("static").map(String::as_str),
             Some("project.templatetags.assets")
+        );
+    }
+
+    #[test]
+    fn later_backend_options_override_earlier_backend_options() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![
+                backend_with_options(
+                    Fact::known(vec![settings_library("custom", "project.templatetags.one")]),
+                    Fact::known(Vec::new()),
+                ),
+                backend_with_options(
+                    Fact::known(vec![settings_library("custom", "project.templatetags.two")]),
+                    Fact::known(Vec::new()),
+                ),
+            ]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert_eq!(
+            loadable_map(&facts).get("custom").map(String::as_str),
+            Some("project.templatetags.two")
         );
     }
 

--- a/crates/djls-semantic/src/project/template_libraries.rs
+++ b/crates/djls-semantic/src/project/template_libraries.rs
@@ -7,10 +7,11 @@
 //! Django's default builtins, and `OPTIONS.builtins`.
 //!
 //! A8 facts are flattened across Django template backends and do not carry
-//! backend identity yet. For duplicate load names, later flattened backend/app
-//! entries replace earlier entries; explicit `OPTIONS.libraries` entries replace
-//! discovered/default libraries for the same backend, matching Django's
-//! `libraries.update(custom_libraries)` behavior.
+//! backend identity yet. Django defaults and installed-app libraries are
+//! assembled once when a standard Django backend is present; explicit
+//! `OPTIONS.libraries` entries are then applied in settings order and replace
+//! discovered/default libraries, matching Django's `libraries.update(...)`
+//! behavior within the flattened model.
 
 #![allow(
     dead_code,
@@ -53,6 +54,13 @@ const DJANGO_DEFAULT_BUILTINS: &[&str] = &[
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BackendKind {
+    Django,
+    NonDjango,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DuplicatePolicy {
     Report,
     SilentOverride,
@@ -83,16 +91,28 @@ fn assemble_template_backend_libraries(
 ) -> Fact<Vec<TemplateLibraryFact>> {
     let mut loadable = BTreeMap::new();
     let mut builtins = Vec::new();
+    let mut has_django_backend = false;
+    let mut option_backends = Vec::new();
 
     for backend in backends {
-        if !is_django_template_backend(backend, &mut reasons) {
-            continue;
+        match classify_template_backend(backend, &mut reasons) {
+            BackendKind::Django => {
+                has_django_backend = true;
+                option_backends.push(backend);
+            }
+            BackendKind::Unknown => option_backends.push(backend),
+            BackendKind::NonDjango => {}
         }
+    }
 
-        append_default_loadable_libraries(&mut loadable, &mut reasons);
+    if has_django_backend {
+        append_default_loadable_libraries(&mut loadable);
         append_app_template_tag_libraries(&mut loadable, &mut reasons, app_registry);
-        append_option_libraries(&mut loadable, &mut reasons, &backend.option_libraries);
         append_default_builtins(&mut builtins);
+    }
+
+    for backend in option_backends {
+        append_option_libraries(&mut loadable, &mut reasons, &backend.option_libraries);
         append_option_builtins(&mut builtins, &mut reasons, &backend.option_builtins);
     }
 
@@ -101,30 +121,34 @@ fn assemble_template_backend_libraries(
     known_or_partial(libraries, reasons)
 }
 
-fn is_django_template_backend(backend: &TemplateBackendFact, reasons: &mut Vec<Reason>) -> bool {
+fn classify_template_backend(
+    backend: &TemplateBackendFact,
+    reasons: &mut Vec<Reason>,
+) -> BackendKind {
     let Some(backend) = backend.backend.as_deref() else {
         reasons.push(Reason::new(
             Field::TemplateLibraries,
             ReasonSource::Unknown,
-            "TEMPLATES BACKEND is not known; skipped template library assembly for this backend",
+            "TEMPLATES BACKEND is not known; only statically known template library options were assembled for this backend",
         ));
-        return false;
+        return BackendKind::Unknown;
     };
 
-    backend == DJANGO_TEMPLATES_BACKEND
+    if backend == DJANGO_TEMPLATES_BACKEND {
+        BackendKind::Django
+    } else {
+        BackendKind::NonDjango
+    }
 }
 
-fn append_default_loadable_libraries(
-    loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>,
-    reasons: &mut Vec<Reason>,
-) {
+fn append_default_loadable_libraries(loadable: &mut BTreeMap<LibraryName, TemplateLibraryFact>) {
     for (load_name, module) in DJANGO_DEFAULT_LOADABLE_LIBRARIES {
         let fact = TemplateLibraryFact {
             load_name: LibraryName::parse(load_name).expect("Django default library name is valid"),
             module: PyModuleName::parse(module).expect("Django default library module is valid"),
             source: TemplateLibrarySource::DjangoDefaultLibrary,
         };
-        upsert_loadable_library(loadable, reasons, fact, DuplicatePolicy::Report);
+        loadable.entry(fact.load_name.clone()).or_insert(fact);
     }
 }
 
@@ -307,10 +331,28 @@ fn defines_template_register(file: &Utf8Path, reasons: &mut Vec<Reason>) -> bool
 }
 
 fn stmt_defines_template_register(stmt: &Stmt) -> bool {
-    let Some(value) = assigned_value(stmt, "register") else {
+    if imported_as_register(stmt) {
+        return true;
+    }
+
+    // Django's discovery accepts any module with a top-level `register`
+    // attribute. Keep the static filter at the same boundary instead of trying
+    // to prove that the value is specifically a `django.template.Library`.
+    assigned_value(stmt, "register").is_some()
+}
+
+fn imported_as_register(stmt: &Stmt) -> bool {
+    let Stmt::ImportFrom(import_from) = stmt else {
         return false;
     };
-    is_template_library_call(value)
+
+    import_from.names.iter().any(|alias| {
+        alias
+            .asname
+            .as_ref()
+            .map_or(alias.name.as_str(), |asname| asname.as_str())
+            == "register"
+    })
 }
 
 fn assigned_value<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
@@ -329,18 +371,6 @@ fn assigned_value<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
 
 fn is_name(expr: &Expr, expected: &str) -> bool {
     matches!(expr, Expr::Name(name) if name.id.as_str() == expected)
-}
-
-fn is_template_library_call(expr: &Expr) -> bool {
-    let Expr::Call(call) = expr else {
-        return false;
-    };
-
-    match call.func.as_ref() {
-        Expr::Name(name) => name.id.as_str() == "Library",
-        Expr::Attribute(attribute) => attribute.attr.as_str() == "Library",
-        _ => false,
-    }
 }
 
 fn append_option_libraries(
@@ -739,6 +769,52 @@ register = template.Library()
     }
 
     #[test]
+    fn accepts_modules_with_top_level_register_attribute() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("blog/templatetags/aliased.py"),
+            r"
+from django.template import Library as L
+
+register = L()
+",
+        );
+        write_file(
+            &root.join("blog/templatetags/indirect.py"),
+            r"
+from django import template
+
+lib = template.Library()
+register = lib
+",
+        );
+        write_file(
+            &root.join("blog/templatetags/reexported.py"),
+            "from .aliased import register\n",
+        );
+
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![backend(Fact::known(true))]),
+            &Fact::known(vec![app(&root, "blog")]),
+        );
+
+        let loadable = loadable_map(&facts);
+        assert_eq!(
+            loadable.get("aliased").map(String::as_str),
+            Some("blog.templatetags.aliased")
+        );
+        assert_eq!(
+            loadable.get("indirect").map(String::as_str),
+            Some("blog.templatetags.indirect")
+        );
+        assert_eq!(
+            loadable.get("reexported").map(String::as_str),
+            Some("blog.templatetags.reexported")
+        );
+    }
+
+    #[test]
     fn filters_templatetag_modules_without_register() {
         let tmp = tempdir().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
@@ -968,7 +1044,7 @@ register = template.Library()
     }
 
     #[test]
-    fn missing_backend_skips_backend_as_partial() {
+    fn missing_backend_preserves_statically_known_options_as_partial() {
         let mut unknown_backend = backend_with_options(
             Fact::known(vec![settings_library(
                 "custom",
@@ -983,11 +1059,36 @@ register = template.Library()
             &Fact::known(Vec::new()),
         );
 
-        let (libraries, reasons) = partial_vec(&facts);
-        assert!(libraries.is_empty());
+        let (_libraries, reasons) = partial_vec(&facts);
+        assert_eq!(
+            loadable_map(&facts).get("custom").map(String::as_str),
+            Some("project.templatetags.custom")
+        );
         assert!(reasons
             .iter()
             .any(|reason| reason.message.contains("BACKEND is not known")));
+    }
+
+    #[test]
+    fn multiple_django_backends_do_not_let_later_defaults_override_settings_libraries() {
+        let facts = assemble_template_libraries(
+            &Fact::known(vec![
+                backend_with_options(
+                    Fact::known(vec![settings_library(
+                        "static",
+                        "project.templatetags.assets",
+                    )]),
+                    Fact::known(Vec::new()),
+                ),
+                backend(Fact::known(false)),
+            ]),
+            &Fact::known(Vec::new()),
+        );
+
+        assert_eq!(
+            loadable_map(&facts).get("static").map(String::as_str),
+            Some("project.templatetags.assets")
+        );
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/template_symbols.rs
+++ b/crates/djls-semantic/src/project/template_symbols.rs
@@ -1,0 +1,673 @@
+//! Static Django template symbol facts.
+//!
+//! This module resolves assembled template libraries to Python files and uses
+//! the existing Ruff-based registration extraction to produce static tag/filter
+//! symbol facts. It does not wire the facts into validators yet.
+//!
+//! The first slice records the registration module as the symbol definition
+//! module and leaves docstrings empty. It also detects only syntactic
+//! registrations against the module-level `register` object; runtime-only
+//! conditional registration remains a partial-static-model limitation.
+
+#![allow(
+    dead_code,
+    reason = "Milestone A9 adds template symbol facts before project facts are assembled."
+)]
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+
+use camino::Utf8Path;
+
+use crate::project::facts::Fact;
+use crate::project::facts::Field;
+use crate::project::facts::ModuleSearchPathEntry;
+use crate::project::facts::Reason;
+use crate::project::facts::ResolvedModule;
+use crate::project::facts::TemplateLibraryFact;
+use crate::project::facts::TemplateLibrarySource;
+use crate::project::facts::TemplateSymbolFact;
+use crate::project::module_resolver::resolve_module;
+use crate::project::names::LibraryName;
+use crate::project::names::PyModuleName;
+use crate::project::names::TemplateSymbolName;
+use crate::project::symbols::TemplateLibrarySnapshot;
+use crate::project::symbols::TemplateSymbolKind;
+use crate::project::symbols::TemplateSymbolSnapshot;
+use crate::python::SymbolKind;
+
+#[must_use]
+pub(crate) fn assemble_template_symbols(
+    template_libraries: &Fact<Vec<TemplateLibraryFact>>,
+    module_search_paths: &Fact<Vec<ModuleSearchPathEntry>>,
+    project_root: &Utf8Path,
+) -> Fact<Vec<TemplateSymbolFact>> {
+    let (libraries, mut reasons) = match fact_value_with_reasons(template_libraries) {
+        Ok((libraries, reasons)) => (libraries, reasons),
+        Err(reasons) => return Fact::unknown(reasons),
+    };
+
+    if libraries.is_empty() {
+        return known_or_partial(Vec::new(), reasons);
+    }
+
+    let search_paths = match fact_value_with_reasons(module_search_paths) {
+        Ok((search_paths, search_reasons)) => {
+            extend_unique_reasons(&mut reasons, search_reasons);
+            search_paths
+        }
+        Err(search_reasons) => {
+            extend_unique_reasons(&mut reasons, search_reasons);
+            return Fact::unknown(reasons);
+        }
+    };
+
+    let mut symbols = Vec::new();
+    for library in libraries {
+        extract_library_symbols(
+            library,
+            search_paths,
+            project_root,
+            &mut symbols,
+            &mut reasons,
+        );
+    }
+
+    symbols.sort_by(|a, b| {
+        a.library
+            .cmp(&b.library)
+            .then_with(|| a.module.cmp(&b.module))
+            .then_with(|| a.kind.cmp(&b.kind))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    symbols.dedup();
+
+    known_or_partial(symbols, reasons)
+}
+
+#[must_use]
+pub(crate) fn assemble_template_library_snapshot(
+    template_libraries: &Fact<Vec<TemplateLibraryFact>>,
+    template_symbols: &Fact<Vec<TemplateSymbolFact>>,
+) -> Fact<TemplateLibrarySnapshot> {
+    let (libraries, mut reasons) = match fact_value_with_reasons(template_libraries) {
+        Ok((libraries, reasons)) => (libraries, reasons),
+        Err(reasons) => return Fact::unknown(reasons),
+    };
+
+    let active_loadable = active_loadable_modules(libraries);
+    let builtin_modules = builtin_modules(libraries);
+    let mut snapshot = TemplateLibrarySnapshot {
+        symbols: Vec::new(),
+        libraries: active_loadable
+            .iter()
+            .map(|(load_name, module)| {
+                (load_name.as_str().to_string(), module.as_str().to_string())
+            })
+            .collect(),
+        builtins: builtin_module_names(libraries),
+    };
+
+    match template_symbols {
+        Fact::Known { value } => {
+            snapshot.symbols = symbol_snapshots(value, &active_loadable, &builtin_modules);
+        }
+        Fact::Partial {
+            value,
+            reasons: symbol_reasons,
+        } => {
+            snapshot.symbols = symbol_snapshots(value, &active_loadable, &builtin_modules);
+            extend_unique_reasons(&mut reasons, symbol_reasons.iter().cloned());
+        }
+        Fact::Unknown {
+            reasons: symbol_reasons,
+        }
+        | Fact::Ambiguous {
+            reasons: symbol_reasons,
+            ..
+        } => {
+            extend_unique_reasons(&mut reasons, symbol_reasons.iter().cloned());
+        }
+    }
+
+    known_or_partial(snapshot, reasons)
+}
+
+fn extract_library_symbols(
+    library: &TemplateLibraryFact,
+    search_paths: &[ModuleSearchPathEntry],
+    project_root: &Utf8Path,
+    symbols: &mut Vec<TemplateSymbolFact>,
+    reasons: &mut Vec<Reason>,
+) {
+    let resolution = resolve_module(library.module.clone(), search_paths, project_root);
+    match resolution.resolved {
+        Fact::Known { value } => {
+            read_and_extract_library_symbols(library, &value, symbols, reasons);
+        }
+        Fact::Partial {
+            value,
+            reasons: resolution_reasons,
+        } => {
+            extend_unique_reasons(reasons, resolution_reasons);
+            read_and_extract_library_symbols(library, &value, symbols, reasons);
+        }
+        Fact::Unknown {
+            reasons: resolution_reasons,
+        }
+        | Fact::Ambiguous {
+            reasons: resolution_reasons,
+            ..
+        } => {
+            extend_unique_reasons(reasons, resolution_reasons);
+        }
+    }
+}
+
+fn read_and_extract_library_symbols(
+    library: &TemplateLibraryFact,
+    resolved: &ResolvedModule,
+    symbols: &mut Vec<TemplateSymbolFact>,
+    reasons: &mut Vec<Reason>,
+) {
+    let source = match fs::read_to_string(resolved.file.as_std_path()) {
+        Ok(source) => source,
+        Err(error) => {
+            reasons.push(Reason::file(
+                Field::TemplateSymbols,
+                &resolved.file,
+                format!("failed to read template library module: {error}"),
+            ));
+            return;
+        }
+    };
+
+    let registrations = match crate::python::extract_template_registrations(&source) {
+        Ok(registrations) => registrations,
+        Err(error) => {
+            reasons.push(Reason::file(
+                Field::TemplateSymbols,
+                &resolved.file,
+                format!("failed to parse template library module: {error}"),
+            ));
+            return;
+        }
+    };
+
+    for registration in registrations {
+        let name = match TemplateSymbolName::parse(&registration.name) {
+            Ok(name) => name,
+            Err(error) => {
+                reasons.push(Reason::file(
+                    Field::TemplateSymbols,
+                    &resolved.file,
+                    format!(
+                        "template symbol `{}` has an invalid name: {error}",
+                        registration.name
+                    ),
+                ));
+                continue;
+            }
+        };
+
+        symbols.push(TemplateSymbolFact {
+            library: library.load_name.clone(),
+            module: library.module.clone(),
+            kind: template_symbol_kind(registration.kind),
+            name,
+        });
+    }
+}
+
+fn symbol_snapshots(
+    symbols: &[TemplateSymbolFact],
+    active_loadable: &BTreeMap<LibraryName, PyModuleName>,
+    builtin_modules: &BTreeSet<PyModuleName>,
+) -> Vec<TemplateSymbolSnapshot> {
+    let mut snapshots = symbols
+        .iter()
+        .filter_map(|symbol| {
+            let load_name = if builtin_modules.contains(&symbol.module) {
+                None
+            } else if active_loadable.get(&symbol.library) == Some(&symbol.module) {
+                Some(symbol.library.as_str().to_string())
+            } else {
+                return None;
+            };
+
+            Some(TemplateSymbolSnapshot {
+                kind: Some(symbol.kind),
+                name: symbol.name.as_str().to_string(),
+                load_name,
+                library_module: symbol.module.as_str().to_string(),
+                module: symbol.module.as_str().to_string(),
+                doc: None,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    snapshots.sort_by(|a, b| {
+        a.load_name
+            .cmp(&b.load_name)
+            .then_with(|| a.library_module.cmp(&b.library_module))
+            .then_with(|| symbol_snapshot_kind_rank(a.kind).cmp(&symbol_snapshot_kind_rank(b.kind)))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    snapshots
+}
+
+fn template_symbol_kind(kind: SymbolKind) -> TemplateSymbolKind {
+    match kind {
+        SymbolKind::Tag => TemplateSymbolKind::Tag,
+        SymbolKind::Filter => TemplateSymbolKind::Filter,
+    }
+}
+
+fn symbol_snapshot_kind_rank(kind: Option<TemplateSymbolKind>) -> u8 {
+    match kind {
+        Some(TemplateSymbolKind::Tag) => 0,
+        Some(TemplateSymbolKind::Filter) => 1,
+        None => 2,
+    }
+}
+
+fn active_loadable_modules(
+    libraries: &[TemplateLibraryFact],
+) -> BTreeMap<LibraryName, PyModuleName> {
+    let mut active = BTreeMap::new();
+    for library in libraries {
+        if !is_builtin_library(&library.source) {
+            active.insert(library.load_name.clone(), library.module.clone());
+        }
+    }
+    active
+}
+
+fn builtin_modules(libraries: &[TemplateLibraryFact]) -> BTreeSet<PyModuleName> {
+    libraries
+        .iter()
+        .filter(|library| is_builtin_library(&library.source))
+        .map(|library| library.module.clone())
+        .collect()
+}
+
+fn builtin_module_names(libraries: &[TemplateLibraryFact]) -> Vec<String> {
+    let mut modules = Vec::new();
+    for library in libraries {
+        if is_builtin_library(&library.source)
+            && !modules
+                .iter()
+                .any(|module| module == library.module.as_str())
+        {
+            modules.push(library.module.as_str().to_string());
+        }
+    }
+    modules
+}
+
+fn is_builtin_library(source: &TemplateLibrarySource) -> bool {
+    match source {
+        TemplateLibrarySource::DjangoDefaultBuiltin | TemplateLibrarySource::SettingsBuiltins => {
+            true
+        }
+        TemplateLibrarySource::AppTemplateTags { .. }
+        | TemplateLibrarySource::SettingsLibraries
+        | TemplateLibrarySource::DjangoDefaultLibrary
+        | TemplateLibrarySource::Discovered
+        | TemplateLibrarySource::UserOverride => false,
+    }
+}
+
+fn fact_value_with_reasons<T>(fact: &Fact<T>) -> Result<(&T, Vec<Reason>), Vec<Reason>> {
+    match fact {
+        Fact::Known { value } => Ok((value, Vec::new())),
+        Fact::Partial { value, reasons } => Ok((value, reasons.clone())),
+        Fact::Unknown { reasons } | Fact::Ambiguous { reasons, .. } => Err(reasons.clone()),
+    }
+}
+
+fn known_or_partial<T>(value: T, reasons: Vec<Reason>) -> Fact<T> {
+    if reasons.is_empty() {
+        Fact::known(value)
+    } else {
+        Fact::partial(value, reasons)
+    }
+}
+
+fn extend_unique_reasons(reasons: &mut Vec<Reason>, new_reasons: impl IntoIterator<Item = Reason>) {
+    for reason in new_reasons {
+        if !reasons.contains(&reason) {
+            reasons.push(reason);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use camino::Utf8PathBuf;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::project::facts::ModuleSearchPathKind;
+    use crate::project::facts::ReasonSource;
+    use crate::project::names::LibraryName;
+    use crate::project::names::PyModuleName;
+
+    fn module(name: &str) -> PyModuleName {
+        PyModuleName::parse(name).unwrap()
+    }
+
+    fn library(name: &str) -> LibraryName {
+        LibraryName::parse(name).unwrap()
+    }
+
+    fn search_path(root: &Utf8Path) -> ModuleSearchPathEntry {
+        ModuleSearchPathEntry {
+            kind: ModuleSearchPathKind::Workspace,
+            path: root.to_path_buf(),
+        }
+    }
+
+    fn write_file(path: &Utf8Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn loadable_library(load_name: &str, module_name: &str) -> TemplateLibraryFact {
+        TemplateLibraryFact {
+            load_name: library(load_name),
+            module: module(module_name),
+            source: TemplateLibrarySource::AppTemplateTags {
+                app: module("blog"),
+            },
+        }
+    }
+
+    fn builtin_library(module_name: &str) -> TemplateLibraryFact {
+        TemplateLibraryFact {
+            load_name: library(module_name.split('.').next_back().unwrap()),
+            module: module(module_name),
+            source: TemplateLibrarySource::DjangoDefaultBuiltin,
+        }
+    }
+
+    fn known_symbols(fact: &Fact<Vec<TemplateSymbolFact>>) -> &[TemplateSymbolFact] {
+        match fact {
+            Fact::Known { value } | Fact::Partial { value, .. } => value,
+            Fact::Unknown { reasons } => panic!("expected symbols, got unknown: {reasons:?}"),
+            Fact::Ambiguous {
+                candidates,
+                reasons,
+            } => panic!("expected symbols, got ambiguous: {candidates:?} {reasons:?}"),
+        }
+    }
+
+    fn partial_reasons<T>(fact: &Fact<T>) -> &[Reason] {
+        match fact {
+            Fact::Known { .. } => panic!("expected partial or unknown fact"),
+            Fact::Partial { reasons, .. }
+            | Fact::Unknown { reasons }
+            | Fact::Ambiguous { reasons, .. } => reasons,
+        }
+    }
+
+    #[test]
+    fn extracts_symbols_from_loadable_and_builtin_modules() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("django/template/defaulttags.py"),
+            r#"
+from django import template
+register = template.Library()
+
+@register.tag("if")
+def do_if(parser, token):
+    pass
+
+@register.filter
+def lower(value):
+    pass
+"#,
+        );
+        write_file(
+            &root.join("blog/templatetags/blog_tags.py"),
+            r#"
+from django import template
+register = template.Library()
+
+@register.simple_tag(name="greet")
+def greet_tag():
+    pass
+
+register.filter("shout", shout)
+"#,
+        );
+
+        let libraries = vec![
+            builtin_library("django.template.defaulttags"),
+            loadable_library("blog_tags", "blog.templatetags.blog_tags"),
+        ];
+        let facts = assemble_template_symbols(
+            &Fact::known(libraries),
+            &Fact::known(vec![search_path(&root)]),
+            &root,
+        );
+
+        let symbols = known_symbols(&facts);
+        assert!(symbols.iter().any(|symbol| {
+            symbol.library == library("defaulttags")
+                && symbol.kind == TemplateSymbolKind::Tag
+                && symbol.name.as_str() == "if"
+        }));
+        assert!(symbols.iter().any(|symbol| {
+            symbol.library == library("defaulttags")
+                && symbol.kind == TemplateSymbolKind::Filter
+                && symbol.name.as_str() == "lower"
+        }));
+        assert!(symbols.iter().any(|symbol| {
+            symbol.library == library("blog_tags")
+                && symbol.kind == TemplateSymbolKind::Tag
+                && symbol.name.as_str() == "greet"
+        }));
+        assert!(symbols.iter().any(|symbol| {
+            symbol.library == library("blog_tags")
+                && symbol.kind == TemplateSymbolKind::Filter
+                && symbol.name.as_str() == "shout"
+        }));
+    }
+
+    #[test]
+    fn unresolved_library_modules_are_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+
+        let facts = assemble_template_symbols(
+            &Fact::known(vec![loadable_library(
+                "missing",
+                "blog.templatetags.missing",
+            )]),
+            &Fact::known(vec![search_path(&root)]),
+            &root,
+        );
+
+        assert!(known_symbols(&facts).is_empty());
+        assert!(partial_reasons(&facts)
+            .iter()
+            .any(|reason| reason.field == Field::ResolverModule));
+    }
+
+    #[test]
+    fn invalid_symbol_names_are_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(
+            &root.join("blog/templatetags/blog_tags.py"),
+            r#"
+from django import template
+register = template.Library()
+
+@register.tag("bad name")
+def bad(parser, token):
+    pass
+"#,
+        );
+
+        let facts = assemble_template_symbols(
+            &Fact::known(vec![loadable_library(
+                "blog_tags",
+                "blog.templatetags.blog_tags",
+            )]),
+            &Fact::known(vec![search_path(&root)]),
+            &root,
+        );
+
+        assert!(known_symbols(&facts).is_empty());
+        assert!(partial_reasons(&facts)
+            .iter()
+            .any(|reason| reason.field == Field::TemplateSymbols));
+    }
+
+    #[test]
+    fn unknown_module_search_paths_make_symbols_unknown_when_libraries_exist() {
+        let reason = Reason::new(
+            Field::ResolverModuleSearchPaths,
+            ReasonSource::Unknown,
+            "module search paths were not discovered",
+        );
+
+        let facts = assemble_template_symbols(
+            &Fact::known(vec![loadable_library(
+                "blog_tags",
+                "blog.templatetags.blog_tags",
+            )]),
+            &Fact::unknown(vec![reason.clone()]),
+            Utf8Path::new("/workspace"),
+        );
+
+        assert!(matches!(facts, Fact::Unknown { .. }));
+        assert_eq!(facts.reasons(), &[reason]);
+    }
+
+    #[test]
+    fn assembles_snapshot_from_library_and_symbol_facts() {
+        let libraries = vec![
+            builtin_library("django.template.defaulttags"),
+            loadable_library("blog_tags", "blog.templatetags.blog_tags"),
+        ];
+        let symbols = vec![
+            TemplateSymbolFact {
+                library: library("defaulttags"),
+                module: module("django.template.defaulttags"),
+                kind: TemplateSymbolKind::Tag,
+                name: TemplateSymbolName::parse("if").unwrap(),
+            },
+            TemplateSymbolFact {
+                library: library("blog_tags"),
+                module: module("blog.templatetags.blog_tags"),
+                kind: TemplateSymbolKind::Filter,
+                name: TemplateSymbolName::parse("shout").unwrap(),
+            },
+        ];
+
+        let snapshot =
+            assemble_template_library_snapshot(&Fact::known(libraries), &Fact::known(symbols));
+
+        let Fact::Known { value } = snapshot else {
+            panic!("expected known snapshot");
+        };
+        assert_eq!(
+            value.libraries,
+            BTreeMap::from([(
+                "blog_tags".to_string(),
+                "blog.templatetags.blog_tags".to_string()
+            )])
+        );
+        assert_eq!(value.builtins, ["django.template.defaulttags"]);
+        assert!(value.symbols.iter().any(|symbol| {
+            symbol.name == "if"
+                && symbol.load_name.is_none()
+                && symbol.library_module == "django.template.defaulttags"
+                && symbol.module == "django.template.defaulttags"
+        }));
+        assert!(value.symbols.iter().any(|symbol| {
+            symbol.name == "shout"
+                && symbol.load_name.as_deref() == Some("blog_tags")
+                && symbol.library_module == "blog.templatetags.blog_tags"
+                && symbol.module == "blog.templatetags.blog_tags"
+        }));
+    }
+
+    #[test]
+    fn snapshot_skips_shadowed_loadable_symbols() {
+        let libraries = vec![
+            loadable_library("foo", "app_a.templatetags.foo"),
+            loadable_library("foo", "app_b.templatetags.foo"),
+        ];
+        let symbols = vec![
+            TemplateSymbolFact {
+                library: library("foo"),
+                module: module("app_a.templatetags.foo"),
+                kind: TemplateSymbolKind::Tag,
+                name: TemplateSymbolName::parse("a_only").unwrap(),
+            },
+            TemplateSymbolFact {
+                library: library("foo"),
+                module: module("app_b.templatetags.foo"),
+                kind: TemplateSymbolKind::Tag,
+                name: TemplateSymbolName::parse("b_only").unwrap(),
+            },
+        ];
+
+        let snapshot =
+            assemble_template_library_snapshot(&Fact::known(libraries), &Fact::known(symbols));
+
+        let Fact::Known { value } = snapshot else {
+            panic!("expected known snapshot");
+        };
+        assert_eq!(
+            value.libraries,
+            BTreeMap::from([("foo".to_string(), "app_b.templatetags.foo".to_string())])
+        );
+        assert!(!value.symbols.iter().any(|symbol| symbol.name == "a_only"));
+        assert!(value.symbols.iter().any(|symbol| {
+            symbol.name == "b_only"
+                && symbol.load_name.as_deref() == Some("foo")
+                && symbol.library_module == "app_b.templatetags.foo"
+        }));
+    }
+
+    #[test]
+    fn snapshot_preserves_symbol_reasons_as_partial() {
+        let reason = Reason::file(
+            Field::TemplateSymbols,
+            "blog/templatetags/blog_tags.py",
+            "failed to parse template library module",
+        );
+
+        let snapshot = assemble_template_library_snapshot(
+            &Fact::known(vec![loadable_library(
+                "blog_tags",
+                "blog.templatetags.blog_tags",
+            )]),
+            &Fact::partial(Vec::new(), vec![reason.clone()]),
+        );
+
+        let Fact::Partial { value, reasons } = snapshot else {
+            panic!("expected partial snapshot");
+        };
+        assert_eq!(
+            value.libraries,
+            BTreeMap::from([(
+                "blog_tags".to_string(),
+                "blog.templatetags.blog_tags".to_string()
+            )])
+        );
+        assert_eq!(reasons, [reason]);
+    }
+}

--- a/crates/djls-semantic/src/python.rs
+++ b/crates/djls-semantic/src/python.rs
@@ -77,6 +77,12 @@ pub(crate) struct HelperCall<'db> {
     pub args: Vec<AbstractValueKey>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TemplateRegistration {
+    pub(crate) name: String,
+    pub(crate) kind: SymbolKind,
+}
+
 /// Parse a Python source file into a cached AST.
 ///
 /// Returns `None` for non-Python files or files that fail to parse.
@@ -308,6 +314,36 @@ pub fn extract_rules(source: &str, module_path: &str) -> ExtractionResult {
     }
 
     result
+}
+
+pub(crate) fn extract_template_registrations(
+    source: &str,
+) -> Result<Vec<TemplateRegistration>, String> {
+    let parsed = ruff_python_parser::parse_module(source).map_err(|error| error.to_string())?;
+    let module = parsed.into_syntax();
+    let mut registrations = registry::collect_registrations_from_body(&module.body)
+        .into_iter()
+        .map(|registration| TemplateRegistration {
+            name: registration.name,
+            kind: registration.kind.symbol_kind(),
+        })
+        .collect::<Vec<_>>();
+
+    registrations.sort_by(|a, b| {
+        symbol_kind_rank(a.kind)
+            .cmp(&symbol_kind_rank(b.kind))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    registrations.dedup_by(|a, b| a.kind == b.kind && a.name == b.name);
+
+    Ok(registrations)
+}
+
+fn symbol_kind_rank(kind: SymbolKind) -> u8 {
+    match kind {
+        SymbolKind::Tag => 0,
+        SymbolKind::Filter => 1,
+    }
 }
 
 fn registered_functions<'a>(

--- a/crates/djls-semantic/src/python/registry.rs
+++ b/crates/djls-semantic/src/python/registry.rs
@@ -198,9 +198,11 @@ fn collect_from_decorated_function(
 /// Returns `Some((name, kind))` if the decorator is a tag registration.
 fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, RegistrationKind)> {
     // Bare decorator: `@register.tag`
-    if let Expr::Attribute(ExprAttribute { attr, .. }) = expr {
-        if let Some(kind) = tag_decorator_kind(attr.as_str()) {
-            return Some((func_name.to_string(), kind));
+    if let Expr::Attribute(ExprAttribute { attr, value, .. }) = expr {
+        if is_register_object(value) {
+            if let Some(kind) = tag_decorator_kind(attr.as_str()) {
+                return Some((func_name.to_string(), kind));
+            }
         }
     }
 
@@ -209,22 +211,24 @@ fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, Regi
         func, arguments, ..
     }) = expr
     {
-        if let Expr::Attribute(ExprAttribute { attr, .. }) = func.as_ref() {
-            if let Some(kind) = tag_decorator_kind(attr.as_str()) {
-                // Priority: name= kwarg > first positional string (for @register.tag only) > func_name
-                let name_override = kw_name_from(&arguments.keywords);
+        if let Expr::Attribute(ExprAttribute { attr, value, .. }) = func.as_ref() {
+            if is_register_object(value) {
+                if let Some(kind) = tag_decorator_kind(attr.as_str()) {
+                    // Priority: name= kwarg > first positional string (for @register.tag only) > func_name
+                    let name_override = kw_name_from(&arguments.keywords);
 
-                let positional_name = if attr.as_str() == "tag" {
-                    first_string_arg(&arguments.args)
-                } else {
-                    None
-                };
+                    let positional_name = if attr.as_str() == "tag" {
+                        first_string_arg(&arguments.args)
+                    } else {
+                        None
+                    };
 
-                let name = name_override
-                    .or(positional_name)
-                    .unwrap_or_else(|| func_name.to_string());
+                    let name = name_override
+                        .or(positional_name)
+                        .unwrap_or_else(|| func_name.to_string());
 
-                return Some((name, kind));
+                    return Some((name, kind));
+                }
             }
         }
     }
@@ -237,8 +241,8 @@ fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, Regi
 /// Returns `Some(name)` if the decorator is a filter registration.
 fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
     // Bare decorator: `@register.filter`
-    if let Expr::Attribute(ExprAttribute { attr, .. }) = expr {
-        if FILTER_DECORATORS.contains(&attr.as_str()) {
+    if let Expr::Attribute(ExprAttribute { attr, value, .. }) = expr {
+        if is_register_object(value) && FILTER_DECORATORS.contains(&attr.as_str()) {
             return Some(func_name.to_string());
         }
     }
@@ -248,8 +252,8 @@ fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
         func, arguments, ..
     }) = expr
     {
-        if let Expr::Attribute(ExprAttribute { attr, .. }) = func.as_ref() {
-            if FILTER_DECORATORS.contains(&attr.as_str()) {
+        if let Expr::Attribute(ExprAttribute { attr, value, .. }) = func.as_ref() {
+            if is_register_object(value) && FILTER_DECORATORS.contains(&attr.as_str()) {
                 let name_override = kw_name_from(&arguments.keywords);
                 let positional_name = first_string_arg(&arguments.args);
                 let name = name_override
@@ -299,9 +303,12 @@ fn collect_from_call_statement(call: &ExprCall, registrations: &mut Vec<Registra
 fn tag_registration_from_call(
     call: &ExprCall,
 ) -> Option<(String, RegistrationKind, Option<String>)> {
-    let Expr::Attribute(ExprAttribute { attr, .. }) = call.func.as_ref() else {
+    let Expr::Attribute(ExprAttribute { attr, value, .. }) = call.func.as_ref() else {
         return None;
     };
+    if !is_register_object(value) {
+        return None;
+    }
     let kind = tag_decorator_kind(attr.as_str())?;
 
     let name_override = kw_name_from(&call.arguments.keywords);
@@ -344,10 +351,10 @@ fn tag_registration_from_call(
 /// - `register.filter("name", func)`
 /// - `register.filter(func, name="alias")`
 fn filter_registration_from_call(call: &ExprCall) -> Option<(String, Option<String>)> {
-    let Expr::Attribute(ExprAttribute { attr, .. }) = call.func.as_ref() else {
+    let Expr::Attribute(ExprAttribute { attr, value, .. }) = call.func.as_ref() else {
         return None;
     };
-    if !FILTER_DECORATORS.contains(&attr.as_str()) {
+    if !is_register_object(value) || !FILTER_DECORATORS.contains(&attr.as_str()) {
         return None;
     }
 
@@ -381,6 +388,10 @@ fn filter_registration_from_call(call: &ExprCall) -> Option<(String, Option<Stri
     }
 
     None
+}
+
+fn is_register_object(expr: &Expr) -> bool {
+    matches!(expr, Expr::Name(ExprName { id, .. }) if id.as_str() == "register")
 }
 
 /// Map decorator attr name to `RegistrationKind`.
@@ -667,6 +678,23 @@ register.simple_tag(my_func, name="alias")
         assert_eq!(regs[0].name, "alias");
         assert_eq!(regs[0].kind, RegistrationKind::SimpleTag);
         assert_eq!(regs[0].func_name.as_deref(), Some("my_func"));
+    }
+
+    #[test]
+    fn ignores_non_register_attribute_registrations() {
+        let source = r#"
+from django import template
+other = template.Library()
+register = template.Library()
+
+@other.tag
+def helper(parser, token):
+    pass
+
+other.filter("also_wrong", helper)
+"#;
+        let regs = collect_registrations(source);
+        assert!(regs.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Splits the second half of the previous static assembly PR into its own review unit:

- assembles template libraries and builtins from Django defaults, settings options, and installed app templatetags
- filters app templatetag modules to real registered libraries
- matches Django template register discovery behavior
- assembles template symbols from resolved registration modules

## Stack Context

This is 5/11 in the static project model review stack. It intentionally comes after #613 even though the PR number is lower.

Review order: #615 -> #605 -> #606 -> #613 -> #607 -> #608 -> #609 -> #610 -> #611 -> #612 -> #614.

Review focus: template library, builtin, and symbol assembly.

## Consolidation Notes

This PR was retargeted onto #613's branch so it now covers only the template-library and symbol assembly portion of the old static assembly diff.

## Validation

- This is a branch retarget only; no code changes were made.
- Restack check: `cargo test -q -p djls-semantic static --no-default-features`
- Restack check: `cargo test -q -p djls-semantic sync::tests --no-default-features`