### PR TITLE
test: share e2e position helpers

### DIFF
--- a/tests/e2e/test_completions.py
+++ b/tests/e2e/test_completions.py
@@ -1,34 +1,21 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from lsprotocol.types import CompletionItemKind
 from lsprotocol.types import CompletionParams
 from lsprotocol.types import DidOpenTextDocumentParams
 from lsprotocol.types import InsertTextFormat
-from lsprotocol.types import Position
 from lsprotocol.types import TextDocumentIdentifier
 from lsprotocol.types import TextDocumentItem
 from pytest_lsp import LanguageClient
 
 from .conftest import TEST_WORKSPACE
+from .utils import position_after
 
-BASE_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
-)
+BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
 LOAD_TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "load.html"
 )
-
-
-def position_after(path: Path, needle: str) -> Position:
-    text = path.read_text(encoding="utf-8")
-    offset = text.index(needle) + len(needle)
-    before = text[:offset]
-    line = before.count("\n")
-    line_start = before.rfind("\n") + 1
-    return Position(line=line, character=offset - line_start)
 
 
 @pytest.mark.asyncio
@@ -153,7 +140,7 @@ async def test_completes_structural_end_tags(client: LanguageClient):
     result = await client.text_document_completion_async(
         CompletionParams(
             text_document=TextDocumentIdentifier(uri=BASE_TEMPLATE.as_uri()),
-            position=position_after(BASE_TEMPLATE, "{% end"),
+            position=position_after(BASE_TEMPLATE, "Django Test App{% end"),
         )
     )
 

--- a/tests/e2e/test_document_symbols.py
+++ b/tests/e2e/test_document_symbols.py
@@ -10,16 +10,8 @@ from pytest_lsp import LanguageClient
 
 from .conftest import TEST_WORKSPACE
 
-BASE_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
-)
-HEADER_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
-)
-
-
-def symbol_summary(symbols):
-    return [(symbol.name, symbol.detail, symbol.kind) for symbol in symbols]
+BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+HEADER_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
 
 
 @pytest.mark.asyncio
@@ -42,7 +34,7 @@ async def test_document_symbols_include_template_outline(client: LanguageClient)
     )
 
     assert result is not None
-    assert symbol_summary(result) == [
+    assert [(symbol.name, symbol.detail, symbol.kind) for symbol in result] == [
         ("static", "load", SymbolKind.Module),
         ("title", "block", SymbolKind.Namespace),
         ("djls_app/header.html", "include", SymbolKind.File),
@@ -54,14 +46,16 @@ async def test_document_symbols_include_template_outline(client: LanguageClient)
     assert content.range.end.line == 28
     assert content.selection_range.start.line == 16
     assert content.selection_range.start.character == 15
-    assert symbol_summary(content.children) == [
+    assert [
+        (symbol.name, symbol.detail, symbol.kind) for symbol in content.children
+    ] == [
         ("user.username", None, SymbolKind.Variable),
         ("if items", "if", SymbolKind.Operator),
         ("images/logo.png", "static", SymbolKind.File),
     ]
 
     user = content.children[0]
-    assert symbol_summary(user.children) == [
+    assert [(symbol.name, symbol.detail, symbol.kind) for symbol in user.children] == [
         ("lower", None, SymbolKind.Function),
     ]
 
@@ -87,4 +81,5 @@ async def test_document_symbols_are_empty_for_plain_html_template(
         )
     )
 
+    assert result is not None
     assert len(result) == 0

--- a/tests/e2e/test_folding_ranges.py
+++ b/tests/e2e/test_folding_ranges.py
@@ -10,15 +10,11 @@ from pytest_lsp import LanguageClient
 
 from .conftest import TEST_WORKSPACE
 
-BASE_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
-)
+BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
 COMMENT_TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "comment.html"
 )
-HEADER_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
-)
+HEADER_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
 
 
 @pytest.mark.asyncio
@@ -43,9 +39,7 @@ async def test_folding_ranges_include_nested_template_regions(
     )
 
     assert result is not None
-    assert {
-        (range.start_line, range.end_line, range.kind) for range in result
-    } == {
+    assert {(range.start_line, range.end_line, range.kind) for range in result} == {
         (16, 28, FoldingRangeKind.Region),
         (19, 25, FoldingRangeKind.Region),
     }
@@ -71,9 +65,7 @@ async def test_folding_ranges_include_comment_blocks(client: LanguageClient):
     )
 
     assert result is not None
-    assert {
-        (range.start_line, range.end_line, range.kind) for range in result
-    } == {
+    assert {(range.start_line, range.end_line, range.kind) for range in result} == {
         (3, 6, FoldingRangeKind.Comment),
         (9, 11, FoldingRangeKind.Comment),
     }
@@ -100,4 +92,5 @@ async def test_folding_ranges_are_empty_for_plain_html_template(
         )
     )
 
+    assert result is not None
     assert len(result) == 0

--- a/tests/e2e/test_hover.py
+++ b/tests/e2e/test_hover.py
@@ -1,36 +1,21 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from lsprotocol.types import DidOpenTextDocumentParams
 from lsprotocol.types import HoverParams
 from lsprotocol.types import MarkupKind
-from lsprotocol.types import Position
 from lsprotocol.types import TextDocumentIdentifier
 from lsprotocol.types import TextDocumentItem
 from pytest_lsp import LanguageClient
 
 from .conftest import TEST_WORKSPACE
+from .utils import position_in
 
-BASE_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
-)
-HEADER_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
-)
+BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+HEADER_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
 LOAD_TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "load.html"
 )
-
-
-def position_in(path: Path, needle: str) -> Position:
-    text = path.read_text(encoding="utf-8")
-    offset = text.index(needle)
-    before = text[:offset]
-    line = before.count("\n")
-    line_start = before.rfind("\n") + 1
-    return Position(line=line, character=offset - line_start)
 
 
 @pytest.mark.asyncio
@@ -75,7 +60,7 @@ async def test_hover_describes_load_libraries(client: LanguageClient):
     result = await client.text_document_hover_async(
         HoverParams(
             text_document=TextDocumentIdentifier(uri=BASE_TEMPLATE.as_uri()),
-            position=position_in(BASE_TEMPLATE, "static"),
+            position=position_in(BASE_TEMPLATE, "static %}"),
         )
     )
 

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from lsprotocol.types import DefinitionParams
 from lsprotocol.types import DidOpenTextDocumentParams
@@ -14,34 +12,18 @@ from lsprotocol.types import TextDocumentItem
 from pytest_lsp import LanguageClient
 
 from .conftest import TEST_WORKSPACE
+from .utils import position_in
 
-BASE_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
-)
-HEADER_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
-)
-HOME_TEMPLATE = (
-    TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "home.html"
-)
+BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+HEADER_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "header.html"
+HOME_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "home.html"
 EXTENDS_TAG_TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "extends.html"
 )
 
 
-def position_in(path: Path, needle: str) -> Position:
-    text = path.read_text(encoding="utf-8")
-    offset = text.index(needle)
-    before = text[:offset]
-    line = before.count("\n")
-    line_start = before.rfind("\n") + 1
-    return Position(line=line, character=offset - line_start)
-
-
 @pytest.mark.asyncio
-async def test_goto_definition_for_extends_template_reference(
-    client: LanguageClient,
-):
+async def test_goto_definition_for_extends_template_reference(client: LanguageClient):
     client.text_document_did_open(
         DidOpenTextDocumentParams(
             text_document=TextDocumentItem(
@@ -69,9 +51,7 @@ async def test_goto_definition_for_extends_template_reference(
 
 
 @pytest.mark.asyncio
-async def test_goto_definition_for_include_template_reference(
-    client: LanguageClient,
-):
+async def test_goto_definition_for_include_template_reference(client: LanguageClient):
     client.text_document_did_open(
         DidOpenTextDocumentParams(
             text_document=TextDocumentItem(

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -6,14 +6,14 @@ from lsprotocol.types import Position
 
 
 def position_in(path: Path, needle: str) -> Position:
-    return _position_at(path, needle, 0)
+    return position_at(path, needle, 0)
 
 
 def position_after(path: Path, needle: str) -> Position:
-    return _position_at(path, needle, len(needle))
+    return position_at(path, needle, len(needle))
 
 
-def _position_at(path: Path, needle: str, needle_offset: int) -> Position:
+def position_at(path: Path, needle: str, needle_offset: int) -> Position:
     if not needle:
         raise AssertionError("position needle must not be empty")
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lsprotocol.types import Position
+
+
+def position_in(path: Path, needle: str) -> Position:
+    return _position_at(path, needle, 0)
+
+
+def position_after(path: Path, needle: str) -> Position:
+    return _position_at(path, needle, len(needle))
+
+
+def _position_at(path: Path, needle: str, needle_offset: int) -> Position:
+    if not needle:
+        raise AssertionError("position needle must not be empty")
+
+    text = path.read_text(encoding="utf-8")
+    needle_start = text.find(needle)
+    if needle_start == -1:
+        raise AssertionError(f"{needle!r} was not found in {path}")
+
+    second_offset = text.find(needle, needle_start + 1)
+    if second_offset != -1:
+        raise AssertionError(
+            f"{needle!r} is ambiguous in {path}; use a more specific needle"
+        )
+
+    offset = needle_start + needle_offset
+    before = text[:offset]
+    line = before.count("\n")
+    line_start = before.rfind("\n") + 1
+    return Position(line=line, character=offset - line_start)


### PR DESCRIPTION
## Summary
- Move e2e cursor-position helpers into tests/e2e/utils.py
- Require helper needles to be present and unique
- Update e2e tests to import shared helpers and use more specific needles

## Validation
- just fmt
- just clippy
- just lint
- uv run pytest -q tests/e2e