### PR TITLE
test: add e2e initialization checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,9 +125,32 @@ jobs:
         run: |
           uv run --no-project --with "nox[uv]" nox --session "tests(python='${PYTHON_VERSION}', django='${DJANGO_VERSION}')"
 
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          activate-environment: true
+          enable-cache: true
+          python-version: "3.10"
+
+      - name: Run e2e tests
+        shell: bash
+        run: |
+          uv run --no-project --with "nox[uv]" nox --session e2e
+
   tests:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, e2e]
     if: always()
     steps:
       - name: OK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,9 +126,7 @@ jobs:
           uv run --no-project --with "nox[uv]" nox --session "tests(python='${PYTHON_VERSION}', django='${DJANGO_VERSION}')"
 
   e2e:
-    name: End-to-end tests
     runs-on: ubuntu-latest
-    needs: generate-matrix
     permissions:
       contents: read
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,6 +109,22 @@ def tests(session, django):
     session.run(*command, external=True)
 
 
+@nox.session(python=PY_DEFAULT)
+def e2e(session):
+    session.run_install(
+        "uv",
+        "sync",
+        "--frozen",
+        "--inexact",
+        "--python",
+        session.python,
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+    )
+    session.install(f"django=={DJ_DEFAULT}")
+
+    session.run("pytest", *session.posargs)
+
+
 @nox.session
 def lint(session):
     for python_version in reversed(PY_VERSIONS):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dev = [
   "django-stubs>=5.1.1",
   "maturin>=1.7.8",
   "nox>=2025.5.1",
+  "pytest>=9.0.3",
+  "pytest-asyncio>=1.4.0",
+  "pytest-lsp>=1.0.0",
   "ruff>=0.8.2",
 ]
 docs = [
@@ -124,6 +127,11 @@ include = [
   { path = "LICENSE", format = "sdist" },
   { path = "rust-toolchain.toml", format = ["sdist", "wheel"] },
 ]
+
+[tool.pytest.ini_options]
+norecursedirs = ".* bin build dist *.egg htmlcov logs node_modules static templates venv"
+python_files = "tests.py test_*.py *_tests.py"
+testpaths = ["tests/e2e"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest_asyncio
+import pytest_lsp
+from lsprotocol.types import InitializeParams
+from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import client_capabilities
+
+SERVER_COMMAND = [
+    "cargo",
+    "run",
+    "-q",
+    "-p",
+    "djls",
+    "--",
+    "serve",
+    "--connection-type",
+    "stdio",
+]
+
+# LSP clients supported by pytest-lsp
+CLIENTS = [
+    "emacs_v29.1",
+    "neovim_v0.6.1",
+    "neovim_v0.7.0",
+    "neovim_v0.8.0",
+    "neovim_v0.9.1",
+    "neovim_v0.10.0",
+    "neovim_v0.11.0",
+    "visual_studio_code_v1.65.2",
+]
+
+
+@pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
+async def emacs_client(lsp_client: LanguageClient, tmp_path):
+    await lsp_client.initialize_session(
+        InitializeParams(
+            capabilities=client_capabilities("emacs"),
+            root_uri=tmp_path.as_uri(),
+        )
+    )
+
+    yield
+
+    await lsp_client.shutdown_session()
+
+
+@pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
+async def neovim_client(lsp_client: LanguageClient, tmp_path):
+    await lsp_client.initialize_session(
+        InitializeParams(
+            capabilities=client_capabilities("neovim"),
+            root_uri=tmp_path.as_uri(),
+        )
+    )
+
+    yield
+
+    await lsp_client.shutdown_session()
+
+
+@pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
+async def vscode_client(lsp_client: LanguageClient, tmp_path):
+    await lsp_client.initialize_session(
+        InitializeParams(
+            capabilities=client_capabilities("visual-studio-code"),
+            root_uri=tmp_path.as_uri(),
+        )
+    )
+
+    yield
+
+    await lsp_client.shutdown_session()
+
+
+@pytest_asyncio.fixture
+async def client(vscode_client):
+    yield vscode_client

--- a/tests/e2e/test_initialized.py
+++ b/tests/e2e/test_initialized.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from lsprotocol import types
+from pytest_lsp import LanguageClient
+
+
+@pytest.mark.asyncio
+async def test_client_initializes(client: LanguageClient):
+    assert client.error is None
+    assert client.capabilities is not None
+
+    messages = [message.message for message in client.log_messages]
+
+    assert "Initializing server..." in messages
+
+
+@pytest.mark.asyncio
+async def test_client_receives_initialized_notification(client: LanguageClient):
+    while not any(
+        message.message.startswith("Server initialization completed")
+        for message in client.log_messages
+    ):
+        await asyncio.wait_for(
+            client.wait_for_notification(types.WINDOW_LOG_MESSAGE),
+            timeout=5,
+        )
+
+    messages = [message.message for message in client.log_messages]
+
+    assert "Server received initialized notification." in messages
+    assert any(
+        message.startswith("Server initialization completed") for message in messages
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "bumpver"
 version = "2026.1132"
 source = { registry = "https://pypi.org/simple" }
@@ -45,6 +54,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/22/c0c9bf9e7ad6877e4c7c3dedd464e390d9fadb8927c61d6d77547eb17539/bumpver-2026.1132.tar.gz", hash = "sha256:80b223c23fca9bc9dd569b7a44680949d34bee23a738860d9a9b36f1abe3b0e0", size = 116784, upload-time = "2026-05-22T18:40:32.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/d6/45c1bf6bcf7b3f174ec0c7fe2d7dce773cbc853cfd8fde06c3153104ffff/bumpver-2026.1132-py2.py3-none-any.whl", hash = "sha256:b060170e7ff5d9ad7043a9d3d6288c7175f9c126744d08a2d6ef9b8377f6bd60", size = 65963, upload-time = "2026-05-22T18:40:30.515Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "25.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/42/988b3a667967e9d2d32346e7ed7edee540ef1cee829b53ef80aa8d4a0222/cattrs-25.2.0.tar.gz", hash = "sha256:f46c918e955db0177be6aa559068390f71988e877c603ae2e56c71827165cc06", size = 506531, upload-time = "2025-08-31T20:41:59.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/a5/b3771ac30b590026b9d721187110194ade05bfbea3d98b423a9cafd80959/cattrs-25.2.0-py3-none-any.whl", hash = "sha256:539d7eedee7d2f0706e4e109182ad096d608ba84633c32c75ef3458f1d11e8f1", size = 70040, upload-time = "2025-08-31T20:41:57.543Z" },
 ]
 
 [[package]]
@@ -146,6 +169,9 @@ dev = [
     { name = "django-stubs" },
     { name = "maturin" },
     { name = "nox" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-lsp" },
     { name = "ruff" },
 ]
 docs = [
@@ -161,6 +187,9 @@ dev = [
     { name = "django-stubs", specifier = ">=5.1.1" },
     { name = "maturin", specifier = ">=1.7.8" },
     { name = "nox", specifier = ">=2025.5.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-lsp", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.8.2" },
 ]
 docs = [{ name = "zensical", specifier = ">=0.0.3" }]
@@ -195,6 +224,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -210,6 +251,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/43/50033d25ad96a7f3845f40999b4778f753c3901a11808a584fed7c00d9f5/humanize-4.14.0.tar.gz", hash = "sha256:2fa092705ea640d605c435b1ca82b2866a1b601cdf96f076d70b79a855eba90d", size = 82939, upload-time = "2025-10-15T13:04:51.214Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/5b/9512c5fb6c8218332b530f13500c6ff5f3ce3342f35e0dd7be9ac3856fd3/humanize-4.14.0-py3-none-any.whl", hash = "sha256:d57701248d040ad456092820e6fde56c930f17749956ac47f4f655c0c547bfff", size = 132092, upload-time = "2025-10-15T13:04:49.404Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -231,6 +281,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/60/0b/28a3f9abc75abbf1fa996eb2dd77e1e33a5d1aac62566e3f60a8ec8b8a22/lexid-2021.1006.tar.gz", hash = "sha256:509a3a4cc926d3dbf22b203b18a4c66c25e6473fb7c0e0d30374533ac28bafe5", size = 11525, upload-time = "2021-04-02T20:18:34.668Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/e3/35764404a4b7e2021be1f88f42264c2e92e0c4720273559a62461ce64a47/lexid-2021.1006-py2.py3-none-any.whl", hash = "sha256:5526bb5606fd74c7add23320da5f02805bddd7c77916f2dc1943e6bada8605ed", size = 7587, upload-time = "2021-04-02T20:18:33.129Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -389,6 +452,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -408,6 +494,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-lsp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pygls" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/8a/bc978a7d1467489a3abcdcd16c98b6846a50fadc67a1936cf3d19bf948f0/pytest_lsp-1.0.0.tar.gz", hash = "sha256:ba8c95b2d975a360249ffa5768e1e6f44d87d10ef7754070d3b321102724a2f1", size = 28452, upload-time = "2025-10-25T12:10:10.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/0f/b8564e8bbec03a6efe76fe450f0d328e8df96c603340055fef7e4428208b/pytest_lsp-1.0.0-py3-none-any.whl", hash = "sha256:36d002eda8d9bcd3ff9a5b33c382dd29dfd054ad9e475ad31d3aac53fdbf516b", size = 26424, upload-time = "2025-10-25T12:10:09.495Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add pytest-lsp e2e initialization fixtures and sanity checks
- add a nox e2e session
- run e2e in the test workflow as a separate job

## Tests
- uv run nox -s e2e