### PR TITLE
test: add fixture groundwork for static discovery

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -35,6 +35,9 @@ clippy *ARGS:
 e2e *ARGS:
     uv run nox -s e2e -- "{{ ARGS }}"
 
+fixtures *ARGS:
+    uv run nox -s fixtures -- "{{ ARGS }}"
+
 fmt *ARGS:
     cargo +nightly fmt {{ ARGS }}
 

--- a/crates/djls-semantic/src/project/resolve.rs
+++ b/crates/djls-semantic/src/project/resolve.rs
@@ -361,18 +361,16 @@ fn discover_model_files_excluding(
 mod tests {
     use std::collections::BTreeMap;
 
-    use djls_conf::Settings;
     use djls_source::Db as _;
     use djls_source::InMemoryFileSystem;
 
     use super::*;
     use crate::compute_filter_arity_specs;
-    use crate::project::ProjectTemplateFiles;
-    use crate::project::TemplateDirs;
     use crate::project::TemplateLibraries;
     use crate::project::TemplateLibrarySnapshot;
     use crate::project::refresh_external_data;
     use crate::python::compute_model_graph;
+    use crate::testing::ProjectFixture;
     use crate::testing::TestDatabase;
 
     fn template_libraries_for_module(module: &str) -> TemplateLibraries {
@@ -384,25 +382,16 @@ mod tests {
     }
 
     fn project_for_search_paths(
-        db: &TestDatabase,
+        db: &mut TestDatabase,
         root: &str,
         search_paths: SearchPaths,
         template_libraries: TemplateLibraries,
     ) -> Project {
-        let settings = Settings::default();
-        Project::new(
-            db,
-            root.into(),
-            search_paths,
-            Interpreter::discover(settings.venv_path()),
-            None,
-            Vec::new(),
-            Vec::new(),
-            TemplateDirs::Unknown,
-            settings.tagspecs().clone(),
-            template_libraries,
-            ProjectTemplateFiles::default(),
-        )
+        ProjectFixture::new(root)
+            .search_paths(search_paths)
+            .register_roots(false)
+            .template_libraries(template_libraries)
+            .build(db)
     }
 
     #[test]
@@ -480,7 +469,7 @@ mod tests {
 
     #[test]
     fn model_modules_use_first_party_search_path_relative_names() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/src/blog/models.py",
             "from django.db import models\nclass Article(models.Model):\n    pass\n",
@@ -494,8 +483,12 @@ mod tests {
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
 
         let modules = model_modules(&db, project);
         assert!(
@@ -544,7 +537,7 @@ mod tests {
 
     #[test]
     fn model_modules_tolerate_unregistered_search_paths() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/shared/blog/models.py",
             "from django.db import models\nclass SharedArticle(models.Model):\n    pass\n",
@@ -557,8 +550,12 @@ mod tests {
             &Interpreter::Auto,
             &pythonpath,
         );
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
 
         let modules = model_modules(&db, project);
         assert!(
@@ -570,7 +567,7 @@ mod tests {
 
     #[test]
     fn templatetag_modules_tolerate_unregistered_search_paths() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/django/templatetags/i18n.py",
             "from django import template\nregister = template.Library()\n",
@@ -583,7 +580,7 @@ mod tests {
             &[],
         );
         let project = project_for_search_paths(
-            &db,
+            &mut db,
             "/project",
             search_paths,
             template_libraries_for_module("django.templatetags.i18n"),
@@ -599,7 +596,7 @@ mod tests {
 
     #[test]
     fn templatetag_resolution_uses_project_venv_site_packages_root() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/.venv/lib/python3.12/site-packages/django/templatetags/i18n.py",
             "from django import template\nregister = template.Library()\n",
@@ -613,7 +610,7 @@ mod tests {
         );
         search_paths.register_roots(&db);
         let project = project_for_search_paths(
-            &db,
+            &mut db,
             "/project",
             search_paths,
             template_libraries_for_module("django.templatetags.i18n"),
@@ -631,7 +628,7 @@ mod tests {
 
     #[test]
     fn templatetag_resolution_prefers_first_party_module_shadowing_dependency() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/django/templatetags/i18n.py",
             "from django import template\nregister = template.Library()\n",
@@ -649,7 +646,7 @@ mod tests {
         );
         search_paths.register_roots(&db);
         let project = project_for_search_paths(
-            &db,
+            &mut db,
             "/project",
             search_paths,
             template_libraries_for_module("django.templatetags.i18n"),
@@ -665,7 +662,7 @@ mod tests {
 
     #[test]
     fn templatetag_modules_preserve_registration_order_across_roots() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/a/templatetags/tags.py",
             "from django import template\nregister = template.Library()\n",
@@ -683,7 +680,7 @@ mod tests {
         );
         search_paths.register_roots(&db);
         let project = project_for_search_paths(
-            &db,
+            &mut db,
             "/project",
             search_paths,
             TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
@@ -710,7 +707,7 @@ mod tests {
 
     #[test]
     fn filter_arity_specs_preserve_builtin_registration_order_across_roots() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/z_first.py",
             r"
@@ -742,7 +739,7 @@ def duplicate(value, arg):
         );
         search_paths.register_roots(&db);
         let project = project_for_search_paths(
-            &db,
+            &mut db,
             "/project",
             search_paths,
             TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
@@ -773,8 +770,12 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -807,8 +808,12 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -841,8 +846,12 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -862,7 +871,7 @@ def duplicate(value, arg):
 
     #[test]
     fn external_model_graph_preserves_pythonpath_precedence() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/zfirst/zapp/models.py",
             "from django.db import models\nclass Duplicate(models.Model):\n    pass\n",
@@ -880,8 +889,12 @@ def duplicate(value, arg):
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
 
         let graph = compute_model_graph(&db, project);
         let model = graph.get("Duplicate").expect("model should be discovered");
@@ -903,8 +916,12 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -941,8 +958,12 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -959,7 +980,7 @@ def duplicate(value, arg):
 
     #[test]
     fn external_model_graph_reads_extra_pythonpath_models() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/shared/blog/models.py",
             "from django.db import models\nclass SharedArticle(models.Model):\n    pass\n",
@@ -973,8 +994,12 @@ def duplicate(value, arg):
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
 
         let graph = compute_model_graph(&db, project);
         assert!(graph.get("SharedArticle").is_some());
@@ -983,7 +1008,6 @@ def duplicate(value, arg):
     #[test]
     fn refresh_external_data_discovers_site_packages_created_after_bootstrap() {
         let mut db = TestDatabase::new();
-        let settings = Settings::default();
         let search_paths = SearchPaths::from_project_settings(
             db.file_system(),
             Utf8Path::new("/project"),
@@ -991,20 +1015,11 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = Project::new(
-            &db,
-            "/project".into(),
-            search_paths,
-            Interpreter::Auto,
-            None,
-            Vec::new(),
-            Vec::new(),
-            TemplateDirs::Unknown,
-            settings.tagspecs().clone(),
-            TemplateLibraries::default(),
-            ProjectTemplateFiles::default(),
-        );
-        db.set_project(project);
+        let project = ProjectFixture::new("/project")
+            .search_paths(search_paths)
+            .interpreter(Interpreter::Auto)
+            .register_roots(false)
+            .install(&mut db);
 
         assert!(
             project
@@ -1244,7 +1259,7 @@ class Article(models.Model):
 
     #[test]
     fn project_model_discovery_skips_registered_non_first_party_paths() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         db.add_file(
             "/project/app/models.py",
             "from django.db import models\nclass App(models.Model): pass\n",
@@ -1262,8 +1277,12 @@ class Article(models.Model):
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project =
-            project_for_search_paths(&db, "/project", search_paths, TemplateLibraries::default());
+        let project = project_for_search_paths(
+            &mut db,
+            "/project",
+            search_paths,
+            TemplateLibraries::default(),
+        );
 
         let modules = model_modules(&db, project);
         let module_paths: Vec<_> = modules

--- a/crates/djls-semantic/src/resolution.rs
+++ b/crates/djls-semantic/src/resolution.rs
@@ -332,60 +332,32 @@ impl<'bits> LiteralTemplateReference<'bits> {
 
 #[cfg(test)]
 mod tests {
-    use djls_conf::Settings;
-    use djls_source::Db as _;
-    use djls_source::FileRootKind;
-
     use super::*;
-    use crate::project::Interpreter;
-    use crate::project::ProjectTemplateFiles;
-    use crate::project::TemplateLibraries;
-    use crate::project::resolve::SearchPaths;
+    use crate::project::TemplateDirs;
+    use crate::testing::ProjectFixture;
     use crate::testing::TestDatabase;
 
     fn project_with_templates(
-        db: &TestDatabase,
+        db: &mut TestDatabase,
         template_dirs: Vec<&str>,
         templates: Vec<(&str, &str, &str)>,
     ) -> Project {
-        for (_, path, source) in &templates {
-            db.add_file(path, source);
-        }
-
-        let template_files = ProjectTemplateFiles::from_ordered_paths(
-            db,
-            templates
-                .into_iter()
-                .map(|(name, path, _)| (name.to_string(), path.into()))
-                .collect(),
-        );
         let template_dirs =
             TemplateDirs::Known(template_dirs.into_iter().map(Into::into).collect());
-        let settings = Settings::default();
-
-        db.files()
-            .try_add_root(db, "/test/project".into(), FileRootKind::Project);
-
-        Project::new(
-            db,
-            "/test/project".into(),
-            SearchPaths::default(),
-            Interpreter::discover(settings.venv_path()),
-            None,
-            Vec::new(),
-            Vec::new(),
-            template_dirs,
-            settings.tagspecs().clone(),
-            TemplateLibraries::default(),
-            template_files,
-        )
+        templates
+            .into_iter()
+            .fold(
+                ProjectFixture::new("/test/project").template_dirs(template_dirs),
+                |fixture, (name, path, source)| fixture.template_file(name, path, source),
+            )
+            .build(db)
     }
 
     #[test]
     fn template_origins_preserve_django_search_order() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         let project = project_with_templates(
-            &db,
+            &mut db,
             vec!["/test/project/templates", "/test/project/app/templates"],
             vec![
                 (
@@ -416,9 +388,9 @@ mod tests {
 
     #[test]
     fn find_template_returns_first_origin_for_duplicate_template_names() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         let project = project_with_templates(
-            &db,
+            &mut db,
             vec!["/test/project/templates", "/test/project/app/templates"],
             vec![
                 (
@@ -448,9 +420,9 @@ mod tests {
 
     #[test]
     fn find_template_reports_tried_sources_for_missing_template() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         let project = project_with_templates(
-            &db,
+            &mut db,
             vec!["/test/project/templates", "/test/project/app/templates"],
             Vec::new(),
         );
@@ -477,9 +449,9 @@ mod tests {
 
     #[test]
     fn template_references_record_extends_and_include_kinds() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         let project = project_with_templates(
-            &db,
+            &mut db,
             vec!["/test/project/templates"],
             vec![
                 (
@@ -514,9 +486,9 @@ mod tests {
 
     #[test]
     fn template_references_ignore_dynamic_template_names() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         let project = project_with_templates(
-            &db,
+            &mut db,
             vec!["/test/project/templates"],
             vec![
                 (
@@ -541,9 +513,9 @@ mod tests {
 
     #[test]
     fn template_references_to_template_name_include_all_sources() {
-        let db = TestDatabase::new();
+        let mut db = TestDatabase::new();
         let project = project_with_templates(
-            &db,
+            &mut db,
             vec!["/test/project/templates"],
             vec![
                 (

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -8,8 +8,14 @@ use std::sync::Mutex;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+#[cfg(test)]
+use djls_conf::Settings;
+#[cfg(test)]
+use djls_conf::TagSpecDef;
 use djls_corpus::Corpus;
 use djls_corpus::module_path_from_file;
+#[cfg(test)]
+use djls_source::Db as _;
 use djls_source::Diagnostic;
 use djls_source::DiagnosticRenderer;
 use djls_source::File;
@@ -25,11 +31,19 @@ use crate::db::ValidationErrorAccumulator;
 use crate::errors::ValidationError;
 use crate::filters::FilterAritySpecs;
 use crate::project::Db as ProjectDb;
+#[cfg(test)]
+use crate::project::Interpreter;
 use crate::project::Project;
 use crate::project::ProjectIntrospector;
+#[cfg(test)]
+use crate::project::ProjectTemplateFiles;
+#[cfg(test)]
+use crate::project::TemplateDirs;
 use crate::project::TemplateLibraries;
 use crate::project::TemplateLibrarySnapshot;
 use crate::project::TemplateSymbolSnapshot;
+#[cfg(test)]
+use crate::project::resolve::SearchPaths;
 use crate::python::ArgumentCountConstraint;
 use crate::python::ChoiceAt;
 use crate::python::ExtractedDiagnosticConstraint;
@@ -203,6 +217,144 @@ impl TestDatabase {
             .durability(salsa::Durability::LOW)
             .path_durability(salsa::Durability::HIGH)
             .new(self)
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct ProjectFixture {
+    root: Utf8PathBuf,
+    files: Vec<(Utf8PathBuf, String)>,
+    django_settings_module: Option<String>,
+    pythonpath: Vec<String>,
+    env_vars: Vec<(String, String)>,
+    interpreter: Interpreter,
+    search_paths: Option<SearchPaths>,
+    register_roots: bool,
+    template_dirs: TemplateDirs,
+    tag_specs: TagSpecDef,
+    template_libraries: TemplateLibraries,
+    template_files: Vec<(String, Utf8PathBuf)>,
+}
+
+#[cfg(test)]
+impl ProjectFixture {
+    #[must_use]
+    pub(crate) fn new(root: impl Into<Utf8PathBuf>) -> Self {
+        let settings = Settings::default();
+        Self {
+            root: root.into(),
+            files: Vec::new(),
+            django_settings_module: None,
+            pythonpath: Vec::new(),
+            env_vars: Vec::new(),
+            interpreter: Interpreter::discover(settings.venv_path()),
+            search_paths: None,
+            register_roots: true,
+            template_dirs: TemplateDirs::Unknown,
+            tag_specs: settings.tagspecs().clone(),
+            template_libraries: TemplateLibraries::default(),
+            template_files: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn file(mut self, path: impl Into<Utf8PathBuf>, source: impl Into<String>) -> Self {
+        self.files.push((path.into(), source.into()));
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn django_settings_module(mut self, module: impl Into<String>) -> Self {
+        self.django_settings_module = Some(module.into());
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn pythonpath(mut self, path: impl Into<String>) -> Self {
+        self.pythonpath.push(path.into());
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn interpreter(mut self, interpreter: Interpreter) -> Self {
+        self.interpreter = interpreter;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn search_paths(mut self, search_paths: SearchPaths) -> Self {
+        self.search_paths = Some(search_paths);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn register_roots(mut self, register_roots: bool) -> Self {
+        self.register_roots = register_roots;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn template_dirs(mut self, template_dirs: TemplateDirs) -> Self {
+        self.template_dirs = template_dirs;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn template_libraries(mut self, template_libraries: TemplateLibraries) -> Self {
+        self.template_libraries = template_libraries;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn template_file(
+        mut self,
+        name: impl Into<String>,
+        path: impl Into<Utf8PathBuf>,
+        source: impl Into<String>,
+    ) -> Self {
+        let path = path.into();
+        self.files.push((path.clone(), source.into()));
+        self.template_files.push((name.into(), path));
+        self
+    }
+
+    pub(crate) fn build(self, db: &TestDatabase) -> Project {
+        for (path, source) in self.files {
+            db.add_file(path.as_str(), &source);
+        }
+
+        let template_files = ProjectTemplateFiles::from_ordered_paths(db, self.template_files);
+        let search_paths = self.search_paths.unwrap_or_else(|| {
+            SearchPaths::from_project_settings(
+                db.file_system(),
+                &self.root,
+                &self.interpreter,
+                &self.pythonpath,
+            )
+        });
+        if self.register_roots {
+            search_paths.register_roots(db);
+        }
+
+        Project::new(
+            db,
+            self.root,
+            search_paths,
+            self.interpreter,
+            self.django_settings_module,
+            self.pythonpath,
+            self.env_vars,
+            self.template_dirs,
+            self.tag_specs,
+            self.template_libraries,
+            template_files,
+        )
+    }
+
+    pub(crate) fn install(self, db: &mut TestDatabase) -> Project {
+        let project = self.build(db);
+        db.set_project(project);
+        project
     }
 }
 
@@ -779,4 +931,42 @@ where
     errors.sort_by_key(|e| e.primary_span().map_or(0, Span::start));
 
     render_diagnostic_snapshot(path, source, &errors)
+}
+
+#[cfg(test)]
+mod project_fixture_tests {
+    use djls_source::Db as _;
+
+    use super::*;
+
+    #[test]
+    fn project_fixture_builds_project_with_settings_and_search_paths() {
+        let mut db = TestDatabase::new();
+        let project = ProjectFixture::new("/fixture")
+            .file("/fixture/app/__init__.py", "")
+            .django_settings_module("fixture.settings")
+            .pythonpath("/fixture/app")
+            .install(&mut db);
+
+        assert_eq!(
+            project.django_settings_module(&db).as_deref(),
+            Some("fixture.settings")
+        );
+
+        let paths: Vec<_> = project
+            .search_paths(&db)
+            .iter()
+            .map(super::super::project::resolve::SearchPath::path)
+            .collect();
+        assert_eq!(
+            paths,
+            [Utf8Path::new("/fixture"), Utf8Path::new("/fixture/app")]
+        );
+        assert!(
+            db.files()
+                .root(&db, Utf8Path::new("/fixture/app/__init__.py"))
+                .is_some()
+        );
+        assert_eq!(db.project(), Some(project));
+    }
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -129,6 +129,31 @@ def e2e(session):
     session.run("pytest", *args)
 
 
+@nox.session(python=PY_DEFAULT)
+def fixtures(session):
+    session.run_install(
+        "uv",
+        "sync",
+        "--frozen",
+        "--inexact",
+        "--python",
+        session.python,
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+    )
+    session.install(f"django=={DJ_DEFAULT}")
+
+    output = session.run(
+        "python",
+        "tools/django_facts.py",
+        "--project",
+        "tests/project",
+        silent=True,
+    )
+    output_path = Path("tests/fixtures/django-facts/django-5.2.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(output, encoding="utf-8")
+
+
 @nox.session
 def lint(session):
     for python_version in reversed(PY_VERSIONS):

--- a/tests/e2e/test_completions.py
+++ b/tests/e2e/test_completions.py
@@ -16,6 +16,14 @@ BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.h
 LOAD_TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "load.html"
 )
+FIRST_PARTY_LOAD_TEMPLATE = (
+    TEST_WORKSPACE
+    / "djls_app"
+    / "templates"
+    / "djls_app"
+    / "tags"
+    / "first_party_load.html"
+)
 
 
 @pytest.mark.asyncio
@@ -69,6 +77,33 @@ async def test_completes_load_library_names(client: LanguageClient):
     assert static.kind == CompletionItemKind.Module
     assert static.insert_text_format == InsertTextFormat.PlainText
     assert static.detail.startswith("Django template library")
+
+
+@pytest.mark.asyncio
+async def test_completes_first_party_load_library_names(client: LanguageClient):
+    client.text_document_did_open(
+        DidOpenTextDocumentParams(
+            text_document=TextDocumentItem(
+                uri=FIRST_PARTY_LOAD_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=FIRST_PARTY_LOAD_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    result = await client.text_document_completion_async(
+        CompletionParams(
+            text_document=TextDocumentIdentifier(uri=FIRST_PARTY_LOAD_TEMPLATE.as_uri()),
+            position=position_after(FIRST_PARTY_LOAD_TEMPLATE, "{% load djls_app"),
+        )
+    )
+
+    assert result is not None
+    first_party = next(item for item in result if item.label == "djls_app_tags")
+    assert first_party.kind == CompletionItemKind.Module
+    assert first_party.insert_text_format == InsertTextFormat.PlainText
+    assert first_party.detail.startswith("Django template library")
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_diagnostics.py
+++ b/tests/e2e/test_diagnostics.py
@@ -9,6 +9,14 @@ from .conftest import TEST_WORKSPACE
 TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "scoping.html"
 )
+FIRST_PARTY_UNLOADED_TEMPLATE = (
+    TEST_WORKSPACE
+    / "djls_app"
+    / "templates"
+    / "djls_app"
+    / "tags"
+    / "first_party_unloaded.html"
+)
 EXPECTED_DIAGNOSTICS = {"S108", "S109", "S111", "S112", "S115", "S116"}
 
 
@@ -33,6 +41,31 @@ async def test_publish_diagnostics_for_existing_template(client: LanguageClient)
         for diagnostic in client.diagnostics[TEMPLATE.as_uri()]
         if diagnostic.code
     } == EXPECTED_DIAGNOSTICS
+
+
+@pytest.mark.asyncio
+async def test_publish_diagnostics_for_unloaded_first_party_tag(
+    client: LanguageClient,
+):
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=FIRST_PARTY_UNLOADED_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=FIRST_PARTY_UNLOADED_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    while not client.diagnostics.get(FIRST_PARTY_UNLOADED_TEMPLATE.as_uri()):
+        await client.wait_for_notification(types.TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
+
+    assert {
+        str(diagnostic.code)
+        for diagnostic in client.diagnostics[FIRST_PARTY_UNLOADED_TEMPLATE.as_uri()]
+        if diagnostic.code
+    } == {"S109"}
 
 
 @pytest.mark.asyncio

--- a/tests/fixtures/django-facts/django-5.2.json
+++ b/tests/fixtures/django-facts/django-5.2.json
@@ -1,0 +1,961 @@
+{
+  "template_dirs": [
+    "${PROJECT}/templates",
+    "${SITE_PACKAGES}/django/contrib/admin/templates",
+    "${SITE_PACKAGES}/django/contrib/auth/templates",
+    "${PROJECT}/djls_app/templates"
+  ],
+  "template_libraries": {
+    "builtins": [
+      "django.template.defaulttags",
+      "django.template.defaultfilters",
+      "django.template.loader_tags"
+    ],
+    "libraries": {
+      "admin_list": "django.contrib.admin.templatetags.admin_list",
+      "admin_modify": "django.contrib.admin.templatetags.admin_modify",
+      "admin_urls": "django.contrib.admin.templatetags.admin_urls",
+      "cache": "django.templatetags.cache",
+      "djls_app_tags": "djls_app.templatetags.djls_app_tags",
+      "humanize": "django.contrib.humanize.templatetags.humanize",
+      "i18n": "django.templatetags.i18n",
+      "l10n": "django.templatetags.l10n",
+      "log": "django.contrib.admin.templatetags.log",
+      "static": "django.templatetags.static",
+      "tz": "django.templatetags.tz"
+    },
+    "symbols": [
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "admin_actions"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "admin_list_filter"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "change_list_object_tools"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "date_hierarchy"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "pagination"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "paginator_number"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "result_list"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_list",
+        "load_name": "admin_list",
+        "module": "django.contrib.admin.templatetags.admin_list",
+        "name": "search_form"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.admin.templatetags.admin_modify",
+        "load_name": "admin_modify",
+        "module": "django.contrib.admin.templatetags.admin_modify",
+        "name": "cell_count"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_modify",
+        "load_name": "admin_modify",
+        "module": "django.contrib.admin.templatetags.admin_modify",
+        "name": "change_form_object_tools"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_modify",
+        "load_name": "admin_modify",
+        "module": "django.contrib.admin.templatetags.admin_modify",
+        "name": "prepopulated_fields_js"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_modify",
+        "load_name": "admin_modify",
+        "module": "django.contrib.admin.templatetags.admin_modify",
+        "name": "submit_row"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.admin.templatetags.admin_urls",
+        "load_name": "admin_urls",
+        "module": "django.contrib.admin.templatetags.admin_urls",
+        "name": "admin_urlname"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.admin.templatetags.admin_urls",
+        "load_name": "admin_urls",
+        "module": "django.contrib.admin.templatetags.admin_urls",
+        "name": "admin_urlquote"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.admin_urls",
+        "load_name": "admin_urls",
+        "module": "django.contrib.admin.templatetags.admin_urls",
+        "name": "add_preserved_filters"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.contrib.admin.templatetags.log",
+        "load_name": "log",
+        "module": "django.contrib.admin.templatetags.log",
+        "name": "get_admin_log"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.humanize.templatetags.humanize",
+        "load_name": "humanize",
+        "module": "django.contrib.humanize.templatetags.humanize",
+        "name": "apnumber"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.humanize.templatetags.humanize",
+        "load_name": "humanize",
+        "module": "django.contrib.humanize.templatetags.humanize",
+        "name": "intcomma"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.humanize.templatetags.humanize",
+        "load_name": "humanize",
+        "module": "django.contrib.humanize.templatetags.humanize",
+        "name": "intword"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.humanize.templatetags.humanize",
+        "load_name": "humanize",
+        "module": "django.contrib.humanize.templatetags.humanize",
+        "name": "naturalday"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.humanize.templatetags.humanize",
+        "load_name": "humanize",
+        "module": "django.contrib.humanize.templatetags.humanize",
+        "name": "naturaltime"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.contrib.humanize.templatetags.humanize",
+        "load_name": "humanize",
+        "module": "django.contrib.humanize.templatetags.humanize",
+        "name": "ordinal"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "add"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "addslashes"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "capfirst"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "center"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "cut"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "date"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "default"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "default_if_none"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "dictsort"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "dictsortreversed"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "divisibleby"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "escape"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "escapejs"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "escapeseq"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "filesizeformat"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "first"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "floatformat"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "force_escape"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "get_digit"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "iriencode"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "join"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "json_script"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "last"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "length"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "linebreaks"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "linebreaksbr"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "linenumbers"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "ljust"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "lower"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "make_list"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "phone2numeric"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "pluralize"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "pprint"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "random"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "rjust"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "safe"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "safeseq"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "slice"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "slugify"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "stringformat"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "striptags"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "time"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "timesince"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "timeuntil"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "title"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "truncatechars"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "truncatechars_html"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "truncatewords"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "truncatewords_html"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "unordered_list"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "upper"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "urlencode"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "urlize"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "urlizetrunc"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "wordcount"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "wordwrap"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.template.defaultfilters",
+        "load_name": null,
+        "module": "django.template.defaultfilters",
+        "name": "yesno"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "autoescape"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "comment"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "csrf_token"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "cycle"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "debug"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "filter"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "firstof"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "for"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "if"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "ifchanged"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "load"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "lorem"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "now"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "querystring"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "regroup"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "resetcycle"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "spaceless"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "templatetag"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "url"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "verbatim"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "widthratio"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.defaulttags",
+        "load_name": null,
+        "module": "django.template.defaulttags",
+        "name": "with"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.loader_tags",
+        "load_name": null,
+        "module": "django.template.loader_tags",
+        "name": "block"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.loader_tags",
+        "load_name": null,
+        "module": "django.template.loader_tags",
+        "name": "extends"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.template.loader_tags",
+        "load_name": null,
+        "module": "django.template.loader_tags",
+        "name": "include"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.cache",
+        "load_name": "cache",
+        "module": "django.templatetags.cache",
+        "name": "cache"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "language_bidi"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "language_name"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "language_name_local"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "language_name_translated"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "blocktrans"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "blocktranslate"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "get_available_languages"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "get_current_language"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "get_current_language_bidi"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "get_language_info"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "get_language_info_list"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "language"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "trans"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.i18n",
+        "load_name": "i18n",
+        "module": "django.templatetags.i18n",
+        "name": "translate"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.l10n",
+        "load_name": "l10n",
+        "module": "django.templatetags.l10n",
+        "name": "localize"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.l10n",
+        "load_name": "l10n",
+        "module": "django.templatetags.l10n",
+        "name": "unlocalize"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.l10n",
+        "load_name": "l10n",
+        "module": "django.templatetags.l10n",
+        "name": "localize"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.static",
+        "load_name": "static",
+        "module": "django.templatetags.static",
+        "name": "get_media_prefix"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.static",
+        "load_name": "static",
+        "module": "django.templatetags.static",
+        "name": "get_static_prefix"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.static",
+        "load_name": "static",
+        "module": "django.templatetags.static",
+        "name": "static"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.tz",
+        "load_name": "tz",
+        "module": "django.templatetags.tz",
+        "name": "localtime"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.tz",
+        "load_name": "tz",
+        "module": "django.templatetags.tz",
+        "name": "timezone"
+      },
+      {
+        "kind": "filter",
+        "library_module": "django.templatetags.tz",
+        "load_name": "tz",
+        "module": "django.templatetags.tz",
+        "name": "utc"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.tz",
+        "load_name": "tz",
+        "module": "django.templatetags.tz",
+        "name": "get_current_timezone"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.tz",
+        "load_name": "tz",
+        "module": "django.templatetags.tz",
+        "name": "localtime"
+      },
+      {
+        "kind": "tag",
+        "library_module": "django.templatetags.tz",
+        "load_name": "tz",
+        "module": "django.templatetags.tz",
+        "name": "timezone"
+      },
+      {
+        "kind": "filter",
+        "library_module": "djls_app.templatetags.djls_app_tags",
+        "load_name": "djls_app_tags",
+        "module": "djls_app.templatetags.djls_app_tags",
+        "name": "djls_shout"
+      },
+      {
+        "kind": "tag",
+        "library_module": "djls_app.templatetags.djls_app_tags",
+        "load_name": "djls_app_tags",
+        "module": "djls_app.templatetags.djls_app_tags",
+        "name": "djls_greeting"
+      }
+    ]
+  }
+}

--- a/tests/project/djls_app/templates/djls_app/tags/first_party_load.html
+++ b/tests/project/djls_app/templates/djls_app/tags/first_party_load.html
@@ -1,0 +1,2 @@
+{# Completion target for first-party templatetag library names. #}
+{% load djls_app_tags %}

--- a/tests/project/djls_app/templates/djls_app/tags/first_party_unloaded.html
+++ b/tests/project/djls_app/templates/djls_app/tags/first_party_unloaded.html
@@ -1,0 +1,2 @@
+{# First-party custom tags must still be loaded before use. #}
+{% djls_greeting "Django" %}

--- a/tests/project/djls_app/templatetags/djls_app_tags.py
+++ b/tests/project/djls_app/templatetags/djls_app_tags.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def djls_greeting(name):
+    return f"hello {name}"
+
+
+@register.filter
+def djls_shout(value):
+    return str(value).upper()

--- a/tests/project/djls_test/settings.py
+++ b/tests/project/djls_test/settings.py
@@ -58,7 +58,7 @@ ROOT_URLCONF = "djls_test.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/tests/project/templates/project_base.html
+++ b/tests/project/templates/project_base.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    {% block content %}Project base{% endblock %}
+  </body>
+</html>

--- a/tools/django_facts.py
+++ b/tools/django_facts.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def main() -> None:
+    args = parse_args()
+    project = args.project.resolve()
+    settings_module = args.settings or read_settings_module(project)
+
+    sys.path.insert(0, str(project))
+    os.environ["DJANGO_SETTINGS_MODULE"] = settings_module
+
+    import django
+
+    site_packages = Path(django.__file__).resolve().parents[1]
+    django.setup()
+
+    facts = {
+        "template_dirs": collect_template_dirs(project, site_packages),
+        "template_libraries": collect_template_libraries(),
+    }
+    json.dump(facts, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate normalized Django facts for the e2e fixture project."
+    )
+    parser.add_argument("--project", type=Path, required=True)
+    parser.add_argument("--settings")
+    return parser.parse_args()
+
+
+def read_settings_module(project: Path) -> str:
+    config = project / "djls.toml"
+    for line in config.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line.startswith("django_settings_module"):
+            continue
+        _, raw_value = line.split("=", 1)
+        return raw_value.strip().strip('"').strip("'")
+    raise RuntimeError(f"{config} does not define django_settings_module")
+
+
+def collect_template_dirs(project: Path, site_packages: Path) -> list[str]:
+    from django.apps import apps
+    from django.conf import settings
+
+    dirs = []
+    for engine in settings.TEMPLATES:
+        if "django" not in engine["BACKEND"].lower():
+            continue
+
+        dirs.extend(Path(path) for path in engine.get("DIRS", []))
+
+        if engine.get("APP_DIRS", False):
+            for app_config in apps.get_app_configs():
+                template_dir = Path(app_config.path) / "templates"
+                if template_dir.exists():
+                    dirs.append(template_dir)
+
+    return [normalize_path(path, project, site_packages) for path in dirs]
+
+
+def collect_template_libraries() -> dict[str, Any]:
+    from django.template.engine import Engine
+    from django.template.library import import_library
+
+    engine = Engine.get_default()
+    builtins = []
+    symbols = []
+
+    for builtin_module, library in zip(engine.builtins, engine.template_builtins):
+        if builtin_module in builtins:
+            continue
+        builtins.append(builtin_module)
+        symbols.extend(symbol_rows(library, builtin_module, None))
+
+    libraries = dict(sorted(engine.libraries.items()))
+    for load_name, library_module in libraries.items():
+        try:
+            library = import_library(library_module)
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to import Django template library {library_module}"
+            ) from exc
+        symbols.extend(symbol_rows(library, library_module, load_name))
+
+    symbols.sort(
+        key=lambda symbol: (
+            symbol["library_module"],
+            symbol["load_name"] or "",
+            symbol["kind"],
+            symbol["name"],
+            symbol["module"],
+        )
+    )
+    return {
+        "builtins": builtins,
+        "libraries": libraries,
+        "symbols": symbols,
+    }
+
+
+def symbol_rows(library: Any, library_module: str, load_name: str | None) -> list[dict[str, str | None]]:
+    rows = []
+    for name, tag_func in sorted(library.tags.items()):
+        rows.append(
+            {
+                "kind": "tag",
+                "name": name,
+                "load_name": load_name,
+                "library_module": library_module,
+                "module": tag_func.__module__,
+            }
+        )
+    for name, filter_func in sorted(library.filters.items()):
+        rows.append(
+            {
+                "kind": "filter",
+                "name": name,
+                "load_name": load_name,
+                "library_module": library_module,
+                "module": filter_func.__module__,
+            }
+        )
+    return rows
+
+
+def normalize_path(path: Path, project: Path, site_packages: Path) -> str:
+    path = path.resolve()
+    if path == project or path.is_relative_to(project):
+        return placeholder_path("${PROJECT}", path.relative_to(project))
+    if path == site_packages or path.is_relative_to(site_packages):
+        return placeholder_path("${SITE_PACKAGES}", path.relative_to(site_packages))
+    return path.as_posix()
+
+
+def placeholder_path(prefix: str, relative: Path) -> str:
+    relative_path = relative.as_posix()
+    if relative_path == ".":
+        return prefix
+    return f"{prefix}/{relative_path}"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a test-only `ProjectFixture` builder and migrate existing semantic tests away from hand-rolled `Project::new` call sites.
- Enrich the e2e Django fixture with a first-party templatetag library and non-empty template `DIRS`.
- Add runtime-inspector e2e assertions for first-party library completion and unloaded first-party tag diagnostics.
- Add `tools/django_facts.py`, `just fixtures`, and checked-in normalized Django 5.2 golden facts.

## Validation

- `cargo build`
- `cargo test`
- `just e2e`
- `just fixtures`
- `just fmt`
- `just clippy --allow-dirty`
- `just lint`
- `DJANGO_SETTINGS_MODULE=definitely.invalid just fixtures`
