### PR TITLE
Preserve resolver confidence details

### DIFF
--- a/crates/djls-semantic/src/project/module_resolver.rs
+++ b/crates/djls-semantic/src/project/module_resolver.rs
@@ -24,7 +24,6 @@ use crate::project::names::PyModuleName;
 
 struct ModuleCandidate {
     module: ResolvedModule,
-    reasons: Vec<Reason>,
 }
 
 #[must_use]
@@ -130,14 +129,7 @@ pub(crate) fn resolve_module(
                 requested.as_str()
             ),
         )]),
-        1 => {
-            let candidate = candidates.pop().unwrap();
-            if candidate.reasons.is_empty() {
-                Fact::known(candidate.module)
-            } else {
-                Fact::partial(candidate.module, candidate.reasons)
-            }
-        }
+        1 => Fact::known(candidates.pop().unwrap().module),
         _ => Fact::ambiguous(
             candidates
                 .into_iter()
@@ -186,14 +178,8 @@ pub(crate) fn module_name_for_file(
             "module file is outside configured module search paths",
         )]),
         1 => {
-            let (module, search_path) = candidates.into_iter().next().unwrap();
-            let parts = module.as_str().split('.').collect::<Vec<_>>();
-            let reasons = namespace_package_reasons(&parts, &search_path);
-            if reasons.is_empty() {
-                Fact::known(module)
-            } else {
-                Fact::partial(module, reasons)
-            }
+            let (module, _) = candidates.into_iter().next().unwrap();
+            Fact::known(module)
         }
         _ => Fact::ambiguous(
             candidates.into_iter().map(|(module, _)| module).collect(),
@@ -399,7 +385,6 @@ fn module_candidate(
         return None;
     };
 
-    let reasons = namespace_package_reasons(&parts, &search_path.path);
     Some(ModuleCandidate {
         module: ResolvedModule {
             module: requested.clone(),
@@ -411,7 +396,6 @@ fn module_candidate(
                 ModuleLocation::External
             },
         },
-        reasons,
     })
 }
 
@@ -550,6 +534,24 @@ mod tests {
     }
 
     #[test]
+    fn resolves_namespace_package_module_name_for_file_as_known() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_file(&project_root.join("src/acme/plugins/blog/apps.py"), "");
+
+        let search_paths = discover_module_search_paths(&project_root, &[], &[]);
+        let fact = module_name_for_file(
+            &project_root.join("src/acme/plugins/blog/apps.py"),
+            search_path_entries(&search_paths),
+        );
+
+        let Fact::Known { value } = fact else {
+            panic!("expected known module for namespace package file, got {fact:?}");
+        };
+        assert_eq!(value, module("acme.plugins.blog.apps"));
+    }
+
+    #[test]
     fn uses_explicit_nested_source_roots() {
         let tmp = tempfile::TempDir::new().unwrap();
         let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
@@ -612,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn namespace_package_resolution_is_partial() {
+    fn namespace_package_resolution_is_known_when_unique() {
         let tmp = tempfile::TempDir::new().unwrap();
         let project_root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         write_file(&project_root.join("src/acme/plugins/blog/apps.py"), "");
@@ -625,16 +627,13 @@ mod tests {
         );
 
         match resolution.resolved {
-            Fact::Partial { value, reasons } => {
+            Fact::Known { value } => {
                 assert_eq!(
                     value.file,
                     project_root.join("src/acme/plugins/blog/apps.py")
                 );
-                assert!(reasons
-                    .iter()
-                    .any(|reason| reason.field == Field::ResolverModule));
             }
-            other => panic!("expected partial namespace package module, got {other:?}"),
+            other => panic!("expected known namespace package module, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Keeps the remaining behavior from the old profile-contract branch after the manifest-selector correction:

- treats unique namespace-package resolution as known
- includes the missing module name in unresolved module confidence reasons

## Stack Context

This is 9/11 in the static project model review stack.

Review order: #615 -> #605 -> #606 -> #613 -> #607 -> #608 -> #609 -> #610 -> #611 -> #612 -> #614.

Review focus: resolver confidence behavior that still belongs after removing authored corpus profile contracts.

## Restack Notes

Most of the previous profile-contract branch was dropped during restack because #615 removes the profile TOML/API and the authored expected-output contract. The only retained behavior is source/runtime resolver behavior, now isolated in this PR.

## Validation

- Restack check: `cargo test -q -p djls-semantic static --no-default-features`
- Restack check: `cargo test -q -p djls-semantic sync::tests --no-default-features`
- Restack check: `cargo clippy -q -p djls-semantic --all-targets --no-default-features -- -D warnings`