### PR TITLE
refactor: delete never-populated discovered-library machinery

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -209,7 +209,6 @@ mod invalidation_tests {
 
     use djls_conf::Settings;
     use djls_semantic::Db as SemanticDb;
-    use djls_semantic::Knowledge;
     use djls_semantic::Project;
     use djls_semantic::TemplateLibraries;
     use djls_source::InMemoryFileSystem;
@@ -558,10 +557,6 @@ def my_filter(value, arg):
         let (db, _event_log) = test_db_with_project();
 
         let project = db.project.lock().unwrap().unwrap();
-        assert_eq!(
-            project.template_libraries(&db).discovery_knowledge,
-            Knowledge::Unknown
-        );
         assert!(
             project.template_libraries(&db).loadable.is_empty(),
             "template libraries should initially be empty"

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -32,7 +32,6 @@ use crate::snippets::generate_snippet_for_tag_with_end;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompletionCandidateKind {
     TagName,
-    ScannedTagName,
     EndTag,
     TagArgumentLiteral,
     TagArgumentChoice,
@@ -41,7 +40,6 @@ pub(crate) enum CompletionCandidateKind {
     LibraryName,
     LoadSymbol,
     Filter,
-    ScannedFilter,
 }
 
 impl CompletionCandidateKind {
@@ -54,7 +52,6 @@ impl CompletionCandidateKind {
             | Self::LibraryName
             | Self::LoadSymbol
             | Self::Filter => 1,
-            Self::ScannedTagName | Self::ScannedFilter => 2,
             Self::TagArgumentPlaceholder => 3,
             Self::TagArgumentSnippet => 4,
         }
@@ -256,21 +253,6 @@ impl CompletionCandidate {
         }
     }
 
-    fn scanned_tag_name(
-        name: &str,
-        prefix: &OffsetPrefix<'_>,
-        needs_leading_space: bool,
-        close: TagClose,
-    ) -> Self {
-        Self {
-            label: name.to_string(),
-            kind: CompletionCandidateKind::ScannedTagName,
-            edit: CompletionEdit::tag_plain(name, prefix, needs_leading_space, close),
-            detail: Some("scanned tag".to_string()),
-            documentation: None,
-        }
-    }
-
     fn end_tag(
         opener_name: &str,
         name: &str,
@@ -387,16 +369,6 @@ impl CompletionCandidate {
             edit: CompletionEdit::plain(prefix.span, name),
             detail: Some(filter_completion_detail(origin)),
             documentation: documentation.map(str::to_string),
-        }
-    }
-
-    fn scanned_filter(name: &str, prefix: &OffsetPrefix<'_>) -> Self {
-        Self {
-            label: name.to_string(),
-            kind: CompletionCandidateKind::ScannedFilter,
-            edit: CompletionEdit::plain(prefix.span, name),
-            detail: Some("scanned filter".to_string()),
-            documentation: None,
         }
     }
 }
@@ -532,17 +504,6 @@ fn generate_tag_name_candidates(
     let mut candidates = Vec::new();
 
     if template_libraries.active_knowledge != Knowledge::Known {
-        for name in template_libraries.discovered_symbol_names(TemplateSymbolKind::Tag) {
-            let name = name.as_str();
-            if name.starts_with(prefix.text) {
-                candidates.push(CompletionCandidate::scanned_tag_name(
-                    name,
-                    prefix,
-                    needs_leading_space,
-                    close,
-                ));
-            }
-        }
         return candidates;
     }
 
@@ -742,12 +703,7 @@ fn generate_filter_candidates(
         return candidates;
     }
 
-    template_libraries
-        .discovered_symbol_names(TemplateSymbolKind::Filter)
-        .into_iter()
-        .filter(|name| name.as_str().starts_with(prefix.text))
-        .map(|name| CompletionCandidate::scanned_filter(name.as_str(), prefix))
-        .collect()
+    Vec::new()
 }
 
 #[cfg(test)]
@@ -802,7 +758,6 @@ mod tests {
 
         TemplateLibraries {
             active_knowledge: Knowledge::Known,
-            discovery_knowledge: Knowledge::Known,
             loadable,
             builtins: BTreeMap::new(),
             builtin_order: Vec::new(),
@@ -836,7 +791,6 @@ mod tests {
 
         TemplateLibraries {
             active_knowledge: Knowledge::Known,
-            discovery_knowledge: Knowledge::Known,
             loadable: BTreeMap::from([(library_name, vec![library])]),
             builtins: BTreeMap::new(),
             builtin_order: Vec::new(),
@@ -874,7 +828,6 @@ mod tests {
 
         TemplateLibraries {
             active_knowledge: Knowledge::Known,
-            discovery_knowledge: Knowledge::Known,
             loadable: BTreeMap::from([(i18n_name, vec![i18n])]),
             builtins: BTreeMap::from([(builtin_module.clone(), builtin)]),
             builtin_order: vec![builtin_module],
@@ -1162,13 +1115,17 @@ mod tests {
 
     #[test]
     fn partial_tag_close_extends_replacement_span() {
-        let candidate = CompletionCandidate::scanned_tag_name(
-            "load",
+        let origin = builtin_origin();
+        let candidate = CompletionCandidate::tag_name(
+            &test_tag_symbol("load"),
             &prefix("lo"),
             false,
             TagClose::Partial {
                 replacement_suffix_len: 1,
             },
+            None,
+            &origin,
+            false,
         );
 
         assert_eq!(candidate.edit.replacement_span, Span::new(0, 3));
@@ -1177,13 +1134,17 @@ mod tests {
 
     #[test]
     fn partial_tag_close_after_whitespace_extends_replacement_span_to_close() {
-        let candidate = CompletionCandidate::scanned_tag_name(
-            "load",
+        let origin = builtin_origin();
+        let candidate = CompletionCandidate::tag_name(
+            &test_tag_symbol("load"),
             &prefix("lo"),
             false,
             TagClose::Partial {
                 replacement_suffix_len: 2,
             },
+            None,
+            &origin,
+            false,
         );
 
         assert_eq!(candidate.edit.replacement_span, Span::new(0, 4));
@@ -1196,7 +1157,6 @@ mod tests {
         let origin = builtin_origin();
         let mut candidates = vec![
             CompletionCandidate::tag_argument_placeholder("<arg>".to_string(), &empty),
-            CompletionCandidate::scanned_tag_name("custom", &empty, false, full_close()),
             CompletionCandidate::tag_name(
                 &test_tag_symbol("url"),
                 &empty,
@@ -1220,9 +1180,6 @@ mod tests {
 
         candidates.sort_by(CompletionCandidate::cmp_rank);
 
-        assert_eq!(
-            labels(&candidates),
-            vec!["endif", "block", "url", "custom", "<arg>"]
-        );
+        assert_eq!(labels(&candidates), vec!["endif", "block", "url", "<arg>"]);
     }
 }

--- a/crates/djls-ide/src/ext.rs
+++ b/crates/djls-ide/src/ext.rs
@@ -165,7 +165,6 @@ impl CompletionCandidateKindExt for CompletionCandidateKind {
     fn to_lsp_completion_kind(self) -> ls_types::CompletionItemKind {
         match self {
             CompletionCandidateKind::TagName
-            | CompletionCandidateKind::ScannedTagName
             | CompletionCandidateKind::EndTag
             | CompletionCandidateKind::TagArgumentLiteral => ls_types::CompletionItemKind::KEYWORD,
             CompletionCandidateKind::TagArgumentChoice => ls_types::CompletionItemKind::ENUM_MEMBER,
@@ -174,8 +173,7 @@ impl CompletionCandidateKindExt for CompletionCandidateKind {
             }
             CompletionCandidateKind::TagArgumentSnippet => ls_types::CompletionItemKind::SNIPPET,
             CompletionCandidateKind::LibraryName => ls_types::CompletionItemKind::MODULE,
-            CompletionCandidateKind::LoadSymbol => ls_types::CompletionItemKind::FUNCTION,
-            CompletionCandidateKind::Filter | CompletionCandidateKind::ScannedFilter => {
+            CompletionCandidateKind::LoadSymbol | CompletionCandidateKind::Filter => {
                 ls_types::CompletionItemKind::FUNCTION
             }
         }

--- a/crates/djls-ide/src/hover.rs
+++ b/crates/djls-ide/src/hover.rs
@@ -4,7 +4,6 @@ use djls_semantic::InstalledSymbolOrigin;
 use djls_semantic::SemanticOffsetContext;
 use djls_semantic::TemplateLibraries;
 use djls_semantic::TemplateSymbolKind;
-use djls_semantic::TemplateSymbolName;
 use djls_semantic::find_template;
 use djls_source::File;
 use djls_source::Offset;
@@ -109,36 +108,7 @@ fn render_symbol_hover(
         return render_installed_symbol_hover(&candidates);
     }
 
-    let symbol_name = TemplateSymbolName::parse(name).ok()?;
-    let discovered = kinds
-        .iter()
-        .filter_map(|kind| {
-            libraries
-                .discovered_symbol_candidates_by_name(*kind)
-                .and_then(|mut candidates| candidates.remove(&symbol_name))
-        })
-        .flatten()
-        .map(|candidate| {
-            format!(
-                "Requires `{{% load {} %}}`.",
-                candidate.library_name.as_str()
-            )
-        })
-        .collect::<Vec<_>>();
-
-    if discovered.is_empty() {
-        None
-    } else {
-        let kind = match kind {
-            Some(TemplateSymbolKind::Tag) => "tag",
-            Some(TemplateSymbolKind::Filter) => "filter",
-            None => "symbol",
-        };
-        Some(format!(
-            "```text\n({kind}) {name}\n```\n---\n{}",
-            discovered.join("\n")
-        ))
-    }
+    None
 }
 
 fn render_installed_symbol_hover(candidates: &[InstalledSymbolCandidate]) -> Option<String> {
@@ -257,14 +227,7 @@ fn format_docstring(doc: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use djls_semantic::Knowledge;
-    use djls_semantic::LibraryName;
-    use djls_semantic::LibraryOrigin;
-    use djls_semantic::PyModuleName;
-    use djls_semantic::TemplateLibraries;
-    use djls_semantic::TemplateLibrary;
+    use djls_semantic::TemplateSymbolName;
 
     use super::*;
 
@@ -296,40 +259,6 @@ mod tests {
             },
             origin,
         }
-    }
-
-    #[test]
-    fn discovered_symbol_hover_shows_load_hint() {
-        let mut library = TemplateLibrary::new_discovered(
-            LibraryName::parse("humanize").unwrap(),
-            LibraryOrigin {
-                app: PyModuleName::parse("django.contrib.humanize").unwrap(),
-                module: PyModuleName::parse("django.contrib.humanize.templatetags.humanize")
-                    .unwrap(),
-                path: "django/contrib/humanize/templatetags/humanize.py".into(),
-            },
-        );
-        library.symbols.push(djls_semantic::TemplateSymbol {
-            kind: TemplateSymbolKind::Filter,
-            name: TemplateSymbolName::parse("intcomma").unwrap(),
-            definition: djls_semantic::SymbolDefinition::Unknown,
-            doc: None,
-        });
-        let libraries = TemplateLibraries {
-            active_knowledge: Knowledge::Unknown,
-            discovery_knowledge: Knowledge::Known,
-            loadable: BTreeMap::from([(LibraryName::parse("humanize").unwrap(), vec![library])]),
-            builtins: BTreeMap::new(),
-            builtin_order: Vec::new(),
-        };
-
-        let markdown =
-            render_symbol_hover(&libraries, "intcomma", Some(TemplateSymbolKind::Filter));
-
-        assert_eq!(
-            markdown.as_deref(),
-            Some("```text\n(filter) intcomma\n```\n---\nRequires `{% load humanize %}`.")
-        );
     }
 
     #[test]

--- a/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
@@ -97,35 +97,3 @@ error[S120]: Unknown template tag library 'nonexistent_library'
 1 | {% load nonexistent_library %}
   |         ^^^^^^^^^^^^^^^^^^^
 ```
-
-## tag app is not installed
-
-```htmldjango
-{% widget_tag %}
-```
-
-```snapshot
-error[S118]: Add 'example.widgets' to INSTALLED_APPS to use tag 'widget_tag'
- --> test.html:1:1
-  |
-1 | {% widget_tag %}
-  | ^^^^^^^^^^^^^^^^
-  |
-  = note: load_name: widgets
-```
-
-## filter app is not installed
-
-```htmldjango
-{{ value|widget_filter }}
-```
-
-```snapshot
-error[S119]: Add 'example.widgets' to INSTALLED_APPS to use filter 'widget_filter'
- --> test.html:1:10
-  |
-1 | {{ value|widget_filter }}
-  |          ^^^^^^^^^^^^^
-  |
-  = note: load_name: widgets
-```

--- a/crates/djls-semantic/src/db.rs
+++ b/crates/djls-semantic/src/db.rs
@@ -20,9 +20,8 @@ pub trait Db: ProjectDb {
 
     /// Get template libraries for the current project.
     ///
-    /// This includes:
-    /// - discovered libraries from scanning `sys.path`
-    /// - installed libraries/symbols from project introspection (when available)
+    /// This includes installed libraries and symbols from project introspection
+    /// when available.
     fn template_libraries(&self) -> &TemplateLibraries;
 
     /// Get the filter arity specifications for filter argument validation.

--- a/crates/djls-semantic/src/errors.rs
+++ b/crates/djls-semantic/src/errors.rs
@@ -96,32 +96,8 @@ pub enum ValidationError {
         span: Span,
     },
 
-    #[error("Add '{app}' to INSTALLED_APPS to use tag '{tag}'")]
-    TagNotInInstalledApps {
-        tag: String,
-        app: String,
-        load_name: String,
-        span: Span,
-    },
-
-    #[error("Add '{app}' to INSTALLED_APPS to use filter '{filter}'")]
-    FilterNotInInstalledApps {
-        filter: String,
-        app: String,
-        load_name: String,
-        span: Span,
-    },
-
     #[error("Unknown template tag library '{name}'")]
     UnknownLibrary { name: String, span: Span },
-
-    #[error("Add '{app}' to INSTALLED_APPS to use template tag library '{name}'")]
-    LibraryNotInInstalledApps {
-        name: String,
-        app: String,
-        candidates: Vec<String>,
-        span: Span,
-    },
 
     #[error("The 'extends' tag must be the first tag in the template")]
     ExtendsMustBeFirst { span: Span },
@@ -156,10 +132,7 @@ impl ValidationError {
             Self::FilterMissingArgument { .. } => "S115",
             Self::FilterUnexpectedArgument { .. } => "S116",
             Self::ExtractedRuleViolation { .. } => "S117",
-            Self::TagNotInInstalledApps { .. } => "S118",
-            Self::FilterNotInInstalledApps { .. } => "S119",
             Self::UnknownLibrary { .. } => "S120",
-            Self::LibraryNotInInstalledApps { .. } => "S121",
             Self::ExtendsMustBeFirst { .. } => "S122",
             Self::MultipleExtends { .. } => "S123",
         }
@@ -183,10 +156,7 @@ impl ValidationError {
             | Self::FilterMissingArgument { span, .. }
             | Self::FilterUnexpectedArgument { span, .. }
             | Self::ExtractedRuleViolation { span, .. }
-            | Self::TagNotInInstalledApps { span, .. }
-            | Self::FilterNotInInstalledApps { span, .. }
             | Self::UnknownLibrary { span, .. }
-            | Self::LibraryNotInInstalledApps { span, .. }
             | Self::ExtendsMustBeFirst { span, .. }
             | Self::MultipleExtends { span, .. } => Some(*span),
         }

--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -20,7 +20,6 @@ pub use crate::project::names::TemplateSymbolName;
 pub use crate::project::python::Interpreter;
 pub(crate) use crate::project::resolve::model_modules;
 pub(crate) use crate::project::resolve::templatetag_modules;
-pub(crate) use crate::project::symbols::DiscoveredSymbolCandidate;
 pub use crate::project::symbols::InstalledSymbolCandidate;
 pub use crate::project::symbols::InstalledSymbolOrigin;
 pub use crate::project::symbols::Knowledge;

--- a/crates/djls-semantic/src/project/input.rs
+++ b/crates/djls-semantic/src/project/input.rs
@@ -188,7 +188,6 @@ pub struct Project {
     /// Template libraries and symbols for this project.
     ///
     /// This value always exists to support progressive enhancement:
-    /// - Discovered libraries are populated by scanning `sys.path`.
     /// - Installed libraries/symbols are populated by project introspection.
     ///
     /// The semantic layer combines this with `{% load %}` scope computed from templates.

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 
 use camino::Utf8PathBuf;
 use serde::Deserialize;
@@ -65,7 +64,6 @@ pub struct LibraryOrigin {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LibraryStatus {
-    Discovered(LibraryOrigin),
     Active {
         module: PyModuleName,
         origin: Option<LibraryOrigin>,
@@ -84,15 +82,6 @@ pub struct TemplateLibrary {
 }
 
 impl TemplateLibrary {
-    #[must_use]
-    pub fn new_discovered(name: LibraryName, origin: LibraryOrigin) -> Self {
-        Self {
-            name,
-            status: LibraryStatus::Discovered(origin),
-            symbols: Vec::new(),
-        }
-    }
-
     #[must_use]
     pub fn new_active(
         name: LibraryName,
@@ -118,7 +107,6 @@ impl TemplateLibrary {
     #[must_use]
     pub fn module(&self) -> &PyModuleName {
         match &self.status {
-            LibraryStatus::Discovered(origin) => &origin.module,
             LibraryStatus::Active { module, .. } | LibraryStatus::Builtin { module } => module,
         }
     }
@@ -126,7 +114,6 @@ impl TemplateLibrary {
     #[must_use]
     pub fn origin(&self) -> Option<&LibraryOrigin> {
         match &self.status {
-            LibraryStatus::Discovered(origin) => Some(origin),
             LibraryStatus::Active { origin, .. } => origin.as_ref(),
             LibraryStatus::Builtin { .. } => None,
         }
@@ -190,16 +177,9 @@ pub struct InstalledSymbolCandidate {
     pub origin: InstalledSymbolOrigin,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DiscoveredSymbolCandidate {
-    pub app_module: PyModuleName,
-    pub library_name: LibraryName,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TemplateLibraries {
     pub active_knowledge: Knowledge,
-    pub discovery_knowledge: Knowledge,
     pub loadable: BTreeMap<LibraryName, Vec<TemplateLibrary>>,
     pub builtins: BTreeMap<PyModuleName, TemplateLibrary>,
     pub builtin_order: Vec<PyModuleName>,
@@ -209,7 +189,6 @@ impl Default for TemplateLibraries {
     fn default() -> Self {
         Self {
             active_knowledge: Knowledge::Unknown,
-            discovery_knowledge: Knowledge::Unknown,
             loadable: BTreeMap::new(),
             builtins: BTreeMap::new(),
             builtin_order: Vec::new(),
@@ -270,7 +249,7 @@ impl TemplateLibraries {
     pub fn completion_library_names(&self) -> Vec<LibraryName> {
         let mut names: Vec<LibraryName> = self
             .loadable_library_names()
-            .filter(|name| self.is_enabled_library(name) || self.has_discovered_library(name))
+            .filter(|name| self.is_enabled_library(name))
             .cloned()
             .collect();
 
@@ -292,13 +271,6 @@ impl TemplateLibraries {
     ) -> impl Iterator<Item = (&LibraryName, &TemplateLibrary)> + '_ {
         self.loadable_libraries()
             .filter(|(_name, library)| library.is_active())
-    }
-
-    pub fn discovered_loadable_libraries(
-        &self,
-    ) -> impl Iterator<Item = (&LibraryName, &TemplateLibrary)> + '_ {
-        self.loadable_libraries()
-            .filter(|(_name, library)| library.origin().is_some())
     }
 
     #[must_use]
@@ -388,88 +360,6 @@ impl TemplateLibraries {
     }
 
     #[must_use]
-    pub fn has_discovered_library(&self, name: &LibraryName) -> bool {
-        if self.discovery_knowledge != Knowledge::Known {
-            return false;
-        }
-
-        self.loadable
-            .get(name)
-            .is_some_and(|libraries| libraries.iter().any(|lib| lib.origin().is_some()))
-    }
-
-    #[must_use]
-    pub fn discovered_app_modules_for_library(&self, name: &LibraryName) -> Vec<PyModuleName> {
-        if self.discovery_knowledge != Knowledge::Known {
-            return Vec::new();
-        }
-
-        self.loadable
-            .get(name)
-            .into_iter()
-            .flatten()
-            .filter_map(|library| library.origin().map(|origin| origin.app.clone()))
-            .collect()
-    }
-
-    #[must_use]
-    pub fn discovered_app_modules_for_library_str(&self, name: &str) -> Vec<String> {
-        let Ok(name) = LibraryName::parse(name) else {
-            return Vec::new();
-        };
-
-        self.discovered_app_modules_for_library(&name)
-            .into_iter()
-            .map(|m| m.as_str().to_string())
-            .collect()
-    }
-
-    #[must_use]
-    pub fn discovered_symbol_candidates_by_name(
-        &self,
-        kind: TemplateSymbolKind,
-    ) -> Option<HashMap<TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>> {
-        if self.discovery_knowledge != Knowledge::Known {
-            return None;
-        }
-
-        let mut map: HashMap<TemplateSymbolName, Vec<DiscoveredSymbolCandidate>> = HashMap::new();
-
-        for (library_name, library) in self.discovered_loadable_libraries() {
-            let Some(origin) = library.origin() else {
-                continue;
-            };
-
-            for symbol in &library.symbols {
-                if symbol.kind != kind {
-                    continue;
-                }
-
-                map.entry(symbol.name.clone())
-                    .or_default()
-                    .push(DiscoveredSymbolCandidate {
-                        app_module: origin.app.clone(),
-                        library_name: library_name.clone(),
-                    });
-            }
-        }
-
-        Some(map)
-    }
-
-    #[must_use]
-    pub fn discovered_symbol_names(&self, kind: TemplateSymbolKind) -> Vec<TemplateSymbolName> {
-        let Some(map) = self.discovered_symbol_candidates_by_name(kind) else {
-            return Vec::new();
-        };
-
-        let mut names: Vec<TemplateSymbolName> = map.keys().cloned().collect();
-        names.sort();
-        names.dedup();
-        names
-    }
-
-    #[must_use]
     pub fn apply_active_snapshot(mut self, response: Option<TemplateLibrarySnapshot>) -> Self {
         let Some(response) = response else {
             self.active_knowledge = Knowledge::Unknown;
@@ -515,28 +405,14 @@ impl TemplateLibraries {
         for (name, libraries) in &mut self.loadable {
             let enabled_module = enabled.get(name);
 
-            for library in libraries.iter_mut() {
-                let current_module = library.module().clone();
-                let Some(active_module) = enabled_module else {
-                    if let Some(origin) = library.origin().cloned() {
-                        library.status = LibraryStatus::Discovered(origin);
-                    }
-                    continue;
-                };
-
-                if &current_module != active_module
-                    && let Some(origin) = library.origin().cloned()
-                {
-                    library.status = LibraryStatus::Discovered(origin);
-                }
-            }
-
             libraries.retain(|library| match &library.status {
-                LibraryStatus::Active { module, origin } => {
-                    enabled_module == Some(module) || origin.is_some()
-                }
-                _ => true,
+                LibraryStatus::Active { module, .. } => enabled_module == Some(module),
+                LibraryStatus::Builtin { .. } => true,
             });
+
+            for library in libraries.iter_mut().filter(|library| library.is_active()) {
+                library.symbols.clear();
+            }
         }
 
         self.builtins.clear();
@@ -680,6 +556,54 @@ mod tests {
                 module: PyModuleName::parse("a_second").unwrap()
             }
         );
+    }
+
+    #[test]
+    fn active_snapshot_replaces_loadable_symbols() {
+        let first = TemplateLibrarySnapshot {
+            symbols: vec![TemplateSymbolSnapshot {
+                kind: Some(TemplateSymbolKind::Tag),
+                name: "old_tag".to_string(),
+                load_name: Some("project_tags".to_string()),
+                library_module: "project.templatetags.project_tags".to_string(),
+                module: "project.templatetags.project_tags".to_string(),
+                doc: None,
+            }],
+            libraries: [(
+                "project_tags".to_string(),
+                "project.templatetags.project_tags".to_string(),
+            )]
+            .into(),
+            builtins: Vec::new(),
+        };
+        let second = TemplateLibrarySnapshot {
+            symbols: vec![TemplateSymbolSnapshot {
+                kind: Some(TemplateSymbolKind::Tag),
+                name: "new_tag".to_string(),
+                load_name: Some("project_tags".to_string()),
+                library_module: "project.templatetags.project_tags".to_string(),
+                module: "project.templatetags.project_tags".to_string(),
+                doc: None,
+            }],
+            libraries: [(
+                "project_tags".to_string(),
+                "project.templatetags.project_tags".to_string(),
+            )]
+            .into(),
+            builtins: Vec::new(),
+        };
+
+        let libraries = TemplateLibraries::default()
+            .apply_active_snapshot(Some(first))
+            .apply_active_snapshot(Some(second));
+
+        let names: Vec<_> = libraries
+            .installed_symbol_candidates(TemplateSymbolKind::Tag)
+            .into_iter()
+            .map(|candidate| candidate.symbol.name().to_string())
+            .collect();
+
+        assert_eq!(names, vec!["new_tag"]);
     }
 
     #[test]

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -25,19 +25,10 @@ use crate::db::ValidationErrorAccumulator;
 use crate::errors::ValidationError;
 use crate::filters::FilterAritySpecs;
 use crate::project::Db as ProjectDb;
-use crate::project::Knowledge;
-use crate::project::LibraryName;
-use crate::project::LibraryOrigin;
 use crate::project::Project;
 use crate::project::ProjectIntrospector;
-use crate::project::PyModuleName;
-use crate::project::SymbolDefinition;
 use crate::project::TemplateLibraries;
-use crate::project::TemplateLibrary;
 use crate::project::TemplateLibrarySnapshot;
-use crate::project::TemplateSymbol;
-use crate::project::TemplateSymbolKind;
-use crate::project::TemplateSymbolName;
 use crate::project::TemplateSymbolSnapshot;
 use crate::python::ArgumentCountConstraint;
 use crate::python::ChoiceAt;
@@ -383,41 +374,6 @@ pub(crate) fn render_diagnostic_snapshot(
         let message = err.to_string();
         let code = err.code();
 
-        // Build notes for variants that carry extra context beyond the
-        // primary message. When adding new ValidationError variants, consider
-        // whether they have fields that would be useful as notes here.
-        let mut notes: Vec<String> = Vec::new();
-        match err {
-            ValidationError::TagNotInInstalledApps { load_name, .. }
-            | ValidationError::FilterNotInInstalledApps { load_name, .. } => {
-                notes.push(format!("load_name: {load_name}"));
-            }
-            ValidationError::LibraryNotInInstalledApps { candidates, .. }
-                if !candidates.is_empty() =>
-            {
-                notes.push(format!("candidates: {candidates:?}"));
-            }
-            ValidationError::UnclosedTag { .. }
-            | ValidationError::OrphanedTag { .. }
-            | ValidationError::OrphanedClosingTag { .. }
-            | ValidationError::UnbalancedStructure { .. }
-            | ValidationError::UnmatchedBlockName { .. }
-            | ValidationError::UnknownTag { .. }
-            | ValidationError::UnloadedTag { .. }
-            | ValidationError::AmbiguousUnloadedTag { .. }
-            | ValidationError::UnknownFilter { .. }
-            | ValidationError::UnloadedFilter { .. }
-            | ValidationError::AmbiguousUnloadedFilter { .. }
-            | ValidationError::ExpressionSyntaxError { .. }
-            | ValidationError::FilterMissingArgument { .. }
-            | ValidationError::FilterUnexpectedArgument { .. }
-            | ValidationError::ExtractedRuleViolation { .. }
-            | ValidationError::UnknownLibrary { .. }
-            | ValidationError::LibraryNotInInstalledApps { .. }
-            | ValidationError::ExtendsMustBeFirst { .. }
-            | ValidationError::MultipleExtends { .. } => {}
-        }
-
         let mut diag = Diagnostic::new(source, path, code, &message, Severity::Error, span, "");
 
         if let ValidationError::UnbalancedStructure {
@@ -426,10 +382,6 @@ pub(crate) fn render_diagnostic_snapshot(
         } = err
         {
             diag = diag.annotation(*cs, "", false);
-        }
-
-        for note in &notes {
-            diag = diag.note(note);
         }
 
         parts.push(renderer.render(&diag));
@@ -736,47 +688,7 @@ fn standard_template_libraries() -> TemplateLibraries {
         "example.templatetags.custom".to_string(),
     ];
 
-    let mut template_libraries = make_template_libraries(&tags, &filters, &libraries, &builtins);
-    add_discovered_widgets_library(&mut template_libraries);
-    template_libraries
-}
-
-fn add_discovered_widgets_library(template_libraries: &mut TemplateLibraries) {
-    template_libraries.discovery_knowledge = Knowledge::Known;
-
-    let name = LibraryName::parse("widgets").unwrap();
-    let app = PyModuleName::parse("example.widgets").unwrap();
-    let module = PyModuleName::parse("example.widgets.templatetags.widgets").unwrap();
-    let origin = LibraryOrigin {
-        app,
-        module: module.clone(),
-        path: Utf8PathBuf::from("/example/widgets/templatetags/widgets.py"),
-    };
-    let mut library = TemplateLibrary::new_discovered(name.clone(), origin);
-    library.merge_symbol(template_symbol(
-        TemplateSymbolKind::Tag,
-        "widget_tag",
-        "example.widgets.templatetags.widgets",
-    ));
-    library.merge_symbol(template_symbol(
-        TemplateSymbolKind::Filter,
-        "widget_filter",
-        "example.widgets.templatetags.widgets",
-    ));
-    template_libraries
-        .loadable
-        .entry(name)
-        .or_default()
-        .push(library);
-}
-
-fn template_symbol(kind: TemplateSymbolKind, name: &str, module: &str) -> TemplateSymbol {
-    TemplateSymbol {
-        kind,
-        name: TemplateSymbolName::parse(name).unwrap(),
-        definition: SymbolDefinition::Module(PyModuleName::parse(module).unwrap()),
-        doc: None,
-    }
+    make_template_libraries(&tags, &filters, &libraries, &builtins)
 }
 
 fn standard_filter_arities() -> FilterAritySpecs {

--- a/crates/djls-semantic/src/validation.rs
+++ b/crates/djls-semantic/src/validation.rs
@@ -3,8 +3,6 @@ pub(crate) mod filters;
 pub(crate) mod if_expressions;
 pub(crate) mod scoping;
 
-use std::collections::HashMap;
-
 use djls_source::Span;
 use djls_templates::Filter;
 use djls_templates::Node;
@@ -13,10 +11,7 @@ use djls_templates::walk_nodelist;
 
 use crate::db::Db;
 use crate::filters::FilterAritySpecs;
-use crate::project::DiscoveredSymbolCandidate;
 use crate::project::TemplateLibraries;
-use crate::project::TemplateSymbolKind;
-use crate::project::TemplateSymbolName;
 use crate::scoping::SymbolIndex;
 use crate::structure::OpaqueRegions;
 use crate::tags::TagSpecs;
@@ -55,10 +50,6 @@ pub(crate) struct TemplateValidator<'a> {
     opaque_regions: &'a OpaqueRegions,
     filter_arity_specs: &'a FilterAritySpecs,
 
-    // Environment symbol caches
-    env_tags: Option<HashMap<TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>>,
-    env_filters: Option<HashMap<TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>>,
-
     // Tracking state for positional checks (e.g. {% extends %})
     extends_position: ExtendsPosition,
 }
@@ -75,11 +66,6 @@ impl<'a> TemplateValidator<'a> {
         let symbol_index = crate::scoping::compute_symbol_index(db, nodelist);
         let filter_arity_specs = db.filter_arity_specs();
 
-        let env_tags =
-            template_libraries.discovered_symbol_candidates_by_name(TemplateSymbolKind::Tag);
-        let env_filters =
-            template_libraries.discovered_symbol_candidates_by_name(TemplateSymbolKind::Filter);
-
         Self {
             db,
             tag_specs,
@@ -87,8 +73,6 @@ impl<'a> TemplateValidator<'a> {
             template_libraries,
             opaque_regions,
             filter_arity_specs,
-            env_tags,
-            env_filters,
             extends_position: ExtendsPosition::default(),
         }
     }
@@ -146,7 +130,6 @@ impl Visitor for TemplateValidator<'_> {
                     name,
                     span,
                     symbols,
-                    self.env_tags.as_ref(),
                     self.template_libraries.active_knowledge,
                 );
             }
@@ -180,7 +163,6 @@ impl Visitor for TemplateValidator<'_> {
                     self.db,
                     filter,
                     symbols,
-                    self.env_filters.as_ref(),
                     self.template_libraries.active_knowledge,
                 );
 

--- a/crates/djls-semantic/src/validation/scoping.rs
+++ b/crates/djls-semantic/src/validation/scoping.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use djls_source::Span;
 use djls_templates::Filter;
 use djls_templates::TagBit;
@@ -9,11 +7,9 @@ use salsa::Accumulator;
 use crate::db::Db;
 use crate::db::ValidationErrorAccumulator;
 use crate::errors::ValidationError;
-use crate::project::DiscoveredSymbolCandidate;
 use crate::project::Knowledge;
 use crate::project::LibraryName;
 use crate::project::TemplateLibraries;
-use crate::project::TemplateSymbolName;
 use crate::scoping::symbols::AvailableSymbols;
 use crate::scoping::symbols::FilterAvailability;
 use crate::scoping::symbols::TagAvailability;
@@ -25,7 +21,6 @@ pub(crate) fn check_tag_scoping_rule(
     name: &str,
     span: Span,
     symbols: &AvailableSymbols,
-    env_tags: Option<&HashMap<TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>>,
     active_knowledge: Knowledge,
 ) {
     if active_knowledge != Knowledge::Known {
@@ -37,20 +32,6 @@ pub(crate) fn check_tag_scoping_rule(
     match symbols.check(name) {
         TagAvailability::Available => {}
         TagAvailability::Unknown => {
-            if let Some(env_tags) = env_tags
-                && let Ok(key) = TemplateSymbolName::parse(name)
-                && let Some(env_symbols) = env_tags.get(&key)
-                && let Some(sym) = env_symbols.first()
-            {
-                ValidationErrorAccumulator(ValidationError::TagNotInInstalledApps {
-                    tag: name.to_string(),
-                    app: sym.app_module.as_str().to_string(),
-                    load_name: sym.library_name.as_str().to_string(),
-                    span: full_span,
-                })
-                .accumulate(db);
-                return;
-            }
             ValidationErrorAccumulator(ValidationError::UnknownTag {
                 tag: name.to_string(),
                 span: full_span,
@@ -81,7 +62,6 @@ pub(crate) fn check_filter_scoping_rule(
     db: &dyn Db,
     filter: &Filter,
     symbols: &AvailableSymbols,
-    env_filters: Option<&HashMap<TemplateSymbolName, Vec<DiscoveredSymbolCandidate>>>,
     active_knowledge: Knowledge,
 ) {
     if active_knowledge != Knowledge::Known {
@@ -91,20 +71,6 @@ pub(crate) fn check_filter_scoping_rule(
     match symbols.check_filter(&filter.name) {
         FilterAvailability::Available => {}
         FilterAvailability::Unknown => {
-            if let Some(env_filters) = env_filters
-                && let Ok(key) = TemplateSymbolName::parse(filter.name.as_str())
-                && let Some(env_symbols) = env_filters.get(&key)
-                && let Some(sym) = env_symbols.first()
-            {
-                ValidationErrorAccumulator(ValidationError::FilterNotInInstalledApps {
-                    filter: filter.name.clone(),
-                    app: sym.app_module.as_str().to_string(),
-                    load_name: sym.library_name.as_str().to_string(),
-                    span: filter.span,
-                })
-                .accumulate(db);
-                return;
-            }
             ValidationErrorAccumulator(ValidationError::UnknownFilter {
                 filter: filter.name.clone(),
                 span: filter.span,
@@ -160,22 +126,11 @@ pub(crate) fn check_load_libraries_rule(
             continue;
         }
 
-        let candidates = template_libraries.discovered_app_modules_for_library_str(lib.as_str());
-        if candidates.is_empty() {
-            ValidationErrorAccumulator(ValidationError::UnknownLibrary {
-                name: lib.as_str().to_string(),
-                span: lib.span(),
-            })
-            .accumulate(db);
-        } else {
-            ValidationErrorAccumulator(ValidationError::LibraryNotInInstalledApps {
-                name: lib.as_str().to_string(),
-                app: candidates[0].clone(),
-                candidates,
-                span: lib.span(),
-            })
-            .accumulate(db);
-        }
+        ValidationErrorAccumulator(ValidationError::UnknownLibrary {
+            name: lib.as_str().to_string(),
+            span: lib.span(),
+        })
+        .accumulate(db);
     }
 }
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -173,13 +173,13 @@ Map diagnostic codes or prefixes to severity levels. Supports:
 
 *Tag Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
 
-- `S108` - Unknown tag (not found in any known library or in the Python environment)
+- `S108` - Unknown tag (not found in any active library)
 - `S109` - Unloaded tag (requires `{% load %}` for a specific library)
 - `S110` - Ambiguous unloaded tag (defined in multiple libraries)
 
 *Filter Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
 
-- `S111` - Unknown filter (not found in any known library or in the Python environment)
+- `S111` - Unknown filter (not found in any active library)
 - `S112` - Unloaded filter (requires `{% load %}` for a specific library)
 - `S113` - Ambiguous unloaded filter (defined in multiple libraries)
 
@@ -193,12 +193,9 @@ Map diagnostic codes or prefixes to severity levels. Supports:
 
 - `S117` - Tag argument rule violation (e.g., wrong number of arguments, missing required keyword)
 
-*Environment-Aware Resolution (requires [inspector](../template-validation.md#inspector-availability) and [environment scanner](../template-validation.md#environment-scanner)):*
+*Library Resolution (requires [inspector](../template-validation.md#inspector-availability)):*
 
-- `S118` - Tag not in `INSTALLED_APPS` (installed package, but Django app not activated)
-- `S119` - Filter not in `INSTALLED_APPS` (installed package, but Django app not activated)
-- `S120` - Unknown template tag library (not found in inspector or environment)
-- `S121` - Library not in `INSTALLED_APPS` (installed package, but Django app not activated)
+- `S120` - Unknown template tag library (not found in inspector inventory)
 
 *Extends Validation:*
 

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -16,15 +16,6 @@ The **inspector** is a Python process that introspects your running Django proje
 
 This gives djls an accurate picture of your project's template tag ecosystem — the same tags Django would see at runtime. The inspector reflects your `INSTALLED_APPS` configuration, so it only reports tags and filters from apps that are actually activated.
 
-### Environment Scanner
-
-The **environment scanner** examines your Python environment (site-packages and `sys.path`) to discover all template tag libraries that are *installed* — regardless of whether their Django app is in `INSTALLED_APPS`. It does this by:
-
-1. Finding all `templatetags/*.py` files across your Python path
-2. Parsing each file with static AST analysis to identify tag and filter registrations
-
-This allows djls to distinguish between tags that are truly unknown (package not installed) and tags that exist in your environment but aren't activated in your Django configuration.
-
 ### Extraction
 
 The **extraction engine** analyzes Python source code (using static AST analysis) to derive validation rules from template tag and filter implementations:
@@ -34,34 +25,27 @@ The **extraction engine** analyzes Python source code (using static AST analysis
 - **Filter arity** — whether a filter expects an argument (e.g., `{{ value|default:"nothing" }}`)
 - **Expression syntax** — valid operator usage in `{% if %}` / `{% elif %}` expressions
 
-Together, the inspector tells djls *what's active in your project*, the environment scanner tells djls *what's installed*, and extraction tells djls *how to validate usage*.
+Together, the inspector tells djls *what's active in your project*, and extraction tells djls *how to validate usage*.
 
-## Three-Layer Resolution
+## Template Symbol Resolution
 
-A template tag or filter must pass through three layers before it's available in a template:
+A template tag or filter must be known to the active Django project and loaded before it's available in a template:
 
 ```
-Python Environment  →  Django Configuration  →  Template Load  →  Available
-(pip install)          (INSTALLED_APPS)          ({% load %})
+Django Configuration  →  Template Load  →  Available
+(INSTALLED_APPS)          ({% load %})
 ```
 
 Each layer has a different failure mode and a different fix:
 
 | Layer | Failure | Diagnostic | Fix |
 |---|---|---|---|
-| Not in environment | Package not installed | S108/S111 (Unknown) | `pip install <package>` |
-| In environment, not in `INSTALLED_APPS` | App not activated | S118/S119 (Not in INSTALLED_APPS) | Add app to `INSTALLED_APPS` |
-| In `INSTALLED_APPS`, not loaded | No `{% load %}` | S109/S112 (Unloaded) | Add `{% load <library> %}` |
+| Not active in the Django project | Package not installed or app not activated | S108/S111 (Unknown) | Install the package and add the app to `INSTALLED_APPS` |
+| Active, not loaded | No `{% load %}` | S109/S112 (Unloaded) | Add `{% load <library> %}` |
 
-The same three-layer model applies to `{% load %}` library names themselves:
+`{% load %}` library names are checked against the active inspector inventory. A library name not reported by the active Django project is reported as S120 (unknown library).
 
-| Layer | Failure | Diagnostic | Fix |
-|---|---|---|---|
-| Library not in environment | Package not installed | S120 (Unknown library) | `pip install <package>` |
-| Library in environment, not in `INSTALLED_APPS` | App not activated | S121 (Library not in INSTALLED_APPS) | Add app to `INSTALLED_APPS` |
-| Library in `INSTALLED_APPS` | Valid load | No diagnostic | — |
-
-This layered approach gives you actionable diagnostics — instead of a generic "unknown tag" error, djls tells you exactly what to do to fix it.
+This gives you diagnostics based on the same template tag inventory Django would use at runtime.
 
 ## What djls Validates
 
@@ -74,30 +58,27 @@ Validates that block tags are properly opened, closed, and nested:
 - **S102** — Orphaned tag (intermediate tag like `{% else %}` without a parent `{% if %}`)
 - **S103** — Unmatched block name (e.g., `{% endblock foo %}` doesn't match `{% block bar %}`)
 
-### Tag Scoping (S108–S110, S118)
+### Tag Scoping (S108–S110)
 
-Validates that template tags are available at their point of use, using [three-layer resolution](#three-layer-resolution):
+Validates that template tags are available at their point of use, using [template symbol resolution](#template-symbol-resolution):
 
-- **S108** — Unknown tag (not found in any known library or in the Python environment)
+- **S108** — Unknown tag (not found in any active library)
 - **S109** — Unloaded tag (defined in a library that hasn't been loaded via `{% load %}`)
 - **S110** — Ambiguous unloaded tag (defined in multiple libraries — load the correct one to resolve)
-- **S118** — Tag not in `INSTALLED_APPS` (the tag exists in an installed package, but its Django app isn't activated)
 
-### Filter Scoping (S111–S113, S119)
+### Filter Scoping (S111–S113)
 
-Validates that template filters are available at their point of use, with the same three-layer resolution as tags:
+Validates that template filters are available at their point of use, with the same resolution layers as tags:
 
-- **S111** — Unknown filter (not found in any known library or in the Python environment)
+- **S111** — Unknown filter (not found in any active library)
 - **S112** — Unloaded filter (defined in a library that hasn't been loaded)
 - **S113** — Ambiguous unloaded filter (defined in multiple libraries)
-- **S119** — Filter not in `INSTALLED_APPS` (the filter exists in an installed package, but its Django app isn't activated)
 
-### Library Validation (S120–S121)
+### Library Validation (S120)
 
 Validates that `{% load %}` library names refer to known template tag libraries:
 
-- **S120** — Unknown library (not found in the inspector inventory or the Python environment)
-- **S121** — Library not in `INSTALLED_APPS` (the library exists in an installed package, but its Django app isn't activated)
+- **S120** — Unknown library (not found in the inspector inventory)
 
 ### Extends Validation (S122–S123)
 
@@ -143,17 +124,17 @@ The inspector requires a working Django environment (correct `DJANGO_SETTINGS_MO
 
 When the inspector is **healthy**:
 
-- Full validation is active — all S108–S121 diagnostics are emitted
+- Full validation is active — all current validation diagnostics are emitted
 - Completions are scoped to loaded libraries at cursor position
 
 When the inspector is **unavailable** (Django init failed, Python not configured, etc.):
 
-- **S108–S113, S118–S121 are suppressed** — Without knowing which tags/filters exist, djls cannot determine if something is unknown, unloaded, or not in `INSTALLED_APPS`
+- **S108–S113 and S120 are suppressed** — Without knowing which tags/filters and libraries exist, djls cannot determine whether something is unknown or unloaded
 - **S115–S116 are suppressed** — Filter arity rules come from extraction, which depends on knowing the source modules
 - **S117 is suppressed** — Tag argument rules come from extraction, which depends on the inspector discovering tag source modules
 - **S100–S103 still work** — Block structure validation uses built-in tag specs
 - **S114 still works** — Expression syntax validation is purely structural
-- **Completions show all known tags** — Without library scoping, all tags are offered as a fallback
+- **Inspector-backed completions are unavailable** — Tag, filter, and library completions that depend on active inventory are suppressed; syntax-only completions may still appear
 
 This design avoids false positives when the Python environment isn't available.
 
@@ -167,15 +148,14 @@ All diagnostics default to error severity. You can adjust or disable them in you
 "S108" = "off"
 "S109" = "off"
 "S110" = "off"
-"S118" = "off"
 
 # Downgrade filter arity checks to warnings
 "S115" = "warning"
 "S116" = "warning"
 
 # Or use prefix matching to control groups
-"S11" = "warning"   # All S110-S119 as warnings
-"S12" = "warning"   # All S120-S121 as warnings
+"S11" = "warning"   # All S110-S117 as warnings
+"S12" = "warning"   # S120 and future S12x diagnostics as warnings
 ```
 
 See the [Configuration](./configuration/index.md#diagnostics) page for full details on severity configuration.


### PR DESCRIPTION
## Summary

- Delete the never-populated Discovered template-library state and helpers.
- Remove scanned/discovered completion and hover fallbacks that depended on that state.
- Remove the dead S118/S119/S121 diagnostics and update validation docs to the active-inspector inventory contract.
- Clear retained active library symbols on snapshot refresh so the inspector inventory stays authoritative.

## Validation

- `cargo build -q`
- `cargo test -q -p djls-semantic active_snapshot_replaces_loadable_symbols`
- Earlier execution pass also ran `cargo test -q`, `just clippy`, `just fmt`, and `just lint` before the final targeted review fix.
