### PR TITLE
Fix search-path invalidation and template library precedence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -174,8 +174,8 @@ This works well for `simple_tag` and `inclusion_tag` registrations where the fun
 
 Both workspace and search-path extraction now flow through Salsa:
 
-- **Search-path modules** (site-packages/extra Python paths) — resolved through typed `SearchPath`s, represented as high-durability tracked files, and extracted through the same Salsa tracked queries as workspace files. External-data refreshes bump search-path root revisions for discovery and bump currently discovered search-path file revisions so stale installed-package content is reread.
-- **Workspace modules** (project code) — indexed into the project file set during project refresh, represented as low-durability tracked files, and extracted through the same Salsa tracked queries. Edits to known files recompute automatically; new files enter the graph on the next project refresh.
+- **Installed package modules** (site-packages/dist-packages) — resolved through typed `SearchPath`s, represented as high-durability tracked files under `SearchPath` roots, and extracted through the same Salsa tracked queries as workspace files. External-data refreshes bump search-path root revisions for discovery and bump currently discovered dependency file revisions so stale installed-package content is reread.
+- **Workspace modules** (project code and extra pythonpath entries) — represented as low-durability tracked files under `Project` roots and extracted through the same Salsa tracked queries. Edits to known files recompute automatically; new files enter the graph on the next project refresh.
 
 ## The Template Pipeline
 

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -805,6 +805,7 @@ mod tests {
             discovery_knowledge: Knowledge::Known,
             loadable,
             builtins: BTreeMap::new(),
+            builtin_order: Vec::new(),
         }
     }
 
@@ -838,6 +839,7 @@ mod tests {
             discovery_knowledge: Knowledge::Known,
             loadable: BTreeMap::from([(library_name, vec![library])]),
             builtins: BTreeMap::new(),
+            builtin_order: Vec::new(),
         }
     }
 
@@ -874,7 +876,8 @@ mod tests {
             active_knowledge: Knowledge::Known,
             discovery_knowledge: Knowledge::Known,
             loadable: BTreeMap::from([(i18n_name, vec![i18n])]),
-            builtins: BTreeMap::from([(builtin_module, builtin)]),
+            builtins: BTreeMap::from([(builtin_module.clone(), builtin)]),
+            builtin_order: vec![builtin_module],
         }
     }
 

--- a/crates/djls-ide/src/hover.rs
+++ b/crates/djls-ide/src/hover.rs
@@ -320,6 +320,7 @@ mod tests {
             discovery_knowledge: Knowledge::Known,
             loadable: BTreeMap::from([(LibraryName::parse("humanize").unwrap(), vec![library])]),
             builtins: BTreeMap::new(),
+            builtin_order: Vec::new(),
         };
 
         let markdown =

--- a/crates/djls-semantic/src/project/python.rs
+++ b/crates/djls-semantic/src/project/python.rs
@@ -1,9 +1,7 @@
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_source::FileSystem;
-#[cfg(not(windows))]
 use djls_source::WalkEntryKind;
-#[cfg(not(windows))]
 use djls_source::WalkOptions;
 
 use crate::project::system;
@@ -58,70 +56,64 @@ impl Interpreter {
     }
 
     fn site_packages_path_in_venv(fs: &dyn FileSystem, venv: &Utf8Path) -> Option<Utf8PathBuf> {
-        #[cfg(windows)]
-        {
-            let site_packages = venv.join("Lib").join("site-packages");
-            fs.is_dir(&site_packages).then_some(site_packages)
+        let windows_site_packages = venv.join("Lib").join("site-packages");
+        if std::env::consts::OS == "windows" && fs.is_dir(&windows_site_packages) {
+            return Some(windows_site_packages);
         }
 
-        #[cfg(not(windows))]
+        let lib_dir = venv.join("lib");
+        let mut site_packages_directories = Vec::new();
+        if fs.is_dir(&lib_dir)
+            && let Ok(entries) = fs.walk_entries(&lib_dir, &WalkOptions::shallow())
         {
-            let lib_dir = venv.join("lib");
-            let mut site_packages_directories = Vec::new();
-            if fs.is_dir(&lib_dir)
-                && let Ok(entries) = fs.walk_entries(&lib_dir, &WalkOptions::shallow())
-            {
-                for entry in entries {
-                    if entry.kind != WalkEntryKind::Directory {
-                        continue;
-                    }
-
-                    let Some(name) = entry.path.file_name() else {
-                        continue;
-                    };
-                    let Some(version_suffix) = name.strip_prefix("python") else {
-                        continue;
-                    };
-
-                    let site_packages = entry.path.join("site-packages");
-                    if !fs.is_dir(&site_packages) {
-                        continue;
-                    }
-
-                    let python_version =
-                        if let Some((major, minor_part)) = version_suffix.split_once('.') {
-                            let minor_digits: String = minor_part
-                                .chars()
-                                .take_while(char::is_ascii_digit)
-                                .collect();
-                            match (major.parse::<u32>(), minor_digits.parse::<u32>()) {
-                                (Ok(major), Ok(minor)) if !minor_digits.is_empty() => {
-                                    Some((major, minor))
-                                }
-                                _ => None,
-                            }
-                        } else {
-                            None
-                        };
-                    site_packages_directories.push((
-                        python_version,
-                        name.to_string(),
-                        site_packages,
-                    ));
+            for entry in entries {
+                if entry.kind != WalkEntryKind::Directory {
+                    continue;
                 }
-            }
 
-            site_packages_directories.sort_by(
-                |(left_version, left_name, _), (right_version, right_name, _)| {
-                    left_version
-                        .cmp(right_version)
-                        .then_with(|| left_name.cmp(right_name))
-                },
-            );
-            site_packages_directories
-                .pop()
-                .map(|(_version, _name, site_packages)| site_packages)
+                let Some(name) = entry.path.file_name() else {
+                    continue;
+                };
+                let Some(version_suffix) = name.strip_prefix("python") else {
+                    continue;
+                };
+
+                let site_packages = entry.path.join("site-packages");
+                if !fs.is_dir(&site_packages) {
+                    continue;
+                }
+
+                let python_version = if let Some((major, minor_part)) =
+                    version_suffix.split_once('.')
+                {
+                    let minor_digits: String = minor_part
+                        .chars()
+                        .take_while(char::is_ascii_digit)
+                        .collect();
+                    match (major.parse::<u32>(), minor_digits.parse::<u32>()) {
+                        (Ok(major), Ok(minor)) if !minor_digits.is_empty() => Some((major, minor)),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                site_packages_directories.push((python_version, name.to_string(), site_packages));
+            }
         }
+
+        site_packages_directories.sort_by(
+            |(left_version, left_name, _), (right_version, right_name, _)| {
+                left_version
+                    .cmp(right_version)
+                    .then_with(|| left_name.cmp(right_name))
+            },
+        );
+        if let Some((_version, _name, site_packages)) = site_packages_directories.pop() {
+            return Some(site_packages);
+        }
+
+        fs.is_dir(&windows_site_packages)
+            .then_some(windows_site_packages)
     }
 
     fn auto_venv_paths(project_root: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
@@ -306,6 +298,63 @@ mod tests {
             let resolved =
                 interpreter.python_path(&djls_source::OsFileSystem, Utf8Path::new("/project"));
             assert_eq!(resolved, None);
+        }
+
+        #[test]
+        fn site_packages_path_finds_posix_venv_layout() {
+            let mut fs = djls_source::InMemoryFileSystem::new();
+            fs.add_file(
+                "/venv/lib/python3.12/site-packages/django/__init__.py".into(),
+                String::new(),
+            );
+
+            let site_packages =
+                Interpreter::site_packages_path_in_venv(&fs, Utf8Path::new("/venv"));
+
+            assert_eq!(
+                site_packages.as_deref(),
+                Some(Utf8Path::new("/venv/lib/python3.12/site-packages"))
+            );
+        }
+
+        #[test]
+        fn site_packages_path_finds_windows_venv_layout() {
+            let mut fs = djls_source::InMemoryFileSystem::new();
+            fs.add_file(
+                "/venv/Lib/site-packages/django/__init__.py".into(),
+                String::new(),
+            );
+
+            let site_packages =
+                Interpreter::site_packages_path_in_venv(&fs, Utf8Path::new("/venv"));
+
+            assert_eq!(
+                site_packages.as_deref(),
+                Some(Utf8Path::new("/venv/Lib/site-packages"))
+            );
+        }
+
+        #[test]
+        fn site_packages_path_uses_platform_layout_before_fallback() {
+            let mut fs = djls_source::InMemoryFileSystem::new();
+            fs.add_file(
+                "/venv/lib/python3.12/site-packages/posix/__init__.py".into(),
+                String::new(),
+            );
+            fs.add_file(
+                "/venv/Lib/site-packages/windows/__init__.py".into(),
+                String::new(),
+            );
+
+            let site_packages =
+                Interpreter::site_packages_path_in_venv(&fs, Utf8Path::new("/venv"));
+            let expected = if std::env::consts::OS == "windows" {
+                Utf8Path::new("/venv/Lib/site-packages")
+            } else {
+                Utf8Path::new("/venv/lib/python3.12/site-packages")
+            };
+
+            assert_eq!(site_packages.as_deref(), Some(expected));
         }
 
         #[test]

--- a/crates/djls-semantic/src/project/resolve.rs
+++ b/crates/djls-semantic/src/project/resolve.rs
@@ -1,13 +1,12 @@
 //! Module path → file path resolution using Python search paths.
 
-use std::sync::Arc;
-
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_source::FileRootKind;
 use djls_source::FileSystem;
 use djls_source::WalkEntryKind;
 use djls_source::WalkOptions;
+use rustc_hash::FxHashMap;
 
 use crate::project::Interpreter;
 use crate::project::db::Db as ProjectDb;
@@ -16,10 +15,7 @@ use crate::project::input::PythonModule;
 use crate::python::ModulePath;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SearchPath(Arc<SearchPathInner>);
-
-#[derive(Debug, PartialEq, Eq)]
-enum SearchPathInner {
+pub enum SearchPath {
     FirstParty(Utf8PathBuf),
     Extra(Utf8PathBuf),
     SitePackages(Utf8PathBuf),
@@ -27,15 +23,15 @@ enum SearchPathInner {
 
 impl SearchPath {
     fn first_party(path: Utf8PathBuf) -> Self {
-        Self(Arc::new(SearchPathInner::FirstParty(path)))
+        Self::FirstParty(path)
     }
 
     fn extra(path: Utf8PathBuf) -> Self {
-        Self(Arc::new(SearchPathInner::Extra(path)))
+        Self::Extra(path)
     }
 
     fn site_packages(path: Utf8PathBuf) -> Self {
-        Self(Arc::new(SearchPathInner::SitePackages(path)))
+        Self::SitePackages(path)
     }
 
     fn from_pythonpath(
@@ -43,7 +39,9 @@ impl SearchPath {
         discovered_site_packages: Option<&Utf8Path>,
         path: Utf8PathBuf,
     ) -> Self {
-        if discovered_site_packages.is_some_and(|site_packages| site_packages == path) {
+        if discovered_site_packages.is_some_and(|site_packages| site_packages == path)
+            || has_installed_package_component(&path)
+        {
             Self::site_packages(path)
         } else if path.starts_with(root) {
             Self::first_party(path)
@@ -54,25 +52,29 @@ impl SearchPath {
 
     #[must_use]
     pub(crate) fn path(&self) -> &Utf8Path {
-        match self.0.as_ref() {
-            SearchPathInner::FirstParty(path)
-            | SearchPathInner::Extra(path)
-            | SearchPathInner::SitePackages(path) => path,
+        match self {
+            Self::FirstParty(path) | Self::Extra(path) | Self::SitePackages(path) => path,
         }
     }
 
     #[must_use]
     pub(crate) fn is_first_party(&self) -> bool {
-        matches!(self.0.as_ref(), SearchPathInner::FirstParty(_))
+        matches!(self, Self::FirstParty(_))
     }
 
     fn root_kind(&self) -> FileRootKind {
-        if self.is_first_party() {
-            FileRootKind::Project
-        } else {
-            FileRootKind::SearchPath
+        match self {
+            // Extra pythonpath entries are user-edited code, so they get the
+            // same low-durability treatment as project files.
+            Self::FirstParty(_) | Self::Extra(_) => FileRootKind::Project,
+            Self::SitePackages(_) => FileRootKind::SearchPath,
         }
     }
+}
+
+fn has_installed_package_component(path: &Utf8Path) -> bool {
+    path.components()
+        .any(|component| matches!(component.as_str(), "site-packages" | "dist-packages"))
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -146,34 +148,53 @@ impl SearchPaths {
 
 #[salsa::tracked(returns(ref))]
 pub(crate) fn model_modules(db: &dyn ProjectDb, project: Project) -> Vec<PythonModule> {
+    let search_paths = project.search_paths(db);
     let mut modules_by_path: Vec<(usize, PythonModule)> = Vec::new();
+    let mut path_indexes: FxHashMap<Utf8PathBuf, usize> = FxHashMap::default();
 
-    for search_path in project.search_paths(db).iter() {
-        let root = db.files().expect_root(db, search_path.path());
-        let _ = root.revision(db);
+    for search_path in search_paths.iter() {
+        if let Some(root) = db.files().root(db, search_path.path()) {
+            let _ = root.revision(db);
+        } else {
+            tracing::warn!(
+                "Search path has no registered source root: {}",
+                search_path.path()
+            );
+        }
+
+        let excluded_paths: Vec<_> = if search_path.is_first_party() {
+            search_paths
+                .iter()
+                .filter(|other| {
+                    !other.is_first_party() && other.path().starts_with(search_path.path())
+                })
+                .map(|other| other.path().to_path_buf())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         let search_path_len = search_path.path().as_str().len();
-        for (module_path, file_path) in discover_model_files(
+        for (module_path, file_path) in discover_model_files_excluding(
             db.file_system(),
             search_path.path(),
             search_path.root_kind(),
+            &excluded_paths,
         ) {
             let module = PythonModule::new(
                 module_path,
                 file_path.clone(),
                 db.get_or_create_file(&file_path),
             );
-            match modules_by_path
-                .iter_mut()
-                .find(|(_search_path_len, existing)| existing.path() == file_path)
-            {
-                Some((existing_search_path_len, existing))
-                    if search_path_len > *existing_search_path_len =>
-                {
+            if let Some(index) = path_indexes.get(&file_path).copied() {
+                let (existing_search_path_len, existing) = &mut modules_by_path[index];
+                if search_path_len > *existing_search_path_len {
                     *existing_search_path_len = search_path_len;
                     *existing = module;
                 }
-                Some(_) => {}
-                None => modules_by_path.push((search_path_len, module)),
+            } else {
+                path_indexes.insert(file_path, modules_by_path.len());
+                modules_by_path.push((search_path_len, module));
             }
         }
     }
@@ -205,48 +226,74 @@ pub(crate) fn templatetag_module_file(
 
 #[salsa::tracked(returns(ref))]
 pub(crate) fn templatetag_modules(db: &dyn ProjectDb, project: Project) -> Vec<PythonModule> {
-    let module_paths: Vec<String> = project
+    let search_paths: Vec<_> = project.search_paths(db).iter().collect();
+    for search_path in &search_paths {
+        if let Some(root) = db.files().root(db, search_path.path()) {
+            let _ = root.revision(db);
+        } else {
+            tracing::warn!(
+                "Search path has no registered source root: {}",
+                search_path.path()
+            );
+        }
+    }
+
+    let mut modules = Vec::new();
+
+    for (module_index, module_path) in project
         .template_libraries(db)
         .registration_modules()
         .into_iter()
-        .map(|module| module.as_str().to_string())
-        .collect();
-
-    let search_paths = project.search_paths(db);
-    let mut modules = Vec::new();
-
-    for module_path in module_paths {
-        for search_path in search_paths.iter() {
-            let root = db.files().expect_root(db, search_path.path());
-            let _ = root.revision(db);
-
+        .enumerate()
+    {
+        for search_path in &search_paths {
             let Some(file_path) =
                 templatetag_module_file(db.file_system(), module_path.as_str(), search_path.path())
             else {
                 continue;
             };
 
-            modules.push(PythonModule::new(
-                ModulePath::new(module_path.clone()),
-                file_path.clone(),
-                db.get_or_create_file(&file_path),
+            modules.push((
+                module_index,
+                PythonModule::new(
+                    ModulePath::new(module_path.as_str().to_string()),
+                    file_path.clone(),
+                    db.get_or_create_file(&file_path),
+                ),
             ));
             break;
         }
     }
 
-    modules
+    modules.sort_by(|(left_index, left), (right_index, right)| {
+        left_index
+            .cmp(right_index)
+            .then_with(|| left.module_path().cmp(right.module_path()))
+            .then_with(|| left.path().cmp(right.path()))
+    });
+
+    modules.into_iter().map(|(_index, module)| module).collect()
 }
 
 /// Discover Django model source files and return their resolved module paths.
 ///
 /// Finds `models.py` files and `.py` files inside `models/` packages
 /// (directories with `__init__.py`) without reading file contents.
+#[cfg(test)]
 #[must_use]
 pub(crate) fn discover_model_files(
     fs: &dyn FileSystem,
     base_dir: &Utf8Path,
     root_kind: FileRootKind,
+) -> Vec<(ModulePath, Utf8PathBuf)> {
+    discover_model_files_excluding(fs, base_dir, root_kind, &[])
+}
+
+fn discover_model_files_excluding(
+    fs: &dyn FileSystem,
+    base_dir: &Utf8Path,
+    root_kind: FileRootKind,
+    excluded_roots: &[Utf8PathBuf],
 ) -> Vec<(ModulePath, Utf8PathBuf)> {
     let options = match root_kind {
         FileRootKind::Project => WalkOptions::project(),
@@ -290,10 +337,9 @@ pub(crate) fn discover_model_files(
             continue;
         }
 
-        if root_kind == FileRootKind::Project
-            && path
-                .components()
-                .any(|component| component.as_str() == "site-packages")
+        if excluded_roots
+            .iter()
+            .any(|excluded| path.starts_with(excluded))
         {
             continue;
         }
@@ -318,6 +364,7 @@ mod tests {
     use djls_source::InMemoryFileSystem;
 
     use super::*;
+    use crate::compute_filter_arity_specs;
     use crate::project::ProjectTemplateFiles;
     use crate::project::TemplateDirs;
     use crate::project::TemplateLibraries;
@@ -477,7 +524,7 @@ mod tests {
         let external_root = db
             .files()
             .expect_root(&db, Utf8Path::new("/external/pkg/models.py"));
-        assert_eq!(external_root.kind(&db), FileRootKind::SearchPath);
+        assert_eq!(external_root.kind(&db), FileRootKind::Project);
 
         let search_paths = SearchPaths::from_project_settings(
             db.file_system(),
@@ -490,6 +537,61 @@ mod tests {
             db.files()
                 .root(&db, Utf8Path::new("/external/pkg/models.py"))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn model_modules_tolerate_unregistered_search_paths() {
+        let db = TestDatabase::new();
+        db.add_file(
+            "/shared/blog/models.py",
+            "from django.db import models\nclass SharedArticle(models.Model):\n    pass\n",
+        );
+
+        let pythonpath = vec!["/shared".to_string()];
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::Auto,
+            &pythonpath,
+        );
+        let project =
+            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+
+        let modules = model_modules(&db, project);
+        assert!(
+            modules
+                .iter()
+                .any(|module| module.module_path().as_str() == "blog.models")
+        );
+    }
+
+    #[test]
+    fn templatetag_modules_tolerate_unregistered_search_paths() {
+        let db = TestDatabase::new();
+        db.add_file(
+            "/project/django/templatetags/i18n.py",
+            "from django import template\nregister = template.Library()\n",
+        );
+
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::Auto,
+            &[],
+        );
+        let project = project_for_search_paths(
+            &db,
+            "/project",
+            search_paths,
+            template_libraries_for_module("django.templatetags.i18n"),
+        );
+
+        let modules = templatetag_modules(&db, project);
+        assert_eq!(modules.len(), 1);
+        assert_eq!(
+            modules[0].module_path().as_str(),
+            "django.templatetags.i18n"
         );
     }
 
@@ -523,6 +625,135 @@ mod tests {
         );
         let root = db.files().expect_root(&db, modules[0].path());
         assert_eq!(root.kind(&db), FileRootKind::SearchPath);
+    }
+
+    #[test]
+    fn templatetag_resolution_prefers_first_party_module_shadowing_dependency() {
+        let db = TestDatabase::new();
+        db.add_file(
+            "/project/django/templatetags/i18n.py",
+            "from django import template\nregister = template.Library()\n",
+        );
+        db.add_file(
+            "/project/.venv/lib/python3.12/site-packages/django/templatetags/i18n.py",
+            "from django import template\nregister = template.Library()\n",
+        );
+
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::Auto,
+            &[],
+        );
+        search_paths.register_roots(&db);
+        let project = project_for_search_paths(
+            &db,
+            "/project",
+            search_paths,
+            template_libraries_for_module("django.templatetags.i18n"),
+        );
+
+        let modules = templatetag_modules(&db, project);
+        assert_eq!(modules.len(), 1);
+        assert_eq!(
+            modules[0].path(),
+            Utf8Path::new("/project/django/templatetags/i18n.py")
+        );
+    }
+
+    #[test]
+    fn templatetag_modules_preserve_registration_order_across_roots() {
+        let db = TestDatabase::new();
+        db.add_file(
+            "/project/a/templatetags/tags.py",
+            "from django import template\nregister = template.Library()\n",
+        );
+        db.add_file(
+            "/project/.venv/lib/python3.12/site-packages/z/templatetags/tags.py",
+            "from django import template\nregister = template.Library()\n",
+        );
+
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::Auto,
+            &[],
+        );
+        search_paths.register_roots(&db);
+        let project = project_for_search_paths(
+            &db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
+                symbols: Vec::new(),
+                libraries: BTreeMap::new(),
+                builtins: vec![
+                    "a.templatetags.tags".to_string(),
+                    "z.templatetags.tags".to_string(),
+                ],
+            })),
+        );
+
+        let modules = templatetag_modules(&db, project);
+        let module_paths: Vec<_> = modules
+            .iter()
+            .map(|module| module.module_path().as_str())
+            .collect();
+
+        assert_eq!(
+            module_paths,
+            vec!["a.templatetags.tags", "z.templatetags.tags"]
+        );
+    }
+
+    #[test]
+    fn filter_arity_specs_preserve_builtin_registration_order_across_roots() {
+        let db = TestDatabase::new();
+        db.add_file(
+            "/project/z_first.py",
+            r"
+from django import template
+register = template.Library()
+
+@register.filter
+def duplicate(value):
+    return value
+",
+        );
+        db.add_file(
+            "/project/.venv/lib/python3.12/site-packages/a_second.py",
+            r"
+from django import template
+register = template.Library()
+
+@register.filter
+def duplicate(value, arg):
+    return value
+",
+        );
+
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::Auto,
+            &[],
+        );
+        search_paths.register_roots(&db);
+        let project = project_for_search_paths(
+            &db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
+                symbols: Vec::new(),
+                libraries: BTreeMap::new(),
+                builtins: vec!["z_first".to_string(), "a_second".to_string()],
+            })),
+        );
+
+        let specs = compute_filter_arity_specs(&db, project);
+        let arity = specs.get("duplicate").expect("filter should be extracted");
+        assert!(arity.expects_arg);
+        assert!(!arity.arg_optional);
     }
 
     #[test]
@@ -748,6 +979,54 @@ mod tests {
     }
 
     #[test]
+    fn refresh_external_data_discovers_site_packages_created_after_bootstrap() {
+        let mut db = TestDatabase::new();
+        let settings = Settings::default();
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::Auto,
+            &[],
+        );
+        search_paths.register_roots(&db);
+        let project = Project::new(
+            &db,
+            "/project".into(),
+            search_paths,
+            Interpreter::Auto,
+            None,
+            Vec::new(),
+            Vec::new(),
+            TemplateDirs::Unknown,
+            settings.tagspecs().clone(),
+            TemplateLibraries::default(),
+            ProjectTemplateFiles::default(),
+        );
+        db.set_project(project);
+
+        assert!(
+            project
+                .search_paths(&db)
+                .iter()
+                .all(|search_path| search_path.path()
+                    != Utf8Path::new("/project/.venv/lib/python3.12/site-packages"))
+        );
+
+        db.add_file(
+            "/project/.venv/lib/python3.12/site-packages/blog/models.py",
+            "from django.db import models\nclass VenvArticle(models.Model):\n    pass\n",
+        );
+
+        refresh_external_data(&mut db);
+
+        assert!(project.search_paths(&db).iter().any(|search_path| {
+            search_path.path() == Utf8Path::new("/project/.venv/lib/python3.12/site-packages")
+        }));
+        let graph = compute_model_graph(&db, project);
+        assert!(graph.get("VenvArticle").is_some());
+    }
+
+    #[test]
     fn discover_external_model_files_finds_models() {
         let tmp = tempfile::TempDir::new().unwrap();
         let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
@@ -962,25 +1241,36 @@ class Article(models.Model):
     }
 
     #[test]
-    fn discover_model_files_workspace_skips_site_packages() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
-
-        // Use a non-hidden venv path so the hidden filter doesn't mask
-        // the site-packages component check we're actually testing.
-        let sp = root.join("venv/lib/python3.12/site-packages/somelib");
-        std::fs::create_dir_all(&sp).unwrap();
-        std::fs::write(
-            sp.join("models.py"),
-            "from django.db import models\nclass Lib(models.Model): pass\n",
-        )
-        .unwrap();
-
-        let results =
-            discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::Project);
-        assert!(
-            results.is_empty(),
-            "should not discover models in site-packages"
+    fn project_model_discovery_skips_registered_non_first_party_paths() {
+        let db = TestDatabase::new();
+        db.add_file(
+            "/project/app/models.py",
+            "from django.db import models\nclass App(models.Model): pass\n",
         );
+        db.add_file(
+            "/project/venv/lib/python3.12/site-packages/somelib/models.py",
+            "from django.db import models\nclass Lib(models.Model): pass\n",
+        );
+
+        let pythonpath = vec!["/project/venv/lib/python3.12/site-packages".to_string()];
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            Utf8Path::new("/project"),
+            &Interpreter::InterpreterPath("/usr/bin/python".to_string()),
+            &pythonpath,
+        );
+        search_paths.register_roots(&db);
+        let project =
+            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+
+        let modules = model_modules(&db, project);
+        let module_paths: Vec<_> = modules
+            .iter()
+            .map(|module| module.module_path().as_str())
+            .collect();
+
+        assert!(module_paths.contains(&"app.models"));
+        assert!(module_paths.contains(&"somelib.models"));
+        assert!(!module_paths.contains(&"venv.lib.python3.12.site-packages.somelib.models"));
     }
 }

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use camino::Utf8PathBuf;
-use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -172,7 +171,7 @@ pub enum Knowledge {
     Unknown,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TemplateLibrarySnapshot {
     pub symbols: Vec<TemplateSymbolSnapshot>,
     pub libraries: BTreeMap<String, String>,
@@ -203,6 +202,7 @@ pub struct TemplateLibraries {
     pub discovery_knowledge: Knowledge,
     pub loadable: BTreeMap<LibraryName, Vec<TemplateLibrary>>,
     pub builtins: BTreeMap<PyModuleName, TemplateLibrary>,
+    pub builtin_order: Vec<PyModuleName>,
 }
 
 impl Default for TemplateLibraries {
@@ -212,6 +212,7 @@ impl Default for TemplateLibraries {
             discovery_knowledge: Knowledge::Unknown,
             loadable: BTreeMap::new(),
             builtins: BTreeMap::new(),
+            builtin_order: Vec::new(),
         }
     }
 }
@@ -225,36 +226,40 @@ impl TemplateLibraries {
     }
 
     #[must_use]
-    pub fn registration_modules(&self) -> FxHashSet<PyModuleName> {
+    pub fn registration_modules(&self) -> Vec<PyModuleName> {
         if self.active_knowledge != Knowledge::Known {
-            return FxHashSet::default();
+            return Vec::new();
         }
 
-        let mut modules = FxHashSet::default();
+        let mut modules = Vec::new();
 
         for (_name, library) in self.enabled_loadable_libraries() {
-            modules.insert(library.module().clone());
+            push_unique_module(&mut modules, library.module().clone());
         }
 
         for module in self.builtin_modules() {
-            modules.insert(module.clone());
+            push_unique_module(&mut modules, module.clone());
         }
 
         modules
     }
 
     pub fn builtin_modules(&self) -> impl Iterator<Item = &PyModuleName> + '_ {
-        self.builtins.keys()
+        self.builtin_order
+            .iter()
+            .filter(|module| self.builtins.contains_key(*module))
     }
 
     pub fn builtin_libraries(&self) -> impl Iterator<Item = &TemplateLibrary> + '_ {
-        self.builtins.values()
+        self.builtin_modules()
+            .filter_map(|module| self.builtins.get(module))
     }
 
     pub fn builtin_libraries_by_module(
         &self,
     ) -> impl Iterator<Item = (&PyModuleName, &TemplateLibrary)> + '_ {
-        self.builtins.iter()
+        self.builtin_modules()
+            .filter_map(|module| self.builtins.get(module).map(|library| (module, library)))
     }
 
     pub fn loadable_library_names(&self) -> impl Iterator<Item = &LibraryName> + '_ {
@@ -302,6 +307,7 @@ impl TemplateLibraries {
         kind: TemplateSymbolKind,
     ) -> Vec<InstalledSymbolCandidate> {
         let mut candidates = Vec::new();
+        let mut builtin_candidates = BTreeMap::new();
 
         for (module, library) in self.builtin_libraries_by_module() {
             for symbol in &library.symbols {
@@ -309,14 +315,18 @@ impl TemplateLibraries {
                     continue;
                 }
 
-                candidates.push(InstalledSymbolCandidate {
-                    symbol: symbol.clone(),
-                    origin: InstalledSymbolOrigin::Builtin {
-                        module: module.clone(),
+                builtin_candidates.insert(
+                    symbol.name.clone(),
+                    InstalledSymbolCandidate {
+                        symbol: symbol.clone(),
+                        origin: InstalledSymbolOrigin::Builtin {
+                            module: module.clone(),
+                        },
                     },
-                });
+                );
             }
         }
+        candidates.extend(builtin_candidates.into_values());
 
         for (name, library) in self.enabled_loadable_libraries() {
             for symbol in &library.symbols {
@@ -464,6 +474,7 @@ impl TemplateLibraries {
         let Some(response) = response else {
             self.active_knowledge = Knowledge::Unknown;
             self.builtins.clear();
+            self.builtin_order.clear();
             return self;
         };
 
@@ -529,6 +540,7 @@ impl TemplateLibraries {
         }
 
         self.builtins.clear();
+        self.builtin_order.clear();
         for builtin_module in response.builtins {
             let Ok(module) = PyModuleName::parse(&builtin_module) else {
                 continue;
@@ -539,6 +551,7 @@ impl TemplateLibraries {
                 continue;
             };
 
+            push_unique_module(&mut self.builtin_order, module.clone());
             self.builtins
                 .entry(module.clone())
                 .or_insert_with(|| TemplateLibrary::new_builtin(name, module));
@@ -608,7 +621,13 @@ impl TemplateLibraries {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
+    if !modules.contains(&module) {
+        modules.push(module);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TemplateSymbolSnapshot {
     #[serde(default)]
     pub kind: Option<TemplateSymbolKind>,
@@ -619,4 +638,76 @@ pub struct TemplateSymbolSnapshot {
     pub module: String,
     #[serde(default)]
     pub doc: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_candidates_keep_last_builtin_symbol() {
+        let libraries =
+            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
+                symbols: vec![
+                    TemplateSymbolSnapshot {
+                        kind: Some(TemplateSymbolKind::Filter),
+                        name: "duplicate".to_string(),
+                        load_name: None,
+                        library_module: "z_first".to_string(),
+                        module: "z_first".to_string(),
+                        doc: Some("first".to_string()),
+                    },
+                    TemplateSymbolSnapshot {
+                        kind: Some(TemplateSymbolKind::Filter),
+                        name: "duplicate".to_string(),
+                        load_name: None,
+                        library_module: "a_second".to_string(),
+                        module: "a_second".to_string(),
+                        doc: Some("second".to_string()),
+                    },
+                ],
+                libraries: BTreeMap::new(),
+                builtins: vec!["z_first".to_string(), "a_second".to_string()],
+            }));
+
+        let candidates = libraries.installed_symbol_candidates(TemplateSymbolKind::Filter);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].symbol.doc.as_deref(), Some("second"));
+        assert_eq!(
+            candidates[0].origin,
+            InstalledSymbolOrigin::Builtin {
+                module: PyModuleName::parse("a_second").unwrap()
+            }
+        );
+    }
+
+    #[test]
+    fn registration_modules_keep_deterministic_precedence_order() {
+        let libraries =
+            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
+                symbols: Vec::new(),
+                libraries: [("project_tags".to_string(), "project.tags".to_string())].into(),
+                builtins: vec![
+                    "z.templatetags.tags".to_string(),
+                    "django.template.defaulttags".to_string(),
+                    "z.templatetags.tags".to_string(),
+                ],
+            }));
+
+        let modules: Vec<_> = libraries
+            .registration_modules()
+            .into_iter()
+            .map(|module| module.as_str().to_string())
+            .collect();
+
+        assert_eq!(
+            modules,
+            vec![
+                "project.tags",
+                "z.templatetags.tags",
+                "django.template.defaulttags",
+            ]
+        );
+    }
 }

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -25,7 +25,7 @@ use crate::project::input::TemplateDirs;
 use crate::project::introspector::IntrospectionRequest;
 use crate::project::python::Interpreter;
 use crate::project::resolve::model_modules;
-use crate::project::resolve::templatetag_module_file;
+use crate::project::resolve::templatetag_modules;
 use crate::project::symbols::TemplateLibrarySnapshot;
 
 /// Refresh all external project data.
@@ -39,6 +39,7 @@ pub fn refresh_external_data(db: &mut dyn ProjectDb) {
         return;
     };
 
+    project.refresh_source_roots(db);
     refresh_template_dirs(db, project);
     refresh_template_libraries(db, project);
     refresh_template_files(db, project);
@@ -167,15 +168,10 @@ fn refresh_template_libraries(db: &mut dyn ProjectDb, project: Project) {
         django_settings_module.as_deref(),
         &pythonpath,
     ) {
-        let Ok(response_value) = serde_json::to_value(&snapshot) else {
-            tracing::warn!("Failed to serialize template library snapshot for cache");
-            apply_template_library_snapshot(db, project, snapshot);
-            return;
+        let envelope = CacheEnvelope {
+            djls_version: env!("CARGO_PKG_VERSION").to_string(),
+            response: snapshot.clone(),
         };
-        let envelope = serde_json::json!({
-            "djls_version": env!("CARGO_PKG_VERSION"),
-            "response": response_value,
-        });
 
         if let Err(e) = fs::create_dir_all(dir.as_std_path()) {
             tracing::warn!("Failed to create template library snapshot cache directory: {e}");
@@ -214,7 +210,7 @@ fn apply_template_library_snapshot(
     true
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct CacheEnvelope {
     djls_version: String,
     response: TemplateLibrarySnapshot,
@@ -309,7 +305,7 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
     let roots: Vec<_> = project
         .search_paths(db)
         .iter()
-        .map(|search_path| db.files().expect_root(db, search_path.path()))
+        .filter_map(|search_path| db.files().root(db, search_path.path()))
         .collect();
 
     for root in roots {
@@ -323,21 +319,11 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
             .map(|module| module.path().to_path_buf()),
     );
 
-    let module_paths: Vec<String> = project
-        .template_libraries(db)
-        .registration_modules()
-        .into_iter()
-        .map(|module| module.as_str().to_string())
-        .collect();
-    for module_path in module_paths {
-        for search_path in project.search_paths(db).iter() {
-            if let Some(file_path) =
-                templatetag_module_file(db.file_system(), module_path.as_str(), search_path.path())
-            {
-                file_paths.push(file_path);
-            }
-        }
-    }
+    file_paths.extend(
+        templatetag_modules(db, project)
+            .iter()
+            .map(|module| module.path().to_path_buf()),
+    );
 
     file_paths.sort();
     file_paths.dedup();
@@ -372,5 +358,24 @@ mod tests {
         let key1 = cache_key(Utf8Path::new("/project-a"), &interpreter, None, &pythonpath);
         let key2 = cache_key(Utf8Path::new("/project-b"), &interpreter, None, &pythonpath);
         assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_envelope_round_trips() {
+        let snapshot = TemplateLibrarySnapshot {
+            symbols: Vec::new(),
+            libraries: [("i18n".to_string(), "django.templatetags.i18n".to_string())].into(),
+            builtins: vec!["django.template.defaulttags".to_string()],
+        };
+        let envelope = CacheEnvelope {
+            djls_version: "test-version".to_string(),
+            response: snapshot.clone(),
+        };
+
+        let json = serde_json::to_string(&envelope).unwrap();
+        let decoded: CacheEnvelope = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.djls_version, "test-version");
+        assert_eq!(decoded.response, snapshot);
     }
 }

--- a/crates/djls-semantic/src/python.rs
+++ b/crates/djls-semantic/src/python.rs
@@ -89,13 +89,6 @@ pub(crate) fn parse_python_module(
     file: File,
 ) -> Option<ParsedPythonModule<'_>> {
     let source = file.source(db);
-    parse_python_source(db, &source)
-}
-
-fn parse_python_source<'db>(
-    db: &'db dyn djls_source::Db,
-    source: &djls_source::SourceText,
-) -> Option<ParsedPythonModule<'db>> {
     if *source.kind() != FileKind::Python {
         return None;
     }

--- a/crates/djls-server/src/workspace.rs
+++ b/crates/djls-server/src/workspace.rs
@@ -93,6 +93,14 @@ impl Workspace {
         &self.buffers
     }
 
+    fn open_changes_file_set(&self, db: &dyn Db, path: &Utf8Path) -> bool {
+        !self.overlay.disk.is_file(path) || !db.files().contains_file(path)
+    }
+
+    fn close_changes_file_set(&self, path: &Utf8Path) -> bool {
+        !self.overlay.disk.is_file(path)
+    }
+
     #[cfg(test)]
     #[must_use]
     pub(crate) fn get_document(&self, path: &Utf8Path) -> Option<TextDocument> {
@@ -108,14 +116,12 @@ impl Workspace {
         version: i32,
         kind: FileKind,
     ) -> TextDocument {
+        let file_set_changes = self.open_changes_file_set(db, path);
         let file = db.get_or_create_file(path);
         let document =
             TextDocument::new(path.to_path_buf(), content.to_string(), version, kind, file);
         debug_assert_eq!(document.kind(), kind);
-        db.bump_file_revision(document.file());
-        if let Some(root) = db.files().root(db, path) {
-            db.bump_file_root_revision(root);
-        }
+        db.bump_file_and_maybe_root_revision(document.file(), path, file_set_changes);
         self.buffers.open(path.to_path_buf(), document.clone());
         document
     }
@@ -147,6 +153,7 @@ impl Workspace {
             Some(document)
         } else if let Some(first_change) = changes.into_iter().next() {
             if first_change.range().is_none() {
+                let file_set_changes = self.open_changes_file_set(db, path);
                 let file = db.get_or_create_file(path);
                 let document = TextDocument::new(
                     path.to_path_buf(),
@@ -155,10 +162,7 @@ impl Workspace {
                     FileKind::Other,
                     file,
                 );
-                db.bump_file_revision(file);
-                if let Some(root) = db.files().root(db, path) {
-                    db.bump_file_root_revision(root);
-                }
+                db.bump_file_and_maybe_root_revision(file, path, file_set_changes);
                 self.buffers.open(path.to_path_buf(), document.clone());
                 Some(document)
             } else {
@@ -175,11 +179,9 @@ impl Workspace {
         db: &mut dyn Db,
         path: &Utf8Path,
     ) -> Option<TextDocument> {
+        let file_set_changes = self.close_changes_file_set(path);
         let document = self.buffers.close(path)?;
-        db.bump_file_revision(document.file());
-        if let Some(root) = db.files().root(db, path) {
-            db.bump_file_root_revision(root);
-        }
+        db.bump_file_and_maybe_root_revision(document.file(), path, file_set_changes);
         Some(document)
     }
 }
@@ -392,6 +394,7 @@ fn buffer_relative_path(root: &Utf8Path, path: &Utf8Path) -> Option<Utf8PathBuf>
 #[cfg(test)]
 mod tests {
     use djls_source::Db as _;
+    use djls_source::FileRootKind;
     use djls_source::InMemoryFileSystem;
     use djls_source::SourceFiles;
     use tempfile::tempdir;
@@ -497,6 +500,84 @@ mod tests {
             .collect();
 
         assert_eq!(relatives, vec!["visible.html"]);
+    }
+
+    #[test]
+    fn disk_backed_open_and_close_do_not_bump_root_revision() {
+        let temp_dir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+        let file_path = root.join("template.html");
+        std::fs::write(file_path.as_std_path(), "disk template").unwrap();
+
+        let mut workspace = Workspace::new();
+        let mut db = TestDb::new(workspace.overlay());
+        let root = db
+            .files()
+            .try_add_root(&db, root.to_path_buf(), FileRootKind::Project);
+        db.get_or_create_file(&file_path);
+
+        workspace.open_document(
+            &mut db,
+            &file_path,
+            "buffer template",
+            1,
+            FileKind::Template,
+        );
+        assert_eq!(root.revision(&db), 0);
+
+        workspace.close_document(&mut db, &file_path).unwrap();
+        assert_eq!(root.revision(&db), 0);
+    }
+
+    #[test]
+    fn untracked_disk_backed_open_bumps_root_revision() {
+        let temp_dir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+        let file_path = root.join("template.html");
+        std::fs::write(file_path.as_std_path(), "disk template").unwrap();
+
+        let mut workspace = Workspace::new();
+        let mut db = TestDb::new(workspace.overlay());
+        let root = db
+            .files()
+            .try_add_root(&db, root.to_path_buf(), FileRootKind::Project);
+
+        workspace.open_document(
+            &mut db,
+            &file_path,
+            "buffer template",
+            1,
+            FileKind::Template,
+        );
+        assert_eq!(root.revision(&db), 1);
+
+        workspace.close_document(&mut db, &file_path).unwrap();
+        assert_eq!(root.revision(&db), 1);
+    }
+
+    #[test]
+    fn buffer_only_open_and_close_bump_root_revision() {
+        let temp_dir = tempdir().unwrap();
+        let root_path = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+        let file_path = root_path.join("template.html");
+
+        let mut workspace = Workspace::new();
+        let mut db = TestDb::new(workspace.overlay());
+        let root = db
+            .files()
+            .try_add_root(&db, root_path.to_path_buf(), FileRootKind::Project);
+
+        workspace.open_document(
+            &mut db,
+            &file_path,
+            "buffer template",
+            1,
+            FileKind::Template,
+        );
+        assert_eq!(root.revision(&db), 1);
+
+        workspace.close_document(&mut db, &file_path).unwrap();
+        assert_eq!(root.revision(&db), 2);
     }
 
     #[test]

--- a/crates/djls-source/src/db.rs
+++ b/crates/djls-source/src/db.rs
@@ -56,4 +56,12 @@ pub trait Db: salsa::Database {
         let new_rev = current_rev + 1;
         root.set_revision(self).to(new_rev);
     }
+
+    /// Bump a tracked file and, when discovery changed, its containing source root.
+    fn bump_file_and_maybe_root_revision(&mut self, file: File, path: &Utf8Path, bump_root: bool) {
+        self.bump_file_revision(file);
+        if bump_root && let Some(root) = self.files().root(self, path) {
+            self.bump_file_root_revision(root);
+        }
+    }
 }

--- a/crates/djls-source/src/files.rs
+++ b/crates/djls-source/src/files.rs
@@ -188,9 +188,10 @@ struct SourceFilesInner {
 /// Classification used to assign durability to files under a root.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FileRootKind {
-    /// First-party files edited by the user.
+    /// User-edited files: project code and extra Python paths.
     Project,
-    /// Files discovered through module/search paths.
+    /// Installed packages discovered through library search paths; these
+    /// rarely change during a session.
     SearchPath,
 }
 
@@ -216,6 +217,11 @@ impl SourceFiles {
                 .path_durability(Durability::HIGH)
                 .new(db)
         })
+    }
+
+    #[must_use]
+    pub fn contains_file(&self, path: &Utf8Path) -> bool {
+        self.0.by_path.contains_key(path)
     }
 
     fn roots(&self) -> RwLockReadGuard<'_, Vec<FileRoot>> {


### PR DESCRIPTION
## Summary
- restore runtime site-packages layout probing and refresh search paths during external refresh
- split dependency root durability, avoid stale/panic root lookups, and tighten open/close root invalidation
- preserve Django template builtin precedence while making module discovery deterministic
- restore typed cache envelope roundtripping and simplify duplicated parsing/resolution paths

## Validation
- cargo test -q
- just fmt --check
- cargo clippy --all-targets --all-features --benches -- -D warnings
- just lint