### PR TITLE
Handle deterministic settings mutations safely

### DIFF
--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -791,8 +791,13 @@ fn star_import_module(
 #[derive(Clone, Copy)]
 enum ListMutation<'a> {
     Append(&'a Expr),
+    Clear,
     Extend(&'a Expr),
     Insert { index: usize, value: &'a Expr },
+    Pop(Option<usize>),
+    Remove(&'a Expr),
+    Reverse,
+    Sort,
     Unsupported,
 }
 
@@ -952,9 +957,45 @@ fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutat
             };
             Some(ListMutation::Insert { index, value })
         }
-        "clear" | "pop" | "remove" | "reverse" | "sort" | "update" => {
-            Some(ListMutation::Unsupported)
+        "clear" => {
+            if call.arguments.args.is_empty() {
+                Some(ListMutation::Clear)
+            } else {
+                Some(ListMutation::Unsupported)
+            }
         }
+        "pop" => match call.arguments.args.as_ref() {
+            [] => Some(ListMutation::Pop(None)),
+            [index] => {
+                if let Some(index) = integer_literal(index) {
+                    Some(ListMutation::Pop(Some(index)))
+                } else {
+                    Some(ListMutation::Unsupported)
+                }
+            }
+            _ => Some(ListMutation::Unsupported),
+        },
+        "remove" => {
+            let [value] = call.arguments.args.as_ref() else {
+                return Some(ListMutation::Unsupported);
+            };
+            Some(ListMutation::Remove(value))
+        }
+        "reverse" => {
+            if call.arguments.args.is_empty() {
+                Some(ListMutation::Reverse)
+            } else {
+                Some(ListMutation::Unsupported)
+            }
+        }
+        "sort" => {
+            if call.arguments.args.is_empty() {
+                Some(ListMutation::Sort)
+            } else {
+                Some(ListMutation::Unsupported)
+            }
+        }
+        "update" => Some(ListMutation::Unsupported),
         _ => None,
     }
 }
@@ -1027,6 +1068,7 @@ fn apply_installed_apps_mutation(
                 ),
             )
         }
+        ListMutation::Clear => clear_vec_fact(current),
         ListMutation::Extend(value) => extend_vec_fact(
             current,
             extract_string_list(
@@ -1061,12 +1103,65 @@ fn apply_installed_apps_mutation(
                 ),
             )
         }
+        ListMutation::Pop(index) => apply_installed_apps_pop(current, index, file),
+        ListMutation::Remove(value) => apply_installed_apps_remove(current, value, file),
+        ListMutation::Reverse => reverse_vec_fact(current),
+        ListMutation::Sort => sort_vec_fact(current),
         ListMutation::Unsupported => current.with_reason(reason(
             Field::SettingsInstalledApps,
             file,
             "unsupported dynamic mutation of INSTALLED_APPS",
         )),
     }
+}
+
+fn apply_installed_apps_pop(
+    current: Fact<Vec<String>>,
+    index: Option<usize>,
+    file: &Utf8Path,
+) -> Fact<Vec<String>> {
+    pop_vec_fact(
+        current,
+        index,
+        reason(
+            Field::SettingsInstalledApps,
+            file,
+            "cannot apply INSTALLED_APPS pop because the index is out of range",
+        ),
+        reason(
+            Field::SettingsInstalledApps,
+            file,
+            "cannot apply INSTALLED_APPS pop because the current value is unknown or ambiguous",
+        ),
+    )
+}
+
+fn apply_installed_apps_remove(
+    current: Fact<Vec<String>>,
+    value: &Expr,
+    file: &Utf8Path,
+) -> Fact<Vec<String>> {
+    let Some(app) = string_literal(value) else {
+        return current.with_reason(reason(
+            Field::SettingsInstalledApps,
+            file,
+            "INSTALLED_APPS remove value must be a string literal",
+        ));
+    };
+    remove_vec_item(
+        current,
+        &app,
+        reason(
+            Field::SettingsInstalledApps,
+            file,
+            "cannot apply INSTALLED_APPS remove because the value is not present",
+        ),
+        reason(
+            Field::SettingsInstalledApps,
+            file,
+            "cannot apply INSTALLED_APPS remove because the current value is unknown or ambiguous",
+        ),
+    )
 }
 
 fn extract_template_backends(
@@ -1150,11 +1245,28 @@ fn apply_template_backends_mutation(
                 "cannot apply TEMPLATES insert because the current value is unknown or ambiguous",
             ),
         ),
-        ListMutation::Unsupported => current.with_reason(reason(
-            Field::SettingsTemplates,
-            file,
-            "unsupported dynamic mutation of TEMPLATES",
-        )),
+        ListMutation::Clear => clear_vec_fact(current),
+        ListMutation::Pop(index) => pop_vec_fact(
+            current,
+            index,
+            reason(
+                Field::SettingsTemplates,
+                file,
+                "cannot apply TEMPLATES pop because the index is out of range",
+            ),
+            reason(
+                Field::SettingsTemplates,
+                file,
+                "cannot apply TEMPLATES pop because the current value is unknown or ambiguous",
+            ),
+        ),
+        ListMutation::Reverse => reverse_vec_fact(current),
+        ListMutation::Remove(_) | ListMutation::Sort | ListMutation::Unsupported => current
+            .with_reason(reason(
+                Field::SettingsTemplates,
+                file,
+                "unsupported dynamic mutation of TEMPLATES",
+            )),
     }
 }
 
@@ -1718,6 +1830,140 @@ fn insert_vec_fact<T>(
             reasons.push(unavailable_reason);
             Fact::ambiguous(candidates, reasons)
         }
+    }
+}
+
+fn clear_vec_fact<T>(fact: Fact<Vec<T>>) -> Fact<Vec<T>> {
+    match fact {
+        Fact::Known { value: _ } => Fact::known(Vec::new()),
+        Fact::Partial { value: _, reasons } => Fact::partial(Vec::new(), reasons),
+        Fact::Unknown { reasons } => Fact::unknown(reasons),
+        Fact::Ambiguous {
+            candidates,
+            reasons,
+        } => Fact::ambiguous(candidates, reasons),
+    }
+}
+
+fn pop_vec_fact<T>(
+    fact: Fact<Vec<T>>,
+    index: Option<usize>,
+    missing_reason: Reason,
+    unavailable_reason: Reason,
+) -> Fact<Vec<T>> {
+    match fact {
+        Fact::Known { mut value } => {
+            let Some(index) = list_pop_index(value.len(), index) else {
+                return Fact::partial(value, vec![missing_reason]);
+            };
+            value.remove(index);
+            Fact::known(value)
+        }
+        Fact::Partial {
+            mut value,
+            mut reasons,
+        } => {
+            let Some(index) = list_pop_index(value.len(), index) else {
+                reasons.push(missing_reason);
+                return Fact::partial(value, reasons);
+            };
+            value.remove(index);
+            Fact::partial(value, reasons)
+        }
+        Fact::Unknown { mut reasons } => {
+            reasons.push(unavailable_reason);
+            Fact::unknown(reasons)
+        }
+        Fact::Ambiguous {
+            candidates,
+            mut reasons,
+        } => {
+            reasons.push(unavailable_reason);
+            Fact::ambiguous(candidates, reasons)
+        }
+    }
+}
+
+fn list_pop_index(len: usize, index: Option<usize>) -> Option<usize> {
+    match index {
+        Some(index) if index < len => Some(index),
+        None if len > 0 => Some(len - 1),
+        Some(_) | None => None,
+    }
+}
+
+fn remove_vec_item<T: Eq>(
+    fact: Fact<Vec<T>>,
+    item: &T,
+    missing_reason: Reason,
+    unavailable_reason: Reason,
+) -> Fact<Vec<T>> {
+    match fact {
+        Fact::Known { mut value } => {
+            let Some(index) = value.iter().position(|candidate| candidate == item) else {
+                return Fact::partial(value, vec![missing_reason]);
+            };
+            value.remove(index);
+            Fact::known(value)
+        }
+        Fact::Partial {
+            mut value,
+            mut reasons,
+        } => {
+            let Some(index) = value.iter().position(|candidate| candidate == item) else {
+                reasons.push(missing_reason);
+                return Fact::partial(value, reasons);
+            };
+            value.remove(index);
+            Fact::partial(value, reasons)
+        }
+        Fact::Unknown { mut reasons } => {
+            reasons.push(unavailable_reason);
+            Fact::unknown(reasons)
+        }
+        Fact::Ambiguous {
+            candidates,
+            mut reasons,
+        } => {
+            reasons.push(unavailable_reason);
+            Fact::ambiguous(candidates, reasons)
+        }
+    }
+}
+
+fn reverse_vec_fact<T>(fact: Fact<Vec<T>>) -> Fact<Vec<T>> {
+    match fact {
+        Fact::Known { mut value } => {
+            value.reverse();
+            Fact::known(value)
+        }
+        Fact::Partial { mut value, reasons } => {
+            value.reverse();
+            Fact::partial(value, reasons)
+        }
+        Fact::Unknown { reasons } => Fact::unknown(reasons),
+        Fact::Ambiguous {
+            candidates,
+            reasons,
+        } => Fact::ambiguous(candidates, reasons),
+    }
+}
+
+fn sort_vec_fact<T: Ord>(fact: Fact<Vec<T>>) -> Fact<Vec<T>> {
+    match fact {
+        Fact::Known { mut value } => {
+            value.sort();
+            Fact::known(value)
+        }
+        Fact::Partial { mut value, reasons } => {
+            value.sort();
+            Fact::partial(value, reasons)
+        }
+        Fact::Unknown { reasons } => Fact::unknown(reasons),
+        Fact::Ambiguous {
+            candidates,
+            reasons,
+        } => Fact::ambiguous(candidates, reasons),
     }
 }
 
@@ -2377,7 +2623,7 @@ INSTALLED_APPS = ["django.contrib.auth", "django.contrib.sites"]
 if not SITE_MULTI:
     INSTALLED_APPS.remove("django.contrib.sites")
 TEMPLATES = [{"DIRS": []}]
-TEMPLATES.pop()
+TEMPLATES.sort()
 "#,
         );
 
@@ -2394,6 +2640,122 @@ TEMPLATES.pop()
         assert!(template_reasons
             .iter()
             .any(|reason| reason.message.contains("unsupported dynamic mutation")));
+    }
+
+    #[test]
+    fn applies_deterministic_installed_apps_list_methods() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["project.b", "project.a", "project.c"]
+INSTALLED_APPS.remove("project.b")
+INSTALLED_APPS.pop(1)
+INSTALLED_APPS.extend(["project.d", "project.b"])
+INSTALLED_APPS.sort()
+INSTALLED_APPS.reverse()
+INSTALLED_APPS.pop()
+TEMPLATES = []
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        assert_eq!(known_vec(&facts.installed_apps), ["project.d", "project.b"]);
+    }
+
+    #[test]
+    fn applies_deterministic_installed_apps_clear() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["project.a", "project.b"]
+INSTALLED_APPS.clear()
+TEMPLATES = []
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        assert!(known_vec(&facts.installed_apps).is_empty());
+    }
+
+    #[test]
+    fn marks_out_of_range_installed_apps_pop_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["project.a"]
+INSTALLED_APPS.pop(3)
+TEMPLATES = []
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let (apps, reasons) = partial_vec(&facts.installed_apps);
+
+        assert_eq!(apps, ["project.a"]);
+        assert!(reasons[0].message.contains("index is out of range"));
+    }
+
+    #[test]
+    fn applies_deterministic_template_backend_list_methods() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [
+    {"DIRS": ["first"]},
+    {"DIRS": ["second"]},
+    {"DIRS": ["third"]},
+]
+TEMPLATES.pop(1)
+TEMPLATES.reverse()
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert_eq!(
+            known_vec(&backends[0].dirs)[0].path,
+            Utf8PathBuf::from("third")
+        );
+        assert_eq!(
+            known_vec(&backends[1].dirs)[0].path,
+            Utf8PathBuf::from("first")
+        );
+    }
+
+    #[test]
+    fn applies_deterministic_template_backend_clear() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"DIRS": ["first"]}]
+TEMPLATES.clear()
+TEMPLATES.append({"DIRS": ["second"]})
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert_eq!(backends.len(), 1);
+        assert_eq!(
+            known_vec(&backends[0].dirs)[0].path,
+            Utf8PathBuf::from("second")
+        );
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -952,7 +952,9 @@ fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutat
             };
             Some(ListMutation::Insert { index, value })
         }
-        "update" => Some(ListMutation::Unsupported),
+        "clear" | "pop" | "remove" | "reverse" | "sort" | "update" => {
+            Some(ListMutation::Unsupported)
+        }
         _ => None,
     }
 }
@@ -2362,6 +2364,36 @@ TEMPLATES.update({"APP_DIRS": True})
         assert!(template_reasons[0]
             .message
             .contains("unsupported dynamic mutation"));
+    }
+
+    #[test]
+    fn marks_destructive_settings_list_methods_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["django.contrib.auth", "django.contrib.sites"]
+if not SITE_MULTI:
+    INSTALLED_APPS.remove("django.contrib.sites")
+TEMPLATES = [{"DIRS": []}]
+TEMPLATES.pop()
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        let (apps, app_reasons) = partial_vec(&facts.installed_apps);
+        assert_eq!(apps, ["django.contrib.auth", "django.contrib.sites"]);
+        assert!(app_reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of INSTALLED_APPS")));
+
+        let (templates, template_reasons) = partial_vec(&facts.template_backends);
+        assert_eq!(templates.len(), 1);
+        assert!(template_reasons
+            .iter()
+            .any(|reason| reason.message.contains("unsupported dynamic mutation")));
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -1274,9 +1274,15 @@ fn contains_nested_template_options_assignment(stmt: &Stmt) -> bool {
 
 fn body_contains_template_options_assignment(body: &[Stmt]) -> bool {
     body.iter().any(|stmt| {
-        template_options_assignment(stmt).is_some()
+        template_options_assignment(stmt)
+            .as_ref()
+            .is_some_and(|assignment| template_option_affects_project_model(&assignment.key))
             || contains_nested_template_options_assignment(stmt)
     })
+}
+
+fn template_option_affects_project_model(key: &str) -> bool {
+    !matches!(key, "context_processors" | "debug" | "string_if_invalid")
 }
 
 fn is_name(expr: &Expr, expected: &str) -> bool {
@@ -1759,6 +1765,10 @@ fn apply_template_options_assignment_to_backends(
     assignment: &TemplateOptionsAssignment,
     file: &Utf8Path,
 ) -> Vec<Reason> {
+    if !template_option_affects_project_model(&assignment.key) {
+        return Vec::new();
+    }
+
     let Some(backend) = backends.get_mut(assignment.backend_index) else {
         return vec![reason(
             Field::SettingsTemplateOptions,
@@ -3478,7 +3488,7 @@ TEMPLATES[3]["OPTIONS"]["builtins"] = ["project.templatetags.builtins"]
     }
 
     #[test]
-    fn marks_unsupported_template_options_assignment_partial() {
+    fn ignores_irrelevant_template_options_assignment() {
         let tmp = tempdir().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         let settings = write_settings(
@@ -3487,6 +3497,28 @@ TEMPLATES[3]["OPTIONS"]["builtins"] = ["project.templatetags.builtins"]
 INSTALLED_APPS = []
 TEMPLATES = [{"OPTIONS": {}}]
 TEMPLATES[0]["OPTIONS"]["context_processors"] = ["project.context_processors.extra"]
+TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG
+TEMPLATES[0]["OPTIONS"]["string_if_invalid"] = "missing"
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert!(known_vec(&backends[0].option_builtins).is_empty());
+    }
+
+    #[test]
+    fn marks_project_model_affecting_template_options_assignment_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"OPTIONS": {}}]
+TEMPLATES[0]["OPTIONS"]["loaders"] = []
+TEMPLATES[0]["OPTIONS"]["unknown_option"] = "unknown"
 "#,
         );
 
@@ -3494,6 +3526,15 @@ TEMPLATES[0]["OPTIONS"]["context_processors"] = ["project.context_processors.ext
         let (backends, reasons) = partial_vec(&facts.template_backends);
 
         assert!(known_vec(&backends[0].option_builtins).is_empty());
+        assert_eq!(
+            reasons
+                .iter()
+                .filter(|reason| reason
+                    .message
+                    .contains("unsupported TEMPLATES OPTIONS assignment"))
+                .count(),
+            2
+        );
         assert!(reasons[0]
             .message
             .contains("unsupported TEMPLATES OPTIONS assignment"));
@@ -3520,6 +3561,26 @@ if ENABLE_EXTRA_BUILTINS:
         assert!(reasons.iter().any(|reason| reason
             .message
             .contains("unsupported nested assignment or mutation of TEMPLATES")));
+    }
+
+    #[test]
+    fn ignores_nested_irrelevant_template_options_assignments() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"OPTIONS": {}}]
+if DEBUG:
+    TEMPLATES[0]["OPTIONS"]["context_processors"] = ["project.context_processors.extra"]
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert!(known_vec(&backends[0].option_builtins).is_empty());
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -121,6 +121,10 @@ impl SettingsExtractionState {
         self.template_backends_import_reasons.extend(reasons);
     }
 
+    fn add_installed_apps_reason(&mut self, reason: Reason) {
+        self.installed_apps_import_reasons.push(reason);
+    }
+
     fn add_files_read(&mut self, files: impl IntoIterator<Item = Utf8PathBuf>) {
         self.files_read.extend(files);
     }
@@ -283,6 +287,18 @@ fn extract_settings_state_inner(
                 file,
             ));
         }
+    }
+
+    if module
+        .body
+        .iter()
+        .any(|stmt| contains_nested_list_mutation(stmt, INSTALLED_APPS))
+    {
+        state.add_installed_apps_reason(reason(
+            Field::SettingsInstalledApps,
+            file,
+            "unsupported nested assignment or mutation of INSTALLED_APPS",
+        ));
     }
 
     state
@@ -778,6 +794,45 @@ fn list_mutation<'a>(stmt: &'a Stmt, target_name: &str) -> Option<ListMutation<'
         Stmt::Expr(expr_stmt) => call_list_mutation(expr_stmt.value.as_ref(), target_name),
         _ => None,
     }
+}
+
+fn contains_nested_list_mutation(stmt: &Stmt, target_name: &str) -> bool {
+    match stmt {
+        Stmt::If(stmt_if) => {
+            body_contains_list_mutation(&stmt_if.body, target_name)
+                || stmt_if
+                    .elif_else_clauses
+                    .iter()
+                    .any(|clause| body_contains_list_mutation(&clause.body, target_name))
+        }
+        Stmt::For(stmt_for) => {
+            body_contains_list_mutation(&stmt_for.body, target_name)
+                || body_contains_list_mutation(&stmt_for.orelse, target_name)
+        }
+        Stmt::While(stmt_while) => {
+            body_contains_list_mutation(&stmt_while.body, target_name)
+                || body_contains_list_mutation(&stmt_while.orelse, target_name)
+        }
+        Stmt::Try(stmt_try) => {
+            body_contains_list_mutation(&stmt_try.body, target_name)
+                || stmt_try.handlers.iter().any(|handler| {
+                    let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    body_contains_list_mutation(&handler.body, target_name)
+                })
+                || body_contains_list_mutation(&stmt_try.orelse, target_name)
+                || body_contains_list_mutation(&stmt_try.finalbody, target_name)
+        }
+        Stmt::With(stmt_with) => body_contains_list_mutation(&stmt_with.body, target_name),
+        _ => false,
+    }
+}
+
+fn body_contains_list_mutation(body: &[Stmt], target_name: &str) -> bool {
+    body.iter().any(|stmt| {
+        assigned_value(stmt, target_name).is_some()
+            || list_mutation(stmt, target_name).is_some()
+            || contains_nested_list_mutation(stmt, target_name)
+    })
 }
 
 fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutation<'a>> {
@@ -2226,6 +2281,30 @@ TEMPLATES.update({"APP_DIRS": True})
         assert!(template_reasons[0]
             .message
             .contains("unsupported dynamic mutation"));
+    }
+
+    #[test]
+    fn marks_nested_installed_apps_updates_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = ["django.contrib.auth"]
+if ENABLE_DEBUG_TOOLBAR:
+    INSTALLED_APPS = [*INSTALLED_APPS, "debug_toolbar"]
+for plugin in plugins:
+    INSTALLED_APPS.append(plugin)
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        let (apps, reasons) = partial_vec(&facts.installed_apps);
+        assert_eq!(apps, ["django.contrib.auth"]);
+        assert!(reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of INSTALLED_APPS")));
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -237,60 +237,14 @@ fn extract_settings_state_inner(
     let mut state = SettingsExtractionState::new(file);
 
     for stmt in &module.body {
-        if let Some(import_from) = star_import(stmt) {
-            follow_star_import(
-                &mut state,
-                import_from,
-                current_module,
-                imports,
-                active_files,
-            );
-            continue;
-        }
-
-        record_imported_module_path_values(stmt, &mut state, current_module, imports);
-        record_imported_module_path_functions(stmt, &mut state, current_module, imports);
-        record_path_assignment(stmt, &mut state.path_values, file);
-        record_path_list_assignment(stmt, &mut state.path_list_values, &state.path_values, file);
-
-        if let Some(value) = assigned_value(stmt, INSTALLED_APPS) {
-            state.installed_apps = Some(extract_string_list(
-                value,
-                Field::SettingsInstalledApps,
-                file,
-                "INSTALLED_APPS",
-            ));
-            continue;
-        }
-
-        if let Some(value) = assigned_value(stmt, TEMPLATES) {
-            state.template_backends = Some(extract_template_backends(
-                value,
-                &state.path_values,
-                &state.path_list_values,
-                file,
-            ));
-            continue;
-        }
-
-        if let Some(mutation) = list_mutation(stmt, INSTALLED_APPS) {
-            state.installed_apps = Some(apply_installed_apps_mutation(
-                state.installed_apps.take(),
-                mutation,
-                file,
-            ));
-            continue;
-        }
-
-        if let Some(mutation) = list_mutation(stmt, TEMPLATES) {
-            state.template_backends = Some(apply_template_backends_mutation(
-                state.template_backends.take(),
-                mutation,
-                &state.path_values,
-                &state.path_list_values,
-                file,
-            ));
-        }
+        process_settings_stmt(
+            stmt,
+            &mut state,
+            current_module,
+            imports,
+            active_files,
+            file,
+        );
     }
 
     if module
@@ -306,6 +260,7 @@ fn extract_settings_state_inner(
     }
     if module.body.iter().any(|stmt| {
         contains_nested_list_mutation(stmt, TEMPLATES)
+            || contains_nested_template_dirs_mutation(stmt)
             || contains_unsupported_setting_update(stmt, TEMPLATES)
     }) {
         state.add_template_backends_reason(reason(
@@ -316,6 +271,75 @@ fn extract_settings_state_inner(
     }
 
     state
+}
+
+fn process_settings_stmt(
+    stmt: &Stmt,
+    state: &mut SettingsExtractionState,
+    current_module: Option<&PyModuleName>,
+    imports: Option<&SettingsImportScope>,
+    active_files: &mut BTreeSet<Utf8PathBuf>,
+    file: &Utf8Path,
+) {
+    if let Some(import_from) = star_import(stmt) {
+        follow_star_import(state, import_from, current_module, imports, active_files);
+        return;
+    }
+
+    record_imported_module_path_values(stmt, state, current_module, imports);
+    record_imported_module_path_functions(stmt, state, current_module, imports);
+    record_path_assignment(stmt, &mut state.path_values, file);
+    record_path_list_assignment(stmt, &mut state.path_list_values, &state.path_values, file);
+
+    if let Some(value) = assigned_value(stmt, INSTALLED_APPS) {
+        state.installed_apps = Some(extract_string_list(
+            value,
+            Field::SettingsInstalledApps,
+            file,
+            "INSTALLED_APPS",
+        ));
+        return;
+    }
+
+    if let Some(value) = assigned_value(stmt, TEMPLATES) {
+        state.template_backends = Some(extract_template_backends(
+            value,
+            &state.path_values,
+            &state.path_list_values,
+            file,
+        ));
+        return;
+    }
+
+    if let Some(mutation) = list_mutation(stmt, INSTALLED_APPS) {
+        state.installed_apps = Some(apply_installed_apps_mutation(
+            state.installed_apps.take(),
+            mutation,
+            file,
+        ));
+        return;
+    }
+
+    if let Some(mutation) = list_mutation(stmt, TEMPLATES) {
+        state.template_backends = Some(apply_template_backends_mutation(
+            state.template_backends.take(),
+            mutation,
+            &state.path_values,
+            &state.path_list_values,
+            file,
+        ));
+        return;
+    }
+
+    if let Some(mutation) = template_dirs_mutation(stmt) {
+        state.template_backends = Some(apply_template_dirs_mutation(
+            state.template_backends.take(),
+            mutation,
+            &state.path_values,
+            &state.path_list_values,
+            file,
+        ));
+    }
 }
 
 fn assigned_value<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
@@ -861,7 +885,10 @@ fn contains_unsupported_setting_update(stmt: &Stmt, target_name: &str) -> bool {
             .iter()
             .any(|target| is_indirect_setting_target(target, target_name)),
         Stmt::AnnAssign(assign) => is_indirect_setting_target(assign.target.as_ref(), target_name),
-        Stmt::AugAssign(assign) => is_indirect_setting_target(assign.target.as_ref(), target_name),
+        Stmt::AugAssign(assign) => {
+            is_indirect_setting_target(assign.target.as_ref(), target_name)
+                && !(target_name == TEMPLATES && template_dirs_mutation(stmt).is_some())
+        }
         Stmt::Expr(expr_stmt) => unsupported_setting_call(expr_stmt.value.as_ref(), target_name),
         Stmt::If(stmt_if) => {
             body_contains_unsupported_setting_update(&stmt_if.body, target_name)
@@ -909,6 +936,9 @@ fn unsupported_setting_call(expr: &Expr, target_name: &str) -> bool {
     let Expr::Attribute(attribute) = call.func.as_ref() else {
         return false;
     };
+    if target_name == TEMPLATES && call_template_dirs_mutation(call).is_some() {
+        return false;
+    }
     is_indirect_setting_target(attribute.value.as_ref(), target_name)
 }
 
@@ -998,6 +1028,149 @@ fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutat
         "update" => Some(ListMutation::Unsupported),
         _ => None,
     }
+}
+
+#[derive(Clone, Copy)]
+struct TemplateDirsMutation<'a> {
+    backend_index: usize,
+    mutation: ListMutation<'a>,
+}
+
+fn template_dirs_mutation(stmt: &Stmt) -> Option<TemplateDirsMutation<'_>> {
+    match stmt {
+        Stmt::AugAssign(assign) => {
+            let backend_index = template_dirs_target(assign.target.as_ref())?;
+            let mutation = if assign.op == Operator::Add {
+                ListMutation::Extend(assign.value.as_ref())
+            } else {
+                ListMutation::Unsupported
+            };
+            Some(TemplateDirsMutation {
+                backend_index,
+                mutation,
+            })
+        }
+        Stmt::Expr(expr_stmt) => {
+            let Expr::Call(call) = expr_stmt.value.as_ref() else {
+                return None;
+            };
+            call_template_dirs_mutation(call)
+        }
+        _ => None,
+    }
+}
+
+fn call_template_dirs_mutation(
+    call: &ruff_python_ast::ExprCall,
+) -> Option<TemplateDirsMutation<'_>> {
+    let Expr::Attribute(attribute) = call.func.as_ref() else {
+        return None;
+    };
+    let backend_index = template_dirs_target(attribute.value.as_ref())?;
+    if !call.arguments.keywords.is_empty() {
+        return Some(TemplateDirsMutation {
+            backend_index,
+            mutation: ListMutation::Unsupported,
+        });
+    }
+
+    let mutation = match attribute.attr.as_str() {
+        "append" => {
+            let [value] = call.arguments.args.as_ref() else {
+                return Some(TemplateDirsMutation {
+                    backend_index,
+                    mutation: ListMutation::Unsupported,
+                });
+            };
+            ListMutation::Append(value)
+        }
+        "extend" => {
+            let [value] = call.arguments.args.as_ref() else {
+                return Some(TemplateDirsMutation {
+                    backend_index,
+                    mutation: ListMutation::Unsupported,
+                });
+            };
+            ListMutation::Extend(value)
+        }
+        "insert" => {
+            let [index, value] = call.arguments.args.as_ref() else {
+                return Some(TemplateDirsMutation {
+                    backend_index,
+                    mutation: ListMutation::Unsupported,
+                });
+            };
+            let Some(index) = integer_literal(index) else {
+                return Some(TemplateDirsMutation {
+                    backend_index,
+                    mutation: ListMutation::Unsupported,
+                });
+            };
+            ListMutation::Insert { index, value }
+        }
+        "clear" | "pop" | "remove" | "reverse" | "sort" | "update" => ListMutation::Unsupported,
+        _ => return None,
+    };
+
+    Some(TemplateDirsMutation {
+        backend_index,
+        mutation,
+    })
+}
+
+fn template_dirs_target(expr: &Expr) -> Option<usize> {
+    let Expr::Subscript(dirs_subscript) = expr else {
+        return None;
+    };
+    let key = string_literal(dirs_subscript.slice.as_ref())?;
+    if key != "DIRS" {
+        return None;
+    }
+
+    let Expr::Subscript(backend_subscript) = dirs_subscript.value.as_ref() else {
+        return None;
+    };
+    if !is_name(backend_subscript.value.as_ref(), TEMPLATES) {
+        return None;
+    }
+    integer_literal(backend_subscript.slice.as_ref())
+}
+
+fn contains_nested_template_dirs_mutation(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::If(stmt_if) => {
+            body_contains_template_dirs_mutation(&stmt_if.body)
+                || stmt_if
+                    .elif_else_clauses
+                    .iter()
+                    .any(|clause| body_contains_template_dirs_mutation(&clause.body))
+        }
+        Stmt::For(stmt_for) => {
+            body_contains_template_dirs_mutation(&stmt_for.body)
+                || body_contains_template_dirs_mutation(&stmt_for.orelse)
+        }
+        Stmt::While(stmt_while) => {
+            body_contains_template_dirs_mutation(&stmt_while.body)
+                || body_contains_template_dirs_mutation(&stmt_while.orelse)
+        }
+        Stmt::Try(stmt_try) => {
+            body_contains_template_dirs_mutation(&stmt_try.body)
+                || stmt_try.handlers.iter().any(|handler| {
+                    let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    body_contains_template_dirs_mutation(&handler.body)
+                })
+                || body_contains_template_dirs_mutation(&stmt_try.orelse)
+                || body_contains_template_dirs_mutation(&stmt_try.finalbody)
+        }
+        Stmt::With(stmt_with) => body_contains_template_dirs_mutation(&stmt_with.body),
+        _ => false,
+    }
+}
+
+fn body_contains_template_dirs_mutation(body: &[Stmt]) -> bool {
+    body.iter().any(|stmt| {
+        template_dirs_mutation(stmt).is_some() || contains_nested_template_dirs_mutation(stmt)
+    })
 }
 
 fn is_name(expr: &Expr, expected: &str) -> bool {
@@ -1270,6 +1443,161 @@ fn apply_template_backends_mutation(
     }
 }
 
+fn apply_template_dirs_mutation(
+    current: Option<Fact<Vec<TemplateBackendFact>>>,
+    mutation: TemplateDirsMutation,
+    path_values: &BTreeMap<String, Utf8PathBuf>,
+    path_list_values: &BTreeMap<String, Fact<Vec<Utf8PathBuf>>>,
+    file: &Utf8Path,
+) -> Fact<Vec<TemplateBackendFact>> {
+    let Some(current) = current else {
+        return mutation_before_assignment(
+            Field::SettingsTemplates,
+            file,
+            "TEMPLATES DIRS mutation appears before TEMPLATES assignment or import",
+        );
+    };
+
+    match current {
+        Fact::Known { mut value } => {
+            let reasons = apply_template_dirs_mutation_to_backends(
+                &mut value,
+                mutation,
+                path_values,
+                path_list_values,
+                file,
+            );
+            known_or_partial(value, reasons)
+        }
+        Fact::Partial {
+            mut value,
+            mut reasons,
+        } => {
+            reasons.extend(apply_template_dirs_mutation_to_backends(
+                &mut value,
+                mutation,
+                path_values,
+                path_list_values,
+                file,
+            ));
+            Fact::partial(value, reasons)
+        }
+        Fact::Unknown { mut reasons } => {
+            reasons.push(reason(
+                Field::SettingsTemplates,
+                file,
+                "cannot apply TEMPLATES DIRS mutation because TEMPLATES is unknown",
+            ));
+            Fact::unknown(reasons)
+        }
+        Fact::Ambiguous {
+            candidates,
+            mut reasons,
+        } => {
+            reasons.push(reason(
+                Field::SettingsTemplates,
+                file,
+                "cannot apply TEMPLATES DIRS mutation because TEMPLATES is ambiguous",
+            ));
+            Fact::ambiguous(candidates, reasons)
+        }
+    }
+}
+
+fn apply_template_dirs_mutation_to_backends(
+    backends: &mut [TemplateBackendFact],
+    mutation: TemplateDirsMutation,
+    path_values: &BTreeMap<String, Utf8PathBuf>,
+    path_list_values: &BTreeMap<String, Fact<Vec<Utf8PathBuf>>>,
+    file: &Utf8Path,
+) -> Vec<Reason> {
+    let Some(backend) = backends.get_mut(mutation.backend_index) else {
+        return vec![reason(
+            Field::SettingsTemplateDirs,
+            file,
+            "cannot apply TEMPLATES DIRS mutation because the backend index is out of range",
+        )];
+    };
+
+    backend.dirs = apply_template_dir_list_mutation(
+        std::mem::replace(&mut backend.dirs, Fact::known(Vec::new())),
+        mutation.mutation,
+        path_values,
+        path_list_values,
+        file,
+    );
+    Vec::new()
+}
+
+fn apply_template_dir_list_mutation(
+    current: Fact<Vec<TemplateDirFact>>,
+    mutation: ListMutation,
+    path_values: &BTreeMap<String, Utf8PathBuf>,
+    path_list_values: &BTreeMap<String, Fact<Vec<Utf8PathBuf>>>,
+    file: &Utf8Path,
+) -> Fact<Vec<TemplateDirFact>> {
+    match mutation {
+        ListMutation::Append(value) => {
+            let Some(dir) = evaluate_template_dir(value, path_values, file) else {
+                return current.with_reason(reason(
+                    Field::SettingsTemplateDirs,
+                    file,
+                    "TEMPLATES DIRS append value contains an unsupported path expression",
+                ));
+            };
+            append_vec_fact(
+                current,
+                dir,
+                Vec::new(),
+                reason(
+                    Field::SettingsTemplateDirs,
+                    file,
+                    "cannot apply TEMPLATES DIRS append because the current value is unknown or ambiguous",
+                ),
+            )
+        }
+        ListMutation::Extend(value) => extend_vec_fact(
+            current,
+            extract_template_dirs(value, path_values, path_list_values, file),
+            reason(
+                Field::SettingsTemplateDirs,
+                file,
+                "cannot apply TEMPLATES DIRS extend because the current value is unknown or ambiguous",
+            ),
+        ),
+        ListMutation::Insert { index, value } => {
+            let Some(dir) = evaluate_template_dir(value, path_values, file) else {
+                return current.with_reason(reason(
+                    Field::SettingsTemplateDirs,
+                    file,
+                    "TEMPLATES DIRS insert value contains an unsupported path expression",
+                ));
+            };
+            insert_vec_fact(
+                current,
+                index,
+                dir,
+                Vec::new(),
+                reason(
+                    Field::SettingsTemplateDirs,
+                    file,
+                    "cannot apply TEMPLATES DIRS insert because the current value is unknown or ambiguous",
+                ),
+            )
+        }
+        ListMutation::Clear
+        | ListMutation::Pop(_)
+        | ListMutation::Remove(_)
+        | ListMutation::Reverse
+        | ListMutation::Sort
+        | ListMutation::Unsupported => current.with_reason(reason(
+            Field::SettingsTemplateDirs,
+            file,
+            "unsupported dynamic mutation of TEMPLATES DIRS",
+        )),
+    }
+}
+
 fn extract_template_backend_list_item(
     expr: &Expr,
     path_values: &BTreeMap<String, Utf8PathBuf>,
@@ -1417,6 +1745,17 @@ fn template_dir_facts(paths: Vec<Utf8PathBuf>) -> Vec<TemplateDirFact> {
             source: TemplateDirSource::SettingsDir,
         })
         .collect()
+}
+
+fn evaluate_template_dir(
+    expr: &Expr,
+    path_values: &BTreeMap<String, Utf8PathBuf>,
+    file: &Utf8Path,
+) -> Option<TemplateDirFact> {
+    evaluate_path(expr, path_values, file).map(|path| TemplateDirFact {
+        path,
+        source: TemplateDirSource::SettingsDir,
+    })
 }
 
 fn extract_option_libraries(
@@ -2799,7 +3138,97 @@ TEMPLATES[0]["DIRS"].insert(0, DATA_DIR / "templates")
         let facts = extract_settings_facts(&settings);
 
         let (backends, reasons) = partial_vec(&facts.template_backends);
-        assert!(known_vec(&backends[0].dirs).is_empty());
+        let (dirs, dir_reasons) = partial_vec(&backends[0].dirs);
+        assert!(dirs.is_empty());
+        assert!(dir_reasons[0]
+            .message
+            .contains("unsupported path expression"));
+        assert!(reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of TEMPLATES")));
+    }
+
+    #[test]
+    fn applies_deterministic_template_dirs_mutations() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+INSTALLED_APPS = []
+TEMPLATES = [{"DIRS": [BASE_DIR / "templates"]}]
+TEMPLATES[0]["DIRS"].append(BASE_DIR / "append")
+TEMPLATES[0]["DIRS"].extend([BASE_DIR / "extend"])
+TEMPLATES[0]["DIRS"].insert(1, BASE_DIR / "insert")
+TEMPLATES[0]["DIRS"] += [BASE_DIR / "added"]
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert_eq!(
+            known_vec(&backends[0].dirs)
+                .into_iter()
+                .map(|dir| dir.path)
+                .collect::<Vec<_>>(),
+            [
+                root.join("templates"),
+                root.join("insert"),
+                root.join("append"),
+                root.join("extend"),
+                root.join("added"),
+            ]
+        );
+    }
+
+    #[test]
+    fn marks_out_of_range_template_dirs_mutation_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"DIRS": ["templates"]}]
+TEMPLATES[3]["DIRS"].append("missing")
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let (backends, reasons) = partial_vec(&facts.template_backends);
+
+        assert_eq!(
+            known_vec(&backends[0].dirs)[0].path,
+            Utf8PathBuf::from("templates")
+        );
+        assert!(reasons[0].message.contains("backend index is out of range"));
+    }
+
+    #[test]
+    fn marks_nested_template_dirs_mutations_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"DIRS": ["templates"]}]
+if ENABLE_EXTRA_TEMPLATES:
+    TEMPLATES[0]["DIRS"].append("extra")
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let (backends, reasons) = partial_vec(&facts.template_backends);
+
+        assert_eq!(
+            known_vec(&backends[0].dirs)[0].path,
+            Utf8PathBuf::from("templates")
+        );
         assert!(reasons.iter().any(|reason| reason
             .message
             .contains("unsupported nested assignment or mutation of TEMPLATES")));

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -125,6 +125,10 @@ impl SettingsExtractionState {
         self.installed_apps_import_reasons.push(reason);
     }
 
+    fn add_template_backends_reason(&mut self, reason: Reason) {
+        self.template_backends_import_reasons.push(reason);
+    }
+
     fn add_files_read(&mut self, files: impl IntoIterator<Item = Utf8PathBuf>) {
         self.files_read.extend(files);
     }
@@ -298,6 +302,16 @@ fn extract_settings_state_inner(
             Field::SettingsInstalledApps,
             file,
             "unsupported nested assignment or mutation of INSTALLED_APPS",
+        ));
+    }
+    if module.body.iter().any(|stmt| {
+        contains_nested_list_mutation(stmt, TEMPLATES)
+            || contains_unsupported_setting_update(stmt, TEMPLATES)
+    }) {
+        state.add_template_backends_reason(reason(
+            Field::SettingsTemplates,
+            file,
+            "unsupported nested assignment or mutation of TEMPLATES",
         ));
     }
 
@@ -833,6 +847,73 @@ fn body_contains_list_mutation(body: &[Stmt], target_name: &str) -> bool {
             || list_mutation(stmt, target_name).is_some()
             || contains_nested_list_mutation(stmt, target_name)
     })
+}
+
+fn contains_unsupported_setting_update(stmt: &Stmt, target_name: &str) -> bool {
+    match stmt {
+        Stmt::Assign(assign) => assign
+            .targets
+            .iter()
+            .any(|target| is_indirect_setting_target(target, target_name)),
+        Stmt::AnnAssign(assign) => is_indirect_setting_target(assign.target.as_ref(), target_name),
+        Stmt::AugAssign(assign) => is_indirect_setting_target(assign.target.as_ref(), target_name),
+        Stmt::Expr(expr_stmt) => unsupported_setting_call(expr_stmt.value.as_ref(), target_name),
+        Stmt::If(stmt_if) => {
+            body_contains_unsupported_setting_update(&stmt_if.body, target_name)
+                || stmt_if.elif_else_clauses.iter().any(|clause| {
+                    body_contains_unsupported_setting_update(&clause.body, target_name)
+                })
+        }
+        Stmt::For(stmt_for) => {
+            body_contains_unsupported_setting_update(&stmt_for.body, target_name)
+                || body_contains_unsupported_setting_update(&stmt_for.orelse, target_name)
+        }
+        Stmt::While(stmt_while) => {
+            body_contains_unsupported_setting_update(&stmt_while.body, target_name)
+                || body_contains_unsupported_setting_update(&stmt_while.orelse, target_name)
+        }
+        Stmt::Try(stmt_try) => {
+            body_contains_unsupported_setting_update(&stmt_try.body, target_name)
+                || stmt_try.handlers.iter().any(|handler| {
+                    let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    body_contains_unsupported_setting_update(&handler.body, target_name)
+                })
+                || body_contains_unsupported_setting_update(&stmt_try.orelse, target_name)
+                || body_contains_unsupported_setting_update(&stmt_try.finalbody, target_name)
+        }
+        Stmt::With(stmt_with) => {
+            body_contains_unsupported_setting_update(&stmt_with.body, target_name)
+        }
+        _ => false,
+    }
+}
+
+fn body_contains_unsupported_setting_update(body: &[Stmt], target_name: &str) -> bool {
+    body.iter()
+        .any(|stmt| contains_unsupported_setting_update(stmt, target_name))
+}
+
+fn is_indirect_setting_target(expr: &Expr, target_name: &str) -> bool {
+    !is_name(expr, target_name) && expr_has_root_name(expr, target_name)
+}
+
+fn unsupported_setting_call(expr: &Expr, target_name: &str) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    let Expr::Attribute(attribute) = call.func.as_ref() else {
+        return false;
+    };
+    is_indirect_setting_target(attribute.value.as_ref(), target_name)
+}
+
+fn expr_has_root_name(expr: &Expr, target_name: &str) -> bool {
+    match expr {
+        Expr::Name(_) => is_name(expr, target_name),
+        Expr::Attribute(attribute) => expr_has_root_name(attribute.value.as_ref(), target_name),
+        Expr::Subscript(subscript) => expr_has_root_name(subscript.value.as_ref(), target_name),
+        _ => false,
+    }
 }
 
 fn call_list_mutation<'a>(expr: &'a Expr, target_name: &str) -> Option<ListMutation<'a>> {
@@ -2305,6 +2386,29 @@ for plugin in plugins:
         assert!(reasons.iter().any(|reason| reason
             .message
             .contains("unsupported nested assignment or mutation of INSTALLED_APPS")));
+    }
+
+    #[test]
+    fn marks_template_backend_internal_updates_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+TEMPLATES = [{"DIRS": []}]
+if not DEBUG:
+    TEMPLATES[0]["OPTIONS"] = {"loaders": []}
+TEMPLATES[0]["DIRS"].insert(0, DATA_DIR / "templates")
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+
+        let (backends, reasons) = partial_vec(&facts.template_backends);
+        assert!(known_vec(&backends[0].dirs).is_empty());
+        assert!(reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of TEMPLATES")));
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -261,6 +261,7 @@ fn extract_settings_state_inner(
     if module.body.iter().any(|stmt| {
         contains_nested_list_mutation(stmt, TEMPLATES)
             || contains_nested_template_dirs_mutation(stmt)
+            || contains_nested_template_options_assignment(stmt)
             || contains_unsupported_setting_update(stmt, TEMPLATES)
     }) {
         state.add_template_backends_reason(reason(
@@ -337,6 +338,15 @@ fn process_settings_stmt(
             mutation,
             &state.path_values,
             &state.path_list_values,
+            file,
+        ));
+        return;
+    }
+
+    if let Some(assignment) = template_options_assignment(stmt) {
+        state.template_backends = Some(apply_template_options_assignment(
+            state.template_backends.take(),
+            &assignment,
             file,
         ));
     }
@@ -880,11 +890,17 @@ fn body_contains_list_mutation(body: &[Stmt], target_name: &str) -> bool {
 
 fn contains_unsupported_setting_update(stmt: &Stmt, target_name: &str) -> bool {
     match stmt {
-        Stmt::Assign(assign) => assign
-            .targets
-            .iter()
-            .any(|target| is_indirect_setting_target(target, target_name)),
-        Stmt::AnnAssign(assign) => is_indirect_setting_target(assign.target.as_ref(), target_name),
+        Stmt::Assign(assign) => {
+            assign
+                .targets
+                .iter()
+                .any(|target| is_indirect_setting_target(target, target_name))
+                && !(target_name == TEMPLATES && template_options_assignment(stmt).is_some())
+        }
+        Stmt::AnnAssign(assign) => {
+            is_indirect_setting_target(assign.target.as_ref(), target_name)
+                && !(target_name == TEMPLATES && template_options_assignment(stmt).is_some())
+        }
         Stmt::AugAssign(assign) => {
             is_indirect_setting_target(assign.target.as_ref(), target_name)
                 && !(target_name == TEMPLATES && template_dirs_mutation(stmt).is_some())
@@ -1170,6 +1186,96 @@ fn contains_nested_template_dirs_mutation(stmt: &Stmt) -> bool {
 fn body_contains_template_dirs_mutation(body: &[Stmt]) -> bool {
     body.iter().any(|stmt| {
         template_dirs_mutation(stmt).is_some() || contains_nested_template_dirs_mutation(stmt)
+    })
+}
+
+struct TemplateOptionsAssignment<'a> {
+    backend_index: usize,
+    key: String,
+    value: &'a Expr,
+}
+
+fn template_options_assignment(stmt: &Stmt) -> Option<TemplateOptionsAssignment<'_>> {
+    match stmt {
+        Stmt::Assign(assign) => {
+            let target = assign.targets.first()?;
+            let (backend_index, key) = template_options_target(target)?;
+            Some(TemplateOptionsAssignment {
+                backend_index,
+                key,
+                value: assign.value.as_ref(),
+            })
+        }
+        Stmt::AnnAssign(assign) => {
+            let (backend_index, key) = template_options_target(assign.target.as_ref())?;
+            Some(TemplateOptionsAssignment {
+                backend_index,
+                key,
+                value: assign.value.as_deref()?,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn template_options_target(expr: &Expr) -> Option<(usize, String)> {
+    let Expr::Subscript(option_key_subscript) = expr else {
+        return None;
+    };
+    let key = string_literal(option_key_subscript.slice.as_ref())?;
+
+    let Expr::Subscript(options_dict_subscript) = option_key_subscript.value.as_ref() else {
+        return None;
+    };
+    let options_key = string_literal(options_dict_subscript.slice.as_ref())?;
+    if options_key != "OPTIONS" {
+        return None;
+    }
+
+    let Expr::Subscript(backend_subscript) = options_dict_subscript.value.as_ref() else {
+        return None;
+    };
+    if !is_name(backend_subscript.value.as_ref(), TEMPLATES) {
+        return None;
+    }
+    Some((integer_literal(backend_subscript.slice.as_ref())?, key))
+}
+
+fn contains_nested_template_options_assignment(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::If(stmt_if) => {
+            body_contains_template_options_assignment(&stmt_if.body)
+                || stmt_if
+                    .elif_else_clauses
+                    .iter()
+                    .any(|clause| body_contains_template_options_assignment(&clause.body))
+        }
+        Stmt::For(stmt_for) => {
+            body_contains_template_options_assignment(&stmt_for.body)
+                || body_contains_template_options_assignment(&stmt_for.orelse)
+        }
+        Stmt::While(stmt_while) => {
+            body_contains_template_options_assignment(&stmt_while.body)
+                || body_contains_template_options_assignment(&stmt_while.orelse)
+        }
+        Stmt::Try(stmt_try) => {
+            body_contains_template_options_assignment(&stmt_try.body)
+                || stmt_try.handlers.iter().any(|handler| {
+                    let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    body_contains_template_options_assignment(&handler.body)
+                })
+                || body_contains_template_options_assignment(&stmt_try.orelse)
+                || body_contains_template_options_assignment(&stmt_try.finalbody)
+        }
+        Stmt::With(stmt_with) => body_contains_template_options_assignment(&stmt_with.body),
+        _ => false,
+    }
+}
+
+fn body_contains_template_options_assignment(body: &[Stmt]) -> bool {
+    body.iter().any(|stmt| {
+        template_options_assignment(stmt).is_some()
+            || contains_nested_template_options_assignment(stmt)
     })
 }
 
@@ -1598,6 +1704,86 @@ fn apply_template_dir_list_mutation(
     }
 }
 
+fn apply_template_options_assignment(
+    current: Option<Fact<Vec<TemplateBackendFact>>>,
+    assignment: &TemplateOptionsAssignment,
+    file: &Utf8Path,
+) -> Fact<Vec<TemplateBackendFact>> {
+    let Some(current) = current else {
+        return mutation_before_assignment(
+            Field::SettingsTemplates,
+            file,
+            "TEMPLATES OPTIONS assignment appears before TEMPLATES assignment or import",
+        );
+    };
+
+    match current {
+        Fact::Known { mut value } => {
+            let reasons =
+                apply_template_options_assignment_to_backends(&mut value, assignment, file);
+            known_or_partial(value, reasons)
+        }
+        Fact::Partial {
+            mut value,
+            mut reasons,
+        } => {
+            reasons.extend(apply_template_options_assignment_to_backends(
+                &mut value, assignment, file,
+            ));
+            Fact::partial(value, reasons)
+        }
+        Fact::Unknown { mut reasons } => {
+            reasons.push(reason(
+                Field::SettingsTemplates,
+                file,
+                "cannot apply TEMPLATES OPTIONS assignment because TEMPLATES is unknown",
+            ));
+            Fact::unknown(reasons)
+        }
+        Fact::Ambiguous {
+            candidates,
+            mut reasons,
+        } => {
+            reasons.push(reason(
+                Field::SettingsTemplates,
+                file,
+                "cannot apply TEMPLATES OPTIONS assignment because TEMPLATES is ambiguous",
+            ));
+            Fact::ambiguous(candidates, reasons)
+        }
+    }
+}
+
+fn apply_template_options_assignment_to_backends(
+    backends: &mut [TemplateBackendFact],
+    assignment: &TemplateOptionsAssignment,
+    file: &Utf8Path,
+) -> Vec<Reason> {
+    let Some(backend) = backends.get_mut(assignment.backend_index) else {
+        return vec![reason(
+            Field::SettingsTemplateOptions,
+            file,
+            "cannot apply TEMPLATES OPTIONS assignment because the backend index is out of range",
+        )];
+    };
+
+    match assignment.key.as_str() {
+        "builtins" => {
+            backend.option_builtins = extract_option_builtins_value(assignment.value, file);
+            Vec::new()
+        }
+        "libraries" => {
+            backend.option_libraries = extract_option_libraries_value(assignment.value, file);
+            Vec::new()
+        }
+        key => vec![reason(
+            Field::SettingsTemplateOptions,
+            file,
+            format!("unsupported TEMPLATES OPTIONS assignment for `{key}`"),
+        )],
+    }
+}
+
 fn extract_template_backend_list_item(
     expr: &Expr,
     path_values: &BTreeMap<String, Utf8PathBuf>,
@@ -1765,6 +1951,10 @@ fn extract_option_libraries(
     let Some(value) = dict_value(options, "libraries") else {
         return Fact::known(Vec::new());
     };
+    extract_option_libraries_value(value, file)
+}
+
+fn extract_option_libraries_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<TemplateLibraryFact>> {
     let Expr::Dict(libraries) = value else {
         return Fact::unknown(vec![reason(
             Field::SettingsTemplateOptions,
@@ -1830,6 +2020,10 @@ fn extract_option_builtins(
     let Some(value) = dict_value(options, "builtins") else {
         return Fact::known(Vec::new());
     };
+    extract_option_builtins_value(value, file)
+}
+
+fn extract_option_builtins_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<PyModuleName>> {
     let Some(elements) = collection_elements(value) else {
         return Fact::unknown(vec![reason(
             Field::SettingsTemplateOptions,
@@ -3229,6 +3423,100 @@ if ENABLE_EXTRA_TEMPLATES:
             known_vec(&backends[0].dirs)[0].path,
             Utf8PathBuf::from("templates")
         );
+        assert!(reasons.iter().any(|reason| reason
+            .message
+            .contains("unsupported nested assignment or mutation of TEMPLATES")));
+    }
+
+    #[test]
+    fn applies_deterministic_template_options_assignments() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"OPTIONS": {}}]
+TEMPLATES[0]["OPTIONS"]["builtins"] = ["project.templatetags.builtins"]
+TEMPLATES[0]["OPTIONS"]["libraries"] = {
+    "custom_tags": "project.templatetags.custom_tags",
+}
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let backends = known_vec(&facts.template_backends);
+
+        assert_eq!(
+            known_vec(&backends[0].option_builtins),
+            [PyModuleName::parse("project.templatetags.builtins").unwrap()]
+        );
+        assert_eq!(
+            known_vec(&backends[0].option_libraries)[0].load_name,
+            LibraryName::parse("custom_tags").unwrap()
+        );
+    }
+
+    #[test]
+    fn marks_out_of_range_template_options_assignment_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"OPTIONS": {}}]
+TEMPLATES[3]["OPTIONS"]["builtins"] = ["project.templatetags.builtins"]
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let (backends, reasons) = partial_vec(&facts.template_backends);
+
+        assert!(known_vec(&backends[0].option_builtins).is_empty());
+        assert!(reasons[0].message.contains("backend index is out of range"));
+    }
+
+    #[test]
+    fn marks_unsupported_template_options_assignment_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"OPTIONS": {}}]
+TEMPLATES[0]["OPTIONS"]["context_processors"] = ["project.context_processors.extra"]
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let (backends, reasons) = partial_vec(&facts.template_backends);
+
+        assert!(known_vec(&backends[0].option_builtins).is_empty());
+        assert!(reasons[0]
+            .message
+            .contains("unsupported TEMPLATES OPTIONS assignment"));
+    }
+
+    #[test]
+    fn marks_nested_template_options_assignments_partial() {
+        let tmp = tempdir().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let settings = write_settings(
+            &root,
+            r#"
+INSTALLED_APPS = []
+TEMPLATES = [{"OPTIONS": {}}]
+if ENABLE_EXTRA_BUILTINS:
+    TEMPLATES[0]["OPTIONS"]["builtins"] = ["project.templatetags.builtins"]
+"#,
+        );
+
+        let facts = extract_settings_facts(&settings);
+        let (backends, reasons) = partial_vec(&facts.template_backends);
+
+        assert!(known_vec(&backends[0].option_builtins).is_empty());
         assert!(reasons.iter().any(|reason| reason
             .message
             .contains("unsupported nested assignment or mutation of TEMPLATES")));


### PR DESCRIPTION
## Summary

Consolidates #593 and #597 through #603 into one settings mutation review unit:

- marks nested `INSTALLED_APPS` updates partial
- marks unsupported template backend updates partial
- marks unsupported destructive/reordering list methods partial
- applies deterministic top-level list methods when representable
- applies deterministic `TEMPLATES[<int>]["DIRS"]` mutations
- applies deterministic `TEMPLATES[<int>]["OPTIONS"]` builtins/libraries assignments
- ignores template OPTIONS keys that do not affect the project model

## Stack Context

This is 10/11 in the static project model review stack.

Review order: #615 -> #605 -> #606 -> #613 -> #607 -> #608 -> #609 -> #610 -> #611 -> #612 -> #614.

Review focus: deterministic settings mutation policy and safe partial downgrades.

## Consolidation Notes

#598 and #599 especially should not be reviewed separately: one adds conservative partial behavior and the next applies the deterministic subset. This PR presents the final source-proven mutation policy as one unit.

## Validation

- Consolidation check: `git diff --name-status static-project-model-ignore-irrelevant-options..static-project-model-consolidated-settings-mutations` produced no differences.
- Restack check: `cargo test -q -p djls-semantic static --no-default-features`
- Restack check: `cargo test -q -p djls-semantic sync::tests --no-default-features`
- Restack check: `cargo clippy -q -p djls-semantic --all-targets --no-default-features -- -D warnings`