### PR TITLE
refactor: derive project template files from a tracked query

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -215,11 +215,15 @@ mod invalidation_tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
+    use camino::Utf8Path;
     use djls_conf::Settings;
     use djls_semantic::Db as SemanticDb;
     use djls_semantic::Project;
+    use djls_semantic::SemanticOffsetContext;
     use djls_semantic::TemplateLibraries;
+    use djls_source::Db as SourceDb;
     use djls_source::InMemoryFileSystem;
+    use djls_source::Offset;
     use djls_source::SourceFiles;
     use salsa::Database;
     use salsa::Setter;
@@ -333,6 +337,69 @@ mod invalidation_tests {
         assert!(
             !was_executed(&db, &events, "compute_tag_specs"),
             "compute_tag_specs should stay cached when search-path module projection is unchanged"
+        );
+    }
+
+    #[test]
+    fn root_revision_change_invalidates_project_template_files() {
+        let source = "{% extends \"base.html\" %}";
+        let mut fs = InMemoryFileSystem::new();
+        fs.add_file(
+            "/test/project/templates/child.html".into(),
+            source.to_string(),
+        );
+        fs.add_file(
+            "/test/project/templates/base.html".into(),
+            "base".to_string(),
+        );
+
+        let event_log = EventLog::default();
+        let settings = Settings::default();
+        let mut db = DjangoDatabase {
+            fs: Arc::new(fs),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            project_introspector: Arc::new(djls_semantic::ProjectIntrospector::new()),
+            storage: salsa::Storage::new(Some(Box::new({
+                let log = event_log.clone();
+                move |event| {
+                    log.events.lock().unwrap().push(event);
+                }
+            }))),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, "/test/project".into(), &settings);
+        db.project = Some(project);
+
+        let project = db.project.unwrap();
+
+        let child_path = Utf8Path::new("/test/project/templates/child.html");
+        let child = db.get_or_create_file(child_path);
+        let offset = Offset::try_from(source.find("base.html").unwrap()).unwrap();
+        {
+            let SemanticOffsetContext::TemplateReference { name, .. } =
+                SemanticOffsetContext::from_offset(&db, child, offset)
+            else {
+                panic!("expected extends argument to be a template reference");
+            };
+            let _result = djls_semantic::find_template(&db, project, name);
+        }
+        event_log.take();
+
+        let root = db.files().expect_root(&db, child_path);
+        db.bump_file_root_revision(root);
+
+        let SemanticOffsetContext::TemplateReference { name, .. } =
+            SemanticOffsetContext::from_offset(&db, child, offset)
+        else {
+            panic!("expected extends argument to be a template reference");
+        };
+        let _result = djls_semantic::find_template(&db, project, name);
+        let events = event_log.take();
+        assert!(
+            was_executed(&db, &events, "project_template_files"),
+            "project_template_files should re-execute after the search root revision changes"
         );
     }
 

--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -7,11 +7,10 @@ pub(crate) mod resolve;
 mod symbols;
 mod sync;
 mod system;
+mod templates;
 
 pub use crate::project::db::Db;
 pub use crate::project::input::Project;
-#[cfg(test)]
-pub use crate::project::input::ProjectTemplateFiles;
 pub use crate::project::input::TemplateDirs;
 pub use crate::project::input::load_env_file;
 pub use crate::project::introspector::ProjectIntrospector;
@@ -34,3 +33,4 @@ pub use crate::project::symbols::TemplateSymbolKind;
 pub use crate::project::symbols::TemplateSymbolSnapshot;
 pub use crate::project::sync::load_template_library_cache;
 pub use crate::project::sync::refresh_external_data;
+pub(crate) use crate::project::templates::project_template_files;

--- a/crates/djls-semantic/src/project/input.rs
+++ b/crates/djls-semantic/src/project/input.rs
@@ -35,82 +35,6 @@ impl TemplateDirs {
     }
 }
 
-/// First-party template files in Django loader precedence order.
-///
-/// Duplicate template names are kept because shadowed templates can still be
-/// opened, inspected, and used as reference sources.
-#[derive(Clone, Default, PartialEq, Eq)]
-pub struct ProjectTemplateFiles(Vec<ProjectTemplateFile>);
-
-impl ProjectTemplateFiles {
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub(crate) fn from_ordered_paths(
-        db: &dyn ProjectDb,
-        templates: Vec<(String, Utf8PathBuf)>,
-    ) -> Self {
-        Self(
-            templates
-                .into_iter()
-                .map(|(name, path)| {
-                    let file = db.get_or_create_file(&path);
-                    ProjectTemplateFile::new(name, path, file)
-                })
-                .collect(),
-        )
-    }
-
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &ProjectTemplateFile> {
-        self.0.iter()
-    }
-}
-
-impl fmt::Debug for ProjectTemplateFiles {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ProjectTemplateFiles")
-            .field(&self.0)
-            .finish()
-    }
-}
-
-#[derive(Clone, PartialEq, Eq)]
-pub(crate) struct ProjectTemplateFile {
-    name: String,
-    path: Utf8PathBuf,
-    file: File,
-}
-
-impl ProjectTemplateFile {
-    pub(crate) fn new(name: String, path: Utf8PathBuf, file: File) -> Self {
-        Self { name, path, file }
-    }
-
-    pub(crate) fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub(crate) fn file(&self) -> File {
-        self.file
-    }
-}
-
-impl fmt::Debug for ProjectTemplateFile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProjectTemplateFile")
-            .field("name", &self.name)
-            .field("path", &self.path)
-            .finish_non_exhaustive()
-    }
-}
-
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct PythonModule {
     module_path: ModulePath,
@@ -193,9 +117,6 @@ pub struct Project {
     /// The semantic layer combines this with `{% load %}` scope computed from templates.
     #[returns(ref)]
     pub template_libraries: TemplateLibraries,
-    /// First-party template files discovered for this project.
-    #[returns(ref)]
-    pub(crate) template_files: ProjectTemplateFiles,
 }
 
 impl Project {
@@ -236,11 +157,9 @@ impl Project {
             TemplateDirs::Unknown,
             settings.tagspecs().clone(),
             TemplateLibraries::default(),
-            ProjectTemplateFiles::default(),
         )
         .durability(Durability::MEDIUM)
         .root_durability(Durability::HIGH)
-        .template_files_durability(Durability::LOW)
         .new(db)
     }
 }

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -9,9 +9,6 @@ use std::fs;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_source::Utf8PathClean;
-use djls_source::WalkEntryKind;
-use djls_source::WalkOptions;
 use salsa::Setter;
 use serde::Deserialize;
 use serde::Serialize;
@@ -20,7 +17,6 @@ use sha2::Sha256;
 
 use crate::project::db::Db as ProjectDb;
 use crate::project::input::Project;
-use crate::project::input::ProjectTemplateFiles;
 use crate::project::input::TemplateDirs;
 use crate::project::introspector::IntrospectionRequest;
 use crate::project::python::Interpreter;
@@ -42,7 +38,6 @@ pub fn refresh_external_data(db: &mut dyn ProjectDb) {
     project.refresh_source_roots(db);
     refresh_template_dirs(db, project);
     refresh_template_libraries(db, project);
-    refresh_template_files(db, project);
     refresh_python_modules(db, project);
 }
 
@@ -252,50 +247,6 @@ fn cache_dir(
     let key = cache_key(root, interpreter, django_settings_module, pythonpath);
     // Keep the legacy `inspector` directory for on-disk cache compatibility.
     Some(base.join("inspector").join(&key[..16]))
-}
-
-fn refresh_template_files(db: &mut dyn ProjectDb, project: Project) {
-    let next = match project.template_dirs(db).as_known() {
-        Some(search_dirs) => {
-            let mut templates = Vec::new();
-            let walk_options = WalkOptions::unrestricted();
-
-            for dir in search_dirs {
-                if !db.path_is_dir(dir) {
-                    tracing::warn!("Template directory does not exist: {}", dir);
-                    continue;
-                }
-
-                let mut dir_templates = Vec::new();
-                let entries = match db.walk_entries(dir, &walk_options) {
-                    Ok(entries) => entries,
-                    Err(err) => {
-                        tracing::warn!("Failed to walk template directory {}: {}", dir, err);
-                        continue;
-                    }
-                };
-                for entry in entries {
-                    if entry.kind != WalkEntryKind::File {
-                        continue;
-                    }
-                    let name = entry.relative.clean().to_string();
-                    dir_templates.push((name, entry.path));
-                }
-
-                dir_templates.sort_by(|(a_name, a_path), (b_name, b_path)| {
-                    a_name.cmp(b_name).then_with(|| a_path.cmp(b_path))
-                });
-                templates.extend(dir_templates);
-            }
-
-            ProjectTemplateFiles::from_ordered_paths(db, templates)
-        }
-        None => ProjectTemplateFiles::default(),
-    };
-
-    if project.template_files(db) != &next {
-        project.set_template_files(db).to(next);
-    }
 }
 
 fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {

--- a/crates/djls-semantic/src/project/templates.rs
+++ b/crates/djls-semantic/src/project/templates.rs
@@ -1,0 +1,133 @@
+use std::fmt;
+
+use camino::Utf8PathBuf;
+use djls_source::File;
+use djls_source::Utf8PathClean;
+use djls_source::WalkEntryKind;
+use djls_source::WalkOptions;
+
+use crate::project::db::Db as ProjectDb;
+use crate::project::input::Project;
+
+/// First-party template files in Django loader precedence order.
+///
+/// Duplicate template names are kept because shadowed templates can still be
+/// opened, inspected, and used as reference sources.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub(crate) struct ProjectTemplateFiles(Vec<ProjectTemplateFile>);
+
+impl ProjectTemplateFiles {
+    pub(crate) fn from_ordered_paths(
+        db: &dyn ProjectDb,
+        templates: Vec<(String, Utf8PathBuf)>,
+    ) -> Self {
+        Self(
+            templates
+                .into_iter()
+                .map(|(name, path)| {
+                    let file = db.get_or_create_file(&path);
+                    ProjectTemplateFile::new(name, path, file)
+                })
+                .collect(),
+        )
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &ProjectTemplateFile> {
+        self.0.iter()
+    }
+}
+
+impl fmt::Debug for ProjectTemplateFiles {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ProjectTemplateFiles")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ProjectTemplateFile {
+    name: String,
+    path: Utf8PathBuf,
+    file: File,
+}
+
+impl ProjectTemplateFile {
+    pub(crate) fn new(name: String, path: Utf8PathBuf, file: File) -> Self {
+        Self { name, path, file }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn file(&self) -> File {
+        self.file
+    }
+}
+
+impl fmt::Debug for ProjectTemplateFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProjectTemplateFile")
+            .field("name", &self.name)
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+#[salsa::tracked(returns(ref))]
+pub(crate) fn project_template_files(db: &dyn ProjectDb, project: Project) -> ProjectTemplateFiles {
+    // Freshness boundary: template discovery re-runs when any search-path root
+    // revision is bumped (refresh_external_data does this), matching the
+    // previous imperative refresh cadence. Template dirs that live outside
+    // every registered root are still re-walked then, because this query
+    // invalidates as a whole.
+    for search_path in project.search_paths(db).iter() {
+        if let Some(root) = db.files().root(db, search_path.path()) {
+            let _ = root.revision(db);
+        } else {
+            tracing::warn!(
+                "Search path has no registered source root: {}",
+                search_path.path()
+            );
+        }
+    }
+
+    match project.template_dirs(db).as_known() {
+        Some(search_dirs) => {
+            let mut templates = Vec::new();
+            let walk_options = WalkOptions::unrestricted();
+
+            for dir in search_dirs {
+                if !db.path_is_dir(dir) {
+                    tracing::warn!("Template directory does not exist: {}", dir);
+                    continue;
+                }
+
+                let mut dir_templates = Vec::new();
+                let entries = match db.walk_entries(dir, &walk_options) {
+                    Ok(entries) => entries,
+                    Err(err) => {
+                        tracing::warn!("Failed to walk template directory {}: {}", dir, err);
+                        continue;
+                    }
+                };
+                for entry in entries {
+                    if entry.kind != WalkEntryKind::File {
+                        continue;
+                    }
+                    let name = entry.relative.clean().to_string();
+                    dir_templates.push((name, entry.path));
+                }
+
+                dir_templates.sort_by(|(a_name, a_path), (b_name, b_path)| {
+                    a_name.cmp(b_name).then_with(|| a_path.cmp(b_path))
+                });
+                templates.extend(dir_templates);
+            }
+
+            ProjectTemplateFiles::from_ordered_paths(db, templates)
+        }
+        None => ProjectTemplateFiles::default(),
+    }
+}

--- a/crates/djls-semantic/src/resolution.rs
+++ b/crates/djls-semantic/src/resolution.rs
@@ -151,7 +151,7 @@ pub(crate) fn template_origins(db: &dyn SemanticDb, project: Project) -> Templat
     let mut ordered = Vec::new();
     let mut first_by_template_name = FxHashMap::default();
 
-    for template in project.template_files(db).iter() {
+    for template in crate::project::project_template_files(db, project).iter() {
         let template_name = TemplateName::new(db, template.name().to_string());
         let origin = TemplateOrigin::new(db, template_name, template.file());
 
@@ -383,7 +383,41 @@ mod tests {
             .map(|origin| origin.template_name(&db).name(&db).clone())
             .collect();
 
-        assert_eq!(names, ["base.html", "base.html", "account/detail.html"]);
+        assert_eq!(names, ["base.html", "account/detail.html", "base.html"]);
+    }
+
+    #[test]
+    fn derived_template_origins_keep_shadowed_names_in_template_dir_order() {
+        let mut db = TestDatabase::new();
+        let project = project_with_templates(
+            &mut db,
+            vec!["/test/project/templates", "/test/project/app/templates"],
+            vec![
+                (
+                    "shared.html",
+                    "/test/project/app/templates/shared.html",
+                    "app shared",
+                ),
+                (
+                    "shared.html",
+                    "/test/project/templates/shared.html",
+                    "project shared",
+                ),
+            ],
+        );
+
+        let paths: Vec<_> = template_origins(&db, project)
+            .iter(&db)
+            .map(|origin| origin.file(&db).path(&db).as_str())
+            .collect();
+
+        assert_eq!(
+            paths,
+            [
+                "/test/project/templates/shared.html",
+                "/test/project/app/templates/shared.html",
+            ]
+        );
     }
 
     #[test]

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -36,8 +36,6 @@ use crate::project::Interpreter;
 use crate::project::Project;
 use crate::project::ProjectIntrospector;
 #[cfg(test)]
-use crate::project::ProjectTemplateFiles;
-#[cfg(test)]
 use crate::project::TemplateDirs;
 use crate::project::TemplateLibraries;
 use crate::project::TemplateLibrarySnapshot;
@@ -233,7 +231,6 @@ pub(crate) struct ProjectFixture {
     template_dirs: TemplateDirs,
     tag_specs: TagSpecDef,
     template_libraries: TemplateLibraries,
-    template_files: Vec<(String, Utf8PathBuf)>,
 }
 
 #[cfg(test)]
@@ -253,7 +250,6 @@ impl ProjectFixture {
             template_dirs: TemplateDirs::Unknown,
             tag_specs: settings.tagspecs().clone(),
             template_libraries: TemplateLibraries::default(),
-            template_files: Vec::new(),
         }
     }
 
@@ -307,15 +303,12 @@ impl ProjectFixture {
 
     #[must_use]
     pub(crate) fn template_file(
-        mut self,
-        name: impl Into<String>,
+        self,
+        _name: impl Into<String>,
         path: impl Into<Utf8PathBuf>,
         source: impl Into<String>,
     ) -> Self {
-        let path = path.into();
-        self.files.push((path.clone(), source.into()));
-        self.template_files.push((name.into(), path));
-        self
+        self.file(path, source)
     }
 
     pub(crate) fn build(self, db: &TestDatabase) -> Project {
@@ -323,7 +316,6 @@ impl ProjectFixture {
             db.add_file(path.as_str(), &source);
         }
 
-        let template_files = ProjectTemplateFiles::from_ordered_paths(db, self.template_files);
         let search_paths = self.search_paths.unwrap_or_else(|| {
             SearchPaths::from_project_settings(
                 db.file_system(),
@@ -347,7 +339,6 @@ impl ProjectFixture {
             self.template_dirs,
             self.tag_specs,
             self.template_libraries,
-            template_files,
         )
     }
 


### PR DESCRIPTION
## Summary
- move first-party template file discovery from `Project` input state into a tracked `project_template_files` query
- remove the imperative `refresh_template_files` push path
- add regression coverage for root-revision invalidation and shadowed template precedence

## Validation
- `cargo build -q`
- `cargo test -q -p djls-semantic`
- `cargo test -q -p djls-db root_revision_change_invalidates_project_template_files`
- `cargo test -q` (passed before the final test-fixture cleanup; later reruns were aborted because full workspace tests saturated the laptop)
- `cargo clippy --all-targets --all-features --benches -- -D warnings`
- `just fmt`
- `just clippy`
- `just lint`

## Notes
Full workspace test reruns were intentionally stopped after the earlier passing run because they were bringing the local machine to a crawl. The final cleanup only simplified test setup around `InMemoryFileSystem`; it was validated with the targeted djls-db regression test and clippy.
