### PR TITLE
Remove fact reason field labels

### DIFF
--- a/crates/djls-semantic/src/project/app_registry.rs
+++ b/crates/djls-semantic/src/project/app_registry.rs
@@ -22,7 +22,6 @@ use ruff_python_ast::StmtClassDef;
 use crate::project::facts::AppConfigFact;
 use crate::project::facts::AppFact;
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::InstalledAppFact;
 use crate::project::facts::ModuleResolution;
 use crate::project::facts::ModuleSearchPathEntry;
@@ -102,7 +101,6 @@ fn resolve_installed_app_entry(
             return unknown_installed_app(
                 entry,
                 vec![Reason::new(
-                    Field::AppsInstalled,
                     ReasonSource::Unknown,
                     format!("installed app entry is not a valid Python module path: {error}"),
                 )],
@@ -177,7 +175,6 @@ fn resolve_app_config_entry(
         Err(error) => {
             let mut reasons = direct_reasons;
             reasons.push(Reason::new(
-                Field::AppsConfig,
                 ReasonSource::Unknown,
                 format!("AppConfig module path is invalid: {error}"),
             ));
@@ -198,7 +195,6 @@ fn resolve_app_config_entry(
     let source = fs::read_to_string(&config_file).map_err(|error| {
         let mut reasons = direct_reasons.clone();
         reasons.push(Reason::file(
-            Field::AppsConfig,
             config_file.clone(),
             format!("failed to read AppConfig module: {error}"),
         ));
@@ -208,7 +204,6 @@ fn resolve_app_config_entry(
         .map_err(|error| {
             let mut reasons = direct_reasons.clone();
             reasons.push(Reason::file(
-                Field::AppsConfig,
                 config_file.clone(),
                 format!("failed to parse AppConfig module: {error}"),
             ));
@@ -227,7 +222,6 @@ fn resolve_app_config_entry(
     }) else {
         let mut reasons = direct_reasons;
         reasons.push(Reason::file(
-            Field::AppsConfig,
             config_file,
             format!(
                 "AppConfig class `{class_name}` was not found or does not inherit from AppConfig"
@@ -261,7 +255,6 @@ fn resolve_default_app_config(
             return installed_app_with_reason(
                 base_app,
                 Reason::file(
-                    Field::AppsConfig,
                     config_file,
                     format!("default AppConfig module path is invalid: {error}"),
                 ),
@@ -275,7 +268,6 @@ fn resolve_default_app_config(
             return installed_app_with_reason(
                 base_app,
                 Reason::file(
-                    Field::AppsConfig,
                     config_file,
                     format!("failed to read default AppConfig module: {error}"),
                 ),
@@ -288,7 +280,6 @@ fn resolve_default_app_config(
             return installed_app_with_reason(
                 base_app,
                 Reason::file(
-                    Field::AppsConfig,
                     config_file,
                     format!("failed to parse default AppConfig module: {error}"),
                 ),
@@ -395,7 +386,6 @@ fn select_default_app_config<'a>(
         }
         _ if explicit_default_candidates.len() > 1 => {
             DefaultAppConfigSelection::Unclear(Reason::file(
-                Field::AppsConfig,
                 config_file,
                 "more than one AppConfig class sets default = True",
             ))
@@ -451,7 +441,6 @@ fn app_config_default_inner<'a>(
         active_classes.remove(class.name.as_str());
         return boolean_literal(default).map(Some).ok_or_else(|| {
             Reason::file(
-                Field::AppsConfig,
                 file,
                 format!(
                     "AppConfig.default on `{}` must be a boolean literal for static default selection",
@@ -557,16 +546,11 @@ fn is_name(expr: &Expr, expected: &str) -> bool {
 
 fn app_config_name(expr: Option<&Expr>, file: &Utf8Path) -> Fact<PyModuleName> {
     let Some(expr) = expr else {
-        return Fact::unknown(vec![Reason::file(
-            Field::AppsConfig,
-            file,
-            "AppConfig.name is not assigned",
-        )]);
+        return Fact::unknown(vec![Reason::file(file, "AppConfig.name is not assigned")]);
     };
 
     let Some(name) = string_literal(expr) else {
         return Fact::unknown(vec![Reason::file(
-            Field::AppsConfig,
             file,
             "AppConfig.name must be a string literal",
         )]);
@@ -575,7 +559,6 @@ fn app_config_name(expr: Option<&Expr>, file: &Utf8Path) -> Fact<PyModuleName> {
     match PyModuleName::parse(&name) {
         Ok(module) => Fact::known(module),
         Err(error) => Fact::unknown(vec![Reason::file(
-            Field::AppsConfig,
             file,
             format!("AppConfig.name is not a valid Python module path: {error}"),
         )]),
@@ -595,7 +578,6 @@ fn app_config_label(
         return add_reasons(
             default_label_from_name(name),
             vec![Reason::file(
-                Field::AppsConfig,
                 file,
                 "AppConfig.label must be a string literal; using the app module basename",
             )],
@@ -617,7 +599,6 @@ fn app_config_path(
 
     let Some(path) = string_literal(expr) else {
         return default_path.with_reason(Reason::file(
-            Field::AppsPath,
             file,
             "AppConfig.path must be a string literal; using the resolved app package path",
         ));
@@ -628,7 +609,6 @@ fn app_config_path(
         Fact::known(path)
     } else {
         default_path.with_reason(Reason::path(
-            Field::AppsPath,
             path,
             "AppConfig.path does not exist or is not a directory; using the resolved app package path",
         ))
@@ -1385,14 +1365,14 @@ class BlogConfig(AppConfig):
         assert!(matches!(installed_apps[1].module, Fact::Unknown { .. }));
         assert!(reasons
             .iter()
-            .any(|reason| reason.field == Field::ResolverModule));
+            .any(|reason| matches!(&reason.source, ReasonSource::Module(_))));
 
         let (app_registry, reasons) = partial_vec(&facts.app_registry);
         assert_eq!(app_registry.len(), 1);
         assert_eq!(app_registry[0].module, module("blog"));
         assert!(reasons
             .iter()
-            .any(|reason| reason.field == Field::ResolverModule));
+            .any(|reason| matches!(&reason.source, ReasonSource::Module(_))));
     }
 
     #[test]

--- a/crates/djls-semantic/src/project/django_environments.rs
+++ b/crates/djls-semantic/src/project/django_environments.rs
@@ -16,7 +16,6 @@ use djls_conf::DjangoEnvironmentConfig;
 use djls_conf::Settings;
 
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::ModuleSearchPathEntry;
 use crate::project::facts::Reason;
 use crate::project::facts::ReasonSource;
@@ -110,11 +109,7 @@ impl DjangoEnvironmentResolution {
     }
 
     fn unknown(root: Utf8PathBuf, message: impl Into<String>) -> Self {
-        let reason = Reason::new(
-            Field::DjangoEnvironmentDiscovery,
-            ReasonSource::DjangoEnvironmentRoot(root.clone()),
-            message,
-        );
+        let reason = Reason::new(ReasonSource::DjangoEnvironmentRoot(root.clone()), message);
 
         Self {
             root,

--- a/crates/djls-semantic/src/project/facts.rs
+++ b/crates/djls-semantic/src/project/facts.rs
@@ -159,77 +159,33 @@ impl<T> Fact<T> {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Reason {
-    pub(crate) field: Field,
     pub(crate) source: ReasonSource,
     pub(crate) message: String,
 }
 
 impl Reason {
     #[must_use]
-    pub(crate) fn new(field: Field, source: ReasonSource, message: impl Into<String>) -> Self {
+    pub(crate) fn new(source: ReasonSource, message: impl Into<String>) -> Self {
         Self {
-            field,
             source,
             message: message.into(),
         }
     }
 
     #[must_use]
-    pub(crate) fn file(
-        field: Field,
-        file: impl Into<Utf8PathBuf>,
-        message: impl Into<String>,
-    ) -> Self {
-        Self::new(field, ReasonSource::File(file.into()), message)
+    pub(crate) fn file(file: impl Into<Utf8PathBuf>, message: impl Into<String>) -> Self {
+        Self::new(ReasonSource::File(file.into()), message)
     }
 
     #[must_use]
-    pub(crate) fn path(
-        field: Field,
-        path: impl Into<Utf8PathBuf>,
-        message: impl Into<String>,
-    ) -> Self {
-        Self::new(field, ReasonSource::Path(path.into()), message)
+    pub(crate) fn path(path: impl Into<Utf8PathBuf>, message: impl Into<String>) -> Self {
+        Self::new(ReasonSource::Path(path.into()), message)
     }
 
     #[must_use]
-    pub(crate) fn module(field: Field, module: PyModuleName, message: impl Into<String>) -> Self {
-        Self::new(field, ReasonSource::Module(module), message)
+    pub(crate) fn module(module: PyModuleName, message: impl Into<String>) -> Self {
+        Self::new(ReasonSource::Module(module), message)
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub(crate) enum Field {
-    #[serde(rename = "resolver.module_search_paths")]
-    ResolverModuleSearchPaths,
-    #[serde(rename = "resolver.module")]
-    ResolverModule,
-    #[serde(rename = "resolver.relative_import")]
-    ResolverRelativeImport,
-    #[serde(rename = "django.environment_discovery")]
-    DjangoEnvironmentDiscovery,
-    #[serde(rename = "settings.installed_apps")]
-    SettingsInstalledApps,
-    #[serde(rename = "settings.templates")]
-    SettingsTemplates,
-    #[serde(rename = "settings.template_dirs")]
-    SettingsTemplateDirs,
-    #[serde(rename = "settings.template_options")]
-    SettingsTemplateOptions,
-    #[serde(rename = "apps.installed")]
-    AppsInstalled,
-    #[serde(rename = "apps.config")]
-    AppsConfig,
-    #[serde(rename = "apps.path")]
-    AppsPath,
-    #[serde(rename = "templates.dirs")]
-    TemplateDirs,
-    #[serde(rename = "templates.libraries")]
-    TemplateLibraries,
-    #[serde(rename = "templates.builtins")]
-    TemplateBuiltins,
-    #[serde(rename = "templates.symbols")]
-    TemplateSymbols,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -382,7 +338,6 @@ mod tests {
 
     fn unsupported_settings_reason() -> Reason {
         Reason::file(
-            Field::SettingsInstalledApps,
             "project/settings.py",
             "unsupported list comprehension in INSTALLED_APPS",
         )
@@ -421,7 +376,6 @@ mod tests {
     #[test]
     fn with_reason_preserves_value_while_downgrading_known_to_partial() {
         let reason = Reason::path(
-            Field::TemplateDirs,
             "templates",
             "template directory expression depends on runtime state",
         );
@@ -435,7 +389,6 @@ mod tests {
     #[test]
     fn map_preserves_confidence_and_reasons() {
         let reason = Reason::module(
-            Field::ResolverModule,
             module("clientname.app2"),
             "module exists in more than one module search path",
         );
@@ -459,7 +412,6 @@ mod tests {
     #[test]
     fn facts_are_cache_serializable() {
         let reason = Reason::file(
-            Field::SettingsTemplates,
             "project/settings.py",
             "TEMPLATES includes an unsupported call expression",
         );

--- a/crates/djls-semantic/src/project/module_resolver.rs
+++ b/crates/djls-semantic/src/project/module_resolver.rs
@@ -13,7 +13,6 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::ModuleLocation;
 use crate::project::facts::ModuleResolution;
 use crate::project::facts::ModuleSearchPathEntry;
@@ -43,7 +42,6 @@ pub(crate) fn discover_module_search_paths(
         );
     } else {
         reasons.push(Reason::path(
-            Field::ResolverModuleSearchPaths,
             project_root,
             "project root does not exist or is not a directory",
         ));
@@ -68,7 +66,6 @@ pub(crate) fn discover_module_search_paths(
             );
         } else {
             reasons.push(Reason::path(
-                Field::ResolverModuleSearchPaths,
                 path,
                 "explicit Python module search path does not exist or is not a directory",
             ));
@@ -85,7 +82,6 @@ pub(crate) fn discover_module_search_paths(
             collect_pth_module_search_paths(site_packages_path, &mut search_paths, &mut reasons);
         } else {
             reasons.push(Reason::path(
-                Field::ResolverModuleSearchPaths,
                 site_packages_path,
                 "site-packages module search path does not exist or is not a directory",
             ));
@@ -122,7 +118,6 @@ pub(crate) fn resolve_module(
 
     let resolved = match candidates.len() {
         0 => Fact::unknown(vec![Reason::module(
-            Field::ResolverModule,
             requested.clone(),
             format!(
                 "module `{}` was not found in module search paths",
@@ -136,7 +131,6 @@ pub(crate) fn resolve_module(
                 .map(|candidate| candidate.module)
                 .collect(),
             vec![Reason::module(
-                Field::ResolverModule,
                 requested.clone(),
                 "module resolves to more than one module search path",
             )],
@@ -156,24 +150,18 @@ pub(crate) fn module_name_for_file(
 ) -> Fact<PyModuleName> {
     if !file.is_file() {
         return Fact::unknown(vec![Reason::file(
-            Field::ResolverModule,
             file,
             "module file does not exist or is not a file",
         )]);
     }
 
     if file.extension() != Some("py") {
-        return Fact::unknown(vec![Reason::file(
-            Field::ResolverModule,
-            file,
-            "module file is not a Python file",
-        )]);
+        return Fact::unknown(vec![Reason::file(file, "module file is not a Python file")]);
     }
 
     let candidates = module_names_for_file(file, search_paths);
     match candidates.len() {
         0 => Fact::unknown(vec![Reason::file(
-            Field::ResolverModule,
             file,
             "module file is outside configured module search paths",
         )]),
@@ -184,7 +172,6 @@ pub(crate) fn module_name_for_file(
         _ => Fact::ambiguous(
             candidates.into_iter().map(|(module, _)| module).collect(),
             vec![Reason::file(
-                Field::ResolverModule,
                 file,
                 "module file maps to more than one module name",
             )],
@@ -200,7 +187,6 @@ pub(crate) fn resolve_relative_import_module(
 ) -> Fact<PyModuleName> {
     if level == 0 {
         return Fact::unknown(vec![Reason::module(
-            Field::ResolverRelativeImport,
             current_module.clone(),
             "relative import level must be greater than zero",
         )]);
@@ -211,7 +197,6 @@ pub(crate) fn resolve_relative_import_module(
 
     if level > parts.len() + 1 {
         return Fact::unknown(vec![Reason::module(
-            Field::ResolverRelativeImport,
             current_module.clone(),
             "relative import escapes the top-level package",
         )]);
@@ -227,7 +212,6 @@ pub(crate) fn resolve_relative_import_module(
 
     if parts.is_empty() {
         return Fact::unknown(vec![Reason::module(
-            Field::ResolverRelativeImport,
             current_module.clone(),
             "relative import does not resolve to a module path",
         )]);
@@ -237,7 +221,6 @@ pub(crate) fn resolve_relative_import_module(
     match PyModuleName::parse(&target) {
         Ok(target) => Fact::known(target),
         Err(error) => Fact::unknown(vec![Reason::module(
-            Field::ResolverRelativeImport,
             current_module.clone(),
             format!("relative import resolves to an invalid module path: {error}"),
         )]),
@@ -309,7 +292,6 @@ fn collect_pth_module_search_paths(
 ) {
     let Ok(entries) = std::fs::read_dir(site_packages_root.as_std_path()) else {
         reasons.push(Reason::path(
-            Field::ResolverModuleSearchPaths,
             site_packages_root,
             "could not read site-packages directory for .pth files",
         ));
@@ -326,7 +308,6 @@ fn collect_pth_module_search_paths(
     for pth_file in pth_files {
         let Ok(contents) = std::fs::read_to_string(pth_file.as_std_path()) else {
             reasons.push(Reason::file(
-                Field::ResolverModuleSearchPaths,
                 pth_file,
                 "could not read .pth module search paths",
             ));
@@ -352,7 +333,6 @@ fn collect_pth_module_search_paths(
                 push_module_search_path(search_paths, ModuleSearchPathKind::PthFile, path);
             } else {
                 reasons.push(Reason::path(
-                    Field::ResolverModuleSearchPaths,
                     path,
                     ".pth entry does not exist or is not a directory",
                 ));
@@ -409,7 +389,6 @@ fn namespace_package_reasons(parts: &[&str], search_path: &Utf8Path) -> Vec<Reas
         dir.push(part);
         if dir.is_dir() && !dir.join("__init__.py").is_file() {
             reasons.push(Reason::path(
-                Field::ResolverModule,
                 dir.clone(),
                 "module resolves through a namespace package segment without __init__.py",
             ));
@@ -422,9 +401,9 @@ fn namespace_package_reasons(parts: &[&str], search_path: &Utf8Path) -> Vec<Reas
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::project::facts::Field;
     use crate::project::facts::ModuleLocation;
     use crate::project::facts::ModuleSearchPathKind;
+    use crate::project::facts::ReasonSource;
     use crate::project::facts::ResolvedModule;
 
     fn module(name: &str) -> PyModuleName {
@@ -607,7 +586,7 @@ mod tests {
                     .any(|candidate| candidate.file == project_root.join("src/shop/apps.py")));
                 assert!(reasons
                     .iter()
-                    .any(|reason| reason.field == Field::ResolverModule));
+                    .any(|reason| matches!(&reason.source, ReasonSource::Module(_))));
             }
             other => panic!("expected ambiguous duplicate module, got {other:?}"),
         }

--- a/crates/djls-semantic/src/project/settings_facts.rs
+++ b/crates/djls-semantic/src/project/settings_facts.rs
@@ -24,7 +24,6 @@ use ruff_python_ast::Operator;
 use ruff_python_ast::Stmt;
 
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::ModuleSearchPathEntry;
 use crate::project::facts::Reason;
 use crate::project::facts::SettingsFacts;
@@ -141,14 +140,12 @@ impl SettingsExtractionState {
         let installed_apps = finalize_setting_fact(
             self.installed_apps,
             self.installed_apps_import_reasons,
-            Field::SettingsInstalledApps,
             &file,
             "INSTALLED_APPS is not assigned in this settings file",
         );
         let template_backends = finalize_setting_fact(
             self.template_backends,
             self.template_backends_import_reasons,
-            Field::SettingsTemplates,
             &file,
             "TEMPLATES is not assigned in this settings file",
         );
@@ -253,7 +250,6 @@ fn extract_settings_state_inner(
         .any(|stmt| contains_nested_list_mutation(stmt, INSTALLED_APPS))
     {
         state.add_installed_apps_reason(reason(
-            Field::SettingsInstalledApps,
             file,
             "unsupported nested assignment or mutation of INSTALLED_APPS",
         ));
@@ -265,7 +261,6 @@ fn extract_settings_state_inner(
             || contains_unsupported_setting_update(stmt, TEMPLATES)
     }) {
         state.add_template_backends_reason(reason(
-            Field::SettingsTemplates,
             file,
             "unsupported nested assignment or mutation of TEMPLATES",
         ));
@@ -293,12 +288,7 @@ fn process_settings_stmt(
     record_path_list_assignment(stmt, &mut state.path_list_values, &state.path_values, file);
 
     if let Some(value) = assigned_value(stmt, INSTALLED_APPS) {
-        state.installed_apps = Some(extract_string_list(
-            value,
-            Field::SettingsInstalledApps,
-            file,
-            "INSTALLED_APPS",
-        ));
+        state.installed_apps = Some(extract_string_list(value, file, "INSTALLED_APPS"));
         return;
     }
 
@@ -410,7 +400,6 @@ fn extract_path_list(
             paths.push(path);
         } else {
             reasons.push(reason(
-                Field::SettingsTemplateDirs,
                 file,
                 "TEMPLATES DIRS contains an unsupported path expression",
             ));
@@ -806,7 +795,6 @@ fn star_import_module(
 
     let Some(module) = module else {
         return Fact::unknown(vec![Reason::module(
-            Field::ResolverModule,
             current_module.clone(),
             "absolute star import must name a module",
         )]);
@@ -815,7 +803,6 @@ fn star_import_module(
     match PyModuleName::parse(module) {
         Ok(module) => Fact::known(module),
         Err(error) => Fact::unknown(vec![Reason::module(
-            Field::ResolverModule,
             current_module.clone(),
             format!("star import resolves to an invalid module path: {error}"),
         )]),
@@ -1289,15 +1276,9 @@ fn is_name(expr: &Expr, expected: &str) -> bool {
     matches!(expr, Expr::Name(name) if name.id.as_str() == expected)
 }
 
-fn extract_string_list(
-    expr: &Expr,
-    field: Field,
-    file: &Utf8Path,
-    setting_name: &str,
-) -> Fact<Vec<String>> {
+fn extract_string_list(expr: &Expr, file: &Utf8Path, setting_name: &str) -> Fact<Vec<String>> {
     let Some(elements) = collection_elements(expr) else {
         return Fact::unknown(vec![reason(
-            field,
             file,
             format!("{setting_name} must be a literal list or tuple of strings"),
         )]);
@@ -1310,7 +1291,6 @@ fn extract_string_list(
             values.push(value);
         } else {
             reasons.push(reason(
-                field,
                 file,
                 format!("{setting_name} contains a non-string entry"),
             ));
@@ -1327,7 +1307,6 @@ fn apply_installed_apps_mutation(
 ) -> Fact<Vec<String>> {
     let Some(current) = current else {
         return mutation_before_assignment(
-            Field::SettingsInstalledApps,
             file,
             "INSTALLED_APPS mutation appears before assignment or import",
         );
@@ -1337,7 +1316,6 @@ fn apply_installed_apps_mutation(
         ListMutation::Append(value) => {
             let Some(app) = string_literal(value) else {
                 return current.with_reason(reason(
-                    Field::SettingsInstalledApps,
                     file,
                     "INSTALLED_APPS append value must be a string literal",
                 ));
@@ -1347,7 +1325,6 @@ fn apply_installed_apps_mutation(
                 app,
                 Vec::new(),
                 reason(
-                    Field::SettingsInstalledApps,
                     file,
                     "cannot apply INSTALLED_APPS append because the current value is unknown or ambiguous",
                 ),
@@ -1358,12 +1335,10 @@ fn apply_installed_apps_mutation(
             current,
             extract_string_list(
                 value,
-                Field::SettingsInstalledApps,
                 file,
                 "INSTALLED_APPS mutation",
             ),
             reason(
-                Field::SettingsInstalledApps,
                 file,
                 "cannot apply INSTALLED_APPS extend because the current value is unknown or ambiguous",
             ),
@@ -1371,7 +1346,6 @@ fn apply_installed_apps_mutation(
         ListMutation::Insert { index, value } => {
             let Some(app) = string_literal(value) else {
                 return current.with_reason(reason(
-                    Field::SettingsInstalledApps,
                     file,
                     "INSTALLED_APPS insert value must be a string literal",
                 ));
@@ -1382,7 +1356,6 @@ fn apply_installed_apps_mutation(
                 app,
                 Vec::new(),
                 reason(
-                    Field::SettingsInstalledApps,
                     file,
                     "cannot apply INSTALLED_APPS insert because the current value is unknown or ambiguous",
                 ),
@@ -1393,7 +1366,6 @@ fn apply_installed_apps_mutation(
         ListMutation::Reverse => reverse_vec_fact(current),
         ListMutation::Sort => sort_vec_fact(current),
         ListMutation::Unsupported => current.with_reason(reason(
-            Field::SettingsInstalledApps,
             file,
             "unsupported dynamic mutation of INSTALLED_APPS",
         )),
@@ -1409,12 +1381,10 @@ fn apply_installed_apps_pop(
         current,
         index,
         reason(
-            Field::SettingsInstalledApps,
             file,
             "cannot apply INSTALLED_APPS pop because the index is out of range",
         ),
         reason(
-            Field::SettingsInstalledApps,
             file,
             "cannot apply INSTALLED_APPS pop because the current value is unknown or ambiguous",
         ),
@@ -1428,7 +1398,6 @@ fn apply_installed_apps_remove(
 ) -> Fact<Vec<String>> {
     let Some(app) = string_literal(value) else {
         return current.with_reason(reason(
-            Field::SettingsInstalledApps,
             file,
             "INSTALLED_APPS remove value must be a string literal",
         ));
@@ -1437,12 +1406,10 @@ fn apply_installed_apps_remove(
         current,
         &app,
         reason(
-            Field::SettingsInstalledApps,
             file,
             "cannot apply INSTALLED_APPS remove because the value is not present",
         ),
         reason(
-            Field::SettingsInstalledApps,
             file,
             "cannot apply INSTALLED_APPS remove because the current value is unknown or ambiguous",
         ),
@@ -1457,7 +1424,6 @@ fn extract_template_backends(
 ) -> Fact<Vec<TemplateBackendFact>> {
     let Some(elements) = collection_elements(expr) else {
         return Fact::unknown(vec![reason(
-            Field::SettingsTemplates,
             file,
             "TEMPLATES must be assigned a literal list or tuple of dictionaries",
         )]);
@@ -1468,7 +1434,6 @@ fn extract_template_backends(
     for element in elements {
         let Expr::Dict(dict) = element else {
             reasons.push(reason(
-                Field::SettingsTemplates,
                 file,
                 "TEMPLATES contains a non-dictionary backend entry",
             ));
@@ -1495,7 +1460,6 @@ fn apply_template_backends_mutation(
 ) -> Fact<Vec<TemplateBackendFact>> {
     let Some(current) = current else {
         return mutation_before_assignment(
-            Field::SettingsTemplates,
             file,
             "TEMPLATES mutation appears before assignment or import",
         );
@@ -1506,7 +1470,6 @@ fn apply_template_backends_mutation(
             current,
             extract_template_backend_list_item(value, path_values, path_list_values, file),
             reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES append because the current value is unknown or ambiguous",
             ),
@@ -1515,7 +1478,6 @@ fn apply_template_backends_mutation(
             current,
             extract_template_backends(value, path_values, path_list_values, file),
             reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES extend because the current value is unknown or ambiguous",
             ),
@@ -1525,7 +1487,6 @@ fn apply_template_backends_mutation(
             index,
             extract_template_backend_item(value, path_values, path_list_values, file),
             reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES insert because the current value is unknown or ambiguous",
             ),
@@ -1535,23 +1496,18 @@ fn apply_template_backends_mutation(
             current,
             index,
             reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES pop because the index is out of range",
             ),
             reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES pop because the current value is unknown or ambiguous",
             ),
         ),
         ListMutation::Reverse => reverse_vec_fact(current),
-        ListMutation::Remove(_) | ListMutation::Sort | ListMutation::Unsupported => current
-            .with_reason(reason(
-                Field::SettingsTemplates,
-                file,
-                "unsupported dynamic mutation of TEMPLATES",
-            )),
+        ListMutation::Remove(_) | ListMutation::Sort | ListMutation::Unsupported => {
+            current.with_reason(reason(file, "unsupported dynamic mutation of TEMPLATES"))
+        }
     }
 }
 
@@ -1564,7 +1520,6 @@ fn apply_template_dirs_mutation(
 ) -> Fact<Vec<TemplateBackendFact>> {
     let Some(current) = current else {
         return mutation_before_assignment(
-            Field::SettingsTemplates,
             file,
             "TEMPLATES DIRS mutation appears before TEMPLATES assignment or import",
         );
@@ -1596,7 +1551,6 @@ fn apply_template_dirs_mutation(
         }
         Fact::Unknown { mut reasons } => {
             reasons.push(reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES DIRS mutation because TEMPLATES is unknown",
             ));
@@ -1607,7 +1561,6 @@ fn apply_template_dirs_mutation(
             mut reasons,
         } => {
             reasons.push(reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES DIRS mutation because TEMPLATES is ambiguous",
             ));
@@ -1625,7 +1578,6 @@ fn apply_template_dirs_mutation_to_backends(
 ) -> Vec<Reason> {
     let Some(backend) = backends.get_mut(mutation.backend_index) else {
         return vec![reason(
-            Field::SettingsTemplateDirs,
             file,
             "cannot apply TEMPLATES DIRS mutation because the backend index is out of range",
         )];
@@ -1652,7 +1604,6 @@ fn apply_template_dir_list_mutation(
         ListMutation::Append(value) => {
             let Some(dir) = evaluate_template_dir(value, path_values, file) else {
                 return current.with_reason(reason(
-                    Field::SettingsTemplateDirs,
                     file,
                     "TEMPLATES DIRS append value contains an unsupported path expression",
                 ));
@@ -1662,7 +1613,6 @@ fn apply_template_dir_list_mutation(
                 dir,
                 Vec::new(),
                 reason(
-                    Field::SettingsTemplateDirs,
                     file,
                     "cannot apply TEMPLATES DIRS append because the current value is unknown or ambiguous",
                 ),
@@ -1672,7 +1622,6 @@ fn apply_template_dir_list_mutation(
             current,
             extract_template_dirs(value, path_values, path_list_values, file),
             reason(
-                Field::SettingsTemplateDirs,
                 file,
                 "cannot apply TEMPLATES DIRS extend because the current value is unknown or ambiguous",
             ),
@@ -1680,7 +1629,6 @@ fn apply_template_dir_list_mutation(
         ListMutation::Insert { index, value } => {
             let Some(dir) = evaluate_template_dir(value, path_values, file) else {
                 return current.with_reason(reason(
-                    Field::SettingsTemplateDirs,
                     file,
                     "TEMPLATES DIRS insert value contains an unsupported path expression",
                 ));
@@ -1691,7 +1639,6 @@ fn apply_template_dir_list_mutation(
                 dir,
                 Vec::new(),
                 reason(
-                    Field::SettingsTemplateDirs,
                     file,
                     "cannot apply TEMPLATES DIRS insert because the current value is unknown or ambiguous",
                 ),
@@ -1703,7 +1650,6 @@ fn apply_template_dir_list_mutation(
         | ListMutation::Reverse
         | ListMutation::Sort
         | ListMutation::Unsupported => current.with_reason(reason(
-            Field::SettingsTemplateDirs,
             file,
             "unsupported dynamic mutation of TEMPLATES DIRS",
         )),
@@ -1717,7 +1663,6 @@ fn apply_template_options_assignment(
 ) -> Fact<Vec<TemplateBackendFact>> {
     let Some(current) = current else {
         return mutation_before_assignment(
-            Field::SettingsTemplates,
             file,
             "TEMPLATES OPTIONS assignment appears before TEMPLATES assignment or import",
         );
@@ -1740,7 +1685,6 @@ fn apply_template_options_assignment(
         }
         Fact::Unknown { mut reasons } => {
             reasons.push(reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES OPTIONS assignment because TEMPLATES is unknown",
             ));
@@ -1751,7 +1695,6 @@ fn apply_template_options_assignment(
             mut reasons,
         } => {
             reasons.push(reason(
-                Field::SettingsTemplates,
                 file,
                 "cannot apply TEMPLATES OPTIONS assignment because TEMPLATES is ambiguous",
             ));
@@ -1771,7 +1714,6 @@ fn apply_template_options_assignment_to_backends(
 
     let Some(backend) = backends.get_mut(assignment.backend_index) else {
         return vec![reason(
-            Field::SettingsTemplateOptions,
             file,
             "cannot apply TEMPLATES OPTIONS assignment because the backend index is out of range",
         )];
@@ -1787,7 +1729,6 @@ fn apply_template_options_assignment_to_backends(
             Vec::new()
         }
         key => vec![reason(
-            Field::SettingsTemplateOptions,
             file,
             format!("unsupported TEMPLATES OPTIONS assignment for `{key}`"),
         )],
@@ -1812,7 +1753,6 @@ fn extract_template_backend_item(
 ) -> Fact<TemplateBackendFact> {
     let Expr::Dict(dict) = expr else {
         return Fact::unknown(vec![reason(
-            Field::SettingsTemplates,
             file,
             "TEMPLATES mutation value must be a dictionary literal",
         )]);
@@ -1839,11 +1779,7 @@ fn extract_template_backend(
             if let Some(backend) = string_literal(value) {
                 Some(backend)
             } else {
-                reasons.push(reason(
-                    Field::SettingsTemplates,
-                    file,
-                    "TEMPLATES BACKEND must be a string literal",
-                ));
+                reasons.push(reason(file, "TEMPLATES BACKEND must be a string literal"));
                 None
             }
         }
@@ -1858,7 +1794,6 @@ fn extract_template_backend(
     let app_dirs = match dict_value(dict, "APP_DIRS") {
         Some(Expr::BooleanLiteral(boolean)) => Fact::known(boolean.value),
         Some(_) => Fact::unknown(vec![reason(
-            Field::SettingsTemplates,
             file,
             "TEMPLATES APP_DIRS must be a boolean literal",
         )]),
@@ -1871,11 +1806,7 @@ fn extract_template_backend(
             extract_option_builtins(options, file),
         ),
         Some(_) => {
-            let option_reason = reason(
-                Field::SettingsTemplateOptions,
-                file,
-                "TEMPLATES OPTIONS must be a dictionary literal",
-            );
+            let option_reason = reason(file, "TEMPLATES OPTIONS must be a dictionary literal");
             (
                 Fact::unknown(vec![option_reason.clone()]),
                 Fact::unknown(vec![option_reason]),
@@ -1907,7 +1838,6 @@ fn extract_template_dirs(
 
     let Some(elements) = collection_elements(expr) else {
         return Fact::unknown(vec![reason(
-            Field::SettingsTemplateDirs,
             file,
             "TEMPLATES DIRS must be a literal list or tuple",
         )]);
@@ -1923,7 +1853,6 @@ fn extract_template_dirs(
             });
         } else {
             reasons.push(reason(
-                Field::SettingsTemplateDirs,
                 file,
                 "TEMPLATES DIRS contains an unsupported path expression",
             ));
@@ -1967,7 +1896,6 @@ fn extract_option_libraries(
 fn extract_option_libraries_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<TemplateLibraryFact>> {
     let Expr::Dict(libraries) = value else {
         return Fact::unknown(vec![reason(
-            Field::SettingsTemplateOptions,
             file,
             "TEMPLATES OPTIONS.libraries must be a dictionary literal",
         )]);
@@ -1978,7 +1906,6 @@ fn extract_option_libraries_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<Tem
     for item in &libraries.items {
         let Some(key) = item.key.as_ref() else {
             reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 "TEMPLATES OPTIONS.libraries contains dictionary unpacking",
             ));
@@ -1986,7 +1913,6 @@ fn extract_option_libraries_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<Tem
         };
         let Some(load_name) = string_literal(key) else {
             reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 "TEMPLATES OPTIONS.libraries contains a non-string load name",
             ));
@@ -1994,7 +1920,6 @@ fn extract_option_libraries_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<Tem
         };
         let Some(module) = string_literal(&item.value) else {
             reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 "TEMPLATES OPTIONS.libraries contains a non-string module path",
             ));
@@ -2008,12 +1933,10 @@ fn extract_option_libraries_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<Tem
                 source: TemplateLibrarySource::SettingsLibraries,
             }),
             (Err(error), _) => reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 format!("invalid TEMPLATES OPTIONS.libraries load name: {error}"),
             )),
             (_, Err(error)) => reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 format!("invalid TEMPLATES OPTIONS.libraries module path: {error}"),
             )),
@@ -2036,7 +1959,6 @@ fn extract_option_builtins(
 fn extract_option_builtins_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<PyModuleName>> {
     let Some(elements) = collection_elements(value) else {
         return Fact::unknown(vec![reason(
-            Field::SettingsTemplateOptions,
             file,
             "TEMPLATES OPTIONS.builtins must be a literal list or tuple",
         )]);
@@ -2047,7 +1969,6 @@ fn extract_option_builtins_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<PyMo
     for element in elements {
         let Some(module) = string_literal(element) else {
             reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 "TEMPLATES OPTIONS.builtins contains a non-string module path",
             ));
@@ -2056,7 +1977,6 @@ fn extract_option_builtins_value(value: &Expr, file: &Utf8Path) -> Fact<Vec<PyMo
         match PyModuleName::parse(&module) {
             Ok(module) => builtins.push(module),
             Err(error) => reasons.push(reason(
-                Field::SettingsTemplateOptions,
                 file,
                 format!("invalid TEMPLATES OPTIONS.builtins module path: {error}"),
             )),
@@ -2273,14 +2193,13 @@ fn known_or_partial<T>(values: Vec<T>, reasons: Vec<Reason>) -> Fact<Vec<T>> {
 fn finalize_setting_fact<T>(
     fact: Option<Fact<T>>,
     mut reasons: Vec<Reason>,
-    field: Field,
     file: &Utf8Path,
     missing_message: &'static str,
 ) -> Fact<T> {
     if let Some(fact) = fact {
         add_reasons(fact, reasons)
     } else {
-        reasons.push(reason(field, file, missing_message));
+        reasons.push(reason(file, missing_message));
         Fact::unknown(reasons)
     }
 }
@@ -2292,12 +2211,8 @@ fn add_reasons<T>(mut fact: Fact<T>, reasons: Vec<Reason>) -> Fact<T> {
     fact
 }
 
-fn mutation_before_assignment<T>(
-    field: Field,
-    file: &Utf8Path,
-    message: &'static str,
-) -> Fact<Vec<T>> {
-    Fact::unknown(vec![reason(field, file, message)])
+fn mutation_before_assignment<T>(file: &Utf8Path, message: &'static str) -> Fact<Vec<T>> {
+    Fact::unknown(vec![reason(file, message)])
 }
 
 fn append_vec_fact<T>(
@@ -2548,17 +2463,13 @@ fn unknown_settings_facts(file: &Utf8Path, message: impl Into<String>) -> Settin
     SettingsFacts {
         file: file.to_path_buf(),
         files_read: vec![file.to_path_buf()],
-        installed_apps: Fact::unknown(vec![reason(
-            Field::SettingsInstalledApps,
-            file,
-            message.clone(),
-        )]),
-        template_backends: Fact::unknown(vec![reason(Field::SettingsTemplates, file, message)]),
+        installed_apps: Fact::unknown(vec![reason(file, message.clone())]),
+        template_backends: Fact::unknown(vec![reason(file, message)]),
     }
 }
 
-fn reason(field: Field, file: &Utf8Path, message: impl Into<String>) -> Reason {
-    Reason::file(field, file, message)
+fn reason(file: &Utf8Path, message: impl Into<String>) -> Reason {
+    Reason::file(file, message)
 }
 
 #[cfg(test)]
@@ -2959,12 +2870,10 @@ from .base import *
         let (apps, reasons) = partial_vec(&facts.installed_apps);
 
         assert_eq!(apps, ["project.dev"]);
-        assert_eq!(reasons[0].field, Field::SettingsInstalledApps);
         assert!(reasons[0].message.contains("failed to parse settings file"));
 
         let (templates, reasons) = partial_vec(&facts.template_backends);
         assert!(templates.is_empty());
-        assert_eq!(reasons[0].field, Field::SettingsTemplates);
         assert!(reasons[0].message.contains("failed to parse settings file"));
     }
 
@@ -3063,7 +2972,6 @@ TEMPLATES = []
 
         let (apps, reasons) = partial_vec(&facts.installed_apps);
         assert_eq!(apps, ["django.contrib.auth"]);
-        assert_eq!(reasons[0].field, Field::SettingsInstalledApps);
         assert!(reasons[0].message.contains("non-string"));
     }
 

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -28,7 +28,6 @@ use crate::project::app_registry::AppRegistryFacts;
 use crate::project::db::Db as ProjectDb;
 use crate::project::facts::Confidence;
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::ModuleLocation;
 use crate::project::facts::ModuleSearchPathEntry;
 use crate::project::facts::ModuleSearchPathKind;
@@ -68,7 +67,7 @@ use crate::python::ModelGraph;
 use crate::python::ModulePath;
 use crate::python::TagRuleMap;
 
-const STATIC_TEMPLATE_LIBRARY_CACHE_VERSION: &str = "static-template-libraries-v1";
+const STATIC_TEMPLATE_LIBRARY_CACHE_VERSION: &str = "static-template-libraries-v2";
 const DJANGO_DEFAULT_TEMPLATE_LIBRARY_POLICY: &str = "django-5.2-default-template-libraries-v1";
 
 /// Refresh all external project data.
@@ -614,7 +613,6 @@ fn assemble_static_project_context(
 ) -> Result<StaticProjectContext, Vec<Reason>> {
     let Some(django_settings_module) = django_settings_module else {
         return Err(vec![Reason::new(
-            Field::DjangoEnvironmentDiscovery,
             ReasonSource::Workspace(root.to_path_buf()),
             "django_settings_module is not configured; skipped static project model assembly",
         )]);
@@ -622,7 +620,6 @@ fn assemble_static_project_context(
 
     let django_settings_module = PyModuleName::parse(django_settings_module).map_err(|error| {
         vec![Reason::new(
-            Field::DjangoEnvironmentDiscovery,
             ReasonSource::Workspace(root.to_path_buf()),
             format!("django_settings_module is not a valid Python module path: {error}"),
         )]
@@ -3816,11 +3813,7 @@ TEMPLATES = [
         let interpreter = Interpreter::InterpreterPath("/missing/python".to_string());
         let static_snapshot = Fact::partial(
             test_response(),
-            vec![Reason::path(
-                Field::TemplateLibraries,
-                root.clone(),
-                "partial static cache entry",
-            )],
+            vec![Reason::path(root.clone(), "partial static cache entry")],
         );
         let status = StaticProjectModelStatus::from_snapshot(
             Some("project.settings"),

--- a/crates/djls-semantic/src/project/template_dirs.rs
+++ b/crates/djls-semantic/src/project/template_dirs.rs
@@ -14,7 +14,6 @@
 
 use crate::project::facts::AppFact;
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::Reason;
 use crate::project::facts::ReasonSource;
 use crate::project::facts::TemplateBackendFact;
@@ -61,7 +60,6 @@ fn assemble_template_backend_dirs(
 fn is_django_template_backend(backend: &TemplateBackendFact, reasons: &mut Vec<Reason>) -> bool {
     let Some(backend) = backend.backend.as_deref() else {
         reasons.push(Reason::new(
-            Field::TemplateDirs,
             ReasonSource::Unknown,
             "TEMPLATES BACKEND is not known; skipped template directory assembly for this backend",
         ));
@@ -283,7 +281,6 @@ mod tests {
 
     fn app_registry_reason() -> Reason {
         Reason::new(
-            Field::AppsInstalled,
             ReasonSource::Unknown,
             "some installed apps could not be resolved",
         )
@@ -291,7 +288,6 @@ mod tests {
 
     fn dirs_reason() -> Reason {
         Reason::path(
-            Field::SettingsTemplateDirs,
             "project/settings.py",
             "TEMPLATES DIRS contains an unsupported path expression",
         )
@@ -299,7 +295,6 @@ mod tests {
 
     fn app_dirs_reason() -> Reason {
         Reason::new(
-            Field::SettingsTemplates,
             ReasonSource::Unknown,
             "TEMPLATES APP_DIRS must be a boolean literal",
         )
@@ -468,7 +463,6 @@ mod tests {
     #[test]
     fn unknown_template_backends_are_unknown_template_dirs() {
         let reason = Reason::new(
-            Field::SettingsTemplates,
             ReasonSource::Unknown,
             "TEMPLATES is not assigned in this settings file",
         );

--- a/crates/djls-semantic/src/project/template_libraries.rs
+++ b/crates/djls-semantic/src/project/template_libraries.rs
@@ -28,7 +28,6 @@ use ruff_python_ast::Stmt;
 
 use crate::project::facts::AppFact;
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::Reason;
 use crate::project::facts::ReasonSource;
 use crate::project::facts::TemplateBackendFact;
@@ -127,7 +126,6 @@ fn classify_template_backend(
 ) -> BackendKind {
     let Some(backend) = backend.backend.as_deref() else {
         reasons.push(Reason::new(
-            Field::TemplateLibraries,
             ReasonSource::Unknown,
             "TEMPLATES BACKEND is not known; only statically known template library options were assembled for this backend",
         ));
@@ -212,7 +210,6 @@ fn discover_app_template_tag_libraries(
 fn collect_python_files(dir: &Utf8Path, files: &mut Vec<Utf8PathBuf>, reasons: &mut Vec<Reason>) {
     let Ok(entries) = fs::read_dir(dir.as_std_path()) else {
         reasons.push(Reason::path(
-            Field::TemplateLibraries,
             dir,
             "failed to read templatetags package directory",
         ));
@@ -286,7 +283,6 @@ fn template_tag_load_name(
         Ok(load_name) => Some(load_name),
         Err(error) => {
             reasons.push(Reason::file(
-                Field::TemplateLibraries,
                 file,
                 format!("template tag module has an invalid load name: {error}"),
             ));
@@ -307,7 +303,6 @@ fn defines_template_register(file: &Utf8Path, reasons: &mut Vec<Reason>) -> bool
         Ok(source) => source,
         Err(error) => {
             reasons.push(Reason::file(
-                Field::TemplateLibraries,
                 file,
                 format!("failed to read template tag module: {error}"),
             ));
@@ -319,7 +314,6 @@ fn defines_template_register(file: &Utf8Path, reasons: &mut Vec<Reason>) -> bool
         Ok(parsed) => parsed.into_syntax(),
         Err(error) => {
             reasons.push(Reason::file(
-                Field::TemplateLibraries,
                 file,
                 format!("failed to parse template tag module: {error}"),
             ));
@@ -504,7 +498,6 @@ fn upsert_loadable_library(
         if let Some(existing) = loadable.get(&library.load_name) {
             if existing.module != library.module {
                 let reason = Reason::module(
-                    Field::TemplateLibraries,
                     library.module.clone(),
                     format!(
                         "template library load name `{}` is provided by both `{}` and `{}`; the later Django discovery entry wins",
@@ -687,7 +680,6 @@ register = template.Library()
 
     fn app_registry_reason() -> Reason {
         Reason::new(
-            Field::AppsInstalled,
             ReasonSource::Unknown,
             "INSTALLED_APPS has an unsupported dynamic entry",
         )
@@ -695,7 +687,6 @@ register = template.Library()
 
     fn option_reason() -> Reason {
         Reason::new(
-            Field::SettingsTemplateOptions,
             ReasonSource::Unknown,
             "TEMPLATES OPTIONS.libraries contains an unsupported value",
         )
@@ -1038,7 +1029,6 @@ register = template.Library()
     #[test]
     fn unknown_template_backends_are_unknown_template_libraries() {
         let reason = Reason::new(
-            Field::SettingsTemplates,
             ReasonSource::Unknown,
             "TEMPLATES is not assigned in this settings file",
         );
@@ -1306,13 +1296,11 @@ register = template.Library()
                         source: TemplateDirSource::SettingsDir,
                     }],
                     vec![Reason::path(
-                        Field::TemplateDirs,
                         "templates",
                         "template dir uncertainty should not affect libraries",
                     )],
                 ),
                 app_dirs: Fact::unknown(vec![Reason::new(
-                    Field::SettingsTemplates,
                     ReasonSource::Unknown,
                     "APP_DIRS is dynamic but irrelevant for libraries",
                 )]),

--- a/crates/djls-semantic/src/project/template_symbols.rs
+++ b/crates/djls-semantic/src/project/template_symbols.rs
@@ -21,7 +21,6 @@ use std::fs;
 use camino::Utf8Path;
 
 use crate::project::facts::Fact;
-use crate::project::facts::Field;
 use crate::project::facts::ModuleSearchPathEntry;
 use crate::project::facts::Reason;
 use crate::project::facts::ResolvedModule;
@@ -175,7 +174,6 @@ fn read_and_extract_library_symbols(
         Ok(source) => source,
         Err(error) => {
             reasons.push(Reason::file(
-                Field::TemplateSymbols,
                 &resolved.file,
                 format!("failed to read template library module: {error}"),
             ));
@@ -187,7 +185,6 @@ fn read_and_extract_library_symbols(
         Ok(registrations) => registrations,
         Err(error) => {
             reasons.push(Reason::file(
-                Field::TemplateSymbols,
                 &resolved.file,
                 format!("failed to parse template library module: {error}"),
             ));
@@ -200,7 +197,6 @@ fn read_and_extract_library_symbols(
             Ok(name) => name,
             Err(error) => {
                 reasons.push(Reason::file(
-                    Field::TemplateSymbols,
                     &resolved.file,
                     format!(
                         "template symbol `{}` has an invalid name: {error}",
@@ -499,7 +495,7 @@ register.filter("shout", shout)
         assert!(known_symbols(&facts).is_empty());
         assert!(partial_reasons(&facts)
             .iter()
-            .any(|reason| reason.field == Field::ResolverModule));
+            .any(|reason| matches!(&reason.source, ReasonSource::Module(_))));
     }
 
     #[test]
@@ -530,13 +526,12 @@ def bad(parser, token):
         assert!(known_symbols(&facts).is_empty());
         assert!(partial_reasons(&facts)
             .iter()
-            .any(|reason| reason.field == Field::TemplateSymbols));
+            .any(|reason| reason.message.contains("invalid name")));
     }
 
     #[test]
     fn unknown_module_search_paths_make_symbols_unknown_when_libraries_exist() {
         let reason = Reason::new(
-            Field::ResolverModuleSearchPaths,
             ReasonSource::Unknown,
             "module search paths were not discovered",
         );
@@ -645,7 +640,6 @@ def bad(parser, token):
     #[test]
     fn snapshot_preserves_symbol_reasons_as_partial() {
         let reason = Reason::file(
-            Field::TemplateSymbols,
             "blog/templatetags/blog_tags.py",
             "failed to parse template library module",
         );


### PR DESCRIPTION
## Summary
- remove the `Field` classification from fact `Reason`
- keep the concrete source/message as the explanation payload
- update tests to assert source/message instead of field labels
- bump the static template library cache version for the serialized `Reason` shape change

## Validation
- just fmt
- just clippy

Stacked on #614.