### PR TITLE
Add static-first rollout modes and status reporting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,18 +149,28 @@ Template parsing does not need its own database trait. `parse_template` depends 
 
 ## How Knowledge Gets In
 
-### The Python Inspector
+### Static Project Model and Python Inspector
 
 > [!NOTE]
-> The inspector is planned for replacement with settings fact extraction ([#401](https://github.com/joshuadavidthomas/django-language-server/issues/401)). The goal: parse `settings.py` with the Ruff AST — the same approach used for templatetag extraction — and eliminate the Python subprocess and calling `django.setup()` entirely.
+> The inspector is being replaced by the static project model ([#401](https://github.com/joshuadavidthomas/django-language-server/issues/401)). The rollout keeps the inspector as a transitional fallback until the documented removal gates are met.
 
-The server needs to know what Django has installed: `INSTALLED_APPS`, template directories, templatetag libraries, and the symbols they export. A Python subprocess currently provides this.
+The server needs to know what Django has installed: `INSTALLED_APPS`, template directories, templatetag libraries, and the symbols they export. The preferred path is the static project model:
 
-A small Python program from `crates/djls-semantic/inspector/` ships embedded in the binary as a zipapp. At startup the server writes it to a temp file and runs it against the project's Python interpreter with Django configured. Project introspection queries Django's template engine registry and returns JSON describing template directories, installed libraries, and their symbols.
+- Resolve Python modules from workspace roots, configured `pythonpath`, auto `src/` roots, and site-packages.
+- Parse Django settings with the Ruff AST.
+- Assemble app registry, template dirs, template libraries, builtins, and symbol snapshots without importing Django.
+
+`project_model` controls rollout behavior:
+
+- `auto` builds static facts first and uses known static outputs without starting the inspector. Partial or unknown static facts can fall back to the inspector during the transition.
+- `static` uses only static facts and never starts the inspector. Partial or unknown facts degrade conservatively.
+- `inspector` uses the legacy runtime path first.
+
+A small Python program from `crates/djls-semantic/inspector/` still ships embedded in the binary as a zipapp for fallback. Project introspection queries Django's template engine registry and returns JSON describing template directories, installed libraries, and their symbols.
 
 Startup uses two phases to avoid blocking the editor:
 
-1. A cache check during `initialized`. The server loads a cached inspector response from `~/.cache/djls/inspector/`. The cache key is a SHA-256 hash of the project root, interpreter path, settings module, and PYTHONPATH. If the cache exists (and its `djls_version` matches), the server becomes functional immediately with the cached data.
+1. A cache check during `initialized`. The server can load cached static template-library facts from `~/.cache/djls/static-project-model/template-libraries/` or legacy inspector responses from `~/.cache/djls/inspector/`, depending on `project_model` and fact confidence.
 2. A background task refreshes project data, updates Salsa inputs, and writes a fresh cache. This includes template directories, template libraries, the first-party project file set, extracted validation rules from installed packages, and external model graphs. When a cache was loaded in phase 1, this runs concurrently with normal operation. If no cache existed, the server waits for this to complete before advertising full capabilities.
 
 This means that in the common case (you've opened this project before and the environment hasn't changed), startup is nearly instant — the server just reads a JSON file from disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Added
 
 - Added opt-in whole-document Django template formatting through `djangofmt`.
+- Added `project_model` configuration for choosing static-first, static-only, or inspector-first discovery of template directories, template libraries, and symbols.
 
 ## [6.0.3]
 

--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -68,10 +68,20 @@ pub enum ConfigError {
     PyprojectSerialize(#[from] toml::ser::Error),
 }
 
+#[derive(Debug, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProjectModelMode {
+    #[default]
+    Auto,
+    Static,
+    Inspector,
+}
+
 #[derive(Debug, Deserialize, Default, PartialEq, Clone)]
 pub struct Settings {
     #[serde(default)]
     debug: bool,
+    project_model: Option<ProjectModelMode>,
     venv_path: Option<String>,
     django_settings_module: Option<String>,
     #[serde(default)]
@@ -96,6 +106,7 @@ impl Settings {
 
         if let Some(overrides) = overrides {
             settings.debug = overrides.debug || settings.debug;
+            settings.project_model = overrides.project_model.or(settings.project_model);
             settings.venv_path = overrides.venv_path.or(settings.venv_path);
             settings.django_settings_module = overrides
                 .django_settings_module
@@ -168,6 +179,11 @@ impl Settings {
     }
 
     #[must_use]
+    pub fn project_model(&self) -> ProjectModelMode {
+        self.project_model.unwrap_or_default()
+    }
+
+    #[must_use]
     pub fn venv_path(&self) -> Option<&str> {
         self.venv_path.as_deref()
     }
@@ -227,6 +243,7 @@ mod tests {
                 settings,
                 Settings {
                     debug: false,
+                    project_model: None,
                     venv_path: None,
                     django_settings_module: None,
                     django_environments: vec![],
@@ -269,6 +286,45 @@ mod tests {
                     ..Default::default()
                 }
             );
+        }
+
+        #[test]
+        fn test_load_project_model_config() {
+            let dir = tempdir().unwrap();
+            fs::write(dir.path().join("djls.toml"), r#"project_model = "static""#).unwrap();
+            let settings = Settings::new(Utf8Path::from_path(dir.path()).unwrap(), None).unwrap();
+
+            assert_eq!(settings.project_model(), ProjectModelMode::Static);
+        }
+
+        #[test]
+        fn test_project_model_defaults_to_auto() {
+            let dir = tempdir().unwrap();
+            let settings = Settings::new(Utf8Path::from_path(dir.path()).unwrap(), None).unwrap();
+
+            assert_eq!(settings.project_model(), ProjectModelMode::Auto);
+        }
+
+        #[test]
+        fn test_overrides_replace_project_model_config() {
+            let dir = tempdir().unwrap();
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"project_model = "inspector""#,
+            )
+            .unwrap();
+
+            let override_settings = Settings {
+                project_model: Some(ProjectModelMode::Static),
+                ..Default::default()
+            };
+            let settings = Settings::new(
+                Utf8Path::from_path(dir.path()).unwrap(),
+                Some(override_settings),
+            )
+            .unwrap();
+
+            assert_eq!(settings.project_model(), ProjectModelMode::Static);
         }
 
         #[test]

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -284,6 +284,7 @@ mod invalidation_tests {
             &db,
             "/test/project".into(),
             interpreter,
+            settings.project_model(),
             dsm,
             settings.pythonpath().to_vec(),
             Vec::new(),

--- a/crates/djls-db/src/settings.rs
+++ b/crates/djls-db/src/settings.rs
@@ -72,6 +72,12 @@ impl DjangoDatabase {
             env_changed = true;
         }
 
+        let new_project_model = settings.project_model();
+        if project.project_model(self) != new_project_model {
+            project.set_project_model(self).to(new_project_model);
+            env_changed = true;
+        }
+
         let new_dsm = settings
             .django_settings_module()
             .map(String::from)

--- a/crates/djls-semantic/src/project/app_registry.rs
+++ b/crates/djls-semantic/src/project/app_registry.rs
@@ -339,6 +339,7 @@ fn app_config_installed_app(
     let label = app_config_label(assignments.label, &name, config_file);
     let config = AppConfigFact {
         module: config_module,
+        file: config_file.to_path_buf(),
         class_name: class.name.to_string(),
         name,
         label,

--- a/crates/djls-semantic/src/project/facts.rs
+++ b/crates/djls-semantic/src/project/facts.rs
@@ -283,6 +283,7 @@ pub(crate) enum ModuleLocation {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SettingsFacts {
     pub(crate) file: Utf8PathBuf,
+    pub(crate) files_read: Vec<Utf8PathBuf>,
     pub(crate) installed_apps: Fact<Vec<String>>,
     pub(crate) template_backends: Fact<Vec<TemplateBackendFact>>,
 }
@@ -298,6 +299,7 @@ pub(crate) struct InstalledAppFact {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct AppConfigFact {
     pub(crate) module: PyModuleName,
+    pub(crate) file: Utf8PathBuf,
     pub(crate) class_name: String,
     pub(crate) name: Fact<PyModuleName>,
     pub(crate) label: Fact<String>,

--- a/crates/djls-semantic/src/project/input.rs
+++ b/crates/djls-semantic/src/project/input.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use djls_conf::ProjectModelMode;
 use djls_conf::Settings;
 use djls_conf::TagSpecDef;
 use djls_source::File;
@@ -233,6 +234,8 @@ pub struct Project {
     /// Interpreter specification for Python environment discovery
     #[returns(ref)]
     pub interpreter: Interpreter,
+    /// Static project model rollout mode.
+    pub project_model: ProjectModelMode,
     /// Django settings module (e.g., "myproject.settings")
     #[returns(ref)]
     pub django_settings_module: Option<String>,
@@ -300,6 +303,7 @@ impl Project {
         Project::builder(
             root.to_path_buf(),
             interpreter,
+            settings.project_model(),
             resolved_django_settings_module,
             settings.pythonpath().to_vec(),
             env_vars,

--- a/crates/djls-semantic/src/project/introspector.rs
+++ b/crates/djls-semantic/src/project/introspector.rs
@@ -4,6 +4,10 @@ use std::io::Write;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
+#[cfg(test)]
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -38,6 +42,8 @@ pub(crate) struct IntrospectionResponse<T = serde_json::Value> {
 #[derive(Clone, Debug)]
 pub struct ProjectIntrospector {
     inspector: Inspector,
+    #[cfg(test)]
+    query_count: Arc<AtomicUsize>,
 }
 
 impl ProjectIntrospector {
@@ -45,7 +51,14 @@ impl ProjectIntrospector {
     pub fn new() -> Self {
         Self {
             inspector: Inspector::new(),
+            #[cfg(test)]
+            query_count: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_count(&self) -> usize {
+        self.query_count.load(Ordering::SeqCst)
     }
 
     pub(crate) fn query<Q: IntrospectionRequest>(
@@ -53,6 +66,9 @@ impl ProjectIntrospector {
         db: &dyn ProjectDb,
         request: &Q,
     ) -> Option<Q::Response> {
+        #[cfg(test)]
+        self.query_count.fetch_add(1, Ordering::SeqCst);
+
         let project = db.project()?;
         let interpreter = project.interpreter(db);
         let project_path = project.root(db);

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -47,6 +47,7 @@ struct SettingsImportScope<'a> {
 
 struct SettingsExtractionState {
     file: Utf8PathBuf,
+    files_read: Vec<Utf8PathBuf>,
     path_values: BTreeMap<String, Utf8PathBuf>,
     installed_apps: Option<Fact<Vec<String>>>,
     template_backends: Option<Fact<Vec<TemplateBackendFact>>>,
@@ -59,6 +60,7 @@ impl SettingsExtractionState {
     fn new(file: &Utf8Path) -> Self {
         Self {
             file: file.to_path_buf(),
+            files_read: vec![file.to_path_buf()],
             path_values: BTreeMap::new(),
             installed_apps: None,
             template_backends: None,
@@ -72,6 +74,7 @@ impl SettingsExtractionState {
         let facts = unknown_settings_facts(file, message);
         Self {
             file: facts.file,
+            files_read: facts.files_read,
             path_values: BTreeMap::new(),
             installed_apps: Some(facts.installed_apps),
             template_backends: Some(facts.template_backends),
@@ -82,6 +85,7 @@ impl SettingsExtractionState {
     }
 
     fn apply_star_import(&mut self, imported: Self) {
+        self.files_read.extend(imported.files_read);
         if imported.load_failed {
             if let Some(installed_apps) = imported.installed_apps {
                 self.installed_apps_import_reasons
@@ -112,8 +116,15 @@ impl SettingsExtractionState {
         self.template_backends_import_reasons.extend(reasons);
     }
 
+    fn add_files_read(&mut self, files: impl IntoIterator<Item = Utf8PathBuf>) {
+        self.files_read.extend(files);
+    }
+
     fn into_facts(self) -> SettingsFacts {
         let file = self.file;
+        let mut files_read = self.files_read;
+        files_read.sort();
+        files_read.dedup();
         let installed_apps = finalize_setting_fact(
             self.installed_apps,
             self.installed_apps_import_reasons,
@@ -131,6 +142,7 @@ impl SettingsExtractionState {
 
         SettingsFacts {
             file,
+            files_read,
             installed_apps,
             template_backends,
         }
@@ -354,6 +366,10 @@ fn follow_star_import(
         }
         Fact::Unknown { reasons } | Fact::Ambiguous { reasons, .. } => {
             state.add_import_reasons(reasons);
+            state.add_files_read(unresolved_module_candidate_files(
+                &target_module,
+                imports.search_paths,
+            ));
             return;
         }
     };
@@ -365,6 +381,24 @@ fn follow_star_import(
         active_files,
     );
     state.apply_star_import(imported);
+}
+
+fn unresolved_module_candidate_files(
+    module: &PyModuleName,
+    search_paths: &[ModuleSearchPathEntry],
+) -> Vec<Utf8PathBuf> {
+    let relative_module_path = module.as_str().replace('.', "/");
+    search_paths
+        .iter()
+        .flat_map(|search_path| {
+            let module_file = search_path.path.join(format!("{relative_module_path}.py"));
+            let package_file = search_path
+                .path
+                .join(&relative_module_path)
+                .join("__init__.py");
+            [module_file, package_file]
+        })
+        .collect()
 }
 
 fn star_import_module(
@@ -1163,6 +1197,7 @@ fn unknown_settings_facts(file: &Utf8Path, message: impl Into<String>) -> Settin
     let message = message.into();
     SettingsFacts {
         file: file.to_path_buf(),
+        files_read: vec![file.to_path_buf()],
         installed_apps: Fact::unknown(vec![reason(
             Field::SettingsInstalledApps,
             file,

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -493,6 +493,20 @@ impl TemplateLibraries {
         let Some(response) = response else {
             self.active_knowledge = Knowledge::Unknown;
             self.builtins.clear();
+            for libraries in self.loadable.values_mut() {
+                for library in libraries.iter_mut() {
+                    if let LibraryStatus::Active {
+                        origin: Some(origin),
+                        ..
+                    } = &library.status
+                    {
+                        library.status = LibraryStatus::Discovered(origin.clone());
+                    }
+                }
+                libraries.retain(|library| {
+                    !matches!(library.status, LibraryStatus::Active { origin: None, .. })
+                });
+            }
             return self;
         };
 

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -1706,7 +1706,6 @@ fn split_extraction_results(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::collections::BTreeSet;
     use std::process::Command;
     use std::sync::Arc;
 
@@ -2763,16 +2762,20 @@ TEMPLATES = []
     }
 
     #[test]
-    fn gh401_profile_static_assembly_matches_profile_environments() {
-        let profiles = djls_corpus::project_model_profiles().unwrap();
-        let profile = profiles.get("gh401-multisite-split-settings").unwrap();
-        let root = profile.root_path(None).unwrap();
-        let pythonpath = profile.source_roots.clone();
+    fn gh401_static_assembly_keeps_split_settings_outputs_separate() {
+        let manifest = djls_corpus::Manifest::load_default().unwrap();
+        let fixture = manifest
+            .fixtures
+            .iter()
+            .find(|fixture| fixture.name == "gh401-multisite")
+            .unwrap();
+        let root = fixture.root_path();
+        let pythonpath = vec!["projects".to_string(), "apps".to_string()];
         let tmp = TempDir::new().unwrap();
         let site_packages = Utf8PathBuf::try_from(tmp.path().join("site-packages")).unwrap();
         write_minimal_django_site_packages(
             &site_packages,
-            &[
+            [
                 "django.contrib.auth",
                 "django.contrib.contenttypes",
                 "django.templatetags.cache",
@@ -2785,91 +2788,107 @@ TEMPLATES = []
                 "django.template.loader_tags",
             ],
         );
-        let all_expected_templatetag_modules = profile
-            .expected_union
-            .templatetag_modules
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<_>>();
 
-        for environment in &profile.django_environments {
-            assert_profile_environment_static_assembly(
-                &root,
-                &pythonpath,
-                &site_packages,
-                environment,
-                &all_expected_templatetag_modules,
-            );
+        for expected in [
+            StaticAssemblyExpectation {
+                settings_module: "site1.settings.dev",
+                template_dirs: &[
+                    "projects/site1/templates",
+                    "apps/clientname/app1/templates",
+                    "apps/clientname/app2/templates",
+                ],
+                templatetag_modules: &[
+                    "clientname.app1.templatetags.app1_tags",
+                    "clientname.app2.templatetags.app2_tags",
+                ],
+                excluded_templatetag_modules: &["clientname.app3.templatetags.app3_tags"],
+            },
+            StaticAssemblyExpectation {
+                settings_module: "site2.settings.dev",
+                template_dirs: &[
+                    "projects/site2/templates",
+                    "apps/clientname/app2/templates",
+                    "apps/clientname/app3/templates",
+                ],
+                templatetag_modules: &[
+                    "clientname.app2.templatetags.app2_tags",
+                    "clientname.app3.templatetags.app3_tags",
+                ],
+                excluded_templatetag_modules: &["clientname.app1.templatetags.app1_tags"],
+            },
+        ] {
+            assert_fixture_static_assembly(&root, &pythonpath, &site_packages, &expected);
         }
     }
 
-    fn assert_profile_environment_static_assembly(
+    struct StaticAssemblyExpectation {
+        settings_module: &'static str,
+        template_dirs: &'static [&'static str],
+        templatetag_modules: &'static [&'static str],
+        excluded_templatetag_modules: &'static [&'static str],
+    }
+
+    fn assert_fixture_static_assembly(
         root: &Utf8Path,
         pythonpath: &[String],
         site_packages: &Utf8PathBuf,
-        environment: &djls_corpus::DjangoEnvironmentProfile,
-        all_expected_templatetag_modules: &BTreeSet<String>,
+        expected: &StaticAssemblyExpectation,
     ) {
         let dirs = assemble_static_template_dirs(
             root,
-            Some(&environment.settings_module),
+            Some(expected.settings_module),
             pythonpath,
             std::slice::from_ref(site_packages),
         );
         assert_eq!(
             dirs.confidence(),
-            expected_profile_confidence(environment.templates_confidence),
+            Confidence::Known,
             "unexpected template dir confidence for `{}`: {:?}",
-            environment.settings_module,
+            expected.settings_module,
             dirs.reasons()
         );
-        assert_eq!(
-            dirs.value().expect("known profile template dirs").clone(),
-            expected_profile_template_dirs(root, pythonpath, environment),
-            "unexpected template dirs for `{}`",
-            environment.settings_module
-        );
+        let dirs = dirs.value().expect("known fixture template dirs");
+        for dir in expected.template_dirs {
+            let dir = root.join(dir);
+            assert!(
+                dirs.contains(&dir),
+                "expected `{}` template dirs to contain `{dir}` in {dirs:?}",
+                expected.settings_module
+            );
+        }
 
         let snapshot = assemble_static_template_library_snapshot(
             root,
-            Some(&environment.settings_module),
+            Some(expected.settings_module),
             pythonpath,
             std::slice::from_ref(site_packages),
         );
         assert_eq!(
             snapshot.confidence(),
-            expected_profile_confidence(environment.templates_confidence),
+            Confidence::Known,
             "unexpected template library confidence for `{}`: {:?}",
-            environment.settings_module,
+            expected.settings_module,
             snapshot.reasons()
         );
         let library_modules = snapshot
             .value()
-            .expect("known profile template library snapshot")
+            .expect("known fixture template library snapshot")
             .libraries
             .values()
             .cloned()
-            .collect::<BTreeSet<_>>();
-        let expected_modules = environment
-            .expected
-            .templatetag_modules
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<_>>();
-        let profile_modules = library_modules
-            .intersection(all_expected_templatetag_modules)
-            .cloned()
-            .collect::<BTreeSet<_>>();
-        assert_eq!(
-            profile_modules, expected_modules,
-            "unexpected profile library modules for `{}`",
-            environment.settings_module
-        );
-        for module in all_expected_templatetag_modules.difference(&expected_modules) {
+            .collect::<Vec<_>>();
+        for module in expected.templatetag_modules {
             assert!(
-                !library_modules.contains(module),
-                "did not expect `{}` libraries to contain context-exclusive `{module}`",
-                environment.settings_module
+                library_modules.iter().any(|candidate| candidate == module),
+                "expected `{}` libraries to contain `{module}` in {library_modules:?}",
+                expected.settings_module
+            );
+        }
+        for module in expected.excluded_templatetag_modules {
+            assert!(
+                library_modules.iter().all(|candidate| candidate != module),
+                "did not expect `{}` libraries to contain `{module}`",
+                expected.settings_module
             );
         }
         assert!(
@@ -2880,38 +2899,14 @@ TEMPLATES = []
         );
     }
 
-    fn expected_profile_template_dirs(
-        root: &Utf8Path,
-        pythonpath: &[String],
-        environment: &djls_corpus::DjangoEnvironmentProfile,
-    ) -> Vec<Utf8PathBuf> {
-        let mut dirs = environment
-            .expected
-            .template_dirs
-            .iter()
-            .map(|dir| root.join(dir))
-            .collect::<Vec<_>>();
-        dirs.extend(
-            environment
-                .expected
-                .local_apps
-                .iter()
-                .filter_map(|app| profile_app_template_dir(root, pythonpath, app)),
-        );
-        dirs
-    }
-
-    fn expected_profile_confidence(confidence: djls_corpus::Confidence) -> Confidence {
-        match confidence {
-            djls_corpus::Confidence::Known => Confidence::Known,
-            djls_corpus::Confidence::Partial => Confidence::Partial,
-            djls_corpus::Confidence::Unknown => Confidence::Unknown,
-        }
-    }
-
-    fn write_minimal_django_site_packages(site_packages: &Utf8Path, modules: &[&str]) {
+    fn write_minimal_django_site_packages<S>(
+        site_packages: &Utf8Path,
+        modules: impl IntoIterator<Item = S>,
+    ) where
+        S: AsRef<str>,
+    {
         for module in modules {
-            write_minimal_python_module(site_packages, module);
+            write_minimal_python_module(site_packages, module.as_ref());
         }
     }
 
@@ -2926,20 +2921,6 @@ TEMPLATES = []
             write_file(&dir.join("__init__.py"), "");
         }
         write_file(&dir.join(format!("{file_name}.py")), "");
-    }
-
-    fn profile_app_template_dir(
-        root: &Utf8Path,
-        source_roots: &[String],
-        module: &str,
-    ) -> Option<Utf8PathBuf> {
-        let module_path = module.replace('.', "/");
-        source_roots
-            .iter()
-            .map(|source_root| root.join(source_root).join(&module_path))
-            .find(|path| path.join("__init__.py").is_file())
-            .map(|path| path.join("templates"))
-            .filter(|path| path.is_dir())
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -1706,6 +1706,7 @@ fn split_extraction_results(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
     use std::process::Command;
     use std::sync::Arc;
 
@@ -2759,6 +2760,186 @@ TEMPLATES = []
         assert!(!snapshot_loadable_symbol_keys(&site2_snapshot)
             .iter()
             .any(|symbol| symbol.contains("app1_marker")));
+    }
+
+    #[test]
+    fn gh401_profile_static_assembly_matches_profile_environments() {
+        let profiles = djls_corpus::project_model_profiles().unwrap();
+        let profile = profiles.get("gh401-multisite-split-settings").unwrap();
+        let root = profile.root_path(None).unwrap();
+        let pythonpath = profile.source_roots.clone();
+        let tmp = TempDir::new().unwrap();
+        let site_packages = Utf8PathBuf::try_from(tmp.path().join("site-packages")).unwrap();
+        write_minimal_django_site_packages(
+            &site_packages,
+            &[
+                "django.contrib.auth",
+                "django.contrib.contenttypes",
+                "django.templatetags.cache",
+                "django.templatetags.i18n",
+                "django.templatetags.l10n",
+                "django.templatetags.static",
+                "django.templatetags.tz",
+                "django.template.defaulttags",
+                "django.template.defaultfilters",
+                "django.template.loader_tags",
+            ],
+        );
+        let all_expected_templatetag_modules = profile
+            .expected_union
+            .templatetag_modules
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        for environment in &profile.django_environments {
+            assert_profile_environment_static_assembly(
+                &root,
+                &pythonpath,
+                &site_packages,
+                environment,
+                &all_expected_templatetag_modules,
+            );
+        }
+    }
+
+    fn assert_profile_environment_static_assembly(
+        root: &Utf8Path,
+        pythonpath: &[String],
+        site_packages: &Utf8PathBuf,
+        environment: &djls_corpus::DjangoEnvironmentProfile,
+        all_expected_templatetag_modules: &BTreeSet<String>,
+    ) {
+        let dirs = assemble_static_template_dirs(
+            root,
+            Some(&environment.settings_module),
+            pythonpath,
+            std::slice::from_ref(site_packages),
+        );
+        assert_eq!(
+            dirs.confidence(),
+            expected_profile_confidence(environment.templates_confidence),
+            "unexpected template dir confidence for `{}`: {:?}",
+            environment.settings_module,
+            dirs.reasons()
+        );
+        assert_eq!(
+            dirs.value().expect("known profile template dirs").clone(),
+            expected_profile_template_dirs(root, pythonpath, environment),
+            "unexpected template dirs for `{}`",
+            environment.settings_module
+        );
+
+        let snapshot = assemble_static_template_library_snapshot(
+            root,
+            Some(&environment.settings_module),
+            pythonpath,
+            std::slice::from_ref(site_packages),
+        );
+        assert_eq!(
+            snapshot.confidence(),
+            expected_profile_confidence(environment.templates_confidence),
+            "unexpected template library confidence for `{}`: {:?}",
+            environment.settings_module,
+            snapshot.reasons()
+        );
+        let library_modules = snapshot
+            .value()
+            .expect("known profile template library snapshot")
+            .libraries
+            .values()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let expected_modules = environment
+            .expected
+            .templatetag_modules
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let profile_modules = library_modules
+            .intersection(all_expected_templatetag_modules)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            profile_modules, expected_modules,
+            "unexpected profile library modules for `{}`",
+            environment.settings_module
+        );
+        for module in all_expected_templatetag_modules.difference(&expected_modules) {
+            assert!(
+                !library_modules.contains(module),
+                "did not expect `{}` libraries to contain context-exclusive `{module}`",
+                environment.settings_module
+            );
+        }
+        assert!(
+            library_modules
+                .iter()
+                .all(|module| !module.starts_with("apps.") && !module.starts_with("projects.")),
+            "expected source-root-aware module names, got {library_modules:?}",
+        );
+    }
+
+    fn expected_profile_template_dirs(
+        root: &Utf8Path,
+        pythonpath: &[String],
+        environment: &djls_corpus::DjangoEnvironmentProfile,
+    ) -> Vec<Utf8PathBuf> {
+        let mut dirs = environment
+            .expected
+            .template_dirs
+            .iter()
+            .map(|dir| root.join(dir))
+            .collect::<Vec<_>>();
+        dirs.extend(
+            environment
+                .expected
+                .local_apps
+                .iter()
+                .filter_map(|app| profile_app_template_dir(root, pythonpath, app)),
+        );
+        dirs
+    }
+
+    fn expected_profile_confidence(confidence: djls_corpus::Confidence) -> Confidence {
+        match confidence {
+            djls_corpus::Confidence::Known => Confidence::Known,
+            djls_corpus::Confidence::Partial => Confidence::Partial,
+            djls_corpus::Confidence::Unknown => Confidence::Unknown,
+        }
+    }
+
+    fn write_minimal_django_site_packages(site_packages: &Utf8Path, modules: &[&str]) {
+        for module in modules {
+            write_minimal_python_module(site_packages, module);
+        }
+    }
+
+    fn write_minimal_python_module(root: &Utf8Path, module: &str) {
+        let mut parts = module.split('.').collect::<Vec<_>>();
+        let Some(file_name) = parts.pop() else {
+            return;
+        };
+        let mut dir = root.to_path_buf();
+        for part in parts {
+            dir = dir.join(part);
+            write_file(&dir.join("__init__.py"), "");
+        }
+        write_file(&dir.join(format!("{file_name}.py")), "");
+    }
+
+    fn profile_app_template_dir(
+        root: &Utf8Path,
+        source_roots: &[String],
+        module: &str,
+    ) -> Option<Utf8PathBuf> {
+        let module_path = module.replace('.', "/");
+        source_roots
+            .iter()
+            .map(|source_root| root.join(source_root).join(&module_path))
+            .find(|path| path.join("__init__.py").is_file())
+            .map(|path| path.join("templates"))
+            .filter(|path| path.is_dir())
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Write;
 use std::fs;
+use std::time::UNIX_EPOCH;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
@@ -23,13 +24,16 @@ use sha2::Sha256;
 use crate::project::app_registry::resolve_app_registry;
 use crate::project::app_registry::AppRegistryFacts;
 use crate::project::db::Db as ProjectDb;
+use crate::project::facts::Confidence;
 use crate::project::facts::Fact;
 use crate::project::facts::Field;
 use crate::project::facts::ModuleLocation;
 use crate::project::facts::ModuleSearchPathEntry;
+use crate::project::facts::ModuleSearchPathKind;
 use crate::project::facts::Reason;
 use crate::project::facts::ReasonSource;
 use crate::project::facts::SettingsFacts;
+use crate::project::facts::TemplateLibraryFact;
 use crate::project::input::Project;
 use crate::project::input::ProjectPythonIndex;
 use crate::project::input::ProjectPythonModule;
@@ -61,6 +65,9 @@ use crate::python::FilterArityMap;
 use crate::python::ModelGraph;
 use crate::python::ModulePath;
 use crate::python::TagRuleMap;
+
+const STATIC_TEMPLATE_LIBRARY_CACHE_VERSION: &str = "static-template-libraries-v1";
+const DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY: &str = "django-5.2-default-template-libraries-v1";
 
 /// Refresh all external project data.
 ///
@@ -115,6 +122,9 @@ fn refresh_template_dirs(db: &mut dyn ProjectDb, project: Project) {
     let static_dirs = inspector_dirs
         .is_none()
         .then(|| assemble_project_static_template_dirs(db, project));
+    if let Some(static_dirs) = &static_dirs {
+        log_static_template_dirs_status(project.django_settings_module(db).as_deref(), static_dirs);
+    }
     apply_template_dirs_or_static_fallback(db, project, inspector_dirs, static_dirs);
 }
 
@@ -239,6 +249,21 @@ fn usable_static_template_dirs(dirs: Fact<Vec<Utf8PathBuf>>) -> Option<Vec<Utf8P
     }
 }
 
+fn log_static_template_dirs_status(
+    django_settings_module: Option<&str>,
+    dirs: &Fact<Vec<Utf8PathBuf>>,
+) {
+    tracing::info!(
+        event = "template_dirs",
+        django_settings_module = django_settings_module.unwrap_or("<unset>"),
+        confidence = ?dirs.confidence(),
+        template_dir_count = dirs.value().map(Vec::len).unwrap_or_default(),
+        reason_count = dirs.reasons().len(),
+        reasons = ?dirs.reasons(),
+        "Static project model status",
+    );
+}
+
 #[derive(Serialize)]
 struct TemplateLibrarySnapshotRequest;
 
@@ -249,7 +274,10 @@ impl IntrospectionRequest for TemplateLibrarySnapshotRequest {
 
 fn load_project_template_library_cache(db: &mut dyn ProjectDb, project: Project) -> bool {
     let Some(snapshot) = load_template_library_snapshot_cache(db, project) else {
-        return false;
+        let Some(entry) = load_static_template_library_snapshot_cache(db, project) else {
+            return false;
+        };
+        return apply_static_template_library_cache_entry(db, project, entry);
     };
 
     if apply_template_library_snapshot(db, project, snapshot) {
@@ -266,8 +294,15 @@ fn refresh_template_libraries(db: &mut dyn ProjectDb, project: Project) {
         return;
     }
 
-    let snapshot = assemble_project_static_template_library_snapshot(db, project);
-    apply_static_template_library_snapshot(db, project, snapshot);
+    let static_cache_entry = load_static_template_library_snapshot_cache(db, project);
+    if refresh_template_libraries_from_static_cache(db, project, static_cache_entry) {
+        return;
+    }
+
+    let assembly = assemble_project_static_template_library_snapshot_with_status(db, project);
+    log_static_project_model_status("assembled", &assembly.status);
+    save_static_template_library_snapshot_cache(db, project, &assembly);
+    apply_static_template_library_snapshot(db, project, assembly.snapshot);
 }
 
 fn apply_template_library_snapshot(
@@ -298,15 +333,40 @@ fn apply_template_library_snapshot_with_knowledge(
     true
 }
 
+fn refresh_template_libraries_from_static_cache(
+    db: &mut dyn ProjectDb,
+    project: Project,
+    entry: Option<StaticTemplateLibraryCacheEntry>,
+) -> bool {
+    let Some(entry) = entry else {
+        return false;
+    };
+    if usable_static_template_library_snapshot(entry.snapshot.clone()).is_none() {
+        return false;
+    }
+
+    log_static_project_model_status("cache_load", &entry.status);
+    apply_static_template_library_snapshot(db, project, entry.snapshot);
+    true
+}
+
 fn fetch_template_library_snapshot(db: &dyn ProjectDb) -> Option<TemplateLibrarySnapshot> {
     db.project_introspector()
         .query(db, &TemplateLibrarySnapshotRequest)
 }
 
+#[cfg(test)]
 fn assemble_project_static_template_library_snapshot(
     db: &dyn ProjectDb,
     project: Project,
 ) -> Fact<TemplateLibrarySnapshot> {
+    assemble_project_static_template_library_snapshot_with_status(db, project).snapshot
+}
+
+fn assemble_project_static_template_library_snapshot_with_status(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> StaticTemplateLibrarySnapshotAssembly {
     let root = project.root(db).clone();
     let interpreter = project.interpreter(db).clone();
     let django_settings_module = project.django_settings_module(db).clone();
@@ -315,12 +375,18 @@ fn assemble_project_static_template_library_snapshot(
         .into_iter()
         .collect::<Vec<_>>();
 
-    assemble_static_template_library_snapshot(
+    assemble_static_template_library_snapshot_with_status(
         &root,
         django_settings_module.as_deref(),
         &pythonpath,
         &site_packages_paths,
     )
+}
+
+struct StaticTemplateLibrarySnapshotAssembly {
+    snapshot: Fact<TemplateLibrarySnapshot>,
+    status: StaticProjectModelStatus,
+    dependencies: Vec<StaticCacheDependency>,
 }
 
 fn apply_static_template_library_snapshot(
@@ -335,12 +401,12 @@ fn apply_static_template_library_snapshot(
     apply_template_library_snapshot_with_knowledge(db, project, snapshot, knowledge)
 }
 
-fn assemble_static_template_library_snapshot(
+fn assemble_static_template_library_snapshot_with_status(
     root: &Utf8Path,
     django_settings_module: Option<&str>,
     pythonpath: &[String],
     site_packages_paths: &[Utf8PathBuf],
-) -> Fact<TemplateLibrarySnapshot> {
+) -> StaticTemplateLibrarySnapshotAssembly {
     let context = match assemble_static_project_context(
         root,
         django_settings_module,
@@ -348,25 +414,128 @@ fn assemble_static_template_library_snapshot(
         site_packages_paths,
     ) {
         Ok(context) => context,
-        Err(reasons) => return Fact::unknown(reasons),
+        Err(reasons) => {
+            let snapshot = Fact::unknown(reasons);
+            let status = StaticProjectModelStatus::from_snapshot(
+                django_settings_module,
+                &snapshot,
+                None,
+                None,
+                None,
+            );
+            return StaticTemplateLibrarySnapshotAssembly {
+                snapshot,
+                status,
+                dependencies: Vec::new(),
+            };
+        }
     };
 
+    let template_dirs = assemble_template_dirs(
+        &context.settings_facts.template_backends,
+        &context.app_registry.app_registry,
+    );
     let template_libraries = assemble_template_libraries(
         &context.settings_facts.template_backends,
         &context.app_registry.app_registry,
     );
     let template_symbols =
         assemble_template_symbols(&template_libraries, &context.module_search_paths, root);
-    let snapshot = assemble_template_library_snapshot(&template_libraries, &template_symbols);
+    let snapshot = add_static_reasons(
+        assemble_template_library_snapshot(&template_libraries, &template_symbols),
+        context.reasons.clone(),
+    );
+    let status = StaticProjectModelStatus::from_snapshot(
+        django_settings_module,
+        &snapshot,
+        fact_len(&context.app_registry.app_registry),
+        fact_len(&template_dirs),
+        context.module_search_paths.value().map(Vec::len),
+    );
+    let dependencies =
+        static_template_library_cache_dependencies(root, &context, &template_libraries, &snapshot);
 
-    add_static_reasons(snapshot, context.reasons)
+    StaticTemplateLibrarySnapshotAssembly {
+        snapshot,
+        status,
+        dependencies,
+    }
+}
+
+#[cfg(test)]
+fn assemble_static_template_library_snapshot(
+    root: &Utf8Path,
+    django_settings_module: Option<&str>,
+    pythonpath: &[String],
+    site_packages_paths: &[Utf8PathBuf],
+) -> Fact<TemplateLibrarySnapshot> {
+    assemble_static_template_library_snapshot_with_status(
+        root,
+        django_settings_module,
+        pythonpath,
+        site_packages_paths,
+    )
+    .snapshot
 }
 
 struct StaticProjectContext {
     module_search_paths: Fact<Vec<ModuleSearchPathEntry>>,
+    site_packages_paths: Vec<Utf8PathBuf>,
     settings_facts: SettingsFacts,
     app_registry: AppRegistryFacts,
     reasons: Vec<Reason>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StaticProjectModelStatus {
+    django_settings_module: Option<String>,
+    confidence: Confidence,
+    module_search_path_count: Option<usize>,
+    app_count: Option<usize>,
+    template_dir_count: Option<usize>,
+    loadable_library_count: usize,
+    builtin_count: usize,
+    symbol_count: usize,
+    reasons: Vec<Reason>,
+}
+
+impl StaticProjectModelStatus {
+    fn from_snapshot(
+        django_settings_module: Option<&str>,
+        snapshot: &Fact<TemplateLibrarySnapshot>,
+        app_count: Option<usize>,
+        template_dir_count: Option<usize>,
+        module_search_path_count: Option<usize>,
+    ) -> Self {
+        let (loadable_library_count, builtin_count, symbol_count) =
+            snapshot.value().map_or((0, 0, 0), |snapshot| {
+                (
+                    snapshot.libraries.len(),
+                    snapshot.builtins.len(),
+                    snapshot.symbols.len(),
+                )
+            });
+
+        Self {
+            django_settings_module: django_settings_module.map(str::to_string),
+            confidence: snapshot.confidence(),
+            module_search_path_count,
+            app_count,
+            template_dir_count,
+            loadable_library_count,
+            builtin_count,
+            symbol_count,
+            reasons: snapshot.reasons().to_vec(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct StaticCacheDependency {
+    path: Utf8PathBuf,
+    exists: bool,
+    modified_unix_secs: Option<u64>,
+    modified_subsec_nanos: Option<u32>,
 }
 
 fn assemble_static_project_context(
@@ -420,10 +589,181 @@ fn assemble_static_project_context(
 
     Ok(StaticProjectContext {
         module_search_paths,
+        site_packages_paths: site_packages_paths.to_vec(),
         settings_facts,
         app_registry,
         reasons: static_reasons,
     })
+}
+
+fn fact_len<T>(fact: &Fact<Vec<T>>) -> Option<usize> {
+    fact.value().map(Vec::len)
+}
+
+fn log_static_project_model_status(event: &str, status: &StaticProjectModelStatus) {
+    tracing::info!(
+        event,
+        django_settings_module = status.django_settings_module.as_deref().unwrap_or("<unset>"),
+        confidence = ?status.confidence,
+        module_search_path_count = status.module_search_path_count,
+        app_count = status.app_count,
+        template_dir_count = status.template_dir_count,
+        loadable_library_count = status.loadable_library_count,
+        builtin_count = status.builtin_count,
+        symbol_count = status.symbol_count,
+        reason_count = status.reasons.len(),
+        reasons = ?status.reasons,
+        "Static project model status",
+    );
+}
+
+fn static_template_library_cache_dependencies(
+    root: &Utf8Path,
+    context: &StaticProjectContext,
+    template_libraries: &Fact<Vec<TemplateLibraryFact>>,
+    snapshot: &Fact<TemplateLibrarySnapshot>,
+) -> Vec<StaticCacheDependency> {
+    let mut paths = Vec::new();
+    paths.extend(context.settings_facts.files_read.iter().cloned());
+
+    if let Some(search_paths) = context.module_search_paths.value() {
+        paths.extend(search_paths.iter().map(|entry| entry.path.clone()));
+        for entry in search_paths {
+            if entry.kind == ModuleSearchPathKind::SitePackages {
+                push_pth_files(&entry.path, &mut paths);
+            }
+        }
+    }
+    for site_packages_path in &context.site_packages_paths {
+        paths.push(site_packages_path.clone());
+        push_pth_files(site_packages_path, &mut paths);
+    }
+
+    if let Some(apps) = context.app_registry.app_registry.value() {
+        for app in apps {
+            paths.push(app.path.clone());
+            let templatetags_dir = app.path.join("templatetags");
+            paths.push(templatetags_dir.clone());
+            push_templatetag_python_files(&templatetags_dir, &mut paths);
+            if let Some(config) = &app.config {
+                paths.push(config.file.clone());
+            }
+        }
+    }
+
+    let Some(search_paths) = context.module_search_paths.value() else {
+        return cache_dependencies(paths);
+    };
+
+    if let Some(libraries) = template_libraries.value() {
+        for library in libraries {
+            if let Some(file) = resolved_module_file(&library.module, search_paths, root) {
+                paths.push(file);
+            }
+        }
+    }
+
+    if let Some(snapshot) = snapshot.value() {
+        for module in snapshot
+            .libraries
+            .values()
+            .chain(snapshot.builtins.iter())
+            .chain(snapshot.symbols.iter().map(|symbol| &symbol.library_module))
+            .chain(snapshot.symbols.iter().map(|symbol| &symbol.module))
+        {
+            let Ok(module) = PyModuleName::parse(module) else {
+                continue;
+            };
+            if let Some(file) = resolved_module_file(&module, search_paths, root) {
+                paths.push(file);
+            }
+        }
+    }
+
+    cache_dependencies(paths)
+}
+
+fn push_pth_files(site_packages_path: &Utf8Path, paths: &mut Vec<Utf8PathBuf>) {
+    let Ok(entries) = fs::read_dir(site_packages_path.as_std_path()) else {
+        return;
+    };
+
+    paths.extend(
+        entries
+            .filter_map(Result::ok)
+            .filter_map(|entry| Utf8PathBuf::try_from(entry.path()).ok())
+            .filter(|path| path.extension() == Some("pth") && path.is_file()),
+    );
+}
+
+fn push_templatetag_python_files(dir: &Utf8Path, paths: &mut Vec<Utf8PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir.as_std_path()) else {
+        return;
+    };
+
+    let mut entries = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| Utf8PathBuf::try_from(entry.path()).ok())
+        .collect::<Vec<_>>();
+    entries.sort();
+
+    for path in entries {
+        if path.is_dir() {
+            if path.join("__init__.py").is_file() {
+                paths.push(path.clone());
+                push_templatetag_python_files(&path, paths);
+            }
+        } else if path.extension() == Some("py") {
+            paths.push(path);
+        }
+    }
+}
+
+fn resolved_module_file(
+    module: &PyModuleName,
+    search_paths: &[ModuleSearchPathEntry],
+    root: &Utf8Path,
+) -> Option<Utf8PathBuf> {
+    let resolution = resolve_static_module(module.clone(), search_paths, root);
+    resolution
+        .resolved
+        .value()
+        .map(|resolved| resolved.file.clone())
+}
+
+fn cache_dependencies(paths: Vec<Utf8PathBuf>) -> Vec<StaticCacheDependency> {
+    let mut paths = paths;
+    paths.sort();
+    paths.dedup();
+    paths
+        .into_iter()
+        .map(StaticCacheDependency::from_path)
+        .collect()
+}
+
+impl StaticCacheDependency {
+    fn from_path(path: Utf8PathBuf) -> Self {
+        let timestamp = modified_timestamp(&path).ok();
+        Self {
+            path,
+            exists: timestamp.is_some(),
+            modified_unix_secs: timestamp.map(|(secs, _)| secs),
+            modified_subsec_nanos: timestamp.map(|(_, nanos)| nanos),
+        }
+    }
+
+    fn is_current(&self) -> bool {
+        let current = Self::from_path(self.path.clone());
+        current.exists == self.exists
+            && current.modified_unix_secs == self.modified_unix_secs
+            && current.modified_subsec_nanos == self.modified_subsec_nanos
+    }
+}
+
+fn modified_timestamp(path: &Utf8Path) -> std::io::Result<(u64, u32)> {
+    let modified = fs::metadata(path.as_std_path())?.modified()?;
+    let duration = modified.duration_since(UNIX_EPOCH).unwrap_or_default();
+    Ok((duration.as_secs(), duration.subsec_nanos()))
 }
 
 fn usable_static_template_library_snapshot(
@@ -526,6 +866,97 @@ fn save_template_library_snapshot_cache(
     );
 }
 
+fn load_static_template_library_snapshot_cache(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> Option<StaticTemplateLibraryCacheEntry> {
+    let interpreter = project.interpreter(db).clone();
+    let root = project.root(db).clone();
+    let django_settings_module = project.django_settings_module(db).clone();
+    let pythonpath = project.pythonpath(db).clone();
+    let site_packages_paths = find_site_packages(&interpreter, &root)
+        .into_iter()
+        .collect::<Vec<_>>();
+    load_static_template_library_snapshot(
+        &root,
+        &interpreter,
+        django_settings_module.as_deref(),
+        &pythonpath,
+        &site_packages_paths,
+    )
+}
+
+#[cfg(test)]
+fn load_static_template_library_snapshot_cache_from_dir(
+    db: &mut dyn ProjectDb,
+    project: Project,
+    dir: &Utf8Path,
+) -> bool {
+    let Some(entry) = load_static_template_library_snapshot_from_dir(dir) else {
+        return false;
+    };
+
+    apply_static_template_library_cache_entry(db, project, entry)
+}
+
+fn apply_static_template_library_cache_entry(
+    db: &mut dyn ProjectDb,
+    project: Project,
+    entry: StaticTemplateLibraryCacheEntry,
+) -> bool {
+    log_static_project_model_status("cache_load", &entry.status);
+    let usable = usable_static_template_library_snapshot(entry.snapshot.clone()).is_some();
+    if apply_static_template_library_snapshot(db, project, entry.snapshot) {
+        refresh_templatetag_modules(db, project);
+    }
+    usable
+}
+
+fn save_static_template_library_snapshot_cache(
+    db: &dyn ProjectDb,
+    project: Project,
+    assembly: &StaticTemplateLibrarySnapshotAssembly,
+) {
+    if assembly.dependencies.is_empty() {
+        tracing::debug!(
+            "Skipping static template library cache write because no dependency metadata was available"
+        );
+        return;
+    }
+
+    let interpreter = project.interpreter(db).clone();
+    let root = project.root(db).clone();
+    let django_settings_module = project.django_settings_module(db).clone();
+    let pythonpath = project.pythonpath(db).clone();
+    let site_packages_paths = find_site_packages(&interpreter, &root)
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    save_static_template_library_snapshot(
+        &root,
+        &interpreter,
+        django_settings_module.as_deref(),
+        &pythonpath,
+        &site_packages_paths,
+        assembly,
+    );
+}
+
+#[derive(Serialize, Deserialize)]
+struct StaticTemplateLibraryCacheEnvelope {
+    cache_version: String,
+    djls_version: String,
+    django_default_policy: String,
+    snapshot: Fact<TemplateLibrarySnapshot>,
+    status: StaticProjectModelStatus,
+    dependencies: Vec<StaticCacheDependency>,
+}
+
+struct StaticTemplateLibraryCacheEntry {
+    snapshot: Fact<TemplateLibrarySnapshot>,
+    status: StaticProjectModelStatus,
+}
+
 fn cache_key(
     root: &Utf8Path,
     interpreter: &Interpreter,
@@ -551,6 +982,42 @@ fn cache_key(
     key
 }
 
+fn static_template_library_cache_key(
+    root: &Utf8Path,
+    interpreter: &Interpreter,
+    django_settings_module: Option<&str>,
+    pythonpath: &[String],
+    site_packages_paths: &[Utf8PathBuf],
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(STATIC_TEMPLATE_LIBRARY_CACHE_VERSION.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
+    hasher.update(b"\0");
+    hasher.update(DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(root.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(format!("{interpreter:?}").as_bytes());
+    hasher.update(b"\0");
+    hasher.update(django_settings_module.unwrap_or("").as_bytes());
+    hasher.update(b"\0");
+    for path in pythonpath {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+    }
+    for path in site_packages_paths {
+        hasher.update(path.as_str().as_bytes());
+        hasher.update(b"\0");
+    }
+    let digest = hasher.finalize();
+    let mut key = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut key, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    key
+}
+
 fn cache_dir(
     root: &Utf8Path,
     interpreter: &Interpreter,
@@ -562,6 +1029,45 @@ fn cache_dir(
     let key = cache_key(root, interpreter, django_settings_module, pythonpath);
     // Keep the legacy `inspector` directory for on-disk cache compatibility.
     Some(base.join("inspector").join(&key[..16]))
+}
+
+fn static_template_library_cache_dir(
+    root: &Utf8Path,
+    interpreter: &Interpreter,
+    django_settings_module: Option<&str>,
+    pythonpath: &[String],
+    site_packages_paths: &[Utf8PathBuf],
+) -> Option<Utf8PathBuf> {
+    let base = djls_conf::project_dirs()
+        .and_then(|dirs| Utf8PathBuf::from_path_buf(dirs.cache_dir().to_path_buf()).ok())?;
+    Some(static_template_library_cache_dir_in(
+        &base,
+        root,
+        interpreter,
+        django_settings_module,
+        pythonpath,
+        site_packages_paths,
+    ))
+}
+
+fn static_template_library_cache_dir_in(
+    base: &Utf8Path,
+    root: &Utf8Path,
+    interpreter: &Interpreter,
+    django_settings_module: Option<&str>,
+    pythonpath: &[String],
+    site_packages_paths: &[Utf8PathBuf],
+) -> Utf8PathBuf {
+    let key = static_template_library_cache_key(
+        root,
+        interpreter,
+        django_settings_module,
+        pythonpath,
+        site_packages_paths,
+    );
+    base.join("static-project-model")
+        .join("template-libraries")
+        .join(&key[..16])
 }
 
 fn load_cached_template_library_snapshot(
@@ -588,6 +1094,73 @@ fn load_cached_template_library_snapshot(
 
     tracing::info!("Loaded template library snapshot from cache: {}", path);
     Some(envelope.response)
+}
+
+fn load_static_template_library_snapshot(
+    root: &Utf8Path,
+    interpreter: &Interpreter,
+    django_settings_module: Option<&str>,
+    pythonpath: &[String],
+    site_packages_paths: &[Utf8PathBuf],
+) -> Option<StaticTemplateLibraryCacheEntry> {
+    let dir = static_template_library_cache_dir(
+        root,
+        interpreter,
+        django_settings_module,
+        pythonpath,
+        site_packages_paths,
+    )?;
+    load_static_template_library_snapshot_from_dir(&dir)
+}
+
+fn load_static_template_library_snapshot_from_dir(
+    dir: &Utf8Path,
+) -> Option<StaticTemplateLibraryCacheEntry> {
+    let path = dir.join("snapshot.json");
+    let content = fs::read_to_string(path.as_std_path()).ok()?;
+    let envelope: StaticTemplateLibraryCacheEnvelope = serde_json::from_str(&content).ok()?;
+
+    if envelope.cache_version != STATIC_TEMPLATE_LIBRARY_CACHE_VERSION {
+        tracing::debug!(
+            "Static template library cache version mismatch: cached={}, current={}",
+            envelope.cache_version,
+            STATIC_TEMPLATE_LIBRARY_CACHE_VERSION,
+        );
+        return None;
+    }
+    if envelope.djls_version != env!("CARGO_PKG_VERSION") {
+        tracing::debug!(
+            "Static template library cache djls version mismatch: cached={}, current={}",
+            envelope.djls_version,
+            env!("CARGO_PKG_VERSION"),
+        );
+        return None;
+    }
+    if envelope.django_default_policy != DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY {
+        tracing::debug!(
+            "Static template library cache Django default policy mismatch: cached={}, current={}",
+            envelope.django_default_policy,
+            DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY,
+        );
+        return None;
+    }
+    if !envelope
+        .dependencies
+        .iter()
+        .all(StaticCacheDependency::is_current)
+    {
+        tracing::debug!("Static template library cache invalidated by dependency change");
+        return None;
+    }
+
+    tracing::info!(
+        "Loaded static template library snapshot from cache: {}",
+        path
+    );
+    Some(StaticTemplateLibraryCacheEntry {
+        snapshot: envelope.snapshot,
+        status: envelope.status,
+    })
 }
 
 fn save_template_library_snapshot(
@@ -630,6 +1203,67 @@ fn save_template_library_snapshot(
         }
         Err(e) => {
             tracing::warn!("Failed to serialize template library snapshot cache: {e}");
+        }
+    }
+}
+
+fn save_static_template_library_snapshot(
+    root: &Utf8Path,
+    interpreter: &Interpreter,
+    django_settings_module: Option<&str>,
+    pythonpath: &[String],
+    site_packages_paths: &[Utf8PathBuf],
+    assembly: &StaticTemplateLibrarySnapshotAssembly,
+) {
+    let Some(dir) = static_template_library_cache_dir(
+        root,
+        interpreter,
+        django_settings_module,
+        pythonpath,
+        site_packages_paths,
+    ) else {
+        return;
+    };
+
+    save_static_template_library_snapshot_to_dir(
+        &dir,
+        &assembly.snapshot,
+        &assembly.status,
+        &assembly.dependencies,
+    );
+}
+
+fn save_static_template_library_snapshot_to_dir(
+    dir: &Utf8Path,
+    snapshot: &Fact<TemplateLibrarySnapshot>,
+    status: &StaticProjectModelStatus,
+    dependencies: &[StaticCacheDependency],
+) {
+    let envelope = StaticTemplateLibraryCacheEnvelope {
+        cache_version: STATIC_TEMPLATE_LIBRARY_CACHE_VERSION.to_string(),
+        djls_version: env!("CARGO_PKG_VERSION").to_string(),
+        django_default_policy: DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY.to_string(),
+        snapshot: snapshot.clone(),
+        status: status.clone(),
+        dependencies: dependencies.to_vec(),
+    };
+
+    if let Err(e) = fs::create_dir_all(dir.as_std_path()) {
+        tracing::warn!("Failed to create static template library cache directory: {e}");
+        return;
+    }
+
+    let path = dir.join("snapshot.json");
+    match serde_json::to_string(&envelope) {
+        Ok(json) => {
+            if let Err(e) = fs::write(path.as_std_path(), json) {
+                tracing::warn!("Failed to write static template library cache: {e}");
+            } else {
+                tracing::debug!("Saved static template library snapshot to cache: {}", path);
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to serialize static template library cache: {e}");
         }
     }
 }
@@ -2104,6 +2738,587 @@ TEMPLATES = []
         let key1 = cache_key(Utf8Path::new("/project-a"), &interpreter, None, &pythonpath);
         let key2 = cache_key(Utf8Path::new("/project-b"), &interpreter, None, &pythonpath);
         assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn static_template_library_cache_uses_separate_namespace_and_inputs() {
+        let base = Utf8Path::new("/cache");
+        let root = Utf8Path::new("/project");
+        let interpreter = Interpreter::VenvPath("/project/.venv".to_string());
+        let pythonpath = vec!["/extra".to_string()];
+        let site_packages = vec![Utf8PathBuf::from("/project/.venv/site-packages")];
+
+        let dir = static_template_library_cache_dir_in(
+            base,
+            root,
+            &interpreter,
+            Some("project.settings"),
+            &pythonpath,
+            &site_packages,
+        );
+        assert!(dir
+            .as_str()
+            .contains("static-project-model/template-libraries"));
+        assert!(!dir.as_str().contains("inspector"));
+
+        let other_dir = static_template_library_cache_dir_in(
+            base,
+            root,
+            &interpreter,
+            Some("project.settings"),
+            &pythonpath,
+            &[Utf8PathBuf::from("/other/site-packages")],
+        );
+        assert_ne!(dir, other_dir);
+    }
+
+    #[test]
+    fn static_template_library_cache_roundtrips_and_invalidates_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        let dependency = root.join("project/settings.py");
+        write_file(&dependency, "INSTALLED_APPS = []\n");
+
+        let interpreter = Interpreter::VenvPath("/test/.venv".to_string());
+        let pythonpath: Vec<String> = vec![];
+        let snapshot = Fact::known(test_response());
+        let status = StaticProjectModelStatus::from_snapshot(
+            Some("project.settings"),
+            &snapshot,
+            Some(1),
+            Some(0),
+            Some(1),
+        );
+        let dependencies = vec![StaticCacheDependency::from_path(dependency.clone())];
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &interpreter,
+            Some("project.settings"),
+            &pythonpath,
+            &[],
+        );
+
+        save_static_template_library_snapshot_to_dir(&dir, &snapshot, &status, &dependencies);
+        let loaded = load_static_template_library_snapshot_from_dir(&dir)
+            .expect("static cache should load while dependencies are current");
+        let loaded_snapshot = loaded.snapshot.value().unwrap();
+        assert_eq!(loaded_snapshot.libraries.len(), 1);
+        assert_eq!(loaded_snapshot.builtins.len(), 1);
+        assert_eq!(loaded.status.confidence, Confidence::Known);
+        assert_eq!(loaded.status.app_count, Some(1));
+
+        fs::remove_file(dependency).unwrap();
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_rejects_version_and_policy_mismatches() {
+        let tmp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::try_from(tmp.path().join("cache-entry")).unwrap();
+        let dependency = dir.join("settings.py");
+        write_file(&dependency, "INSTALLED_APPS = []\n");
+
+        let snapshot = Fact::known(test_response());
+        let status = StaticProjectModelStatus::from_snapshot(
+            Some("project.settings"),
+            &snapshot,
+            Some(1),
+            Some(0),
+            Some(1),
+        );
+        let dependencies = vec![StaticCacheDependency::from_path(dependency)];
+
+        let mut envelope = StaticTemplateLibraryCacheEnvelope {
+            cache_version: STATIC_TEMPLATE_LIBRARY_CACHE_VERSION.to_string(),
+            djls_version: env!("CARGO_PKG_VERSION").to_string(),
+            django_default_policy: DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY.to_string(),
+            snapshot: snapshot.clone(),
+            status: status.clone(),
+            dependencies: dependencies.clone(),
+        };
+
+        envelope.cache_version = "old-cache".to_string();
+        write_static_template_library_cache_envelope(&dir, &envelope);
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+
+        envelope.cache_version = STATIC_TEMPLATE_LIBRARY_CACHE_VERSION.to_string();
+        envelope.djls_version = "0.0.bad".to_string();
+        write_static_template_library_cache_envelope(&dir, &envelope);
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+
+        envelope.djls_version = env!("CARGO_PKG_VERSION").to_string();
+        envelope.django_default_policy = "old-django-defaults".to_string();
+        write_static_template_library_cache_envelope(&dir, &envelope);
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+
+        envelope.django_default_policy = DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY.to_string();
+        write_static_template_library_cache_envelope(&dir, &envelope);
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+    }
+
+    fn write_static_template_library_cache_envelope(
+        dir: &Utf8Path,
+        envelope: &StaticTemplateLibraryCacheEnvelope,
+    ) {
+        fs::create_dir_all(dir.as_std_path()).unwrap();
+        fs::write(
+            dir.join("snapshot.json").as_std_path(),
+            serde_json::to_string(envelope).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_imported_settings_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(&root.join("project/settings/__init__.py"), "");
+        let base_settings = root.join("project/settings/base.py");
+        write_file(
+            &base_settings,
+            r"
+INSTALLED_APPS = []
+TEMPLATES = []
+",
+        );
+        let dev_settings = root.join("project/settings/dev.py");
+        write_file(&dev_settings, "from .base import *\n");
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings.dev"),
+            &[],
+            &[],
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == base_settings));
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == dev_settings));
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == root));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings.dev"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        fs::remove_file(base_settings).unwrap();
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_missing_imported_settings_candidates() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(&root.join("project/settings/__init__.py"), "");
+        let local_settings = root.join("project/settings/local.py");
+        let dev_settings = root.join("project/settings/dev.py");
+        write_file(&dev_settings, "from .local import *\n");
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings.dev"),
+            &[],
+            &[],
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| { dependency.path == local_settings && !dependency.exists }));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings.dev"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        write_file(&local_settings, "INSTALLED_APPS = []\nTEMPLATES = []\n");
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_missing_imported_settings_package_candidates() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(&root.join("project/settings/__init__.py"), "");
+        let local_package_settings = root.join("project/settings/local/__init__.py");
+        write_file(
+            &root.join("project/settings/dev.py"),
+            "from .local import *\n",
+        );
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings.dev"),
+            &[],
+            &[],
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| { dependency.path == local_package_settings && !dependency.exists }));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings.dev"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        write_file(
+            &local_package_settings,
+            "INSTALLED_APPS = []\nTEMPLATES = []\n",
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_app_config_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(
+            &root.join("project/settings.py"),
+            r#"
+INSTALLED_APPS = ["blog.apps.BlogConfig"]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    }
+]
+"#,
+        );
+        write_file(&root.join("blog/__init__.py"), "");
+        let apps_file = root.join("blog/apps.py");
+        write_file(
+            &apps_file,
+            r#"
+from django.apps import AppConfig
+
+class BlogConfig(AppConfig):
+    name = "blog"
+"#,
+        );
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == apps_file));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        fs::remove_file(apps_file).unwrap();
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_pth_files() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        let site_packages = Utf8PathBuf::try_from(tmp.path().join("site-packages")).unwrap();
+        let pth_root = Utf8PathBuf::try_from(tmp.path().join("editable")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(
+            &root.join("project/settings.py"),
+            "INSTALLED_APPS = []\nTEMPLATES = []\n",
+        );
+        write_file(&pth_root.join("pkg/__init__.py"), "");
+        let pth_file = site_packages.join("editable.pth");
+        write_file(&pth_file, "../editable\n");
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings"),
+            &[],
+            std::slice::from_ref(&site_packages),
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == pth_file));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings"),
+            &[],
+            std::slice::from_ref(&site_packages),
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        fs::remove_file(pth_file).unwrap();
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_filtered_templatetag_files() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(
+            &root.join("project/settings.py"),
+            r#"
+INSTALLED_APPS = ["blog"]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    }
+]
+"#,
+        );
+        write_file(&root.join("blog/__init__.py"), "");
+        write_file(&root.join("blog/templatetags/__init__.py"), "");
+        let helper_file = root.join("blog/templatetags/helper.py");
+        write_file(&helper_file, "HELPER = True\n");
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == helper_file));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        fs::remove_file(helper_file).unwrap();
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn static_template_library_cache_tracks_nested_templatetag_package_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(
+            &root.join("project/settings.py"),
+            r#"
+INSTALLED_APPS = ["blog"]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    }
+]
+"#,
+        );
+        write_file(&root.join("blog/__init__.py"), "");
+        write_file(&root.join("blog/templatetags/__init__.py"), "");
+        let nested_dir = root.join("blog/templatetags/nested");
+        write_file(&nested_dir.join("__init__.py"), "");
+
+        let assembly = assemble_static_template_library_snapshot_with_status(
+            &root,
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        assert!(assembly
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.path == nested_dir));
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &Interpreter::VenvPath("/test/.venv".to_string()),
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_some());
+
+        write_file(
+            &nested_dir.join("new_tags.py"),
+            "from django import template\nregister = template.Library()\n",
+        );
+        assert!(load_static_template_library_snapshot_from_dir(&dir).is_none());
+    }
+
+    #[test]
+    fn startup_cache_can_load_static_template_library_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let base = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        let dependency = root.join("project/settings.py");
+        write_file(&dependency, "INSTALLED_APPS = []\n");
+
+        let interpreter = Interpreter::VenvPath("/test/.venv".to_string());
+        let snapshot = Fact::known(test_response());
+        let status = StaticProjectModelStatus::from_snapshot(
+            Some("project.settings"),
+            &snapshot,
+            Some(1),
+            Some(0),
+            Some(1),
+        );
+        let assembly = StaticTemplateLibrarySnapshotAssembly {
+            snapshot,
+            status,
+            dependencies: vec![StaticCacheDependency::from_path(dependency)],
+        };
+
+        let dir = static_template_library_cache_dir_in(
+            &base,
+            &root,
+            &interpreter,
+            Some("project.settings"),
+            &[],
+            &[],
+        );
+        save_static_template_library_snapshot_to_dir(
+            &dir,
+            &assembly.snapshot,
+            &assembly.status,
+            &assembly.dependencies,
+        );
+        assert!(dir.join("snapshot.json").is_file());
+
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options(
+            root,
+            interpreter,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        assert!(load_static_template_library_snapshot_cache_from_dir(
+            &mut db, project, &dir,
+        ));
+        assert!(project
+            .template_libraries(&db)
+            .is_enabled_library_str("i18n"));
+    }
+
+    #[test]
+    fn static_cache_refresh_short_circuits_when_snapshot_is_already_applied() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        let snapshot = Fact::known(test_response());
+        let status = StaticProjectModelStatus::from_snapshot(
+            Some("project.settings"),
+            &snapshot,
+            Some(1),
+            Some(0),
+            Some(1),
+        );
+        let entry = StaticTemplateLibraryCacheEntry {
+            snapshot: snapshot.clone(),
+            status,
+        };
+        let (mut db, project) =
+            StaticSnapshotTestDb::with_project(root, Some("project.settings".to_string()));
+
+        assert!(apply_static_template_library_snapshot(
+            &mut db, project, snapshot,
+        ));
+        assert!(refresh_template_libraries_from_static_cache(
+            &mut db,
+            project,
+            Some(entry),
+        ));
+        assert!(project
+            .template_libraries(&db)
+            .is_enabled_library_str("i18n"));
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -4,12 +4,14 @@
 //! Django, Python, and the filesystem for facts, then writes changed facts to
 //! the `Project` input. Pure semantic derivation stays in tracked queries.
 
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs;
 use std::time::UNIX_EPOCH;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use djls_conf::ProjectModelMode;
 use djls_source::FileRootKind;
 use djls_source::Utf8PathClean;
 use ignore::WalkBuilder;
@@ -118,6 +120,32 @@ impl IntrospectionRequest for TemplateDirsRequest {
 }
 
 fn refresh_template_dirs(db: &mut dyn ProjectDb, project: Project) {
+    match project.project_model(db) {
+        ProjectModelMode::Auto => refresh_template_dirs_auto(db, project),
+        ProjectModelMode::Static => refresh_template_dirs_static(db, project),
+        ProjectModelMode::Inspector => refresh_template_dirs_inspector(db, project),
+    }
+}
+
+fn refresh_template_dirs_auto(db: &mut dyn ProjectDb, project: Project) {
+    let static_dirs = assemble_project_static_template_dirs(db, project);
+    log_static_template_dirs_status(project.django_settings_module(db).as_deref(), &static_dirs);
+    if usable_static_template_dirs(static_dirs.clone()).is_some() {
+        apply_static_template_dirs(db, project, static_dirs);
+        return;
+    }
+
+    let inspector_dirs = fetch_template_dirs(db);
+    apply_template_dirs_or_static_fallback(db, project, inspector_dirs, Some(static_dirs));
+}
+
+fn refresh_template_dirs_static(db: &mut dyn ProjectDb, project: Project) {
+    let static_dirs = assemble_project_static_template_dirs(db, project);
+    log_static_template_dirs_status(project.django_settings_module(db).as_deref(), &static_dirs);
+    apply_static_template_dirs(db, project, static_dirs);
+}
+
+fn refresh_template_dirs_inspector(db: &mut dyn ProjectDb, project: Project) {
     let inspector_dirs = fetch_template_dirs(db);
     let static_dirs = inspector_dirs
         .is_none()
@@ -273,6 +301,58 @@ impl IntrospectionRequest for TemplateLibrarySnapshotRequest {
 }
 
 fn load_project_template_library_cache(db: &mut dyn ProjectDb, project: Project) -> bool {
+    match project.project_model(db) {
+        ProjectModelMode::Auto => load_project_template_library_cache_auto(db, project),
+        ProjectModelMode::Static => load_project_template_library_cache_static(db, project),
+        ProjectModelMode::Inspector => load_project_template_library_cache_inspector(db, project),
+    }
+}
+
+fn load_project_template_library_cache_auto(db: &mut dyn ProjectDb, project: Project) -> bool {
+    let static_entry = load_static_template_library_snapshot_cache(db, project);
+    if static_entry
+        .as_ref()
+        .and_then(static_template_library_cache_entry_knowledge)
+        == Some(Knowledge::Known)
+    {
+        let entry = static_entry.expect("known static cache entry should exist");
+        return apply_static_template_library_cache_entry(db, project, entry);
+    }
+
+    let inspector_snapshot = load_template_library_snapshot_cache(db, project);
+    apply_auto_template_library_cache(db, project, static_entry, inspector_snapshot)
+}
+
+fn apply_auto_template_library_cache(
+    db: &mut dyn ProjectDb,
+    project: Project,
+    static_entry: Option<StaticTemplateLibraryCacheEntry>,
+    inspector_snapshot: Option<TemplateLibrarySnapshot>,
+) -> bool {
+    if let Some(snapshot) = inspector_snapshot {
+        if apply_template_library_snapshot(db, project, snapshot) {
+            refresh_templatetag_modules(db, project);
+        }
+
+        return true;
+    }
+
+    let Some(entry) = static_entry else {
+        return false;
+    };
+
+    apply_static_template_library_cache_entry(db, project, entry)
+}
+
+fn load_project_template_library_cache_static(db: &mut dyn ProjectDb, project: Project) -> bool {
+    let Some(entry) = load_static_template_library_snapshot_cache(db, project) else {
+        return false;
+    };
+
+    apply_static_template_library_cache_entry(db, project, entry)
+}
+
+fn load_project_template_library_cache_inspector(db: &mut dyn ProjectDb, project: Project) -> bool {
     let Some(snapshot) = load_template_library_snapshot_cache(db, project) else {
         let Some(entry) = load_static_template_library_snapshot_cache(db, project) else {
             return false;
@@ -288,6 +368,60 @@ fn load_project_template_library_cache(db: &mut dyn ProjectDb, project: Project)
 }
 
 fn refresh_template_libraries(db: &mut dyn ProjectDb, project: Project) {
+    match project.project_model(db) {
+        ProjectModelMode::Auto => refresh_template_libraries_auto(db, project),
+        ProjectModelMode::Static => refresh_template_libraries_static(db, project),
+        ProjectModelMode::Inspector => refresh_template_libraries_inspector(db, project),
+    }
+}
+
+fn refresh_template_libraries_auto(db: &mut dyn ProjectDb, project: Project) {
+    if let Some(entry) = load_static_template_library_snapshot_cache(db, project) {
+        if static_template_library_cache_entry_knowledge(&entry) == Some(Knowledge::Known) {
+            apply_static_template_library_cache_entry(db, project, entry);
+            return;
+        }
+
+        if let Some(snapshot) = fetch_template_library_snapshot(db) {
+            save_template_library_snapshot_cache(db, project, &snapshot);
+            apply_template_library_snapshot(db, project, snapshot);
+            return;
+        }
+
+        apply_static_template_library_cache_entry(db, project, entry);
+        return;
+    }
+
+    let assembly = assemble_project_static_template_library_snapshot_with_status(db, project);
+    log_static_project_model_status("assembled", &assembly.status);
+    save_static_template_library_snapshot_cache(db, project, &assembly);
+    if static_template_library_snapshot_knowledge(&assembly.snapshot) == Some(Knowledge::Known) {
+        apply_static_template_library_snapshot(db, project, assembly.snapshot);
+        return;
+    }
+
+    if let Some(snapshot) = fetch_template_library_snapshot(db) {
+        save_template_library_snapshot_cache(db, project, &snapshot);
+        apply_template_library_snapshot(db, project, snapshot);
+        return;
+    }
+
+    apply_static_template_library_snapshot(db, project, assembly.snapshot);
+}
+
+fn refresh_template_libraries_static(db: &mut dyn ProjectDb, project: Project) {
+    let static_cache_entry = load_static_template_library_snapshot_cache(db, project);
+    if refresh_template_libraries_from_static_cache(db, project, static_cache_entry) {
+        return;
+    }
+
+    let assembly = assemble_project_static_template_library_snapshot_with_status(db, project);
+    log_static_project_model_status("assembled", &assembly.status);
+    save_static_template_library_snapshot_cache(db, project, &assembly);
+    apply_static_template_library_snapshot(db, project, assembly.snapshot);
+}
+
+fn refresh_template_libraries_inspector(db: &mut dyn ProjectDb, project: Project) {
     if let Some(snapshot) = fetch_template_library_snapshot(db) {
         save_template_library_snapshot_cache(db, project, &snapshot);
         apply_template_library_snapshot(db, project, snapshot);
@@ -350,6 +484,18 @@ fn refresh_template_libraries_from_static_cache(
     true
 }
 
+fn static_template_library_cache_entry_knowledge(
+    entry: &StaticTemplateLibraryCacheEntry,
+) -> Option<Knowledge> {
+    static_template_library_snapshot_knowledge(&entry.snapshot)
+}
+
+fn static_template_library_snapshot_knowledge(
+    snapshot: &Fact<TemplateLibrarySnapshot>,
+) -> Option<Knowledge> {
+    usable_static_template_library_snapshot(snapshot.clone()).map(|(_, knowledge)| knowledge)
+}
+
 fn fetch_template_library_snapshot(db: &dyn ProjectDb) -> Option<TemplateLibrarySnapshot> {
     db.project_introspector()
         .query(db, &TemplateLibrarySnapshotRequest)
@@ -395,10 +541,23 @@ fn apply_static_template_library_snapshot(
     snapshot: Fact<TemplateLibrarySnapshot>,
 ) -> bool {
     let Some((snapshot, knowledge)) = usable_static_template_library_snapshot(snapshot) else {
-        return false;
+        return apply_template_library_snapshot_with_knowledge(
+            db,
+            project,
+            empty_template_library_snapshot(),
+            Knowledge::Unknown,
+        );
     };
 
     apply_template_library_snapshot_with_knowledge(db, project, snapshot, knowledge)
+}
+
+fn empty_template_library_snapshot() -> TemplateLibrarySnapshot {
+    TemplateLibrarySnapshot {
+        symbols: Vec::new(),
+        libraries: BTreeMap::default(),
+        builtins: Vec::new(),
+    }
 }
 
 fn assemble_static_template_library_snapshot_with_status(
@@ -1602,11 +1761,28 @@ mod tests {
             django_settings_module: Option<String>,
             pythonpath: Vec<String>,
         ) -> (Self, Project) {
+            Self::with_project_options_and_model(
+                root,
+                interpreter,
+                ProjectModelMode::Inspector,
+                django_settings_module,
+                pythonpath,
+            )
+        }
+
+        fn with_project_options_and_model(
+            root: Utf8PathBuf,
+            interpreter: Interpreter,
+            project_model: ProjectModelMode,
+            django_settings_module: Option<String>,
+            pythonpath: Vec<String>,
+        ) -> (Self, Project) {
             let mut db = Self::new();
             let project = Project::new(
                 &db,
                 root,
                 interpreter,
+                project_model,
                 django_settings_module,
                 pythonpath,
                 Vec::new(),
@@ -1659,6 +1835,10 @@ mod tests {
             )]),
             builtins: vec!["django.template.defaulttags".to_string()],
         }
+    }
+
+    fn missing_interpreter(root: &Utf8Path) -> Interpreter {
+        Interpreter::InterpreterPath(root.join("missing-python").to_string())
     }
 
     fn write_file(path: &Utf8Path, contents: &str) {
@@ -2232,6 +2412,102 @@ def emph(value):
     }
 
     #[test]
+    fn auto_template_dirs_use_known_static_without_inspector_query() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_static_template_dirs_fixture(&root);
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_dirs(&mut db, project);
+
+        assert_eq!(db.introspector.query_count(), 0);
+        assert_eq!(
+            project.template_dirs(&db),
+            &TemplateDirs::Known(vec![root.join("templates"), root.join("blog/templates")])
+        );
+    }
+
+    #[test]
+    fn static_template_dirs_do_not_query_inspector_for_partial_static_data() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(
+            &root.join("project/settings.py"),
+            r#"
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+INSTALLED_APPS = ["missing"]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {},
+    }
+]
+"#,
+        );
+        write_file(&root.join("templates/base.html"), "");
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Static,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_dirs(&mut db, project);
+
+        assert_eq!(db.introspector.query_count(), 0);
+        assert_eq!(project.template_dirs(&db), &TemplateDirs::Unknown);
+    }
+
+    #[test]
+    fn auto_template_dirs_query_inspector_for_partial_static_data() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&root.join("project/__init__.py"), "");
+        write_file(
+            &root.join("project/settings.py"),
+            r#"
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+INSTALLED_APPS = ["missing"]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {},
+    }
+]
+"#,
+        );
+        write_file(&root.join("templates/base.html"), "");
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_dirs(&mut db, project);
+
+        assert_eq!(db.introspector.query_count(), 1);
+        assert_eq!(project.template_dirs(&db), &TemplateDirs::Unknown);
+    }
+
+    #[test]
     fn template_dirs_routing_does_not_assemble_static_when_inspector_dirs_exist() {
         let tmp = TempDir::new().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
@@ -2575,6 +2851,124 @@ TEMPLATES = []
 
         let libraries = project.template_libraries(&db);
         assert!(libraries.is_enabled_library_str("blog_tags"));
+    }
+
+    #[test]
+    fn auto_template_libraries_use_known_static_without_inspector_query() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_static_template_fixture(&root);
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_libraries(&mut db, project);
+
+        assert_eq!(db.introspector.query_count(), 0);
+        assert!(project
+            .template_libraries(&db)
+            .is_enabled_library_str("blog_tags"));
+    }
+
+    #[test]
+    fn static_template_libraries_clear_stale_active_libraries_when_static_is_unusable() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Static,
+            None,
+            Vec::new(),
+        );
+        assert!(apply_template_library_snapshot(
+            &mut db,
+            project,
+            TemplateLibrarySnapshot {
+                symbols: Vec::new(),
+                libraries: BTreeMap::from([(
+                    "inspector_only".to_string(),
+                    "inspector.templatetags.only".to_string(),
+                )]),
+                builtins: Vec::new(),
+            },
+        ));
+
+        refresh_template_libraries(&mut db, project);
+
+        let libraries = project.template_libraries(&db);
+        assert_eq!(db.introspector.query_count(), 0);
+        assert_eq!(libraries.active_knowledge, Knowledge::Unknown);
+        assert!(!libraries.is_enabled_library_str("inspector_only"));
+    }
+
+    #[test]
+    fn auto_template_libraries_query_inspector_for_partial_static_data() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_static_template_fixture(&root);
+        fs::remove_file(root.join("django/templatetags/i18n.py")).unwrap();
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_libraries(&mut db, project);
+
+        let libraries = project.template_libraries(&db);
+        assert_eq!(db.introspector.query_count(), 1);
+        assert_eq!(libraries.active_knowledge, Knowledge::Partial);
+        assert!(libraries.is_enabled_library_str("blog_tags"));
+    }
+
+    #[test]
+    fn static_template_libraries_do_not_query_inspector_for_partial_static_data() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_static_template_fixture(&root);
+        fs::remove_file(root.join("django/templatetags/i18n.py")).unwrap();
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Static,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_libraries(&mut db, project);
+
+        let libraries = project.template_libraries(&db);
+        assert_eq!(db.introspector.query_count(), 0);
+        assert_eq!(libraries.active_knowledge, Knowledge::Partial);
+        assert!(libraries.is_enabled_library_str("blog_tags"));
+    }
+
+    #[test]
+    fn inspector_template_libraries_query_inspector_before_static_fallback() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_static_template_fixture(&root);
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Inspector,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_template_libraries(&mut db, project);
+
+        assert_eq!(db.introspector.query_count(), 1);
+        assert!(project
+            .template_libraries(&db)
+            .is_enabled_library_str("blog_tags"));
     }
 
     #[test]
@@ -3287,6 +3681,57 @@ TEMPLATES = [
         assert!(project
             .template_libraries(&db)
             .is_enabled_library_str("i18n"));
+    }
+
+    #[test]
+    fn auto_startup_cache_uses_inspector_cache_when_static_cache_is_partial() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+        let static_snapshot = Fact::partial(
+            test_response(),
+            vec![Reason::path(
+                Field::TemplateLibraries,
+                root.clone(),
+                "partial static cache entry",
+            )],
+        );
+        let status = StaticProjectModelStatus::from_snapshot(
+            Some("project.settings"),
+            &static_snapshot,
+            Some(1),
+            Some(0),
+            Some(1),
+        );
+        let static_entry = StaticTemplateLibraryCacheEntry {
+            snapshot: static_snapshot,
+            status,
+        };
+        let inspector_snapshot = TemplateLibrarySnapshot {
+            symbols: Vec::new(),
+            libraries: BTreeMap::from([(
+                "inspector_only".to_string(),
+                "inspector.templatetags.only".to_string(),
+            )]),
+            builtins: Vec::new(),
+        };
+
+        assert!(apply_auto_template_library_cache(
+            &mut db,
+            project,
+            Some(static_entry),
+            Some(inspector_snapshot),
+        ));
+
+        let libraries = project.template_libraries(&db);
+        assert!(libraries.is_enabled_library_str("inspector_only"));
+        assert!(!libraries.is_enabled_library_str("i18n"));
     }
 
     #[test]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -50,18 +50,72 @@ If you prefer not to use an env file:
 
 ## Options
 
+### `project_model`
+
+**Default:** `"auto"`
+
+Selects how djls builds Django project facts for template directories, active template tag libraries, builtins, and symbols.
+
+Supported values:
+
+- `"auto"` — Build the static project model first. When static facts are known, djls uses them without starting the Python inspector. When static facts are partial or unknown, djls can fall back to the inspector during the transition period.
+- `"static"` — Use only the static project model. This avoids the Python inspector, `django.setup()`, and runtime imports. If settings are too dynamic to understand statically, djls degrades conservatively and suppresses diagnostics that would risk false positives.
+- `"inspector"` — Use the legacy Python/Django inspector path first. This keeps the runtime behavior used by older releases while the static model rollout continues.
+
+```toml
+[tool.djls]
+project_model = "auto"
+```
+
+Use `"static"` when you want editor behavior that does not run Django. Use `"inspector"` if a dynamic project still needs the runtime fallback while static support catches up.
+
 ### `django_settings_module`
 
 **Default:** `DJANGO_SETTINGS_MODULE` environment variable
 
 Your Django settings module path (e.g., `"myproject.settings"`).
 
-The server uses this to introspect your Django project and provide template tag completions, diagnostics, and navigation. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
+The server uses this to build Django project facts for template tag completions, diagnostics, and navigation. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
 
 **When to configure:**
 
 - Your editor doesn't pass environment variables to LSP servers (e.g., Sublime Text)
 - You need to override the environment variable for a specific workspace
+
+### `django_environments`
+
+**Default:** `[]` (empty list)
+
+Path-scoped Django settings modules for monorepos or workspaces with more than one Django project.
+
+```toml
+[tool.djls]
+pythonpath = ["projects", "apps"]
+
+[[tool.djls.django_environments]]
+root = "projects/site1"
+django_settings_module = "site1.settings.dev"
+
+[[tool.djls.django_environments]]
+root = "projects/site2"
+django_settings_module = "site2.settings.dev"
+```
+
+Use this when one workspace contains multiple Django settings modules and each applies to a different subtree. Static project model facts stay tied to their environment. Completions can use the union of known facts, while diagnostics only use facts that are safe for the template's environment and suppress unsafe absence claims.
+
+### `django_settings_file_patterns`
+
+**Default:** `[]` (empty list)
+
+Glob patterns for discovering Django settings files and mapping them back to module names through the configured module search paths.
+
+```toml
+[tool.djls]
+pythonpath = ["projects", "apps"]
+django_settings_file_patterns = ["projects/*/settings/dev.py"]
+```
+
+Use this for repetitive monorepo layouts where each project follows the same split-settings pattern. Do not configure this together with `django_environments`; explicit environments are clearer when roots do not follow a pattern.
 
 ### `venv_path`
 
@@ -80,7 +134,7 @@ The server needs access to your virtual environment to discover installed Django
 
 **Default:** `[]` (empty list)
 
-Additional directories to add to Python's import search path when the inspector process runs. These paths are added to `PYTHONPATH` alongside the project root and any existing `PYTHONPATH` environment variable.
+Additional directories to add to Python's import search path. Static project model discovery uses these paths as module search roots. The inspector also adds them to `PYTHONPATH` alongside the project root and any existing `PYTHONPATH` environment variable.
 
 **When to configure:**
 
@@ -103,6 +157,9 @@ If no `env_file` is configured, the server looks for a `.env` file in the projec
 
 - Your `.env` file has a non-standard name (e.g., `.env.local`, `.env.development`)
 - Your `.env` file lives in a subdirectory
+
+!!! note
+    `env_file` is only needed by runtime Django settings. In `project_model = "static"`, djls does not execute your settings module, but static extraction may still need `django_settings_module` and `pythonpath` to find the right files.
 
 ### `tagspecs`
 
@@ -171,13 +228,13 @@ Map diagnostic codes or prefixes to severity levels. Supports:
     S108 = "warning" # New
     ```
 
-*Tag Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
+*Tag Scoping (requires [project model facts](../template-validation.md#project-model-availability)):*
 
 - `S108` - Unknown tag (not found in any known library or in the Python environment)
 - `S109` - Unloaded tag (requires `{% load %}` for a specific library)
 - `S110` - Ambiguous unloaded tag (defined in multiple libraries)
 
-*Filter Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
+*Filter Scoping (requires [project model facts](../template-validation.md#project-model-availability)):*
 
 - `S111` - Unknown filter (not found in any known library or in the Python environment)
 - `S112` - Unloaded filter (requires `{% load %}` for a specific library)
@@ -193,11 +250,11 @@ Map diagnostic codes or prefixes to severity levels. Supports:
 
 - `S117` - Tag argument rule violation (e.g., wrong number of arguments, missing required keyword)
 
-*Environment-Aware Resolution (requires [inspector](../template-validation.md#inspector-availability) and [environment scanner](../template-validation.md#environment-scanner)):*
+*Environment-Aware Resolution (requires [project model facts](../template-validation.md#project-model-availability) and [environment scanner](../template-validation.md#environment-scanner)):*
 
 - `S118` - Tag not in `INSTALLED_APPS` (installed package, but Django app not activated)
 - `S119` - Filter not in `INSTALLED_APPS` (installed package, but Django app not activated)
-- `S120` - Unknown template tag library (not found in inspector or environment)
+- `S120` - Unknown template tag library (not found in the project model or Python environment)
 - `S121` - Library not in `INSTALLED_APPS` (installed package, but Django app not activated)
 
 *Extends Validation:*
@@ -295,6 +352,7 @@ Pass configuration through your editor's LSP client using `initializationOptions
 
 ```json
 {
+  "project_model": "auto",
   "django_settings_module": "myproject.settings",
   "venv_path": "/path/to/venv",
   "pythonpath": ["/path/to/shared/libs"],
@@ -320,6 +378,7 @@ If you use `pyproject.toml`, add a `[tool.djls]` section:
 
 ```toml
 [tool.djls]
+project_model = "auto"
 django_settings_module = "myproject.settings"
 venv_path = "/path/to/venv"  # Optional: only if auto-detection fails
 pythonpath = ["/path/to/shared/libs"]  # Optional: additional import paths

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -6,15 +6,28 @@ Django Language Server validates your Django templates as you write them, catchi
 
 Template validation relies on three systems working together:
 
-### Inspector
+### Project Model
 
-The **inspector** is a Python process that introspects your running Django project to discover:
+The **project model** describes the Django facts djls needs for templates:
 
 - Which template tags and filters exist
 - Which libraries they belong to (builtins vs third-party)
 - Which library load-name maps to which module
+- Which template directories Django searches
 
-This gives djls an accurate picture of your project's template tag ecosystem — the same tags Django would see at runtime. The inspector reflects your `INSTALLED_APPS` configuration, so it only reports tags and filters from apps that are actually activated.
+By default, `project_model = "auto"` builds these facts statically from your workspace, `django_settings_module`, `pythonpath`, and available source files. When static facts are known, djls can provide scoped completions and diagnostics without spawning Python or calling `django.setup()`.
+
+During the transition, auto mode can still fall back to the Python inspector when static facts are partial or unknown. You can force one path with [`project_model`](configuration/index.md#project_model):
+
+- `"auto"` — static first, inspector fallback for partial/unknown facts
+- `"static"` — static only, no inspector subprocess
+- `"inspector"` — legacy runtime inspector first
+
+The static model tracks confidence. Known facts enable scoped availability diagnostics. Partial or unknown facts still allow diagnostics backed by positive facts, but suppress absence-based diagnostics unless inspector fallback supplies known facts.
+
+### Inspector
+
+The **inspector** is the legacy Python process that introspects your running Django project. It remains available as a fallback during the static project model rollout.
 
 ### Environment Scanner
 
@@ -34,7 +47,7 @@ The **extraction engine** analyzes Python source code (using static AST analysis
 - **Filter arity** — whether a filter expects an argument (e.g., `{{ value|default:"nothing" }}`)
 - **Expression syntax** — valid operator usage in `{% if %}` / `{% elif %}` expressions
 
-Together, the inspector tells djls *what's active in your project*, the environment scanner tells djls *what's installed*, and extraction tells djls *how to validate usage*.
+Together, the project model tells djls *what's active in your project*, the environment scanner tells djls *what's installed*, and extraction tells djls *how to validate usage*.
 
 ## Three-Layer Resolution
 
@@ -96,7 +109,7 @@ Validates that template filters are available at their point of use, with the sa
 
 Validates that `{% load %}` library names refer to known template tag libraries:
 
-- **S120** — Unknown library (not found in the inspector inventory or the Python environment)
+- **S120** — Unknown library (not found in the project model or the Python environment)
 - **S121** — Library not in `INSTALLED_APPS` (the library exists in an installed package, but its Django app isn't activated)
 
 ### Extends Validation (S122–S123)
@@ -137,25 +150,29 @@ Django templates are deeply dynamic — many things can only be checked at runti
 - **Dynamic tag behavior** — Tags whose validation depends on runtime state
 - **Format strings** — Whether date/time format strings are valid
 
-## Inspector Availability
+## Project Model Availability
 
-The inspector requires a working Django environment (correct `DJANGO_SETTINGS_MODULE`, virtual environment with Django installed, no import errors during Django setup).
+The static project model needs enough source files and configuration to find your Django settings, installed apps, template directories, and templatetag modules. For typical literal or split settings, it can work without a configured Python runtime.
 
-When the inspector is **healthy**:
+When project model facts are **known**:
 
-- Full validation is active — all S108–S121 diagnostics are emitted
+- Scoped tag, filter, and library availability diagnostics can run from project facts
 - Completions are scoped to loaded libraries at cursor position
+- Argument and arity diagnostics run when extraction or built-in specs provide rules
 
-When the inspector is **unavailable** (Django init failed, Python not configured, etc.):
+When project model facts are **partial or unknown**:
 
-- **S108–S113, S118–S121 are suppressed** — Without knowing which tags/filters exist, djls cannot determine if something is unknown, unloaded, or not in `INSTALLED_APPS`
-- **S115–S116 are suppressed** — Filter arity rules come from extraction, which depends on knowing the source modules
-- **S117 is suppressed** — Tag argument rules come from extraction, which depends on the inspector discovering tag source modules
+- **Absence-based diagnostics are suppressed when unsafe** — Without complete project facts, djls avoids claiming that a tag, filter, or library is unknown or missing from `INSTALLED_APPS` (S108, S111, S118, S119, S120, S121)
+- **Positive-fact diagnostics can still run** — Known but unloaded or ambiguous tags and filters can still produce S109, S110, S112, and S113
+- **Known argument rules can still run** — Tag argument diagnostics (S117) run when extraction or built-in specs provide the needed rules
+- **Known arity rules can still run with positive project facts** — Filter arity diagnostics (S115–S116) run when active project facts include known filters and extraction or built-in specs provide the needed rules
 - **S100–S103 still work** — Block structure validation uses built-in tag specs
 - **S114 still works** — Expression syntax validation is purely structural
 - **Completions show all known tags** — Without library scoping, all tags are offered as a fallback
 
 This design avoids false positives when the Python environment isn't available.
+
+In `project_model = "auto"`, the inspector can still fill gaps for partial or unknown static facts. In `project_model = "static"`, djls does not fall back to the inspector.
 
 ## Configuring Diagnostic Severity
 


### PR DESCRIPTION
## Summary

Consolidates the rollout/status review unit after the manifest-selector correction:

- adds static project model cache/status reporting
- adds static-first project model modes with inspector fallback retained
- adds manifest-selector static assembly fixture coverage
- documents rollout modes and confidence behavior
- keeps corpus project selection in `manifest.toml` without authored expected analyzer output

## Stack Context

This is 7/11 in the static project model review stack.

Review order: #615 -> #605 -> #606 -> #613 -> #607 -> #608 -> #609 -> #610 -> #611 -> #612 -> #614.

Review focus: rollout modes, status reporting, docs, and baseline corpus selector coverage.

## Consolidation Notes

This keeps the user-visible rollout behavior, observability, docs, and baseline corpus evidence together. During restack, the old profile expected-output file was removed in favor of the manifest-selector shape introduced by #615.

## Validation

- Restack check: `cargo test -q -p djls-corpus`
- Restack check: `cargo test -q -p djls-semantic gh401_fixture_static_assembly_matches_manifest_settings_modules --no-default-features`
- Restack check: `cargo test -q -p djls-semantic static --no-default-features`
- Restack check: `cargo test -q -p djls-semantic sync::tests --no-default-features`