### PR TITLE
Stop auto mode inspector fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Template parsing does not need its own database trait. `parse_template` depends 
 ### Static Project Model and Python Inspector
 
 > [!NOTE]
-> The inspector is being replaced by the static project model ([#401](https://github.com/joshuadavidthomas/django-language-server/issues/401)). The rollout keeps the inspector as a transitional fallback until the documented removal gates are met.
+> The inspector is being replaced by the static project model ([#401](https://github.com/joshuadavidthomas/django-language-server/issues/401)). The rollout keeps the inspector available as an explicit compatibility mode until the documented removal gates are met.
 
 The server needs to know what Django has installed: `INSTALLED_APPS`, template directories, templatetag libraries, and the symbols they export. The preferred path is the static project model:
 
@@ -162,15 +162,15 @@ The server needs to know what Django has installed: `INSTALLED_APPS`, template d
 
 `project_model` controls rollout behavior:
 
-- `auto` builds static facts first and uses known static outputs without starting the inspector. Partial or unknown static facts can fall back to the inspector during the transition.
-- `static` uses only static facts and never starts the inspector. Partial or unknown facts degrade conservatively.
+- `auto` uses static facts without starting the inspector. Partial or unknown static facts degrade conservatively.
+- `static` uses the same static-only behavior as `auto`, for users who want to make that choice explicit.
 - `inspector` uses the legacy runtime path first.
 
 A small Python program from `crates/djls-semantic/inspector/` still ships embedded in the binary as a zipapp for fallback. Project introspection queries Django's template engine registry and returns JSON describing template directories, installed libraries, and their symbols.
 
 Startup uses two phases to avoid blocking the editor:
 
-1. A cache check during `initialized`. The server can load cached static template-library facts from `~/.cache/djls/static-project-model/template-libraries/` or legacy inspector responses from `~/.cache/djls/inspector/`, depending on `project_model` and fact confidence.
+1. A cache check during `initialized`. The server can load cached static template-library facts from `~/.cache/djls/static-project-model/template-libraries/` or, when `project_model = "inspector"`, legacy inspector responses from `~/.cache/djls/inspector/`.
 2. A background task refreshes project data, updates Salsa inputs, and writes a fresh cache. This includes template directories, template libraries, the first-party project file set, extracted validation rules from installed packages, and external model graphs. When a cache was loaded in phase 1, this runs concurrently with normal operation. If no cache existed, the server waits for this to complete before advertising full capabilities.
 
 This means that in the common case (you've opened this project before and the environment hasn't changed), startup is nearly instant — the server just reads a JSON file from disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Added opt-in whole-document Django template formatting through `djangofmt`.
 - Added `project_model` configuration for choosing static-first, static-only, or inspector-first discovery of template directories, template libraries, and symbols.
 
+### Changed
+
+- Changed `project_model = "auto"` to use the static project model without falling back to the Python inspector for partial or unknown static facts. Use `project_model = "inspector"` to opt into the legacy runtime path.
+
 ## [6.0.3]
 
 ### Added

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -121,22 +121,11 @@ impl IntrospectionRequest for TemplateDirsRequest {
 
 fn refresh_template_dirs(db: &mut dyn ProjectDb, project: Project) {
     match project.project_model(db) {
-        ProjectModelMode::Auto => refresh_template_dirs_auto(db, project),
-        ProjectModelMode::Static => refresh_template_dirs_static(db, project),
+        ProjectModelMode::Auto | ProjectModelMode::Static => {
+            refresh_template_dirs_static(db, project);
+        }
         ProjectModelMode::Inspector => refresh_template_dirs_inspector(db, project),
     }
-}
-
-fn refresh_template_dirs_auto(db: &mut dyn ProjectDb, project: Project) {
-    let static_dirs = assemble_project_static_template_dirs(db, project);
-    log_static_template_dirs_status(project.django_settings_module(db).as_deref(), &static_dirs);
-    if usable_static_template_dirs(static_dirs.clone()).is_some() {
-        apply_static_template_dirs(db, project, static_dirs);
-        return;
-    }
-
-    let inspector_dirs = fetch_template_dirs(db);
-    apply_template_dirs_or_static_fallback(db, project, inspector_dirs, Some(static_dirs));
 }
 
 fn refresh_template_dirs_static(db: &mut dyn ProjectDb, project: Project) {
@@ -302,46 +291,11 @@ impl IntrospectionRequest for TemplateLibrarySnapshotRequest {
 
 fn load_project_template_library_cache(db: &mut dyn ProjectDb, project: Project) -> bool {
     match project.project_model(db) {
-        ProjectModelMode::Auto => load_project_template_library_cache_auto(db, project),
-        ProjectModelMode::Static => load_project_template_library_cache_static(db, project),
+        ProjectModelMode::Auto | ProjectModelMode::Static => {
+            load_project_template_library_cache_static(db, project)
+        }
         ProjectModelMode::Inspector => load_project_template_library_cache_inspector(db, project),
     }
-}
-
-fn load_project_template_library_cache_auto(db: &mut dyn ProjectDb, project: Project) -> bool {
-    let static_entry = load_static_template_library_snapshot_cache(db, project);
-    if static_entry
-        .as_ref()
-        .and_then(static_template_library_cache_entry_knowledge)
-        == Some(Knowledge::Known)
-    {
-        let entry = static_entry.expect("known static cache entry should exist");
-        return apply_static_template_library_cache_entry(db, project, entry);
-    }
-
-    let inspector_snapshot = load_template_library_snapshot_cache(db, project);
-    apply_auto_template_library_cache(db, project, static_entry, inspector_snapshot)
-}
-
-fn apply_auto_template_library_cache(
-    db: &mut dyn ProjectDb,
-    project: Project,
-    static_entry: Option<StaticTemplateLibraryCacheEntry>,
-    inspector_snapshot: Option<TemplateLibrarySnapshot>,
-) -> bool {
-    if let Some(snapshot) = inspector_snapshot {
-        if apply_template_library_snapshot(db, project, snapshot) {
-            refresh_templatetag_modules(db, project);
-        }
-
-        return true;
-    }
-
-    let Some(entry) = static_entry else {
-        return false;
-    };
-
-    apply_static_template_library_cache_entry(db, project, entry)
 }
 
 fn load_project_template_library_cache_static(db: &mut dyn ProjectDb, project: Project) -> bool {
@@ -369,44 +323,11 @@ fn load_project_template_library_cache_inspector(db: &mut dyn ProjectDb, project
 
 fn refresh_template_libraries(db: &mut dyn ProjectDb, project: Project) {
     match project.project_model(db) {
-        ProjectModelMode::Auto => refresh_template_libraries_auto(db, project),
-        ProjectModelMode::Static => refresh_template_libraries_static(db, project),
+        ProjectModelMode::Auto | ProjectModelMode::Static => {
+            refresh_template_libraries_static(db, project);
+        }
         ProjectModelMode::Inspector => refresh_template_libraries_inspector(db, project),
     }
-}
-
-fn refresh_template_libraries_auto(db: &mut dyn ProjectDb, project: Project) {
-    if let Some(entry) = load_static_template_library_snapshot_cache(db, project) {
-        if static_template_library_cache_entry_knowledge(&entry) == Some(Knowledge::Known) {
-            apply_static_template_library_cache_entry(db, project, entry);
-            return;
-        }
-
-        if let Some(snapshot) = fetch_template_library_snapshot(db) {
-            save_template_library_snapshot_cache(db, project, &snapshot);
-            apply_template_library_snapshot(db, project, snapshot);
-            return;
-        }
-
-        apply_static_template_library_cache_entry(db, project, entry);
-        return;
-    }
-
-    let assembly = assemble_project_static_template_library_snapshot_with_status(db, project);
-    log_static_project_model_status("assembled", &assembly.status);
-    save_static_template_library_snapshot_cache(db, project, &assembly);
-    if static_template_library_snapshot_knowledge(&assembly.snapshot) == Some(Knowledge::Known) {
-        apply_static_template_library_snapshot(db, project, assembly.snapshot);
-        return;
-    }
-
-    if let Some(snapshot) = fetch_template_library_snapshot(db) {
-        save_template_library_snapshot_cache(db, project, &snapshot);
-        apply_template_library_snapshot(db, project, snapshot);
-        return;
-    }
-
-    apply_static_template_library_snapshot(db, project, assembly.snapshot);
 }
 
 fn refresh_template_libraries_static(db: &mut dyn ProjectDb, project: Project) {
@@ -482,18 +403,6 @@ fn refresh_template_libraries_from_static_cache(
     log_static_project_model_status("cache_load", &entry.status);
     apply_static_template_library_snapshot(db, project, entry.snapshot);
     true
-}
-
-fn static_template_library_cache_entry_knowledge(
-    entry: &StaticTemplateLibraryCacheEntry,
-) -> Option<Knowledge> {
-    static_template_library_snapshot_knowledge(&entry.snapshot)
-}
-
-fn static_template_library_snapshot_knowledge(
-    snapshot: &Fact<TemplateLibrarySnapshot>,
-) -> Option<Knowledge> {
-    usable_static_template_library_snapshot(snapshot.clone()).map(|(_, knowledge)| knowledge)
 }
 
 fn fetch_template_library_snapshot(db: &dyn ProjectDb) -> Option<TemplateLibrarySnapshot> {
@@ -2471,7 +2380,7 @@ TEMPLATES = [
     }
 
     #[test]
-    fn auto_template_dirs_query_inspector_for_partial_static_data() {
+    fn auto_template_dirs_do_not_query_inspector_for_partial_static_data() {
         let tmp = TempDir::new().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         write_file(&root.join("project/__init__.py"), "");
@@ -2503,8 +2412,60 @@ TEMPLATES = [
 
         refresh_template_dirs(&mut db, project);
 
-        assert_eq!(db.introspector.query_count(), 1);
+        assert_eq!(db.introspector.query_count(), 0);
         assert_eq!(project.template_dirs(&db), &TemplateDirs::Unknown);
+    }
+
+    #[test]
+    fn auto_project_external_data_refresh_does_not_query_inspector() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        write_static_template_fixture(&root);
+        write_file(
+            &root.join("project/settings.py"),
+            r#"
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+INSTALLED_APPS = ["blog"]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {},
+    }
+]
+"#,
+        );
+        write_file(&root.join("templates/base.html"), "");
+        write_file(&root.join("blog/templates/blog/detail.html"), "");
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root.clone(),
+            missing_interpreter(&root),
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
+
+        refresh_project_external_data(&mut db, project);
+
+        assert_eq!(db.introspector.query_count(), 0);
+        assert_eq!(
+            project.template_dirs(&db),
+            &TemplateDirs::Known(vec![root.join("templates"), root.join("blog/templates")])
+        );
+        assert!(project
+            .template_libraries(&db)
+            .is_enabled_library_str("blog_tags"));
+        assert!(project
+            .template_files(&db)
+            .iter()
+            .any(|template| template.name() == "base.html"));
+        assert!(project
+            .python_index(&db)
+            .templatetags()
+            .any(|module| module.module_path().as_str() == "blog.templatetags.blog_tags"));
     }
 
     #[test]
@@ -3069,7 +3030,7 @@ TEMPLATES = []
     }
 
     #[test]
-    fn auto_template_libraries_query_inspector_for_partial_static_data() {
+    fn auto_template_libraries_do_not_query_inspector_for_partial_static_data() {
         let tmp = TempDir::new().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         write_static_template_fixture(&root);
@@ -3085,7 +3046,7 @@ TEMPLATES = []
         refresh_template_libraries(&mut db, project);
 
         let libraries = project.template_libraries(&db);
-        assert_eq!(db.introspector.query_count(), 1);
+        assert_eq!(db.introspector.query_count(), 0);
         assert_eq!(libraries.active_knowledge, Knowledge::Partial);
         assert!(libraries.is_enabled_library_str("blog_tags"));
     }
@@ -3846,16 +3807,13 @@ TEMPLATES = [
     }
 
     #[test]
-    fn auto_startup_cache_uses_inspector_cache_when_static_cache_is_partial() {
+    fn auto_startup_cache_ignores_inspector_cache_when_static_cache_is_partial() {
         let tmp = TempDir::new().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().join("project")).unwrap();
-        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
-            root.clone(),
-            missing_interpreter(&root),
-            ProjectModelMode::Auto,
-            Some("project.settings".to_string()),
-            Vec::new(),
-        );
+        let dependency = root.join("project/settings.py");
+        write_file(&dependency, "INSTALLED_APPS = []\n");
+
+        let interpreter = Interpreter::InterpreterPath("/missing/python".to_string());
         let static_snapshot = Fact::partial(
             test_response(),
             vec![Reason::path(
@@ -3871,10 +3829,20 @@ TEMPLATES = [
             Some(0),
             Some(1),
         );
-        let static_entry = StaticTemplateLibraryCacheEntry {
+        let assembly = StaticTemplateLibrarySnapshotAssembly {
             snapshot: static_snapshot,
             status,
+            dependencies: vec![StaticCacheDependency::from_path(dependency)],
         };
+        save_static_template_library_snapshot(
+            &root,
+            &interpreter,
+            Some("project.settings"),
+            &[],
+            &[],
+            &assembly,
+        );
+
         let inspector_snapshot = TemplateLibrarySnapshot {
             symbols: Vec::new(),
             libraries: BTreeMap::from([(
@@ -3883,17 +3851,27 @@ TEMPLATES = [
             )]),
             builtins: Vec::new(),
         };
+        save_template_library_snapshot(
+            &root,
+            &interpreter,
+            Some("project.settings"),
+            &[],
+            &inspector_snapshot,
+        );
 
-        assert!(apply_auto_template_library_cache(
-            &mut db,
-            project,
-            Some(static_entry),
-            Some(inspector_snapshot),
-        ));
+        let (mut db, project) = StaticSnapshotTestDb::with_project_options_and_model(
+            root,
+            interpreter,
+            ProjectModelMode::Auto,
+            Some("project.settings".to_string()),
+            Vec::new(),
+        );
 
+        assert!(load_project_template_library_cache(&mut db, project));
         let libraries = project.template_libraries(&db);
-        assert!(libraries.is_enabled_library_str("inspector_only"));
-        assert!(!libraries.is_enabled_library_str("i18n"));
+        assert_eq!(libraries.active_knowledge, Knowledge::Partial);
+        assert!(libraries.is_enabled_library_str("i18n"));
+        assert!(!libraries.is_enabled_library_str("inspector_only"));
     }
 
     #[test]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,52 +1,8 @@
 # Configuration
 
-Django Language Server auto-detects your project configuration in most cases. It reads the `DJANGO_SETTINGS_MODULE` environment variable and searches for standard virtual environment directories (`.venv`, `venv`, `env`, `.env`).
+Django Language Server auto-detects your project configuration in most cases. By default, `project_model = "auto"` builds Django template facts statically from your workspace, configured settings module, import roots, and available source files. It does not run Django or start the Python inspector.
 
-**Most users don't need any configuration.** The settings below are for edge cases like non-standard virtual environment locations, editors that don't pass environment variables, or custom template tag definitions.
-
-## Handling environment variables
-
-Django projects commonly read secrets and configuration from environment variables — whether through `os.environ`, `django-environ`, `environs`, `python-decouple`, or similar libraries.
-
-When a required variable is missing, the language server's inspector process fails to initialize Django and you'll see an error like:
-
-> Missing required environment variable: DJANGO_SECRET_KEY. Django settings failed to load because 'DJANGO_SECRET_KEY' is not set in the editor's environment.
-
-This happens because editors launched from desktop environments (app launchers, dock icons) don't inherit shell variables set in `.bashrc`, `.zshrc`, or similar.
-
-### How environment variables reach the inspector
-
-The inspector subprocess inherits the full environment of its parent process (the language server, which inherits from the editor). Variables set in your shell are available automatically **if the editor was launched from that shell**. The [`env_file`](#env_file) option exists for cases where that inheritance doesn't work.
-
-### Recommended setup
-
-If your Django settings depend on environment variables, create a `.env` file in your project root:
-
-```shell
-# .env
-DJANGO_SECRET_KEY=not-a-real-secret
-DATABASE_URL=postgres://localhost/mydb
-```
-
-The server automatically detects `.env` in the project root and loads its variables into the inspector process — no configuration needed. This is the same format used by `python-dotenv` and similar tools.
-
-!!! tip
-    The values only need to be valid enough for Django to initialize. For a language server, a placeholder `SECRET_KEY` works fine.
-
-If your env file has a different name or location, point to it explicitly:
-
-```toml
-[tool.djls]
-env_file = ".env.local"
-```
-
-### Other approaches
-
-If you prefer not to use an env file:
-
-- **Launch your editor from the terminal** where the variables are already set. Most editors inherit the shell's environment when started this way.
-- **Configure your editor** to set environment variables before starting language servers. See your editor's documentation for details.
-- **Set `django_settings_module`** in your djls config if the only missing variable is `DJANGO_SETTINGS_MODULE`.
+**Most users don't need any configuration.** The settings below are for edge cases like multiple Django settings modules, non-standard import roots, non-standard virtual environment locations, runtime inspector compatibility, or custom template tag definitions.
 
 ## Options
 
@@ -58,8 +14,8 @@ Selects how djls builds Django project facts for template directories, active te
 
 Supported values:
 
-- `"auto"` — Build the static project model first. When static facts are known, djls uses them without starting the Python inspector. When static facts are partial or unknown, djls can fall back to the inspector during the transition period.
-- `"static"` — Use only the static project model. This avoids the Python inspector, `django.setup()`, and runtime imports. If settings are too dynamic to understand statically, djls degrades conservatively and suppresses diagnostics that would risk false positives.
+- `"auto"` — Use the static project model without starting the Python inspector. If settings are too dynamic to understand statically, djls degrades conservatively and suppresses diagnostics that would risk false positives.
+- `"static"` — Same static-only project model behavior as `"auto"`, useful when you want to make that choice explicit.
 - `"inspector"` — Use the legacy Python/Django inspector path first. This keeps the runtime behavior used by older releases while the static model rollout continues.
 
 ```toml
@@ -67,7 +23,7 @@ Supported values:
 project_model = "auto"
 ```
 
-Use `"static"` when you want editor behavior that does not run Django. Use `"inspector"` if a dynamic project still needs the runtime fallback while static support catches up.
+Use `"auto"` or `"static"` when you want editor behavior that does not run Django. Use `"inspector"` if a dynamic project still needs the runtime project model while static support catches up.
 
 ### `django_settings_module`
 
@@ -123,7 +79,7 @@ Use this for repetitive monorepo layouts where each project follows the same spl
 
 Absolute path to your project's virtual environment directory.
 
-The server needs access to your virtual environment to discover installed Django apps and their template tags.
+The static project model can read source files from a virtual environment's `site-packages` directory when one is available. The legacy inspector also uses the virtual environment's Python executable when `project_model = "inspector"`.
 
 **When to configure:**
 
@@ -141,7 +97,7 @@ Additional directories to add to Python's import search path. Static project mod
 - Your project has a non-standard structure where Django code imports from directories outside the project root
 - You're working in a monorepo where Django imports shared packages from other directories
 - Your project depends on internal libraries in non-standard locations
-- You need to make additional packages importable for Django introspection
+- You need to make additional packages importable for static discovery or legacy Django introspection
 
 ### `env_file`
 
@@ -149,7 +105,7 @@ Additional directories to add to Python's import search path. Static project mod
 
 Path to an environment file (relative to the project root) whose variables are injected into the inspector subprocess.
 
-Many Django projects read secrets and configuration from environment variables at settings load time. When the editor is launched from a desktop environment rather than a terminal, those variables aren't available and the inspector fails. This option tells the server to read a `.env` file and forward the variables to the inspector process, so Django settings load correctly without duplicating secrets into config files.
+This option only matters for `project_model = "inspector"`. Static project model modes read settings source code without executing Django settings, so missing runtime environment variables do not prevent static project discovery.
 
 If no `env_file` is configured, the server looks for a `.env` file in the project root automatically. If the file doesn't exist, nothing happens. When `env_file` is set explicitly and the file is missing, a warning is logged.
 
@@ -157,9 +113,35 @@ If no `env_file` is configured, the server looks for a `.env` file in the projec
 
 - Your `.env` file has a non-standard name (e.g., `.env.local`, `.env.development`)
 - Your `.env` file lives in a subdirectory
+- You use `project_model = "inspector"` and your Django settings need environment variables that your editor does not pass to language servers
 
 !!! note
-    `env_file` is only needed by runtime Django settings. In `project_model = "static"`, djls does not execute your settings module, but static extraction may still need `django_settings_module` and `pythonpath` to find the right files.
+    `env_file` is only needed by runtime Django settings. In `project_model = "auto"` or `"static"`, djls does not execute your settings module, but static extraction may still need `django_settings_module` and `pythonpath` to find the right files.
+
+#### Inspector environment variables
+
+Django projects commonly read secrets and configuration from environment variables through `os.environ`, `django-environ`, `environs`, `python-decouple`, or similar libraries. When a required variable is missing in inspector mode, Django setup can fail before the language server can inspect template facts.
+
+The inspector subprocess inherits the full environment of its parent process. Variables set in your shell are available automatically if the editor was launched from that shell. Editors launched from desktop environments, app launchers, or dock icons often do not inherit shell variables set in `.bashrc`, `.zshrc`, or similar files.
+
+If your runtime Django settings depend on environment variables, create a `.env` file in your project root:
+
+```shell
+# .env
+DJANGO_SECRET_KEY=not-a-real-secret
+DATABASE_URL=postgres://localhost/mydb
+```
+
+The values only need to be valid enough for Django to initialize. For a language server, a placeholder `SECRET_KEY` works fine.
+
+If your env file has a different name or location, point to it explicitly:
+
+```toml
+[tool.djls]
+env_file = ".env.local"
+```
+
+Other options are to launch your editor from a terminal where the variables are already set, configure your editor to set environment variables before starting language servers, or set `django_settings_module` in djls config if the only missing variable is `DJANGO_SETTINGS_MODULE`.
 
 ### `tagspecs`
 
@@ -382,7 +364,7 @@ project_model = "auto"
 django_settings_module = "myproject.settings"
 venv_path = "/path/to/venv"  # Optional: only if auto-detection fails
 pythonpath = ["/path/to/shared/libs"]  # Optional: additional import paths
-env_file = ".env"  # Optional: path to env file (auto-detects .env by default)
+env_file = ".env"  # Optional: inspector-mode env file
 
 [tool.djls.diagnostics.severity]
 S100 = "off"
@@ -414,4 +396,4 @@ Django Language Server reads standard Python and Django environment variables:
 
 If you're already running Django with these environment variables set, the language server will automatically use them.
 
-If your editor doesn't pass these environment variables to the language server, configure them explicitly using one of the methods above. See [Handling environment variables](#handling-environment-variables) for details on `.env` file support.
+If your editor doesn't pass these environment variables to the language server, configure them explicitly using one of the methods above. See [`env_file`](#env_file) for inspector-mode `.env` file support.

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -15,19 +15,19 @@ The **project model** describes the Django facts djls needs for templates:
 - Which library load-name maps to which module
 - Which template directories Django searches
 
-By default, `project_model = "auto"` builds these facts statically from your workspace, `django_settings_module`, `pythonpath`, and available source files. When static facts are known, djls can provide scoped completions and diagnostics without spawning Python or calling `django.setup()`.
+By default, `project_model = "auto"` builds these facts statically from your workspace, `django_settings_module`, `pythonpath`, and available source files. When static facts are available, djls can provide scoped completions and diagnostics without spawning Python or calling `django.setup()`.
 
-During the transition, auto mode can still fall back to the Python inspector when static facts are partial or unknown. You can force one path with [`project_model`](configuration/index.md#project_model):
+You can choose the project model path with [`project_model`](configuration/index.md#project_model):
 
-- `"auto"` — static first, inspector fallback for partial/unknown facts
-- `"static"` — static only, no inspector subprocess
+- `"auto"` — static project model, no inspector subprocess
+- `"static"` — same static-only project model behavior, useful when you want to make that choice explicit
 - `"inspector"` — legacy runtime inspector first
 
-The static model tracks confidence. Known facts enable scoped availability diagnostics. Partial or unknown facts still allow diagnostics backed by positive facts, but suppress absence-based diagnostics unless inspector fallback supplies known facts.
+The static model tracks confidence. Known facts enable scoped availability diagnostics. Partial or unknown facts still allow diagnostics backed by positive facts, but suppress absence-based diagnostics.
 
 ### Inspector
 
-The **inspector** is the legacy Python process that introspects your running Django project. It remains available as a fallback during the static project model rollout.
+The **inspector** is the legacy Python process that introspects your running Django project. It remains available through `project_model = "inspector"` during the static project model rollout.
 
 ### Environment Scanner
 
@@ -172,7 +172,7 @@ When project model facts are **partial or unknown**:
 
 This design avoids false positives when the Python environment isn't available.
 
-In `project_model = "auto"`, the inspector can still fill gaps for partial or unknown static facts. In `project_model = "static"`, djls does not fall back to the inspector.
+In `project_model = "auto"` or `"static"`, djls does not fall back to the inspector for partial or unknown static facts. Use `project_model = "inspector"` when you need the legacy runtime path for a dynamic project.
 
 ## Configuring Diagnostic Severity
 


### PR DESCRIPTION
## Summary

- routes `project_model = "auto"` through the same static-only template dir and template library paths as `static`
- keeps `project_model = "inspector"` as the explicit legacy runtime path with static fallback if runtime data is unavailable
- updates tests and docs so partial or unknown static facts degrade through confidence gates instead of querying the inspector
- adds an end-to-end refresh regression that template dirs, libraries, template files, and templatetag indexing populate in auto mode without inspector queries
- makes configuration and architecture docs lead with static project model behavior and describe the inspector as an explicit compatibility mode

## Stack Context

This is 11/11 in the static project model review stack.

Review order: #615 -> #605 -> #606 -> #613 -> #607 -> #608 -> #609 -> #610 -> #611 -> #612 -> #614.

Review focus: removing inspector fallback from `project_model = "auto"` while preserving explicit `inspector` mode.

## Validation

- Restack check: `cargo test -q -p djls-corpus`
- Restack check: `cargo test -q -p djls-semantic gh401_fixture_static_assembly_matches_manifest_settings_modules --no-default-features`
- Restack check: `cargo test -q -p djls-semantic static --no-default-features`
- Restack check: `cargo test -q -p djls-semantic sync::tests --no-default-features`
- Restack check: `just fmt --check`
- Restack check: `cargo clippy -q -p djls-corpus --all-targets -- -D warnings`
- Restack check: `cargo clippy -q -p djls-semantic --all-targets --no-default-features -- -D warnings`