### PR TITLE
Derive template libraries from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
+- Changed template tag library discovery to derive libraries from project source and Django settings instead of the runtime inspector.
 - Bumped Rust toolchain from 1.95 to 1.96.
+
+### Removed
+
+- Removed the template library snapshot disk cache and startup cache-loading phase.
 
 ## [6.0.3]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,15 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,12 +547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,15 +606,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -703,15 +679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "css_dataset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,19 +724,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.6",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -993,7 +949,6 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -1533,15 +1488,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -2276,7 +2222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3111,19 +3057,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ reqwest = { version = "0.13", features = ["blocking", "json"] }
 rustc-hash = "2.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-sha2 = "0.11"
 tar = "0.4"
 tempfile = "3.26"
 thiserror = "2.0"

--- a/crates/djls-bench/src/specs.rs
+++ b/crates/djls-bench/src/specs.rs
@@ -1,14 +1,17 @@
-use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use djls_semantic::FilterArity;
 use djls_semantic::FilterAritySpecs;
+use djls_semantic::LibraryName;
+use djls_semantic::PyModuleName;
+use djls_semantic::SymbolDefinition;
 use djls_semantic::SymbolKey;
 use djls_semantic::TagSpecs;
 use djls_semantic::TemplateLibraries;
-use djls_semantic::TemplateLibrarySnapshot;
+use djls_semantic::TemplateLibrary;
+use djls_semantic::TemplateSymbol;
 use djls_semantic::TemplateSymbolKind;
-use djls_semantic::TemplateSymbolSnapshot;
+use djls_semantic::TemplateSymbolName;
 
 use crate::Db;
 
@@ -17,36 +20,43 @@ const DEFAULTFILTERS: &str = "django.template.defaultfilters";
 const I18N: &str = "django.templatetags.i18n";
 const STATIC: &str = "django.templatetags.static";
 
-fn builtin_tag(name: &str, module: &str) -> TemplateSymbolSnapshot {
-    TemplateSymbolSnapshot {
-        kind: Some(TemplateSymbolKind::Tag),
-        name: name.to_string(),
-        load_name: None,
-        library_module: module.to_string(),
-        module: module.to_string(),
+struct BenchSymbol {
+    load_name: Option<&'static str>,
+    module: &'static str,
+    symbol: TemplateSymbol,
+}
+
+fn template_symbol(kind: TemplateSymbolKind, name: &str, module: &str) -> TemplateSymbol {
+    TemplateSymbol {
+        kind,
+        name: TemplateSymbolName::parse(name).unwrap(),
+        definition: PyModuleName::parse(module)
+            .map_or(SymbolDefinition::Unknown, SymbolDefinition::Module),
         doc: None,
     }
 }
 
-fn library_tag(name: &str, load_name: &str, module: &str) -> TemplateSymbolSnapshot {
-    TemplateSymbolSnapshot {
-        kind: Some(TemplateSymbolKind::Tag),
-        name: name.to_string(),
-        load_name: Some(load_name.to_string()),
-        library_module: module.to_string(),
-        module: module.to_string(),
-        doc: None,
+fn builtin_tag(name: &str, module: &'static str) -> BenchSymbol {
+    BenchSymbol {
+        load_name: None,
+        module,
+        symbol: template_symbol(TemplateSymbolKind::Tag, name, module),
     }
 }
 
-fn builtin_filter(name: &str, module: &str) -> TemplateSymbolSnapshot {
-    TemplateSymbolSnapshot {
-        kind: Some(TemplateSymbolKind::Filter),
-        name: name.to_string(),
+fn library_tag(name: &str, load_name: &'static str, module: &'static str) -> BenchSymbol {
+    BenchSymbol {
+        load_name: Some(load_name),
+        module,
+        symbol: template_symbol(TemplateSymbolKind::Tag, name, module),
+    }
+}
+
+fn builtin_filter(name: &str, module: &'static str) -> BenchSymbol {
+    BenchSymbol {
         load_name: None,
-        library_module: module.to_string(),
-        module: module.to_string(),
-        doc: None,
+        module,
+        symbol: template_symbol(TemplateSymbolKind::Filter, name, module),
     }
 }
 
@@ -56,7 +66,7 @@ struct RealisticSpecs {
     filter_arity_specs: FilterAritySpecs,
 }
 
-fn build_template_symbol_snapshots() -> Vec<TemplateSymbolSnapshot> {
+fn build_template_symbols() -> Vec<BenchSymbol> {
     vec![
         builtin_tag("if", DEFAULTTAGS),
         builtin_tag("for", DEFAULTTAGS),
@@ -143,22 +153,64 @@ fn build_filter_arities(
     specs
 }
 
-fn build_realistic_specs() -> RealisticSpecs {
-    let symbols = build_template_symbol_snapshots();
-
-    let mut libraries_map = BTreeMap::new();
-    libraries_map.insert("i18n".to_string(), I18N.to_string());
-    libraries_map.insert("static".to_string(), STATIC.to_string());
-
-    let builtins = vec![DEFAULTTAGS.to_string(), DEFAULTFILTERS.to_string()];
-
-    let response = TemplateLibrarySnapshot {
-        symbols,
-        libraries: libraries_map,
-        builtins,
+fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
+    let mut libraries = TemplateLibraries {
+        active_knowledge: djls_semantic::StaticKnowledge::Known,
+        ..TemplateLibraries::default()
     };
 
-    let template_libraries = TemplateLibraries::default().apply_active_snapshot(Some(response));
+    for module_name in [DEFAULTTAGS, DEFAULTFILTERS] {
+        let module = PyModuleName::parse(module_name).unwrap();
+        let name = LibraryName::parse(module.as_str().split('.').next_back().unwrap()).unwrap();
+        push_unique_module(&mut libraries.builtin_order, module.clone());
+        libraries
+            .builtins
+            .insert(module.clone(), TemplateLibrary::new_builtin(name, module));
+    }
+
+    for (load_name, module_name) in [("i18n", I18N), ("static", STATIC)] {
+        let load_name = LibraryName::parse(load_name).unwrap();
+        let module = PyModuleName::parse(module_name).unwrap();
+        libraries
+            .loadable
+            .entry(load_name.clone())
+            .or_default()
+            .push(TemplateLibrary::new_active(load_name, module, None));
+    }
+
+    for bench_symbol in symbols {
+        match bench_symbol.load_name {
+            None => {
+                let module = PyModuleName::parse(bench_symbol.module).unwrap();
+                if let Some(library) = libraries.builtins.get_mut(&module) {
+                    library.merge_symbol(bench_symbol.symbol);
+                }
+            }
+            Some(load_name) => {
+                let load_name = LibraryName::parse(load_name).unwrap();
+                let module = PyModuleName::parse(bench_symbol.module).unwrap();
+                if let Some(libraries) = libraries.loadable.get_mut(&load_name)
+                    && let Some(library) = libraries
+                        .iter_mut()
+                        .find(|library| library.module() == &module)
+                {
+                    library.merge_symbol(bench_symbol.symbol);
+                }
+            }
+        }
+    }
+
+    libraries
+}
+
+fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
+    if !modules.contains(&module) {
+        modules.push(module);
+    }
+}
+
+fn build_realistic_specs() -> RealisticSpecs {
+    let template_libraries = build_template_libraries(build_template_symbols());
 
     let mut tag_specs = TagSpecs::default();
 

--- a/crates/djls-bench/src/specs.rs
+++ b/crates/djls-bench/src/specs.rs
@@ -155,7 +155,7 @@ fn build_filter_arities(
 
 fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
     let mut libraries = TemplateLibraries {
-        active_knowledge: djls_semantic::StaticKnowledge::Known,
+        knowledge: djls_semantic::StaticKnowledge::Known,
         ..TemplateLibraries::default()
     };
 

--- a/crates/djls-bench/src/specs.rs
+++ b/crates/djls-bench/src/specs.rs
@@ -162,10 +162,9 @@ fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
     for module_name in [DEFAULTTAGS, DEFAULTFILTERS] {
         let module = PyModuleName::parse(module_name).unwrap();
         let name = LibraryName::parse(module.as_str().split('.').next_back().unwrap()).unwrap();
-        push_unique_module(&mut libraries.builtin_order, module.clone());
         libraries
             .builtins
-            .insert(module.clone(), TemplateLibrary::new_builtin(name, module));
+            .push(TemplateLibrary::new_builtin(name, module));
     }
 
     for (load_name, module_name) in [("i18n", I18N), ("static", STATIC)] {
@@ -182,7 +181,11 @@ fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
         match bench_symbol.load_name {
             None => {
                 let module = PyModuleName::parse(bench_symbol.module).unwrap();
-                if let Some(library) = libraries.builtins.get_mut(&module) {
+                if let Some(library) = libraries
+                    .builtins
+                    .iter_mut()
+                    .find(|library| library.module() == &module)
+                {
                     library.merge_symbol(bench_symbol.symbol);
                 }
             }
@@ -201,12 +204,6 @@ fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
     }
 
     libraries
-}
-
-fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
-    if !modules.contains(&module) {
-        modules.push(module);
-    }
 }
 
 fn build_realistic_specs() -> RealisticSpecs {

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -165,7 +165,7 @@ impl SemanticDb for DjangoDatabase {
     fn template_libraries(&self) -> &TemplateLibraries {
         self.project()
             .map_or(TemplateLibraries::empty_ref(), |project| {
-                project.template_libraries(self)
+                djls_semantic::template_libraries(self, project)
             })
     }
 
@@ -209,7 +209,6 @@ mod marker_tests {
 
 #[cfg(test)]
 mod invalidation_tests {
-    use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::sync::Mutex;
 
@@ -219,7 +218,6 @@ mod invalidation_tests {
     use djls_semantic::Db as SemanticDb;
     use djls_semantic::Project;
     use djls_semantic::SemanticOffsetContext;
-    use djls_semantic::TemplateLibraries;
     use djls_source::Db as SourceDb;
     use djls_source::InMemoryFileSystem;
     use djls_source::Offset;
@@ -305,38 +303,69 @@ mod invalidation_tests {
     }
 
     #[test]
-    fn template_libraries_change_validates_templatetag_module_projection() {
-        let (mut db, event_log) = test_db_with_project();
+    fn settings_source_change_validates_templatetag_module_projection() {
+        let event_log = EventLog::default();
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "django_settings_module = \"settings\"\n",
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        let settings_path = root.join("settings.py");
+        let builtin_path = root.join("project_tags.py");
 
-        // Prime the cache
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(root.join("manage.py"), String::new());
+            fs.add_file(
+                settings_path.clone(),
+                "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['project_tags']}}]\n".to_string(),
+            );
+            fs.add_file(
+                builtin_path,
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef project_tag():\n    pass\n".to_string(),
+            );
+        }
+
+        let mut db = DjangoDatabase {
+            fs: fs.clone(),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            project_introspector: Arc::new(djls_semantic::ProjectIntrospector::new()),
+            storage: salsa::Storage::new(Some(Box::new({
+                let log = event_log.clone();
+                move |event| {
+                    log.events.lock().unwrap().push(event);
+                }
+            }))),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
+
         let _specs = db.tag_specs();
         event_log.take();
 
-        // Update template_libraries on the project
-        let project = db.project.unwrap();
+        let settings_file = db.get_or_create_file(&settings_path);
+        fs.lock().unwrap().add_file(
+            settings_path,
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'builtins': []}}]\n".to_string(),
+        );
+        db.bump_file_revision(settings_file);
 
-        let response = djls_semantic::TemplateLibrarySnapshot {
-            symbols: Vec::new(),
-            libraries: BTreeMap::new(),
-            builtins: Vec::new(),
-        };
-
-        let new_libraries = TemplateLibraries::default().apply_active_snapshot(Some(response));
-
-        project.set_template_libraries(&mut db).to(new_libraries);
-
-        // Access again. The templatetag module projection depends on template
-        // libraries, but `compute_tag_specs` can stay green when the projected
-        // module list backdates to the same value.
         let _specs = db.tag_specs();
         let events = event_log.take();
         assert!(
-            was_executed(&db, &events, "templatetag_modules"),
-            "templatetag_modules should re-execute after template_libraries change"
+            was_executed(&db, &events, "template_libraries"),
+            "template_libraries should re-execute after the settings source changes"
         );
         assert!(
-            !was_executed(&db, &events, "compute_tag_specs"),
-            "compute_tag_specs should stay cached when search-path module projection is unchanged"
+            was_executed(&db, &events, "templatetag_modules"),
+            "templatetag_modules should re-execute after derived libraries change"
         );
     }
 
@@ -779,39 +808,197 @@ def my_filter(value, arg):
     }
 
     #[test]
-    fn discovered_template_libraries_stored_on_project() {
-        let (db, _event_log) = test_db_with_project();
+    fn refresh_external_data_reads_changed_star_imported_settings_source_for_template_libraries() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "django_settings_module = \"settings\"\n",
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        let settings_path = root.join("settings.py");
+        let base_settings_path = root.join("base.py");
 
-        let project = db.project.unwrap();
-        assert!(
-            project.template_libraries(&db).loadable.is_empty(),
-            "template libraries should initially be empty"
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(root.join("manage.py"), String::new());
+            fs.add_file(settings_path, "from .base import *\n".to_string());
+            fs.add_file(
+                base_settings_path.clone(),
+                "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'old_tags'}}}]\n".to_string(),
+            );
+            fs.add_file(
+                root.join("old_tags.py"),
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef old_tag():\n    pass\n".to_string(),
+            );
+            fs.add_file(
+                root.join("new_tags.py"),
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef new_tag():\n    pass\n".to_string(),
+            );
+        }
+
+        let mut db = DjangoDatabase {
+            fs: fs.clone(),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            project_introspector: Arc::new(djls_semantic::ProjectIntrospector::new()),
+            storage: salsa::Storage::default(),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
+
+        assert_eq!(
+            db.template_libraries()
+                .best_loadable_library_str("custom")
+                .unwrap()
+                .module()
+                .as_str(),
+            "old_tags"
+        );
+
+        fs.lock().unwrap().add_file(
+            base_settings_path,
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'new_tags'}}}]\n".to_string(),
+        );
+        djls_semantic::refresh_external_data(&mut db);
+
+        assert_eq!(
+            db.template_libraries()
+                .best_loadable_library_str("custom")
+                .unwrap()
+                .module()
+                .as_str(),
+            "new_tags"
         );
     }
 
     #[test]
-    fn template_libraries_same_value_no_invalidation() {
-        let (mut db, event_log) = test_db_with_project();
+    fn semantic_db_template_libraries_returns_derived_app_libraries() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "django_settings_module = \"settings\"\n",
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
 
-        // Prime tag_specs cache
-        let _specs = db.tag_specs();
-        event_log.take();
+        let mut fs = InMemoryFileSystem::new();
+        fs.add_file(root.join("manage.py"), String::new());
+        fs.add_file(
+            root.join("settings.py"),
+            "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n".to_string(),
+        );
+        fs.add_file(root.join("blog/templatetags/__init__.py"), String::new());
+        fs.add_file(
+            root.join("blog/templatetags/custom.py"),
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef hello():\n    pass\n".to_string(),
+        );
 
-        let project = db.project.unwrap();
+        let mut db = DjangoDatabase {
+            fs: Arc::new(fs),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            project_introspector: Arc::new(djls_semantic::ProjectIntrospector::new()),
+            storage: salsa::Storage::default(),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
 
-        // Setting the same value should not trigger invalidation.
-        // (manual comparison prevents setter call)
-        let current = project.template_libraries(&db).clone();
-        if project.template_libraries(&db) != &current {
-            project.set_template_libraries(&mut db).to(current);
+        let libraries = db.template_libraries();
+        let custom = libraries
+            .best_loadable_library_str("custom")
+            .expect("custom library should be derived");
+        assert_eq!(custom.module().as_str(), "blog.templatetags.custom");
+        assert!(custom.symbols.iter().any(|symbol| symbol.name() == "hello"));
+    }
+
+    #[test]
+    fn templatetag_source_change_invalidates_template_libraries() {
+        let event_log = EventLog::default();
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "django_settings_module = \"settings\"\n",
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        let tag_path = root.join("blog/templatetags/custom.py");
+
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(root.join("manage.py"), String::new());
+            fs.add_file(
+                root.join("settings.py"),
+                "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n".to_string(),
+            );
+            fs.add_file(root.join("blog/templatetags/__init__.py"), String::new());
+            fs.add_file(
+                tag_path.clone(),
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef old_tag():\n    pass\n".to_string(),
+            );
         }
 
-        // tag_specs should NOT re-execute
-        let _specs = db.tag_specs();
+        let mut db = DjangoDatabase {
+            fs: fs.clone(),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            project_introspector: Arc::new(djls_semantic::ProjectIntrospector::new()),
+            storage: salsa::Storage::new(Some(Box::new({
+                let log = event_log.clone();
+                move |event| {
+                    log.events.lock().unwrap().push(event);
+                }
+            }))),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
+
+        let libraries = db.template_libraries();
+        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        assert!(
+            custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "old_tag")
+        );
+        event_log.take();
+
+        let tag_file = db.get_or_create_file(&tag_path);
+        fs.lock().unwrap().add_file(
+            tag_path,
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef new_tag():\n    pass\n".to_string(),
+        );
+        db.bump_file_revision(tag_file);
+
+        let libraries = db.template_libraries();
+        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        assert!(
+            custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "new_tag")
+        );
+        assert!(
+            !custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "old_tag")
+        );
         let events = event_log.take();
         assert!(
-            !was_executed(&db, &events, "compute_tag_specs"),
-            "compute_tag_specs should not re-execute when template_libraries unchanged"
+            was_executed(&db, &events, "template_libraries"),
+            "template_libraries should re-execute after a templatetag source change"
         );
     }
 

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -408,7 +408,7 @@ pub fn completion(
     let context = CompletionOffsetContext::new(*source.kind(), source.as_str(), tokens, offset);
     let template_libraries = db.template_libraries();
 
-    let available_symbols = if template_libraries.active_knowledge == StaticKnowledge::Known {
+    let available_symbols = if template_libraries.knowledge == StaticKnowledge::Known {
         match &context {
             CompletionOffsetContext::Template(
                 TemplateCompletionContext::TagName { .. }
@@ -503,7 +503,7 @@ fn generate_tag_name_candidates(
 ) -> Vec<CompletionCandidate> {
     let mut candidates = Vec::new();
 
-    if template_libraries.active_knowledge != StaticKnowledge::Known {
+    if template_libraries.knowledge != StaticKnowledge::Known {
         return candidates;
     }
 
@@ -647,7 +647,7 @@ fn generate_load_symbol_candidates(
     needs_trailing_space: bool,
     template_libraries: &TemplateLibraries,
 ) -> Vec<CompletionCandidate> {
-    if template_libraries.active_knowledge != StaticKnowledge::Known {
+    if template_libraries.knowledge != StaticKnowledge::Known {
         return Vec::new();
     }
 
@@ -677,7 +677,7 @@ fn generate_filter_candidates(
     template_libraries: &TemplateLibraries,
     available_symbols: Option<&AvailableSymbols>,
 ) -> Vec<CompletionCandidate> {
-    if template_libraries.active_knowledge == StaticKnowledge::Known {
+    if template_libraries.knowledge == StaticKnowledge::Known {
         let mut candidates = Vec::new();
 
         for candidate in template_libraries.installed_symbol_candidates(TemplateSymbolKind::Filter)
@@ -757,7 +757,7 @@ mod tests {
         }
 
         TemplateLibraries {
-            active_knowledge: StaticKnowledge::Known,
+            knowledge: StaticKnowledge::Known,
             loadable,
             builtins: BTreeMap::new(),
             builtin_order: Vec::new(),
@@ -790,7 +790,7 @@ mod tests {
         ));
 
         TemplateLibraries {
-            active_knowledge: StaticKnowledge::Known,
+            knowledge: StaticKnowledge::Known,
             loadable: BTreeMap::from([(library_name, vec![library])]),
             builtins: BTreeMap::new(),
             builtin_order: Vec::new(),
@@ -827,7 +827,7 @@ mod tests {
         ));
 
         TemplateLibraries {
-            active_knowledge: StaticKnowledge::Known,
+            knowledge: StaticKnowledge::Known,
             loadable: BTreeMap::from([(i18n_name, vec![i18n])]),
             builtins: BTreeMap::from([(builtin_module.clone(), builtin)]),
             builtin_order: vec![builtin_module],

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -759,8 +759,7 @@ mod tests {
         TemplateLibraries {
             knowledge: StaticKnowledge::Known,
             loadable,
-            builtins: BTreeMap::new(),
-            builtin_order: Vec::new(),
+            builtins: Vec::new(),
         }
     }
 
@@ -792,8 +791,7 @@ mod tests {
         TemplateLibraries {
             knowledge: StaticKnowledge::Known,
             loadable: BTreeMap::from([(library_name, vec![library])]),
-            builtins: BTreeMap::new(),
-            builtin_order: Vec::new(),
+            builtins: Vec::new(),
         }
     }
 
@@ -829,8 +827,7 @@ mod tests {
         TemplateLibraries {
             knowledge: StaticKnowledge::Known,
             loadable: BTreeMap::from([(i18n_name, vec![i18n])]),
-            builtins: BTreeMap::from([(builtin_module.clone(), builtin)]),
-            builtin_order: vec![builtin_module],
+            builtins: vec![builtin],
         }
     }
 

--- a/crates/djls-project/src/extraction/settings.rs
+++ b/crates/djls-project/src/extraction/settings.rs
@@ -4,12 +4,31 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use rustc_hash::FxHashMap;
 
+const DJANGO_TEMPLATES_BACKEND: &str = "django.template.backends.django.DjangoTemplates";
+
 /// How much to trust an extracted value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum StaticKnowledge {
     Known,
     Partial,
     Unknown,
+}
+
+impl StaticKnowledge {
+    #[must_use]
+    pub fn weakened_by(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
+            (Self::Partial, _) | (_, Self::Partial) => Self::Partial,
+            (Self::Known, Self::Known) => Self::Known,
+        }
+    }
+
+    pub fn demote_to_partial(&mut self) {
+        if *self == Self::Known {
+            *self = Self::Partial;
+        }
+    }
 }
 
 /// Why an extracted value is [`StaticKnowledge::Partial`] or [`StaticKnowledge::Unknown`].
@@ -156,6 +175,15 @@ impl Default for TemplateBackend {
 }
 
 impl TemplateBackend {
+    #[must_use]
+    pub fn is_django_templates_backend(&self, backend_count: usize) -> bool {
+        match self.backend.as_deref() {
+            Some(DJANGO_TEMPLATES_BACKEND) => true,
+            None if backend_count == 1 => true,
+            _ => false,
+        }
+    }
+
     pub(crate) fn make_partial(&mut self, reason: Reason) {
         if self.knowledge != StaticKnowledge::Unknown || self.reasons.is_empty() {
             self.knowledge = StaticKnowledge::Partial;

--- a/crates/djls-project/src/extraction/settings.rs
+++ b/crates/djls-project/src/extraction/settings.rs
@@ -24,9 +24,11 @@ impl StaticKnowledge {
         }
     }
 
-    pub fn demote_to_partial(&mut self) {
-        if *self == Self::Known {
-            *self = Self::Partial;
+    #[must_use]
+    pub fn demoted_to_partial(self) -> Self {
+        match self {
+            Self::Known | Self::Partial => Self::Partial,
+            Self::Unknown => Self::Unknown,
         }
     }
 }

--- a/crates/djls-semantic/Cargo.toml
+++ b/crates/djls-semantic/Cargo.toml
@@ -18,7 +18,6 @@ rustc-hash = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -216,7 +216,7 @@ mod tests {
 
     fn partial_db() -> TestDatabase {
         let mut libraries = standard_inventory();
-        libraries.active_knowledge = StaticKnowledge::Partial;
+        libraries.knowledge = StaticKnowledge::Partial;
         TestDatabase::new()
             .with_template_libraries(libraries)
             .with_arity_specs(standard_arities())
@@ -235,7 +235,7 @@ mod tests {
         ]);
         let builtins = vec![default_builtins_module().to_string()];
         let mut libraries = make_template_libraries(&tags, &filters, &libraries, &builtins);
-        libraries.active_knowledge = StaticKnowledge::Partial;
+        libraries.knowledge = StaticKnowledge::Partial;
         TestDatabase::new().with_template_libraries(libraries)
     }
 

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -33,15 +33,13 @@ pub use project::StaticKnowledge;
 pub use project::SymbolDefinition;
 pub use project::TemplateLibraries;
 pub use project::TemplateLibrary;
-pub use project::TemplateLibrarySnapshot;
 pub use project::TemplateSymbol;
 pub use project::TemplateSymbolKind;
 pub use project::TemplateSymbolName;
-pub use project::TemplateSymbolSnapshot;
 pub use project::load_env_file;
-pub use project::load_template_library_cache;
 pub use project::refresh_external_data;
 pub use project::template_dirs;
+pub use project::template_libraries;
 pub use python::ExtractionResult;
 pub use python::FilterArity;
 pub use python::ModelGraph;
@@ -122,6 +120,7 @@ mod tests {
     use camino::Utf8PathBuf;
 
     use crate::FilterArity;
+    use crate::StaticKnowledge;
     use crate::SymbolKey;
     use crate::TemplateLibraries;
     use crate::ValidationError;
@@ -215,8 +214,150 @@ mod tests {
             .with_arity_specs(standard_arities())
     }
 
+    fn partial_db() -> TestDatabase {
+        let mut libraries = standard_inventory();
+        libraries.active_knowledge = StaticKnowledge::Partial;
+        TestDatabase::new()
+            .with_template_libraries(libraries)
+            .with_arity_specs(standard_arities())
+    }
+
+    fn partial_ambiguous_db() -> TestDatabase {
+        let tags = vec![
+            builtin_tag_json("load", default_builtins_module()),
+            library_tag_json("shared", "alpha", "project.alpha_tags"),
+            library_tag_json("shared", "beta", "project.beta_tags"),
+        ];
+        let filters = Vec::new();
+        let libraries = HashMap::from([
+            ("alpha".to_string(), "project.alpha_tags".to_string()),
+            ("beta".to_string(), "project.beta_tags".to_string()),
+        ]);
+        let builtins = vec![default_builtins_module().to_string()];
+        let mut libraries = make_template_libraries(&tags, &filters, &libraries, &builtins);
+        libraries.active_knowledge = StaticKnowledge::Partial;
+        TestDatabase::new().with_template_libraries(libraries)
+    }
+
     fn collect_all_errors(db: &TestDatabase, source: &str) -> Vec<ValidationError> {
         collect_errors(db, "test.html", source)
+    }
+
+    #[test]
+    fn partial_knowledge_suppresses_unknown_tag() {
+        let db = partial_db();
+        let errors = collect_all_errors(&db, "{% definitely_unknown %}\n");
+
+        assert!(
+            !errors
+                .iter()
+                .any(|error| matches!(error, ValidationError::UnknownTag { .. })),
+            "unknown tags should be suppressed under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_keeps_unloaded_tag() {
+        let db = partial_db();
+        let errors = collect_all_errors(&db, "{% trans \"hello\" %}\n");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UnloadedTag { tag, library, .. }
+                    if tag == "trans" && library == "i18n"
+            )),
+            "known unloaded tags should still be reported under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_keeps_ambiguous_unloaded_tag() {
+        let db = partial_ambiguous_db();
+        let errors = collect_all_errors(&db, "{% shared %}\n");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::AmbiguousUnloadedTag { tag, libraries, .. }
+                    if tag == "shared" && libraries == &vec!["alpha".to_string(), "beta".to_string()]
+            )),
+            "known ambiguous unloaded tags should still be reported under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_suppresses_unknown_load_library() {
+        let db = partial_db();
+        let errors = collect_all_errors(&db, "{% load missing_library %}\n");
+
+        assert!(
+            !errors
+                .iter()
+                .any(|error| matches!(error, ValidationError::UnknownLibrary { .. })),
+            "unknown load libraries should be suppressed under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_suppresses_unknown_filter() {
+        let db = partial_db();
+        let errors = collect_all_errors(&db, "{{ value|definitely_unknown }}\n");
+
+        assert!(
+            !errors
+                .iter()
+                .any(|error| matches!(error, ValidationError::UnknownFilter { .. })),
+            "unknown filters should be suppressed under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_keeps_known_filter_arity() {
+        let db = partial_db();
+        let errors = collect_all_errors(&db, "{{ value|truncatewords }}\n");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::FilterMissingArgument { filter, .. } if filter == "truncatewords"
+            )),
+            "known filter arity diagnostics should still be reported under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_suppresses_filter_arity_after_unknown_load() {
+        let db = partial_db();
+        let errors = collect_all_errors(
+            &db,
+            "{% load project_filters %}\n{{ value|truncatewords }}\n",
+        );
+
+        assert!(
+            !errors.iter().any(|error| matches!(
+                error,
+                ValidationError::FilterMissingArgument { filter, .. } if filter == "truncatewords"
+            )),
+            "unknown loaded libraries may shadow known filters under partial knowledge: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn partial_knowledge_keeps_filter_arity_after_unrelated_unknown_selective_load() {
+        let db = partial_db();
+        let errors = collect_all_errors(
+            &db,
+            "{% load other_filter from project_filters %}\n{{ value|truncatewords }}\n",
+        );
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ValidationError::FilterMissingArgument { filter, .. } if filter == "truncatewords"
+            )),
+            "unknown selective loads should only shadow named filters: {errors:?}"
+        );
     }
 
     // Integration: Mixed diagnostics

--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -1,5 +1,6 @@
 mod db;
 mod input;
+#[allow(dead_code)]
 mod introspector;
 mod names;
 mod python;
@@ -23,16 +24,14 @@ pub use crate::project::python::Interpreter;
 pub(crate) use crate::project::resolve::model_modules;
 pub(crate) use crate::project::resolve::templatetag_modules;
 pub use crate::project::settings::template_dirs;
+pub use crate::project::settings::template_libraries;
 pub use crate::project::symbols::InstalledSymbolCandidate;
 pub use crate::project::symbols::InstalledSymbolOrigin;
 pub use crate::project::symbols::LibraryOrigin;
 pub use crate::project::symbols::SymbolDefinition;
 pub use crate::project::symbols::TemplateLibraries;
 pub use crate::project::symbols::TemplateLibrary;
-pub use crate::project::symbols::TemplateLibrarySnapshot;
 pub use crate::project::symbols::TemplateSymbol;
 pub use crate::project::symbols::TemplateSymbolKind;
-pub use crate::project::symbols::TemplateSymbolSnapshot;
-pub use crate::project::sync::load_template_library_cache;
 pub use crate::project::sync::refresh_external_data;
 pub(crate) use crate::project::templates::project_template_files;

--- a/crates/djls-semantic/src/project/input.rs
+++ b/crates/djls-semantic/src/project/input.rs
@@ -101,6 +101,19 @@ impl Project {
         }
     }
 
+    pub(crate) fn touch_search_path_roots(self, db: &dyn ProjectDb) {
+        for search_path in self.search_paths(db).iter() {
+            if let Some(root) = db.files().root(db, search_path.path()) {
+                let _ = root.revision(db);
+            } else {
+                tracing::warn!(
+                    "Search path has no registered source root: {}",
+                    search_path.path()
+                );
+            }
+        }
+    }
+
     pub fn bootstrap(db: &dyn ProjectDb, root: &Utf8Path, settings: &Settings) -> Project {
         let interpreter = Interpreter::discover(settings.venv_path());
         let resolved_django_settings_module =

--- a/crates/djls-semantic/src/project/input.rs
+++ b/crates/djls-semantic/src/project/input.rs
@@ -12,7 +12,6 @@ use salsa::Setter;
 use crate::project::db::Db as ProjectDb;
 use crate::project::python::Interpreter;
 use crate::project::resolve::SearchPaths;
-use crate::project::symbols::TemplateLibraries;
 use crate::python::ModulePath;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -86,14 +85,6 @@ pub struct Project {
     /// Manual TagSpecs configuration from TOML (fallback for extraction gaps)
     #[returns(ref)]
     pub tagspecs: TagSpecDef,
-    /// Template libraries and symbols for this project.
-    ///
-    /// This value always exists to support progressive enhancement:
-    /// - Installed libraries/symbols are populated by project introspection.
-    ///
-    /// The semantic layer combines this with `{% load %}` scope computed from templates.
-    #[returns(ref)]
-    pub template_libraries: TemplateLibraries,
 }
 
 impl Project {
@@ -132,7 +123,6 @@ impl Project {
             settings.pythonpath().to_vec(),
             env_vars,
             settings.tagspecs().clone(),
-            TemplateLibraries::default(),
         )
         .durability(Durability::MEDIUM)
         .root_durability(Durability::HIGH)

--- a/crates/djls-semantic/src/project/resolve.rs
+++ b/crates/djls-semantic/src/project/resolve.rs
@@ -240,8 +240,7 @@ pub(crate) fn templatetag_modules(db: &dyn ProjectDb, project: Project) -> Vec<P
 
     let mut modules = Vec::new();
 
-    for (module_index, module_path) in project
-        .template_libraries(db)
+    for (module_index, module_path) in crate::project::template_libraries(db, project)
         .registration_modules()
         .into_iter()
         .enumerate()
@@ -359,39 +358,57 @@ fn discover_model_files_excluding(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use djls_source::Db as _;
     use djls_source::InMemoryFileSystem;
 
     use super::*;
     use crate::compute_filter_arity_specs;
-    use crate::project::TemplateLibraries;
-    use crate::project::TemplateLibrarySnapshot;
     use crate::project::refresh_external_data;
     use crate::python::compute_model_graph;
     use crate::testing::ProjectFixture;
     use crate::testing::TestDatabase;
 
-    fn template_libraries_for_module(module: &str) -> TemplateLibraries {
-        TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
-            symbols: Vec::new(),
-            libraries: BTreeMap::new(),
-            builtins: vec![module.to_string()],
-        }))
-    }
-
     fn project_for_search_paths(
         db: &mut TestDatabase,
         root: &str,
         search_paths: SearchPaths,
-        template_libraries: TemplateLibraries,
     ) -> Project {
         ProjectFixture::new(root)
             .search_paths(search_paths)
             .register_roots(false)
-            .template_libraries(template_libraries)
             .build(db)
+    }
+
+    fn project_with_template_settings(
+        db: &mut TestDatabase,
+        root: &str,
+        search_paths: SearchPaths,
+        settings_source: impl Into<String>,
+    ) -> Project {
+        ProjectFixture::new(root)
+            .search_paths(search_paths)
+            .register_roots(false)
+            .django_settings_module("settings")
+            .file(format!("{root}/settings.py"), settings_source)
+            .build(db)
+    }
+
+    fn django_template_settings(installed_apps: &[&str], builtins: &[&str]) -> String {
+        let installed_apps = installed_apps
+            .iter()
+            .map(|app| format!("'{app}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let builtins = builtins
+            .iter()
+            .map(|module| format!("'{module}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "INSTALLED_APPS = [{installed_apps}]\n\
+             TEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', \
+             'DIRS': [], 'APP_DIRS': True, 'OPTIONS': {{'builtins': [{builtins}]}}}}]\n"
+        )
     }
 
     #[test]
@@ -483,12 +500,7 @@ mod tests {
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
 
         let modules = model_modules(&db, project);
         assert!(
@@ -550,12 +562,7 @@ mod tests {
             &Interpreter::Auto,
             &pythonpath,
         );
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
 
         let modules = model_modules(&db, project);
         assert!(
@@ -568,9 +575,10 @@ mod tests {
     #[test]
     fn templatetag_modules_tolerate_unregistered_search_paths() {
         let mut db = TestDatabase::new();
+        db.add_file("/project/django/templatetags/__init__.py", "");
         db.add_file(
             "/project/django/templatetags/i18n.py",
-            "from django import template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef trans():\n    pass\n",
         );
 
         let search_paths = SearchPaths::from_project_settings(
@@ -579,11 +587,11 @@ mod tests {
             &Interpreter::Auto,
             &[],
         );
-        let project = project_for_search_paths(
+        let project = project_with_template_settings(
             &mut db,
             "/project",
             search_paths,
-            template_libraries_for_module("django.templatetags.i18n"),
+            django_template_settings(&[], &[]),
         );
 
         let modules = templatetag_modules(&db, project);
@@ -598,8 +606,12 @@ mod tests {
     fn templatetag_resolution_uses_project_venv_site_packages_root() {
         let mut db = TestDatabase::new();
         db.add_file(
+            "/project/.venv/lib/python3.12/site-packages/django/templatetags/__init__.py",
+            "",
+        );
+        db.add_file(
             "/project/.venv/lib/python3.12/site-packages/django/templatetags/i18n.py",
-            "from django import template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef trans():\n    pass\n",
         );
 
         let search_paths = SearchPaths::from_project_settings(
@@ -609,11 +621,11 @@ mod tests {
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
+        let project = project_with_template_settings(
             &mut db,
             "/project",
             search_paths,
-            template_libraries_for_module("django.templatetags.i18n"),
+            django_template_settings(&[], &[]),
         );
 
         let modules = templatetag_modules(&db, project);
@@ -629,13 +641,18 @@ mod tests {
     #[test]
     fn templatetag_resolution_prefers_first_party_module_shadowing_dependency() {
         let mut db = TestDatabase::new();
+        db.add_file("/project/django/templatetags/__init__.py", "");
         db.add_file(
             "/project/django/templatetags/i18n.py",
-            "from django import template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef trans():\n    pass\n",
+        );
+        db.add_file(
+            "/project/.venv/lib/python3.12/site-packages/django/templatetags/__init__.py",
+            "",
         );
         db.add_file(
             "/project/.venv/lib/python3.12/site-packages/django/templatetags/i18n.py",
-            "from django import template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef trans():\n    pass\n",
         );
 
         let search_paths = SearchPaths::from_project_settings(
@@ -645,11 +662,11 @@ mod tests {
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
+        let project = project_with_template_settings(
             &mut db,
             "/project",
             search_paths,
-            template_libraries_for_module("django.templatetags.i18n"),
+            django_template_settings(&[], &[]),
         );
 
         let modules = templatetag_modules(&db, project);
@@ -665,11 +682,11 @@ mod tests {
         let mut db = TestDatabase::new();
         db.add_file(
             "/project/a/templatetags/tags.py",
-            "from django import template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef a_tag():\n    pass\n",
         );
         db.add_file(
             "/project/.venv/lib/python3.12/site-packages/z/templatetags/tags.py",
-            "from django import template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef z_tag():\n    pass\n",
         );
 
         let search_paths = SearchPaths::from_project_settings(
@@ -679,18 +696,11 @@ mod tests {
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
+        let project = project_with_template_settings(
             &mut db,
             "/project",
             search_paths,
-            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
-                symbols: Vec::new(),
-                libraries: BTreeMap::new(),
-                builtins: vec![
-                    "a.templatetags.tags".to_string(),
-                    "z.templatetags.tags".to_string(),
-                ],
-            })),
+            django_template_settings(&[], &["a.templatetags.tags", "z.templatetags.tags"]),
         );
 
         let modules = templatetag_modules(&db, project);
@@ -738,15 +748,11 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
+        let project = project_with_template_settings(
             &mut db,
             "/project",
             search_paths,
-            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
-                symbols: Vec::new(),
-                libraries: BTreeMap::new(),
-                builtins: vec!["z_first".to_string(), "a_second".to_string()],
-            })),
+            django_template_settings(&[], &["z_first", "a_second"]),
         );
 
         let specs = compute_filter_arity_specs(&db, project);
@@ -770,12 +776,7 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -808,12 +809,7 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -846,12 +842,7 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -889,12 +880,7 @@ def duplicate(value, arg):
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
 
         let graph = compute_model_graph(&db, project);
         let model = graph.get("Duplicate").expect("model should be discovered");
@@ -916,12 +902,7 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -958,12 +939,7 @@ def duplicate(value, arg):
             &[],
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
         db.set_project(project);
 
         let graph = compute_model_graph(&db, project);
@@ -994,12 +970,7 @@ def duplicate(value, arg):
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
 
         let graph = compute_model_graph(&db, project);
         assert!(graph.get("SharedArticle").is_some());
@@ -1277,12 +1248,7 @@ class Article(models.Model):
             &pythonpath,
         );
         search_paths.register_roots(&db);
-        let project = project_for_search_paths(
-            &mut db,
-            "/project",
-            search_paths,
-            TemplateLibraries::default(),
-        );
+        let project = project_for_search_paths(&mut db, "/project", search_paths);
 
         let modules = model_modules(&db, project);
         let module_paths: Vec<_> = modules

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -92,7 +92,7 @@ pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>,
         for dir in &backend.dirs {
             match dir {
                 TemplateDirPath::Resolved(path) => dirs.push(path.clone()),
-                TemplateDirPath::Unknown => knowledge.demote_to_partial(),
+                TemplateDirPath::Unknown => knowledge = knowledge.demoted_to_partial(),
             }
         }
 
@@ -100,7 +100,7 @@ pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>,
             knowledge = knowledge.weakened_by(settings.installed_apps.knowledge);
             for app in &settings.installed_apps.values {
                 let Some(app_dir) = resolver.package_dir(installed_app_package_module(app)) else {
-                    knowledge.demote_to_partial();
+                    knowledge = knowledge.demoted_to_partial();
                     continue;
                 };
 
@@ -135,7 +135,7 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     };
 
     if settings.templates.knowledge != StaticKnowledge::Known {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
     }
 
     scan_templatetags_package(&resolver, "django", &mut libraries);
@@ -180,17 +180,17 @@ fn scan_templatetags_package(
     libraries: &mut TemplateLibraries,
 ) {
     if package_module.is_empty() {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     }
 
     let Ok(app_module) = PyModuleName::parse(package_module) else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     };
 
     let Some(package_dir) = resolver.package_dir(package_module) else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     };
 
@@ -209,7 +209,7 @@ fn scan_templatetags_package(
         Ok(entries) => entries,
         Err(err) => {
             tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
-            libraries.knowledge.demote_to_partial();
+            libraries.knowledge = libraries.knowledge.demoted_to_partial();
             return;
         }
     };
@@ -227,12 +227,12 @@ fn scan_templatetags_package(
         }
 
         let Ok(load_name) = LibraryName::parse(stem) else {
-            libraries.knowledge.demote_to_partial();
+            libraries.knowledge = libraries.knowledge.demoted_to_partial();
             continue;
         };
         let module_path = format!("{package_module}.templatetags.{stem}");
         let Ok(module) = PyModuleName::parse(&module_path) else {
-            libraries.knowledge.demote_to_partial();
+            libraries.knowledge = libraries.knowledge.demoted_to_partial();
             continue;
         };
 
@@ -262,11 +262,11 @@ fn add_configured_library(
     module_path: &str,
 ) {
     let Ok(load_name) = LibraryName::parse(load_name) else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     };
     let Ok(module) = PyModuleName::parse(module_path) else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     };
 
@@ -274,7 +274,7 @@ fn add_configured_library(
     if let Some(file) = resolver.module_file(module.as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
     } else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
     }
     libraries
         .loadable
@@ -287,12 +287,12 @@ fn add_builtin_library(
     module_path: &str,
 ) {
     let Ok(module) = PyModuleName::parse(module_path) else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     };
     let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
     else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
         return;
     };
 
@@ -308,7 +308,7 @@ fn add_builtin_library(
     if let Some(file) = resolver.module_file(module.as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
     } else {
-        libraries.knowledge.demote_to_partial();
+        libraries.knowledge = libraries.knowledge.demoted_to_partial();
     }
 
     libraries.builtins.push(library);

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -26,6 +26,7 @@ use crate::project::names::PyModuleName;
 use crate::project::names::TemplateSymbolName;
 use crate::project::resolve::module_file_in_search_path;
 use crate::project::symbols::LibraryOrigin;
+use crate::project::symbols::LibraryStatus;
 use crate::project::symbols::SymbolDefinition;
 use crate::project::symbols::TemplateLibraries;
 use crate::project::symbols::TemplateLibrary;
@@ -138,18 +139,14 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         libraries.knowledge = libraries.knowledge.demoted_to_partial();
     }
 
-    let derived = templatetag_package_libraries(&resolver, "django");
-    libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
-    libraries.extend_loadable(derived.libraries);
+    libraries.apply_derived(templatetag_package_libraries(&resolver, "django"));
 
     if settings.installed_apps.knowledge != StaticKnowledge::Unknown {
         for installed_app in &settings.installed_apps.values {
-            let derived = templatetag_package_libraries(
+            libraries.apply_derived(templatetag_package_libraries(
                 &resolver,
                 installed_app_package_module(installed_app),
-            );
-            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
-            libraries.extend_loadable(derived.libraries);
+            ));
         }
     }
 
@@ -162,31 +159,36 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     {
         libraries.knowledge = libraries.knowledge.weakened_by(backend.knowledge);
 
-        for (load_name, module_path) in &backend.libraries {
-            let derived = configured_library(&resolver, load_name, module_path);
-            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
-            if let Some(library) = derived.library {
-                libraries.set_loadable(library);
+        let configured = backend.libraries.iter().map(|(load_name, module_path)| {
+            SettingsLibraryDeclaration::Loadable {
+                load_name,
+                module_path,
             }
-        }
+        });
+        let builtins = DEFAULT_TEMPLATE_BUILTINS
+            .iter()
+            .copied()
+            .chain(backend.builtins.iter().map(String::as_str))
+            .map(|module_path| SettingsLibraryDeclaration::Builtin { module_path });
 
-        for module_path in DEFAULT_TEMPLATE_BUILTINS {
-            let derived = builtin_library(&resolver, module_path);
-            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
-            if let Some(library) = derived.library {
-                libraries.push_builtin(library);
-            }
-        }
-        for module_path in &backend.builtins {
-            let derived = builtin_library(&resolver, module_path);
-            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
-            if let Some(library) = derived.library {
-                libraries.push_builtin(library);
-            }
+        for declaration in configured.chain(builtins) {
+            libraries.apply_derived(declaration.derive(&resolver));
         }
     }
 
     libraries
+}
+
+impl TemplateLibraries {
+    fn apply_derived(&mut self, derived: DerivedTemplateLibraries) {
+        self.knowledge = self.knowledge.weakened_by(derived.knowledge);
+        for library in derived.libraries {
+            match &library.status {
+                LibraryStatus::Active { .. } => self.set_loadable(library),
+                LibraryStatus::Builtin { .. } => self.push_builtin(library),
+            }
+        }
+    }
 }
 
 struct DerivedTemplateLibraries {
@@ -204,28 +206,44 @@ impl Default for DerivedTemplateLibraries {
 }
 
 impl DerivedTemplateLibraries {
-    fn demote_to_partial(&mut self) {
-        self.knowledge = self.knowledge.demoted_to_partial();
-    }
-}
-
-struct DerivedTemplateLibrary {
-    knowledge: StaticKnowledge,
-    library: Option<TemplateLibrary>,
-}
-
-impl DerivedTemplateLibrary {
     fn known(library: TemplateLibrary) -> Self {
         Self {
             knowledge: StaticKnowledge::Known,
-            library: Some(library),
+            libraries: vec![library],
         }
     }
 
     fn partial(library: Option<TemplateLibrary>) -> Self {
         Self {
             knowledge: StaticKnowledge::Partial,
-            library,
+            libraries: library.into_iter().collect(),
+        }
+    }
+
+    fn demote_to_partial(&mut self) {
+        self.knowledge = self.knowledge.demoted_to_partial();
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SettingsLibraryDeclaration<'a> {
+    Loadable {
+        load_name: &'a str,
+        module_path: &'a str,
+    },
+    Builtin {
+        module_path: &'a str,
+    },
+}
+
+impl SettingsLibraryDeclaration<'_> {
+    fn derive(self, resolver: &SalsaSettingsResolver<'_>) -> DerivedTemplateLibraries {
+        match self {
+            Self::Loadable {
+                load_name,
+                module_path,
+            } => configured_library(resolver, load_name, module_path),
+            Self::Builtin { module_path } => builtin_library(resolver, module_path),
         }
     }
 }
@@ -316,12 +334,12 @@ fn configured_library(
     resolver: &SalsaSettingsResolver<'_>,
     load_name: &str,
     module_path: &str,
-) -> DerivedTemplateLibrary {
+) -> DerivedTemplateLibraries {
     let Ok(load_name) = LibraryName::parse(load_name) else {
-        return DerivedTemplateLibrary::partial(None);
+        return DerivedTemplateLibraries::partial(None);
     };
     let Ok(module) = PyModuleName::parse(module_path) else {
-        return DerivedTemplateLibrary::partial(None);
+        return DerivedTemplateLibraries::partial(None);
     };
 
     library_with_symbols(
@@ -333,13 +351,13 @@ fn configured_library(
 fn builtin_library(
     resolver: &SalsaSettingsResolver<'_>,
     module_path: &str,
-) -> DerivedTemplateLibrary {
+) -> DerivedTemplateLibraries {
     let Ok(module) = PyModuleName::parse(module_path) else {
-        return DerivedTemplateLibrary::partial(None);
+        return DerivedTemplateLibraries::partial(None);
     };
     let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
     else {
-        return DerivedTemplateLibrary::partial(None);
+        return DerivedTemplateLibraries::partial(None);
     };
 
     library_with_symbols(resolver, TemplateLibrary::new_builtin(name, module))
@@ -348,12 +366,12 @@ fn builtin_library(
 fn library_with_symbols(
     resolver: &SalsaSettingsResolver<'_>,
     mut library: TemplateLibrary,
-) -> DerivedTemplateLibrary {
+) -> DerivedTemplateLibraries {
     if let Some(file) = resolver.module_file(library.module().as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
-        DerivedTemplateLibrary::known(library)
+        DerivedTemplateLibraries::known(library)
     } else {
-        DerivedTemplateLibrary::partial(Some(library))
+        DerivedTemplateLibraries::partial(Some(library))
     }
 }
 

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -138,15 +138,18 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         libraries.knowledge = libraries.knowledge.demoted_to_partial();
     }
 
-    scan_templatetags_package(&resolver, "django", &mut libraries);
+    let derived = templatetag_package_libraries(&resolver, "django");
+    libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
+    libraries.extend_loadable(derived.libraries);
 
     if settings.installed_apps.knowledge != StaticKnowledge::Unknown {
         for installed_app in &settings.installed_apps.values {
-            scan_templatetags_package(
+            let derived = templatetag_package_libraries(
                 &resolver,
                 installed_app_package_module(installed_app),
-                &mut libraries,
             );
+            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
+            libraries.extend_loadable(derived.libraries);
         }
     }
 
@@ -160,38 +163,92 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         libraries.knowledge = libraries.knowledge.weakened_by(backend.knowledge);
 
         for (load_name, module_path) in &backend.libraries {
-            add_configured_library(&resolver, &mut libraries, load_name, module_path);
+            let derived = configured_library(&resolver, load_name, module_path);
+            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
+            if let Some(library) = derived.library {
+                libraries.set_loadable(library);
+            }
         }
 
         for module_path in DEFAULT_TEMPLATE_BUILTINS {
-            add_builtin_library(&resolver, &mut libraries, module_path);
+            let derived = builtin_library(&resolver, module_path);
+            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
+            if let Some(library) = derived.library {
+                libraries.push_builtin(library);
+            }
         }
         for module_path in &backend.builtins {
-            add_builtin_library(&resolver, &mut libraries, module_path);
+            let derived = builtin_library(&resolver, module_path);
+            libraries.knowledge = libraries.knowledge.weakened_by(derived.knowledge);
+            if let Some(library) = derived.library {
+                libraries.push_builtin(library);
+            }
         }
     }
 
     libraries
 }
 
-fn scan_templatetags_package(
+struct DerivedTemplateLibraries {
+    knowledge: StaticKnowledge,
+    libraries: Vec<TemplateLibrary>,
+}
+
+impl Default for DerivedTemplateLibraries {
+    fn default() -> Self {
+        Self {
+            knowledge: StaticKnowledge::Known,
+            libraries: Vec::new(),
+        }
+    }
+}
+
+impl DerivedTemplateLibraries {
+    fn demote_to_partial(&mut self) {
+        self.knowledge = self.knowledge.demoted_to_partial();
+    }
+}
+
+struct DerivedTemplateLibrary {
+    knowledge: StaticKnowledge,
+    library: Option<TemplateLibrary>,
+}
+
+impl DerivedTemplateLibrary {
+    fn known(library: TemplateLibrary) -> Self {
+        Self {
+            knowledge: StaticKnowledge::Known,
+            library: Some(library),
+        }
+    }
+
+    fn partial(library: Option<TemplateLibrary>) -> Self {
+        Self {
+            knowledge: StaticKnowledge::Partial,
+            library,
+        }
+    }
+}
+
+fn templatetag_package_libraries(
     resolver: &SalsaSettingsResolver<'_>,
     package_module: &str,
-    libraries: &mut TemplateLibraries,
-) {
+) -> DerivedTemplateLibraries {
+    let mut derived = DerivedTemplateLibraries::default();
+
     if package_module.is_empty() {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        derived.demote_to_partial();
+        return derived;
     }
 
     let Ok(app_module) = PyModuleName::parse(package_module) else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        derived.demote_to_partial();
+        return derived;
     };
 
     let Some(package_dir) = resolver.package_dir(package_module) else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        derived.demote_to_partial();
+        return derived;
     };
 
     let templatetags_dir = package_dir.join("templatetags");
@@ -199,7 +256,7 @@ fn scan_templatetags_package(
         .db
         .path_is_file(&templatetags_dir.join("__init__.py"))
     {
-        return;
+        return derived;
     }
 
     let entries = match resolver
@@ -209,8 +266,8 @@ fn scan_templatetags_package(
         Ok(entries) => entries,
         Err(err) => {
             tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
-            libraries.knowledge = libraries.knowledge.demoted_to_partial();
-            return;
+            derived.demote_to_partial();
+            return derived;
         }
     };
 
@@ -227,12 +284,12 @@ fn scan_templatetags_package(
         }
 
         let Ok(load_name) = LibraryName::parse(stem) else {
-            libraries.knowledge = libraries.knowledge.demoted_to_partial();
+            derived.demote_to_partial();
             continue;
         };
         let module_path = format!("{package_module}.templatetags.{stem}");
         let Ok(module) = PyModuleName::parse(&module_path) else {
-            libraries.knowledge = libraries.knowledge.demoted_to_partial();
+            derived.demote_to_partial();
             continue;
         };
 
@@ -249,69 +306,55 @@ fn scan_templatetags_package(
         };
         let mut library = TemplateLibrary::new_active(load_name, module, Some(origin));
         library.merge_symbols(analysis.symbols);
-        libraries
-            .loadable
-            .insert(library.name.clone(), vec![library]);
+        derived.libraries.push(library);
     }
+
+    derived
 }
 
-fn add_configured_library(
+fn configured_library(
     resolver: &SalsaSettingsResolver<'_>,
-    libraries: &mut TemplateLibraries,
     load_name: &str,
     module_path: &str,
-) {
+) -> DerivedTemplateLibrary {
     let Ok(load_name) = LibraryName::parse(load_name) else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        return DerivedTemplateLibrary::partial(None);
     };
     let Ok(module) = PyModuleName::parse(module_path) else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        return DerivedTemplateLibrary::partial(None);
     };
 
-    let mut library = TemplateLibrary::new_active(load_name, module.clone(), None);
-    if let Some(file) = resolver.module_file(module.as_str()) {
-        library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
-    } else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-    }
-    libraries
-        .loadable
-        .insert(library.name.clone(), vec![library]);
+    library_with_symbols(
+        resolver,
+        TemplateLibrary::new_active(load_name, module, None),
+    )
 }
 
-fn add_builtin_library(
+fn builtin_library(
     resolver: &SalsaSettingsResolver<'_>,
-    libraries: &mut TemplateLibraries,
     module_path: &str,
-) {
+) -> DerivedTemplateLibrary {
     let Ok(module) = PyModuleName::parse(module_path) else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        return DerivedTemplateLibrary::partial(None);
     };
     let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
     else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
-        return;
+        return DerivedTemplateLibrary::partial(None);
     };
 
-    if libraries
-        .builtins
-        .iter()
-        .any(|library| library.module() == &module)
-    {
-        return;
-    }
+    library_with_symbols(resolver, TemplateLibrary::new_builtin(name, module))
+}
 
-    let mut library = TemplateLibrary::new_builtin(name, module.clone());
-    if let Some(file) = resolver.module_file(module.as_str()) {
+fn library_with_symbols(
+    resolver: &SalsaSettingsResolver<'_>,
+    mut library: TemplateLibrary,
+) -> DerivedTemplateLibrary {
+    if let Some(file) = resolver.module_file(library.module().as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
+        DerivedTemplateLibrary::known(library)
     } else {
-        libraries.knowledge = libraries.knowledge.demoted_to_partial();
+        DerivedTemplateLibrary::partial(Some(library))
     }
-
-    libraries.builtins.push(library);
 }
 
 struct TemplateLibraryAnalysis {

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -74,7 +74,7 @@ pub(super) fn settings_source_files(db: &dyn ProjectDb, project: Project) -> Vec
 #[salsa::tracked(returns(ref))]
 pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>, StaticKnowledge) {
     let resolver = SalsaSettingsResolver { db, project };
-    resolver.touch_search_path_roots();
+    project.touch_search_path_roots(db);
 
     let settings = django_settings(db, project);
     let mut dirs = Vec::new();
@@ -118,7 +118,7 @@ pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>,
 #[salsa::tracked(returns(ref))]
 pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibraries {
     let resolver = SalsaSettingsResolver { db, project };
-    resolver.touch_search_path_roots();
+    project.touch_search_path_roots(db);
 
     if settings_module_file(db, project).is_none() {
         return TemplateLibraries::default();
@@ -420,7 +420,7 @@ impl SalsaSettingsResolver<'_> {
     }
 
     fn module_file(&self, module_path: &str) -> Option<File> {
-        self.touch_search_path_roots();
+        self.project.touch_search_path_roots(self.db);
 
         for search_path in self.project.search_paths(self.db).iter() {
             let Some(path) =
@@ -448,19 +448,6 @@ impl SalsaSettingsResolver<'_> {
         }
 
         None
-    }
-
-    fn touch_search_path_roots(&self) {
-        for search_path in self.project.search_paths(self.db).iter() {
-            if let Some(root) = self.db.files().root(self.db, search_path.path()) {
-                let _ = root.revision(self.db);
-            } else {
-                tracing::warn!(
-                    "Search path has no registered source root: {}",
-                    search_path.path()
-                );
-            }
-        }
     }
 
     fn resolve_star_import_module(

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -49,36 +49,29 @@ pub(crate) fn settings_module_file(db: &dyn ProjectDb, project: Project) -> Opti
 }
 
 #[salsa::tracked(returns(ref))]
-pub(crate) fn django_settings_for_file(
-    db: &dyn ProjectDb,
-    file: File,
-    project: Project,
-) -> DjangoSettings {
+pub(crate) fn django_settings(db: &dyn ProjectDb, project: Project) -> DjangoSettings {
+    let Some(file) = settings_module_file(db, project) else {
+        return DjangoSettings::default();
+    };
+
     let source = file.source(db);
     let path = file.path(db);
     let mut resolver = SalsaSettingsSources { db, project };
     extract_settings(source.as_str(), path, &mut resolver)
 }
 
-#[salsa::tracked(returns(ref))]
-pub(crate) fn django_settings(db: &dyn ProjectDb, project: Project) -> DjangoSettings {
-    settings_module_file(db, project).map_or_else(DjangoSettings::default, |file| {
-        django_settings_for_file(db, file, project).clone()
-    })
-}
-
-pub(crate) fn settings_dependency_files(db: &dyn ProjectDb, project: Project) -> Vec<File> {
+pub(super) fn settings_source_files(db: &dyn ProjectDb, project: Project) -> Vec<File> {
     let Some(file) = settings_module_file(db, project) else {
         return Vec::new();
     };
 
     let mut seen = BTreeSet::new();
     let mut files = Vec::new();
-    collect_settings_dependency_files(db, project, file.path(db), &mut seen, &mut files);
+    collect_settings_source_files(db, project, file.path(db), &mut seen, &mut files);
     files
 }
 
-fn collect_settings_dependency_files(
+fn collect_settings_source_files(
     db: &dyn ProjectDb,
     project: Project,
     path: &Utf8Path,
@@ -116,7 +109,7 @@ fn collect_settings_dependency_files(
         let Some(file) = module_file_for_project(db, project, &module_path) else {
             continue;
         };
-        collect_settings_dependency_files(db, project, file.path(db), seen, files);
+        collect_settings_source_files(db, project, file.path(db), seen, files);
     }
 }
 
@@ -146,7 +139,9 @@ pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>,
         if backend.app_dirs == Some(true) {
             knowledge = weakest(knowledge, settings.installed_apps.knowledge);
             for app in &settings.installed_apps.values {
-                let Some(app_dir) = resolve_installed_app_dir(db, project, app) else {
+                let Some(app_dir) =
+                    resolve_package_dir(db, project, installed_app_package_module(app))
+                else {
                     demote_to_partial(&mut knowledge);
                     continue;
                 };
@@ -184,11 +179,16 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         demote_to_partial(&mut libraries.active_knowledge);
     }
 
-    scan_package_template_libraries(db, project, "django", &mut libraries);
+    scan_templatetags_package(db, project, "django", &mut libraries);
 
     if settings.installed_apps.knowledge != StaticKnowledge::Unknown {
         for installed_app in &settings.installed_apps.values {
-            scan_installed_app_template_libraries(db, project, installed_app, &mut libraries);
+            scan_templatetags_package(
+                db,
+                project,
+                installed_app_package_module(installed_app),
+                &mut libraries,
+            );
         }
     }
 
@@ -215,17 +215,7 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     libraries
 }
 
-fn scan_installed_app_template_libraries(
-    db: &dyn ProjectDb,
-    project: Project,
-    installed_app: &str,
-    libraries: &mut TemplateLibraries,
-) {
-    let module_path = installed_app_package_module(installed_app);
-    scan_package_template_libraries(db, project, module_path, libraries);
-}
-
-fn scan_package_template_libraries(
+fn scan_templatetags_package(
     db: &dyn ProjectDb,
     project: Project,
     package_module: &str,
@@ -241,7 +231,7 @@ fn scan_package_template_libraries(
         return;
     };
 
-    let Some(package_dir) = resolve_installed_app_dir(db, project, package_module) else {
+    let Some(package_dir) = resolve_package_dir(db, project, package_module) else {
         demote_to_partial(&mut libraries.active_knowledge);
         return;
     };
@@ -295,7 +285,9 @@ fn scan_package_template_libraries(
         };
         let mut library = TemplateLibrary::new_active(load_name, module, Some(origin));
         merge_symbols(&mut library, analysis.symbols);
-        set_loadable_library(libraries, library);
+        libraries
+            .loadable
+            .insert(library.name.clone(), vec![library]);
     }
 }
 
@@ -321,7 +313,9 @@ fn add_configured_library(
     } else {
         demote_to_partial(&mut libraries.active_knowledge);
     }
-    set_loadable_library(libraries, library);
+    libraries
+        .loadable
+        .insert(library.name.clone(), vec![library]);
 }
 
 fn add_builtin_library(
@@ -340,7 +334,9 @@ fn add_builtin_library(
         return;
     };
 
-    push_unique_module(&mut libraries.builtin_order, module.clone());
+    if !libraries.builtin_order.contains(&module) {
+        libraries.builtin_order.push(module.clone());
+    }
     let mut library = TemplateLibrary::new_builtin(name, module.clone());
     if let Some(file) = module_file_for_project(db, project, module.as_str()) {
         merge_symbols(
@@ -412,19 +408,15 @@ fn stmt_defines_template_library(stmt: &Stmt) -> bool {
     let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt else {
         return false;
     };
+    if !targets.iter().any(
+        |target| matches!(target, Expr::Name(ExprName { id, .. }) if id.as_str() == "register"),
+    ) {
+        return false;
+    }
 
-    targets.iter().any(is_register_name) && is_template_library_call(value)
-}
-
-fn is_register_name(expr: &Expr) -> bool {
-    matches!(expr, Expr::Name(ExprName { id, .. }) if id.as_str() == "register")
-}
-
-fn is_template_library_call(expr: &Expr) -> bool {
-    let Expr::Call(ExprCall { func, .. }) = expr else {
+    let Expr::Call(ExprCall { func, .. }) = value.as_ref() else {
         return false;
     };
-
     match func.as_ref() {
         Expr::Attribute(ExprAttribute { value, attr, .. }) => {
             attr.as_str() == "Library"
@@ -438,18 +430,6 @@ fn is_template_library_call(expr: &Expr) -> bool {
 fn merge_symbols(library: &mut TemplateLibrary, symbols: Vec<TemplateSymbol>) {
     for symbol in symbols {
         library.merge_symbol(symbol);
-    }
-}
-
-fn set_loadable_library(libraries: &mut TemplateLibraries, library: TemplateLibrary) {
-    libraries
-        .loadable
-        .insert(library.name.clone(), vec![library]);
-}
-
-fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
-    if !modules.contains(&module) {
-        modules.push(module);
     }
 }
 
@@ -587,17 +567,16 @@ fn is_django_templates_backend(backend: Option<&str>, backend_count: usize) -> b
     }
 }
 
-fn resolve_installed_app_dir(
+fn resolve_package_dir(
     db: &dyn ProjectDb,
     project: Project,
-    installed_app: &str,
+    package_module: &str,
 ) -> Option<Utf8PathBuf> {
-    let module = installed_app_package_module(installed_app);
-    if module.is_empty() {
+    if package_module.is_empty() {
         return None;
     }
 
-    let relative = module.replace('.', "/");
+    let relative = package_module.replace('.', "/");
     for search_path in project.search_paths(db).iter() {
         let candidate = search_path.path().join(&relative);
         if db.path_is_dir(&candidate) {

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -296,9 +296,14 @@ fn add_builtin_library(
         return;
     };
 
-    if !libraries.builtin_order.contains(&module) {
-        libraries.builtin_order.push(module.clone());
+    if libraries
+        .builtins
+        .iter()
+        .any(|library| library.module() == &module)
+    {
+        return;
     }
+
     let mut library = TemplateLibrary::new_builtin(name, module.clone());
     if let Some(file) = resolver.module_file(module.as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
@@ -306,7 +311,7 @@ fn add_builtin_library(
         libraries.knowledge.demote_to_partial();
     }
 
-    libraries.builtins.entry(module).or_insert(library);
+    libraries.builtins.push(library);
 }
 
 struct TemplateLibraryAnalysis {

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_project::DjangoSettings;
@@ -8,12 +10,37 @@ use djls_project::StaticKnowledge;
 use djls_project::TemplateDirPath;
 use djls_project::extract_settings;
 use djls_source::File;
+use djls_source::WalkEntryKind;
+use djls_source::WalkOptions;
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprAttribute;
+use ruff_python_ast::ExprCall;
+use ruff_python_ast::ExprName;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtAssign;
 
 use crate::project::db::Db as ProjectDb;
 use crate::project::input::Project;
+use crate::project::names::LibraryName;
+use crate::project::names::PyModuleName;
+use crate::project::names::TemplateSymbolName;
 use crate::project::resolve::module_file_in_search_path;
+use crate::project::symbols::LibraryOrigin;
+use crate::project::symbols::SymbolDefinition;
+use crate::project::symbols::TemplateLibraries;
+use crate::project::symbols::TemplateLibrary;
+use crate::project::symbols::TemplateSymbol;
+use crate::project::symbols::TemplateSymbolKind;
+use crate::python::SymbolKind;
+use crate::python::collect_registrations_from_body;
+use crate::python::parse_python_module;
 
 const DJANGO_TEMPLATES_BACKEND: &str = "django.template.backends.django.DjangoTemplates";
+const DEFAULT_TEMPLATE_BUILTINS: &[&str] = &[
+    "django.template.defaulttags",
+    "django.template.defaultfilters",
+    "django.template.loader_tags",
+];
 
 #[salsa::tracked]
 pub(crate) fn settings_module_file(db: &dyn ProjectDb, project: Project) -> Option<File> {
@@ -38,6 +65,59 @@ pub(crate) fn django_settings(db: &dyn ProjectDb, project: Project) -> DjangoSet
     settings_module_file(db, project).map_or_else(DjangoSettings::default, |file| {
         django_settings_for_file(db, file, project).clone()
     })
+}
+
+pub(crate) fn settings_dependency_files(db: &dyn ProjectDb, project: Project) -> Vec<File> {
+    let Some(file) = settings_module_file(db, project) else {
+        return Vec::new();
+    };
+
+    let mut seen = BTreeSet::new();
+    let mut files = Vec::new();
+    collect_settings_dependency_files(db, project, file.path(db), &mut seen, &mut files);
+    files
+}
+
+fn collect_settings_dependency_files(
+    db: &dyn ProjectDb,
+    project: Project,
+    path: &Utf8Path,
+    seen: &mut BTreeSet<Utf8PathBuf>,
+    files: &mut Vec<File>,
+) {
+    if !seen.insert(path.to_path_buf()) {
+        return;
+    }
+
+    files.push(db.get_or_create_file(path));
+
+    let Ok(source) = db.read_file(path) else {
+        return;
+    };
+    let Ok(parsed) = ruff_python_parser::parse_module(&source) else {
+        return;
+    };
+
+    for stmt in parsed.into_syntax().body {
+        let Stmt::ImportFrom(import) = stmt else {
+            continue;
+        };
+        if !import.names.iter().any(|alias| alias.name.as_str() == "*") {
+            continue;
+        }
+
+        let star_import = SettingsStarImport {
+            level: import.level,
+            module: import.module.map(|module| module.to_string()),
+        };
+        let Some(module_path) = resolve_star_import_module(db, project, path, &star_import) else {
+            continue;
+        };
+        let Some(file) = module_file_for_project(db, project, &module_path) else {
+            continue;
+        };
+        collect_settings_dependency_files(db, project, file.path(db), seen, files);
+    }
 }
 
 #[salsa::tracked(returns(ref))]
@@ -80,6 +160,297 @@ pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>,
     }
 
     (dirs, knowledge)
+}
+
+#[salsa::tracked(returns(ref))]
+pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibraries {
+    touch_search_path_roots(db, project);
+
+    if settings_module_file(db, project).is_none() {
+        return TemplateLibraries::default();
+    }
+
+    let settings = django_settings(db, project);
+
+    let mut libraries = TemplateLibraries {
+        active_knowledge: match settings.installed_apps.knowledge {
+            StaticKnowledge::Known => StaticKnowledge::Known,
+            StaticKnowledge::Partial | StaticKnowledge::Unknown => StaticKnowledge::Partial,
+        },
+        ..TemplateLibraries::default()
+    };
+
+    if settings.templates.knowledge != StaticKnowledge::Known {
+        demote_to_partial(&mut libraries.active_knowledge);
+    }
+
+    scan_package_template_libraries(db, project, "django", &mut libraries);
+
+    if settings.installed_apps.knowledge != StaticKnowledge::Unknown {
+        for installed_app in &settings.installed_apps.values {
+            scan_installed_app_template_libraries(db, project, installed_app, &mut libraries);
+        }
+    }
+
+    let backend_count = settings.templates.backends.len();
+    for backend in
+        settings.templates.backends.iter().filter(|backend| {
+            is_django_templates_backend(backend.backend.as_deref(), backend_count)
+        })
+    {
+        libraries.active_knowledge = weakest(libraries.active_knowledge, backend.knowledge);
+
+        for (load_name, module_path) in &backend.libraries {
+            add_configured_library(db, project, &mut libraries, load_name, module_path);
+        }
+
+        for module_path in DEFAULT_TEMPLATE_BUILTINS {
+            add_builtin_library(db, project, &mut libraries, module_path);
+        }
+        for module_path in &backend.builtins {
+            add_builtin_library(db, project, &mut libraries, module_path);
+        }
+    }
+
+    libraries
+}
+
+fn scan_installed_app_template_libraries(
+    db: &dyn ProjectDb,
+    project: Project,
+    installed_app: &str,
+    libraries: &mut TemplateLibraries,
+) {
+    let module_path = installed_app_package_module(installed_app);
+    scan_package_template_libraries(db, project, module_path, libraries);
+}
+
+fn scan_package_template_libraries(
+    db: &dyn ProjectDb,
+    project: Project,
+    package_module: &str,
+    libraries: &mut TemplateLibraries,
+) {
+    if package_module.is_empty() {
+        demote_to_partial(&mut libraries.active_knowledge);
+        return;
+    }
+
+    let Ok(app_module) = PyModuleName::parse(package_module) else {
+        demote_to_partial(&mut libraries.active_knowledge);
+        return;
+    };
+
+    let Some(package_dir) = resolve_installed_app_dir(db, project, package_module) else {
+        demote_to_partial(&mut libraries.active_knowledge);
+        return;
+    };
+
+    let templatetags_dir = package_dir.join("templatetags");
+    if !db.path_is_file(&templatetags_dir.join("__init__.py")) {
+        return;
+    }
+
+    let entries = match db.walk_entries(&templatetags_dir, &WalkOptions::shallow()) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
+            demote_to_partial(&mut libraries.active_knowledge);
+            return;
+        }
+    };
+
+    for entry in entries {
+        if entry.kind != WalkEntryKind::File || entry.path.extension() != Some("py") {
+            continue;
+        }
+
+        let Some(stem) = entry.path.file_stem() else {
+            continue;
+        };
+        if stem.starts_with('_') {
+            continue;
+        }
+
+        let Ok(load_name) = LibraryName::parse(stem) else {
+            demote_to_partial(&mut libraries.active_knowledge);
+            continue;
+        };
+        let module_path = format!("{package_module}.templatetags.{stem}");
+        let Ok(module) = PyModuleName::parse(&module_path) else {
+            demote_to_partial(&mut libraries.active_knowledge);
+            continue;
+        };
+
+        let file = db.get_or_create_file(&entry.path);
+        let analysis = analyze_template_library_file(db, file);
+        if !analysis.defines_library && analysis.symbols.is_empty() {
+            continue;
+        }
+
+        let origin = LibraryOrigin {
+            app: app_module.clone(),
+            module: module.clone(),
+            path: entry.path,
+        };
+        let mut library = TemplateLibrary::new_active(load_name, module, Some(origin));
+        merge_symbols(&mut library, analysis.symbols);
+        set_loadable_library(libraries, library);
+    }
+}
+
+fn add_configured_library(
+    db: &dyn ProjectDb,
+    project: Project,
+    libraries: &mut TemplateLibraries,
+    load_name: &str,
+    module_path: &str,
+) {
+    let Some((load_name, module)) =
+        parse_library_mapping(&mut libraries.active_knowledge, load_name, module_path)
+    else {
+        return;
+    };
+
+    let mut library = TemplateLibrary::new_active(load_name, module.clone(), None);
+    if let Some(file) = module_file_for_project(db, project, module.as_str()) {
+        merge_symbols(
+            &mut library,
+            analyze_template_library_file(db, file).symbols,
+        );
+    } else {
+        demote_to_partial(&mut libraries.active_knowledge);
+    }
+    set_loadable_library(libraries, library);
+}
+
+fn add_builtin_library(
+    db: &dyn ProjectDb,
+    project: Project,
+    libraries: &mut TemplateLibraries,
+    module_path: &str,
+) {
+    let Ok(module) = PyModuleName::parse(module_path) else {
+        demote_to_partial(&mut libraries.active_knowledge);
+        return;
+    };
+    let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
+    else {
+        demote_to_partial(&mut libraries.active_knowledge);
+        return;
+    };
+
+    push_unique_module(&mut libraries.builtin_order, module.clone());
+    let mut library = TemplateLibrary::new_builtin(name, module.clone());
+    if let Some(file) = module_file_for_project(db, project, module.as_str()) {
+        merge_symbols(
+            &mut library,
+            analyze_template_library_file(db, file).symbols,
+        );
+    } else {
+        demote_to_partial(&mut libraries.active_knowledge);
+    }
+
+    libraries.builtins.entry(module).or_insert(library);
+}
+
+fn parse_library_mapping(
+    knowledge: &mut StaticKnowledge,
+    load_name: &str,
+    module_path: &str,
+) -> Option<(LibraryName, PyModuleName)> {
+    let Ok(load_name) = LibraryName::parse(load_name) else {
+        demote_to_partial(knowledge);
+        return None;
+    };
+    let Ok(module) = PyModuleName::parse(module_path) else {
+        demote_to_partial(knowledge);
+        return None;
+    };
+    Some((load_name, module))
+}
+
+struct TemplateLibraryAnalysis {
+    defines_library: bool,
+    symbols: Vec<TemplateSymbol>,
+}
+
+fn analyze_template_library_file(db: &dyn ProjectDb, file: File) -> TemplateLibraryAnalysis {
+    let Some(parsed) = parse_python_module(db, file) else {
+        return TemplateLibraryAnalysis {
+            defines_library: false,
+            symbols: Vec::new(),
+        };
+    };
+
+    let mut symbols = Vec::new();
+    for registration in collect_registrations_from_body(parsed.body(db)) {
+        let Ok(name) = TemplateSymbolName::parse(&registration.name) else {
+            continue;
+        };
+        let kind = match registration.kind.symbol_kind() {
+            SymbolKind::Tag => TemplateSymbolKind::Tag,
+            SymbolKind::Filter => TemplateSymbolKind::Filter,
+        };
+        symbols.push(TemplateSymbol {
+            kind,
+            name,
+            definition: SymbolDefinition::Exact {
+                file: file.path(db).to_path_buf(),
+            },
+            doc: None,
+        });
+    }
+
+    TemplateLibraryAnalysis {
+        defines_library: parsed.body(db).iter().any(stmt_defines_template_library),
+        symbols,
+    }
+}
+
+fn stmt_defines_template_library(stmt: &Stmt) -> bool {
+    let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt else {
+        return false;
+    };
+
+    targets.iter().any(is_register_name) && is_template_library_call(value)
+}
+
+fn is_register_name(expr: &Expr) -> bool {
+    matches!(expr, Expr::Name(ExprName { id, .. }) if id.as_str() == "register")
+}
+
+fn is_template_library_call(expr: &Expr) -> bool {
+    let Expr::Call(ExprCall { func, .. }) = expr else {
+        return false;
+    };
+
+    match func.as_ref() {
+        Expr::Attribute(ExprAttribute { value, attr, .. }) => {
+            attr.as_str() == "Library"
+                && matches!(value.as_ref(), Expr::Name(ExprName { id, .. }) if id.as_str() == "template")
+        }
+        Expr::Name(ExprName { id, .. }) => id.as_str() == "Library",
+        _ => false,
+    }
+}
+
+fn merge_symbols(library: &mut TemplateLibrary, symbols: Vec<TemplateSymbol>) {
+    for symbol in symbols {
+        library.merge_symbol(symbol);
+    }
+}
+
+fn set_loadable_library(libraries: &mut TemplateLibraries, library: TemplateLibrary) {
+    libraries
+        .loadable
+        .insert(library.name.clone(), vec![library]);
+}
+
+fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
+    if !modules.contains(&module) {
+        modules.push(module);
+    }
 }
 
 struct SalsaSettingsSources<'db> {
@@ -265,6 +636,7 @@ fn demote_to_partial(knowledge: &mut StaticKnowledge) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -287,6 +659,23 @@ mod tests {
     #[derive(Deserialize)]
     struct DjangoFactsGolden {
         template_dirs: Vec<String>,
+        template_libraries: GoldenTemplateLibraries,
+    }
+
+    #[derive(Deserialize)]
+    struct GoldenTemplateLibraries {
+        builtins: Vec<String>,
+        libraries: BTreeMap<String, String>,
+        symbols: Vec<GoldenTemplateSymbol>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+    struct GoldenTemplateSymbol {
+        kind: TemplateSymbolKind,
+        name: String,
+        load_name: Option<String>,
+        library_module: String,
+        module: String,
     }
 
     #[salsa::db]
@@ -512,8 +901,263 @@ mod tests {
     }
 
     #[test]
+    fn template_libraries_discover_app_templatetags_and_builtins() {
+        let mut db = TestDatabase::new();
+        let project = project_with_settings(
+            &mut db,
+            "myproject.settings",
+            &[
+                (
+                    "/proj/django/template/defaulttags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef default_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/django/template/defaultfilters.py",
+                    "from django import template\nregister = template.Library()\n@register.filter\ndef default_filter(value):\n    return value\n",
+                ),
+                (
+                    "/proj/django/template/loader_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef loader_tag():\n    pass\n",
+                ),
+                ("/proj/blog/templatetags/__init__.py", ""),
+                (
+                    "/proj/blog/templatetags/custom.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef hello():\n    pass\n",
+                ),
+                (
+                    "/proj/myproject/settings.py",
+                    "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+                ),
+            ],
+        );
+
+        let libraries = template_libraries(&db, project);
+
+        assert_eq!(libraries.active_knowledge, StaticKnowledge::Known);
+        let custom = libraries
+            .best_loadable_library_str("custom")
+            .expect("custom library should be discovered");
+        assert_eq!(custom.module().as_str(), "blog.templatetags.custom");
+        assert!(custom.symbols.iter().any(|symbol| symbol.name() == "hello"));
+        assert_eq!(
+            libraries
+                .builtin_modules()
+                .map(PyModuleName::as_str)
+                .collect::<Vec<_>>(),
+            vec![
+                "django.template.defaulttags",
+                "django.template.defaultfilters",
+                "django.template.loader_tags",
+            ]
+        );
+    }
+
+    #[test]
+    fn template_libraries_include_empty_registered_modules() {
+        let mut db = TestDatabase::new();
+        let project = project_with_settings(
+            &mut db,
+            "myproject.settings",
+            &[
+                (
+                    "/proj/django/template/defaulttags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef default_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/django/template/defaultfilters.py",
+                    "from django import template\nregister = template.Library()\n@register.filter\ndef default_filter(value):\n    return value\n",
+                ),
+                (
+                    "/proj/django/template/loader_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef loader_tag():\n    pass\n",
+                ),
+                ("/proj/blog/templatetags/__init__.py", ""),
+                (
+                    "/proj/blog/templatetags/empty.py",
+                    "from django import template\nregister = template.Library()\n",
+                ),
+                (
+                    "/proj/myproject/settings.py",
+                    "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+                ),
+            ],
+        );
+
+        let libraries = template_libraries(&db, project);
+
+        let empty = libraries.best_loadable_library_str("empty").unwrap();
+        assert_eq!(empty.module().as_str(), "blog.templatetags.empty");
+        assert!(empty.symbols.is_empty());
+    }
+
+    #[test]
+    fn template_libraries_demote_unresolved_app_to_partial() {
+        let mut db = TestDatabase::new();
+        let project = project_with_settings(
+            &mut db,
+            "myproject.settings",
+            &[(
+                "/proj/myproject/settings.py",
+                "INSTALLED_APPS = ['missing']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+            )],
+        );
+
+        let libraries = template_libraries(&db, project);
+
+        assert_eq!(libraries.active_knowledge, StaticKnowledge::Partial);
+    }
+
+    #[test]
+    fn template_libraries_include_options_libraries_and_builtins() {
+        let mut db = TestDatabase::new();
+        let project = project_with_settings(
+            &mut db,
+            "myproject.settings",
+            &[
+                (
+                    "/proj/django/template/defaulttags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef default_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/django/template/defaultfilters.py",
+                    "from django import template\nregister = template.Library()\n@register.filter\ndef default_filter(value):\n    return value\n",
+                ),
+                (
+                    "/proj/django/template/loader_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef loader_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/custom_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef configured():\n    pass\n",
+                ),
+                (
+                    "/proj/custom_builtin.py",
+                    "from django import template\nregister = template.Library()\n@register.filter\ndef configured_filter(value):\n    return value\n",
+                ),
+                (
+                    "/proj/myproject/settings.py",
+                    "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}, 'builtins': ['custom_builtin']}}]\n",
+                ),
+            ],
+        );
+
+        let libraries = template_libraries(&db, project);
+
+        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        assert_eq!(custom.module().as_str(), "custom_tags");
+        assert!(
+            custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "configured")
+        );
+        assert!(
+            libraries
+                .builtin_libraries()
+                .flat_map(|library| &library.symbols)
+                .any(|symbol| symbol.name() == "configured_filter")
+        );
+    }
+
+    #[test]
+    fn template_libraries_keep_configured_libraries_when_installed_apps_unknown() {
+        let mut db = TestDatabase::new();
+        let project = project_with_settings(
+            &mut db,
+            "myproject.settings",
+            &[
+                (
+                    "/proj/django/template/defaulttags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef default_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/django/template/defaultfilters.py",
+                    "from django import template\nregister = template.Library()\n@register.filter\ndef default_filter(value):\n    return value\n",
+                ),
+                (
+                    "/proj/django/template/loader_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef loader_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/project_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef configured():\n    pass\n",
+                ),
+                (
+                    "/proj/myproject/settings.py",
+                    "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'project_tags'}}}]\n",
+                ),
+            ],
+        );
+
+        let libraries = template_libraries(&db, project);
+
+        assert_eq!(libraries.active_knowledge, StaticKnowledge::Partial);
+        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        assert_eq!(custom.module().as_str(), "project_tags");
+        assert!(
+            custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "configured")
+        );
+    }
+
+    #[test]
+    fn template_libraries_options_override_app_library_load_name() {
+        let mut db = TestDatabase::new();
+        let project = project_with_settings(
+            &mut db,
+            "myproject.settings",
+            &[
+                (
+                    "/proj/django/template/defaulttags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef default_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/django/template/defaultfilters.py",
+                    "from django import template\nregister = template.Library()\n@register.filter\ndef default_filter(value):\n    return value\n",
+                ),
+                (
+                    "/proj/django/template/loader_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef loader_tag():\n    pass\n",
+                ),
+                ("/proj/blog/templatetags/__init__.py", ""),
+                (
+                    "/proj/blog/templatetags/custom.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef old_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/project_tags.py",
+                    "from django import template\nregister = template.Library()\n@register.simple_tag\ndef new_tag():\n    pass\n",
+                ),
+                (
+                    "/proj/myproject/settings.py",
+                    "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True, 'OPTIONS': {'libraries': {'custom': 'project_tags'}}}]\n",
+                ),
+            ],
+        );
+
+        let libraries = template_libraries(&db, project);
+
+        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        assert_eq!(custom.module().as_str(), "project_tags");
+        assert!(
+            custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "new_tag")
+        );
+        assert!(
+            !custom
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name() == "old_tag")
+        );
+    }
+
+    #[test]
     #[ignore = "requires the e2e Django virtualenv with Django installed"]
-    fn template_dirs_match_django_facts_golden() {
+    fn django_facts_golden_template_dirs_match() {
         let Ok(venv) = std::env::var("VIRTUAL_ENV") else {
             eprintln!("skipping golden comparison because VIRTUAL_ENV is not set");
             return;
@@ -566,5 +1210,88 @@ mod tests {
             .collect();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[ignore = "requires the e2e Django virtualenv with Django installed"]
+    fn django_facts_golden_template_libraries_match() {
+        let Ok(venv) = std::env::var("VIRTUAL_ENV") else {
+            eprintln!("skipping golden comparison because VIRTUAL_ENV is not set");
+            return;
+        };
+        let _guard = sys_mock::MockGuard;
+        sys_mock::set_env_var("VIRTUAL_ENV", venv);
+
+        let workspace = Utf8PathBuf::from_path_buf(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .canonicalize()
+                .unwrap(),
+        )
+        .unwrap();
+        let project_root = workspace.join("tests/project");
+        let golden_path = workspace.join("tests/fixtures/django-facts/django-5.2.json");
+        let golden: DjangoFactsGolden =
+            serde_json::from_str(&std::fs::read_to_string(golden_path.as_std_path()).unwrap())
+                .unwrap();
+
+        let mut db = OsTestDatabase::new();
+        let settings = djls_conf::Settings::new(project_root.as_path(), None).unwrap();
+        let project = Project::bootstrap(&db, project_root.as_path(), &settings);
+        db.project = Some(project);
+
+        let libraries = template_libraries(&db, project);
+        let actual_builtins: Vec<_> = libraries
+            .builtin_modules()
+            .map(|module| module.as_str().to_string())
+            .collect();
+        assert_eq!(actual_builtins, golden.template_libraries.builtins);
+
+        let actual_libraries: BTreeMap<_, _> = libraries
+            .loadable_libraries()
+            .map(|(name, library)| {
+                (
+                    name.as_str().to_string(),
+                    library.module().as_str().to_string(),
+                )
+            })
+            .collect();
+        assert_eq!(actual_libraries, golden.template_libraries.libraries);
+
+        let mut actual_symbols = comparable_symbols(libraries);
+        let mut expected_symbols = golden.template_libraries.symbols;
+        actual_symbols.sort();
+        expected_symbols.sort();
+        assert_eq!(actual_symbols, expected_symbols);
+    }
+
+    fn comparable_symbols(libraries: &TemplateLibraries) -> Vec<GoldenTemplateSymbol> {
+        let mut symbols = Vec::new();
+
+        for library in libraries.builtin_libraries() {
+            for symbol in &library.symbols {
+                symbols.push(GoldenTemplateSymbol {
+                    kind: symbol.kind,
+                    name: symbol.name().to_string(),
+                    load_name: None,
+                    library_module: library.module().as_str().to_string(),
+                    module: library.module().as_str().to_string(),
+                });
+            }
+        }
+
+        for (load_name, library) in libraries.loadable_libraries() {
+            for symbol in &library.symbols {
+                symbols.push(GoldenTemplateSymbol {
+                    kind: symbol.kind,
+                    name: symbol.name().to_string(),
+                    load_name: Some(load_name.as_str().to_string()),
+                    library_module: library.module().as_str().to_string(),
+                    module: library.module().as_str().to_string(),
+                });
+            }
+        }
+
+        symbols
     }
 }

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -35,7 +35,6 @@ use crate::python::SymbolKind;
 use crate::python::collect_registrations_from_body;
 use crate::python::parse_python_module;
 
-const DJANGO_TEMPLATES_BACKEND: &str = "django.template.backends.django.DjangoTemplates";
 const DEFAULT_TEMPLATE_BUILTINS: &[&str] = &[
     "django.template.defaulttags",
     "django.template.defaultfilters",
@@ -45,7 +44,7 @@ const DEFAULT_TEMPLATE_BUILTINS: &[&str] = &[
 #[salsa::tracked]
 pub(crate) fn settings_module_file(db: &dyn ProjectDb, project: Project) -> Option<File> {
     let django_settings_module = project.django_settings_module(db).as_deref()?;
-    module_file_for_project(db, project, django_settings_module)
+    SalsaSettingsResolver { db, project }.module_file(django_settings_module)
 }
 
 #[salsa::tracked(returns(ref))]
@@ -56,7 +55,7 @@ pub(crate) fn django_settings(db: &dyn ProjectDb, project: Project) -> DjangoSet
 
     let source = file.source(db);
     let path = file.path(db);
-    let mut resolver = SalsaSettingsSources { db, project };
+    let mut resolver = SalsaSettingsResolver { db, project };
     extract_settings(source.as_str(), path, &mut resolver)
 }
 
@@ -65,84 +64,43 @@ pub(super) fn settings_source_files(db: &dyn ProjectDb, project: Project) -> Vec
         return Vec::new();
     };
 
+    let resolver = SalsaSettingsResolver { db, project };
     let mut seen = BTreeSet::new();
     let mut files = Vec::new();
-    collect_settings_source_files(db, project, file.path(db), &mut seen, &mut files);
+    resolver.collect_settings_source_files(file.path(db), &mut seen, &mut files);
     files
-}
-
-fn collect_settings_source_files(
-    db: &dyn ProjectDb,
-    project: Project,
-    path: &Utf8Path,
-    seen: &mut BTreeSet<Utf8PathBuf>,
-    files: &mut Vec<File>,
-) {
-    if !seen.insert(path.to_path_buf()) {
-        return;
-    }
-
-    files.push(db.get_or_create_file(path));
-
-    let Ok(source) = db.read_file(path) else {
-        return;
-    };
-    let Ok(parsed) = ruff_python_parser::parse_module(&source) else {
-        return;
-    };
-
-    for stmt in parsed.into_syntax().body {
-        let Stmt::ImportFrom(import) = stmt else {
-            continue;
-        };
-        if !import.names.iter().any(|alias| alias.name.as_str() == "*") {
-            continue;
-        }
-
-        let star_import = SettingsStarImport {
-            level: import.level,
-            module: import.module.map(|module| module.to_string()),
-        };
-        let Some(module_path) = resolve_star_import_module(db, project, path, &star_import) else {
-            continue;
-        };
-        let Some(file) = module_file_for_project(db, project, &module_path) else {
-            continue;
-        };
-        collect_settings_source_files(db, project, file.path(db), seen, files);
-    }
 }
 
 #[salsa::tracked(returns(ref))]
 pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>, StaticKnowledge) {
-    touch_search_path_roots(db, project);
+    let resolver = SalsaSettingsResolver { db, project };
+    resolver.touch_search_path_roots();
 
     let settings = django_settings(db, project);
     let mut dirs = Vec::new();
     let mut knowledge = settings.templates.knowledge;
     let backend_count = settings.templates.backends.len();
 
-    for backend in
-        settings.templates.backends.iter().filter(|backend| {
-            is_django_templates_backend(backend.backend.as_deref(), backend_count)
-        })
+    for backend in settings
+        .templates
+        .backends
+        .iter()
+        .filter(|backend| backend.is_django_templates_backend(backend_count))
     {
-        knowledge = weakest(knowledge, backend.knowledge);
+        knowledge = knowledge.weakened_by(backend.knowledge);
 
         for dir in &backend.dirs {
             match dir {
                 TemplateDirPath::Resolved(path) => dirs.push(path.clone()),
-                TemplateDirPath::Unknown => demote_to_partial(&mut knowledge),
+                TemplateDirPath::Unknown => knowledge.demote_to_partial(),
             }
         }
 
         if backend.app_dirs == Some(true) {
-            knowledge = weakest(knowledge, settings.installed_apps.knowledge);
+            knowledge = knowledge.weakened_by(settings.installed_apps.knowledge);
             for app in &settings.installed_apps.values {
-                let Some(app_dir) =
-                    resolve_package_dir(db, project, installed_app_package_module(app))
-                else {
-                    demote_to_partial(&mut knowledge);
+                let Some(app_dir) = resolver.package_dir(installed_app_package_module(app)) else {
+                    knowledge.demote_to_partial();
                     continue;
                 };
 
@@ -159,7 +117,8 @@ pub fn template_dirs(db: &dyn ProjectDb, project: Project) -> (Vec<Utf8PathBuf>,
 
 #[salsa::tracked(returns(ref))]
 pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibraries {
-    touch_search_path_roots(db, project);
+    let resolver = SalsaSettingsResolver { db, project };
+    resolver.touch_search_path_roots();
 
     if settings_module_file(db, project).is_none() {
         return TemplateLibraries::default();
@@ -176,16 +135,15 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     };
 
     if settings.templates.knowledge != StaticKnowledge::Known {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
     }
 
-    scan_templatetags_package(db, project, "django", &mut libraries);
+    scan_templatetags_package(&resolver, "django", &mut libraries);
 
     if settings.installed_apps.knowledge != StaticKnowledge::Unknown {
         for installed_app in &settings.installed_apps.values {
             scan_templatetags_package(
-                db,
-                project,
+                &resolver,
                 installed_app_package_module(installed_app),
                 &mut libraries,
             );
@@ -193,22 +151,23 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     }
 
     let backend_count = settings.templates.backends.len();
-    for backend in
-        settings.templates.backends.iter().filter(|backend| {
-            is_django_templates_backend(backend.backend.as_deref(), backend_count)
-        })
+    for backend in settings
+        .templates
+        .backends
+        .iter()
+        .filter(|backend| backend.is_django_templates_backend(backend_count))
     {
-        libraries.active_knowledge = weakest(libraries.active_knowledge, backend.knowledge);
+        libraries.active_knowledge = libraries.active_knowledge.weakened_by(backend.knowledge);
 
         for (load_name, module_path) in &backend.libraries {
-            add_configured_library(db, project, &mut libraries, load_name, module_path);
+            add_configured_library(&resolver, &mut libraries, load_name, module_path);
         }
 
         for module_path in DEFAULT_TEMPLATE_BUILTINS {
-            add_builtin_library(db, project, &mut libraries, module_path);
+            add_builtin_library(&resolver, &mut libraries, module_path);
         }
         for module_path in &backend.builtins {
-            add_builtin_library(db, project, &mut libraries, module_path);
+            add_builtin_library(&resolver, &mut libraries, module_path);
         }
     }
 
@@ -216,36 +175,41 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
 }
 
 fn scan_templatetags_package(
-    db: &dyn ProjectDb,
-    project: Project,
+    resolver: &SalsaSettingsResolver<'_>,
     package_module: &str,
     libraries: &mut TemplateLibraries,
 ) {
     if package_module.is_empty() {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
         return;
     }
 
     let Ok(app_module) = PyModuleName::parse(package_module) else {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
         return;
     };
 
-    let Some(package_dir) = resolve_package_dir(db, project, package_module) else {
-        demote_to_partial(&mut libraries.active_knowledge);
+    let Some(package_dir) = resolver.package_dir(package_module) else {
+        libraries.active_knowledge.demote_to_partial();
         return;
     };
 
     let templatetags_dir = package_dir.join("templatetags");
-    if !db.path_is_file(&templatetags_dir.join("__init__.py")) {
+    if !resolver
+        .db
+        .path_is_file(&templatetags_dir.join("__init__.py"))
+    {
         return;
     }
 
-    let entries = match db.walk_entries(&templatetags_dir, &WalkOptions::shallow()) {
+    let entries = match resolver
+        .db
+        .walk_entries(&templatetags_dir, &WalkOptions::shallow())
+    {
         Ok(entries) => entries,
         Err(err) => {
             tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
-            demote_to_partial(&mut libraries.active_knowledge);
+            libraries.active_knowledge.demote_to_partial();
             return;
         }
     };
@@ -263,17 +227,17 @@ fn scan_templatetags_package(
         }
 
         let Ok(load_name) = LibraryName::parse(stem) else {
-            demote_to_partial(&mut libraries.active_knowledge);
+            libraries.active_knowledge.demote_to_partial();
             continue;
         };
         let module_path = format!("{package_module}.templatetags.{stem}");
         let Ok(module) = PyModuleName::parse(&module_path) else {
-            demote_to_partial(&mut libraries.active_knowledge);
+            libraries.active_knowledge.demote_to_partial();
             continue;
         };
 
-        let file = db.get_or_create_file(&entry.path);
-        let analysis = analyze_template_library_file(db, file);
+        let file = resolver.db.get_or_create_file(&entry.path);
+        let analysis = TemplateLibraryAnalysis::from_file(resolver.db, file);
         if !analysis.defines_library && analysis.symbols.is_empty() {
             continue;
         }
@@ -284,7 +248,7 @@ fn scan_templatetags_package(
             path: entry.path,
         };
         let mut library = TemplateLibrary::new_active(load_name, module, Some(origin));
-        merge_symbols(&mut library, analysis.symbols);
+        library.merge_symbols(analysis.symbols);
         libraries
             .loadable
             .insert(library.name.clone(), vec![library]);
@@ -292,26 +256,25 @@ fn scan_templatetags_package(
 }
 
 fn add_configured_library(
-    db: &dyn ProjectDb,
-    project: Project,
+    resolver: &SalsaSettingsResolver<'_>,
     libraries: &mut TemplateLibraries,
     load_name: &str,
     module_path: &str,
 ) {
-    let Some((load_name, module)) =
-        parse_library_mapping(&mut libraries.active_knowledge, load_name, module_path)
-    else {
+    let Ok(load_name) = LibraryName::parse(load_name) else {
+        libraries.active_knowledge.demote_to_partial();
+        return;
+    };
+    let Ok(module) = PyModuleName::parse(module_path) else {
+        libraries.active_knowledge.demote_to_partial();
         return;
     };
 
     let mut library = TemplateLibrary::new_active(load_name, module.clone(), None);
-    if let Some(file) = module_file_for_project(db, project, module.as_str()) {
-        merge_symbols(
-            &mut library,
-            analyze_template_library_file(db, file).symbols,
-        );
+    if let Some(file) = resolver.module_file(module.as_str()) {
+        library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
     } else {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
     }
     libraries
         .loadable
@@ -319,18 +282,17 @@ fn add_configured_library(
 }
 
 fn add_builtin_library(
-    db: &dyn ProjectDb,
-    project: Project,
+    resolver: &SalsaSettingsResolver<'_>,
     libraries: &mut TemplateLibraries,
     module_path: &str,
 ) {
     let Ok(module) = PyModuleName::parse(module_path) else {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
         return;
     };
     let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
     else {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
         return;
     };
 
@@ -338,32 +300,13 @@ fn add_builtin_library(
         libraries.builtin_order.push(module.clone());
     }
     let mut library = TemplateLibrary::new_builtin(name, module.clone());
-    if let Some(file) = module_file_for_project(db, project, module.as_str()) {
-        merge_symbols(
-            &mut library,
-            analyze_template_library_file(db, file).symbols,
-        );
+    if let Some(file) = resolver.module_file(module.as_str()) {
+        library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
     } else {
-        demote_to_partial(&mut libraries.active_knowledge);
+        libraries.active_knowledge.demote_to_partial();
     }
 
     libraries.builtins.entry(module).or_insert(library);
-}
-
-fn parse_library_mapping(
-    knowledge: &mut StaticKnowledge,
-    load_name: &str,
-    module_path: &str,
-) -> Option<(LibraryName, PyModuleName)> {
-    let Ok(load_name) = LibraryName::parse(load_name) else {
-        demote_to_partial(knowledge);
-        return None;
-    };
-    let Ok(module) = PyModuleName::parse(module_path) else {
-        demote_to_partial(knowledge);
-        return None;
-    };
-    Some((load_name, module))
 }
 
 struct TemplateLibraryAnalysis {
@@ -371,81 +314,195 @@ struct TemplateLibraryAnalysis {
     symbols: Vec<TemplateSymbol>,
 }
 
-fn analyze_template_library_file(db: &dyn ProjectDb, file: File) -> TemplateLibraryAnalysis {
-    let Some(parsed) = parse_python_module(db, file) else {
-        return TemplateLibraryAnalysis {
-            defines_library: false,
-            symbols: Vec::new(),
+impl TemplateLibraryAnalysis {
+    fn from_file(db: &dyn ProjectDb, file: File) -> Self {
+        let Some(parsed) = parse_python_module(db, file) else {
+            return Self {
+                defines_library: false,
+                symbols: Vec::new(),
+            };
         };
-    };
 
-    let mut symbols = Vec::new();
-    for registration in collect_registrations_from_body(parsed.body(db)) {
-        let Ok(name) = TemplateSymbolName::parse(&registration.name) else {
-            continue;
-        };
-        let kind = match registration.kind.symbol_kind() {
-            SymbolKind::Tag => TemplateSymbolKind::Tag,
-            SymbolKind::Filter => TemplateSymbolKind::Filter,
-        };
-        symbols.push(TemplateSymbol {
-            kind,
-            name,
-            definition: SymbolDefinition::Exact {
-                file: file.path(db).to_path_buf(),
-            },
-            doc: None,
-        });
-    }
-
-    TemplateLibraryAnalysis {
-        defines_library: parsed.body(db).iter().any(stmt_defines_template_library),
-        symbols,
-    }
-}
-
-fn stmt_defines_template_library(stmt: &Stmt) -> bool {
-    let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt else {
-        return false;
-    };
-    if !targets.iter().any(
-        |target| matches!(target, Expr::Name(ExprName { id, .. }) if id.as_str() == "register"),
-    ) {
-        return false;
-    }
-
-    let Expr::Call(ExprCall { func, .. }) = value.as_ref() else {
-        return false;
-    };
-    match func.as_ref() {
-        Expr::Attribute(ExprAttribute { value, attr, .. }) => {
-            attr.as_str() == "Library"
-                && matches!(value.as_ref(), Expr::Name(ExprName { id, .. }) if id.as_str() == "template")
+        let mut symbols = Vec::new();
+        for registration in collect_registrations_from_body(parsed.body(db)) {
+            let Ok(name) = TemplateSymbolName::parse(&registration.name) else {
+                continue;
+            };
+            let kind = match registration.kind.symbol_kind() {
+                SymbolKind::Tag => TemplateSymbolKind::Tag,
+                SymbolKind::Filter => TemplateSymbolKind::Filter,
+            };
+            symbols.push(TemplateSymbol {
+                kind,
+                name,
+                definition: SymbolDefinition::Exact {
+                    file: file.path(db).to_path_buf(),
+                },
+                doc: None,
+            });
         }
-        Expr::Name(ExprName { id, .. }) => id.as_str() == "Library",
-        _ => false,
+
+        Self {
+            defines_library: parsed.body(db).iter().any(Self::stmt_defines_library),
+            symbols,
+        }
+    }
+
+    fn stmt_defines_library(stmt: &Stmt) -> bool {
+        let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt else {
+            return false;
+        };
+        if !targets.iter().any(
+            |target| matches!(target, Expr::Name(ExprName { id, .. }) if id.as_str() == "register"),
+        ) {
+            return false;
+        }
+
+        let Expr::Call(ExprCall { func, .. }) = value.as_ref() else {
+            return false;
+        };
+        match func.as_ref() {
+            Expr::Attribute(ExprAttribute { value, attr, .. }) => {
+                attr.as_str() == "Library"
+                    && matches!(value.as_ref(), Expr::Name(ExprName { id, .. }) if id.as_str() == "template")
+            }
+            Expr::Name(ExprName { id, .. }) => id.as_str() == "Library",
+            _ => false,
+        }
     }
 }
 
-fn merge_symbols(library: &mut TemplateLibrary, symbols: Vec<TemplateSymbol>) {
-    for symbol in symbols {
-        library.merge_symbol(symbol);
-    }
-}
-
-struct SalsaSettingsSources<'db> {
+struct SalsaSettingsResolver<'db> {
     db: &'db dyn ProjectDb,
     project: Project,
 }
 
-impl SettingsSourceResolver for SalsaSettingsSources<'_> {
+impl SalsaSettingsResolver<'_> {
+    fn collect_settings_source_files(
+        &self,
+        path: &Utf8Path,
+        seen: &mut BTreeSet<Utf8PathBuf>,
+        files: &mut Vec<File>,
+    ) {
+        if !seen.insert(path.to_path_buf()) {
+            return;
+        }
+
+        files.push(self.db.get_or_create_file(path));
+
+        let Ok(source) = self.db.read_file(path) else {
+            return;
+        };
+        let Ok(parsed) = ruff_python_parser::parse_module(&source) else {
+            return;
+        };
+
+        for stmt in parsed.into_syntax().body {
+            let Stmt::ImportFrom(import) = stmt else {
+                continue;
+            };
+            if !import.names.iter().any(|alias| alias.name.as_str() == "*") {
+                continue;
+            }
+
+            let star_import = SettingsStarImport {
+                level: import.level,
+                module: import.module.map(|module| module.to_string()),
+            };
+            let Some(module_path) = self.resolve_star_import_module(path, &star_import) else {
+                continue;
+            };
+            let Some(file) = self.module_file(&module_path) else {
+                continue;
+            };
+            self.collect_settings_source_files(file.path(self.db), seen, files);
+        }
+    }
+
+    fn module_file(&self, module_path: &str) -> Option<File> {
+        self.touch_search_path_roots();
+
+        for search_path in self.project.search_paths(self.db).iter() {
+            let Some(path) =
+                module_file_in_search_path(self.db.file_system(), module_path, search_path.path())
+            else {
+                continue;
+            };
+            return Some(self.db.get_or_create_file(&path));
+        }
+
+        None
+    }
+
+    fn package_dir(&self, package_module: &str) -> Option<Utf8PathBuf> {
+        if package_module.is_empty() {
+            return None;
+        }
+
+        let relative = package_module.replace('.', "/");
+        for search_path in self.project.search_paths(self.db).iter() {
+            let candidate = search_path.path().join(&relative);
+            if self.db.path_is_dir(&candidate) {
+                return Some(candidate);
+            }
+        }
+
+        None
+    }
+
+    fn touch_search_path_roots(&self) {
+        for search_path in self.project.search_paths(self.db).iter() {
+            if let Some(root) = self.db.files().root(self.db, search_path.path()) {
+                let _ = root.revision(self.db);
+            } else {
+                tracing::warn!(
+                    "Search path has no registered source root: {}",
+                    search_path.path()
+                );
+            }
+        }
+    }
+
+    fn resolve_star_import_module(
+        &self,
+        base: &Utf8Path,
+        import: &SettingsStarImport,
+    ) -> Option<String> {
+        if import.level == 0 {
+            return import.module.clone();
+        }
+
+        let module_file = ModuleFileParts::from_path(self.db, self.project, base)?;
+        let mut parts = module_file.parts;
+        if !module_file.is_package_init {
+            parts.pop()?;
+        }
+
+        for _ in 1..import.level {
+            parts.pop()?;
+        }
+
+        if let Some(module) = &import.module {
+            parts.extend(
+                module
+                    .split('.')
+                    .filter(|part| !part.is_empty())
+                    .map(str::to_string),
+            );
+        }
+
+        (!parts.is_empty()).then(|| parts.join("."))
+    }
+}
+
+impl SettingsSourceResolver for SalsaSettingsResolver<'_> {
     fn resolve_star_import(
         &mut self,
         import: &SettingsStarImport,
         importer: &Utf8Path,
     ) -> Option<SettingsSource> {
-        let module_path = resolve_star_import_module(self.db, self.project, importer, import)?;
-        let file = module_file_for_project(self.db, self.project, &module_path)?;
+        let module_path = self.resolve_star_import_module(importer, import)?;
+        let file = self.module_file(&module_path)?;
         Some(SettingsSource {
             source: file.source(self.db).as_str().to_string(),
             path: file.path(self.db).to_path_buf(),
@@ -453,138 +510,44 @@ impl SettingsSourceResolver for SalsaSettingsSources<'_> {
     }
 }
 
-fn module_file_for_project(
-    db: &dyn ProjectDb,
-    project: Project,
-    module_path: &str,
-) -> Option<File> {
-    touch_search_path_roots(db, project);
-
-    for search_path in project.search_paths(db).iter() {
-        let Some(path) =
-            module_file_in_search_path(db.file_system(), module_path, search_path.path())
-        else {
-            continue;
-        };
-        return Some(db.get_or_create_file(&path));
-    }
-
-    None
-}
-
-fn touch_search_path_roots(db: &dyn ProjectDb, project: Project) {
-    for search_path in project.search_paths(db).iter() {
-        if let Some(root) = db.files().root(db, search_path.path()) {
-            let _ = root.revision(db);
-        } else {
-            tracing::warn!(
-                "Search path has no registered source root: {}",
-                search_path.path()
-            );
-        }
-    }
-}
-
-fn resolve_star_import_module(
-    db: &dyn ProjectDb,
-    project: Project,
-    base: &Utf8Path,
-    import: &SettingsStarImport,
-) -> Option<String> {
-    if import.level == 0 {
-        return import.module.clone();
-    }
-
-    let module_file = module_parts_for_file(db, project, base)?;
-    let mut parts = module_file.parts;
-    if !module_file.is_package_init {
-        parts.pop()?;
-    }
-
-    for _ in 1..import.level {
-        parts.pop()?;
-    }
-
-    if let Some(module) = &import.module {
-        parts.extend(
-            module
-                .split('.')
-                .filter(|part| !part.is_empty())
-                .map(str::to_string),
-        );
-    }
-
-    (!parts.is_empty()).then(|| parts.join("."))
-}
-
 struct ModuleFileParts {
     parts: Vec<String>,
     is_package_init: bool,
 }
 
-fn module_parts_for_file(
-    db: &dyn ProjectDb,
-    project: Project,
-    file_path: &Utf8Path,
-) -> Option<ModuleFileParts> {
-    let root = project
-        .search_paths(db)
-        .iter()
-        .filter(|search_path| file_path.starts_with(search_path.path()))
-        .max_by_key(|search_path| search_path.path().as_str().len())?
-        .path();
-    let relative = file_path.strip_prefix(root).ok()?;
-    let mut parts: Vec<String> = relative
-        .components()
-        .map(|component| component.as_str().to_string())
-        .collect();
-    let last = parts.pop()?;
+impl ModuleFileParts {
+    fn from_path(db: &dyn ProjectDb, project: Project, file_path: &Utf8Path) -> Option<Self> {
+        let root = project
+            .search_paths(db)
+            .iter()
+            .filter(|search_path| file_path.starts_with(search_path.path()))
+            .max_by_key(|search_path| search_path.path().as_str().len())?
+            .path();
+        let relative = file_path.strip_prefix(root).ok()?;
+        let mut parts: Vec<String> = relative
+            .components()
+            .map(|component| component.as_str().to_string())
+            .collect();
+        let last = parts.pop()?;
 
-    if last == "__init__.py" {
-        return Some(ModuleFileParts {
-            parts,
-            is_package_init: true,
-        });
-    }
-
-    let last_path = Utf8Path::new(&last);
-    if last_path.extension() != Some("py") {
-        return None;
-    }
-    parts.push(last_path.file_stem()?.to_string());
-
-    Some(ModuleFileParts {
-        parts,
-        is_package_init: false,
-    })
-}
-
-fn is_django_templates_backend(backend: Option<&str>, backend_count: usize) -> bool {
-    match backend {
-        Some(DJANGO_TEMPLATES_BACKEND) => true,
-        None if backend_count == 1 => true,
-        _ => false,
-    }
-}
-
-fn resolve_package_dir(
-    db: &dyn ProjectDb,
-    project: Project,
-    package_module: &str,
-) -> Option<Utf8PathBuf> {
-    if package_module.is_empty() {
-        return None;
-    }
-
-    let relative = package_module.replace('.', "/");
-    for search_path in project.search_paths(db).iter() {
-        let candidate = search_path.path().join(&relative);
-        if db.path_is_dir(&candidate) {
-            return Some(candidate);
+        if last == "__init__.py" {
+            return Some(Self {
+                parts,
+                is_package_init: true,
+            });
         }
-    }
 
-    None
+        let last_path = Utf8Path::new(&last);
+        if last_path.extension() != Some("py") {
+            return None;
+        }
+        parts.push(last_path.file_stem()?.to_string());
+
+        Some(Self {
+            parts,
+            is_package_init: false,
+        })
+    }
 }
 
 fn installed_app_package_module(installed_app: &str) -> &str {
@@ -596,20 +559,6 @@ fn installed_app_package_module(installed_app: &str) -> &str {
             .map_or(installed_app, |(module, _)| module)
     } else {
         installed_app
-    }
-}
-
-fn weakest(left: StaticKnowledge, right: StaticKnowledge) -> StaticKnowledge {
-    match (left, right) {
-        (StaticKnowledge::Unknown, _) | (_, StaticKnowledge::Unknown) => StaticKnowledge::Unknown,
-        (StaticKnowledge::Partial, _) | (_, StaticKnowledge::Partial) => StaticKnowledge::Partial,
-        (StaticKnowledge::Known, StaticKnowledge::Known) => StaticKnowledge::Known,
-    }
-}
-
-fn demote_to_partial(knowledge: &mut StaticKnowledge) {
-    if *knowledge == StaticKnowledge::Known {
-        *knowledge = StaticKnowledge::Partial;
     }
 }
 
@@ -739,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn django_settings_for_file_resolves_relative_star_imports() {
+    fn django_settings_resolves_relative_star_imports() {
         let mut db = TestDatabase::new();
         let project = project_with_settings(
             &mut db,
@@ -766,7 +715,7 @@ mod tests {
     }
 
     #[test]
-    fn django_settings_for_file_recovers_from_star_import_cycle() {
+    fn django_settings_recovers_from_star_import_cycle() {
         let mut db = TestDatabase::new();
         let project = project_with_settings(
             &mut db,

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -127,7 +127,7 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     let settings = django_settings(db, project);
 
     let mut libraries = TemplateLibraries {
-        active_knowledge: match settings.installed_apps.knowledge {
+        knowledge: match settings.installed_apps.knowledge {
             StaticKnowledge::Known => StaticKnowledge::Known,
             StaticKnowledge::Partial | StaticKnowledge::Unknown => StaticKnowledge::Partial,
         },
@@ -135,7 +135,7 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     };
 
     if settings.templates.knowledge != StaticKnowledge::Known {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
     }
 
     scan_templatetags_package(&resolver, "django", &mut libraries);
@@ -157,7 +157,7 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         .iter()
         .filter(|backend| backend.is_django_templates_backend(backend_count))
     {
-        libraries.active_knowledge = libraries.active_knowledge.weakened_by(backend.knowledge);
+        libraries.knowledge = libraries.knowledge.weakened_by(backend.knowledge);
 
         for (load_name, module_path) in &backend.libraries {
             add_configured_library(&resolver, &mut libraries, load_name, module_path);
@@ -180,17 +180,17 @@ fn scan_templatetags_package(
     libraries: &mut TemplateLibraries,
 ) {
     if package_module.is_empty() {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     }
 
     let Ok(app_module) = PyModuleName::parse(package_module) else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     };
 
     let Some(package_dir) = resolver.package_dir(package_module) else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     };
 
@@ -209,7 +209,7 @@ fn scan_templatetags_package(
         Ok(entries) => entries,
         Err(err) => {
             tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
-            libraries.active_knowledge.demote_to_partial();
+            libraries.knowledge.demote_to_partial();
             return;
         }
     };
@@ -227,12 +227,12 @@ fn scan_templatetags_package(
         }
 
         let Ok(load_name) = LibraryName::parse(stem) else {
-            libraries.active_knowledge.demote_to_partial();
+            libraries.knowledge.demote_to_partial();
             continue;
         };
         let module_path = format!("{package_module}.templatetags.{stem}");
         let Ok(module) = PyModuleName::parse(&module_path) else {
-            libraries.active_knowledge.demote_to_partial();
+            libraries.knowledge.demote_to_partial();
             continue;
         };
 
@@ -262,11 +262,11 @@ fn add_configured_library(
     module_path: &str,
 ) {
     let Ok(load_name) = LibraryName::parse(load_name) else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     };
     let Ok(module) = PyModuleName::parse(module_path) else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     };
 
@@ -274,7 +274,7 @@ fn add_configured_library(
     if let Some(file) = resolver.module_file(module.as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
     } else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
     }
     libraries
         .loadable
@@ -287,12 +287,12 @@ fn add_builtin_library(
     module_path: &str,
 ) {
     let Ok(module) = PyModuleName::parse(module_path) else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     };
     let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
     else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
         return;
     };
 
@@ -303,7 +303,7 @@ fn add_builtin_library(
     if let Some(file) = resolver.module_file(module.as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
     } else {
-        libraries.active_knowledge.demote_to_partial();
+        libraries.knowledge.demote_to_partial();
     }
 
     libraries.builtins.entry(module).or_insert(library);
@@ -848,7 +848,7 @@ mod tests {
 
         let libraries = template_libraries(&db, project);
 
-        assert_eq!(libraries.active_knowledge, StaticKnowledge::Known);
+        assert_eq!(libraries.knowledge, StaticKnowledge::Known);
         let custom = libraries
             .best_loadable_library_str("custom")
             .expect("custom library should be discovered");
@@ -919,7 +919,7 @@ mod tests {
 
         let libraries = template_libraries(&db, project);
 
-        assert_eq!(libraries.active_knowledge, StaticKnowledge::Partial);
+        assert_eq!(libraries.knowledge, StaticKnowledge::Partial);
     }
 
     #[test]
@@ -1006,7 +1006,7 @@ mod tests {
 
         let libraries = template_libraries(&db, project);
 
-        assert_eq!(libraries.active_knowledge, StaticKnowledge::Partial);
+        assert_eq!(libraries.knowledge, StaticKnowledge::Partial);
         let custom = libraries.best_loadable_library_str("custom").unwrap();
         assert_eq!(custom.module().as_str(), "project_tags");
         assert!(

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -151,6 +151,12 @@ impl TemplateLibrary {
         self.symbols
             .dedup_by(|a, b| a.kind == b.kind && a.name == b.name);
     }
+
+    pub(crate) fn merge_symbols(&mut self, symbols: impl IntoIterator<Item = TemplateSymbol>) {
+        for symbol in symbols {
+            self.merge_symbol(symbol);
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -256,6 +256,26 @@ impl TemplateLibraries {
             .flat_map(|(name, libraries)| libraries.iter().map(move |library| (name, library)))
     }
 
+    pub(crate) fn set_loadable(&mut self, library: TemplateLibrary) {
+        self.loadable.insert(library.name.clone(), vec![library]);
+    }
+
+    pub(crate) fn extend_loadable(&mut self, libraries: impl IntoIterator<Item = TemplateLibrary>) {
+        for library in libraries {
+            self.set_loadable(library);
+        }
+    }
+
+    pub(crate) fn push_builtin(&mut self, library: TemplateLibrary) {
+        if !self
+            .builtins
+            .iter()
+            .any(|existing| existing.module() == library.module())
+        {
+            self.builtins.push(library);
+        }
+    }
+
     pub fn enabled_loadable_libraries(
         &self,
     ) -> impl Iterator<Item = (&LibraryName, &TemplateLibrary)> + '_ {

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -260,12 +260,6 @@ impl TemplateLibraries {
         self.loadable.insert(library.name.clone(), vec![library]);
     }
 
-    pub(crate) fn extend_loadable(&mut self, libraries: impl IntoIterator<Item = TemplateLibrary>) {
-        for library in libraries {
-            self.set_loadable(library);
-        }
-    }
-
     pub(crate) fn push_builtin(&mut self, library: TemplateLibrary) {
         if !self
             .builtins

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -153,13 +153,6 @@ impl TemplateLibrary {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TemplateLibrarySnapshot {
-    pub symbols: Vec<TemplateSymbolSnapshot>,
-    pub libraries: BTreeMap<String, String>,
-    pub builtins: Vec<String>,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InstalledSymbolOrigin {
     Builtin { module: PyModuleName },
@@ -201,7 +194,7 @@ impl TemplateLibraries {
 
     #[must_use]
     pub fn registration_modules(&self) -> Vec<PyModuleName> {
-        if self.active_knowledge != StaticKnowledge::Known {
+        if self.active_knowledge == StaticKnowledge::Unknown {
             return Vec::new();
         }
 
@@ -353,143 +346,6 @@ impl TemplateLibraries {
     pub fn is_enabled_library_str(&self, name: &str) -> bool {
         LibraryName::parse(name).is_ok_and(|name| self.is_enabled_library(&name))
     }
-
-    #[must_use]
-    pub fn apply_active_snapshot(mut self, response: Option<TemplateLibrarySnapshot>) -> Self {
-        let Some(response) = response else {
-            self.active_knowledge = StaticKnowledge::Unknown;
-            self.builtins.clear();
-            self.builtin_order.clear();
-            return self;
-        };
-
-        self.active_knowledge = StaticKnowledge::Known;
-
-        let mut enabled: BTreeMap<LibraryName, PyModuleName> = BTreeMap::new();
-        for (name, module) in response.libraries {
-            let Ok(name) = LibraryName::parse(&name) else {
-                continue;
-            };
-            let Ok(module) = PyModuleName::parse(&module) else {
-                continue;
-            };
-            enabled.insert(name, module);
-        }
-
-        for (name, module) in &enabled {
-            let entry = self.loadable.entry(name.clone()).or_default();
-
-            if let Some(existing) = entry
-                .iter_mut()
-                .find(|existing| existing.module() == module)
-            {
-                let origin = existing.origin().cloned();
-                existing.status = LibraryStatus::Active {
-                    module: module.clone(),
-                    origin,
-                };
-            } else {
-                entry.push(TemplateLibrary::new_active(
-                    name.clone(),
-                    module.clone(),
-                    None,
-                ));
-            }
-        }
-
-        for (name, libraries) in &mut self.loadable {
-            let enabled_module = enabled.get(name);
-
-            libraries.retain(|library| match &library.status {
-                LibraryStatus::Active { module, .. } => enabled_module == Some(module),
-                LibraryStatus::Builtin { .. } => true,
-            });
-
-            for library in libraries.iter_mut().filter(|library| library.is_active()) {
-                library.symbols.clear();
-            }
-        }
-
-        self.builtins.clear();
-        self.builtin_order.clear();
-        for builtin_module in response.builtins {
-            let Ok(module) = PyModuleName::parse(&builtin_module) else {
-                continue;
-            };
-            let Ok(name) =
-                LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("unknown"))
-            else {
-                continue;
-            };
-
-            push_unique_module(&mut self.builtin_order, module.clone());
-            self.builtins
-                .entry(module.clone())
-                .or_insert_with(|| TemplateLibrary::new_builtin(name, module));
-        }
-
-        for symbol in response.symbols {
-            self.apply_active_snapshot_symbol(&enabled, symbol);
-        }
-
-        self
-    }
-
-    fn apply_active_snapshot_symbol(
-        &mut self,
-        enabled: &BTreeMap<LibraryName, PyModuleName>,
-        snapshot: TemplateSymbolSnapshot,
-    ) {
-        let Some(kind) = snapshot.kind else {
-            return;
-        };
-
-        let Ok(name) = TemplateSymbolName::parse(&snapshot.name) else {
-            return;
-        };
-
-        let definition = PyModuleName::parse(&snapshot.module)
-            .map_or(SymbolDefinition::Unknown, SymbolDefinition::Module);
-
-        let symbol = TemplateSymbol {
-            kind,
-            name,
-            definition,
-            doc: snapshot.doc,
-        };
-
-        match snapshot.load_name {
-            None => {
-                let Ok(module) = PyModuleName::parse(&snapshot.library_module) else {
-                    return;
-                };
-
-                if let Some(library) = self.builtins.get_mut(&module) {
-                    library.merge_symbol(symbol);
-                }
-            }
-            Some(load_name) => {
-                let Ok(library_name) = LibraryName::parse(&load_name) else {
-                    return;
-                };
-
-                let module = enabled
-                    .get(&library_name)
-                    .cloned()
-                    .or_else(|| PyModuleName::parse(&snapshot.library_module).ok());
-
-                let Some(module) = module else {
-                    return;
-                };
-
-                if let Some(libraries) = self.loadable.get_mut(&library_name)
-                    && let Some(library) = libraries.iter_mut().find(|l| l.module() == &module)
-                {
-                    library.merge_symbol(symbol);
-                }
-            }
-        }
-    }
 }
 
 fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
@@ -498,48 +354,77 @@ fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TemplateSymbolSnapshot {
-    #[serde(default)]
-    pub kind: Option<TemplateSymbolKind>,
-    pub name: String,
-    #[serde(default)]
-    pub load_name: Option<String>,
-    pub library_module: String,
-    pub module: String,
-    #[serde(default)]
-    pub doc: Option<String>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn module(name: &str) -> PyModuleName {
+        PyModuleName::parse(name).unwrap()
+    }
+
+    fn library_name(name: &str) -> LibraryName {
+        LibraryName::parse(name).unwrap()
+    }
+
+    fn symbol(kind: TemplateSymbolKind, name: &str, doc: Option<&str>) -> TemplateSymbol {
+        TemplateSymbol {
+            kind,
+            name: TemplateSymbolName::parse(name).unwrap(),
+            definition: SymbolDefinition::Unknown,
+            doc: doc.map(str::to_string),
+        }
+    }
+
+    fn builtin_library(
+        name: &str,
+        module_name: &str,
+        symbols: Vec<TemplateSymbol>,
+    ) -> TemplateLibrary {
+        let mut library = TemplateLibrary::new_builtin(library_name(name), module(module_name));
+        for symbol in symbols {
+            library.merge_symbol(symbol);
+        }
+        library
+    }
+
+    fn active_library(name: &str, module_name: &str) -> TemplateLibrary {
+        TemplateLibrary::new_active(library_name(name), module(module_name), None)
+    }
+
     #[test]
     fn builtin_candidates_keep_last_builtin_symbol() {
-        let libraries =
-            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
-                symbols: vec![
-                    TemplateSymbolSnapshot {
-                        kind: Some(TemplateSymbolKind::Filter),
-                        name: "duplicate".to_string(),
-                        load_name: None,
-                        library_module: "z_first".to_string(),
-                        module: "z_first".to_string(),
-                        doc: Some("first".to_string()),
-                    },
-                    TemplateSymbolSnapshot {
-                        kind: Some(TemplateSymbolKind::Filter),
-                        name: "duplicate".to_string(),
-                        load_name: None,
-                        library_module: "a_second".to_string(),
-                        module: "a_second".to_string(),
-                        doc: Some("second".to_string()),
-                    },
-                ],
-                libraries: BTreeMap::new(),
-                builtins: vec!["z_first".to_string(), "a_second".to_string()],
-            }));
+        let mut libraries = TemplateLibraries {
+            active_knowledge: StaticKnowledge::Known,
+            ..TemplateLibraries::default()
+        };
+        let z_first = module("z_first");
+        let a_second = module("a_second");
+        libraries.builtin_order.push(z_first.clone());
+        libraries.builtin_order.push(a_second.clone());
+        libraries.builtins.insert(
+            z_first,
+            builtin_library(
+                "z_first",
+                "z_first",
+                vec![symbol(
+                    TemplateSymbolKind::Filter,
+                    "duplicate",
+                    Some("first"),
+                )],
+            ),
+        );
+        libraries.builtins.insert(
+            a_second.clone(),
+            builtin_library(
+                "a_second",
+                "a_second",
+                vec![symbol(
+                    TemplateSymbolKind::Filter,
+                    "duplicate",
+                    Some("second"),
+                )],
+            ),
+        );
 
         let candidates = libraries.installed_symbol_candidates(TemplateSymbolKind::Filter);
 
@@ -547,72 +432,33 @@ mod tests {
         assert_eq!(candidates[0].symbol.doc.as_deref(), Some("second"));
         assert_eq!(
             candidates[0].origin,
-            InstalledSymbolOrigin::Builtin {
-                module: PyModuleName::parse("a_second").unwrap()
-            }
+            InstalledSymbolOrigin::Builtin { module: a_second }
         );
     }
 
     #[test]
-    fn active_snapshot_replaces_loadable_symbols() {
-        let first = TemplateLibrarySnapshot {
-            symbols: vec![TemplateSymbolSnapshot {
-                kind: Some(TemplateSymbolKind::Tag),
-                name: "old_tag".to_string(),
-                load_name: Some("project_tags".to_string()),
-                library_module: "project.templatetags.project_tags".to_string(),
-                module: "project.templatetags.project_tags".to_string(),
-                doc: None,
-            }],
-            libraries: [(
-                "project_tags".to_string(),
-                "project.templatetags.project_tags".to_string(),
-            )]
-            .into(),
-            builtins: Vec::new(),
-        };
-        let second = TemplateLibrarySnapshot {
-            symbols: vec![TemplateSymbolSnapshot {
-                kind: Some(TemplateSymbolKind::Tag),
-                name: "new_tag".to_string(),
-                load_name: Some("project_tags".to_string()),
-                library_module: "project.templatetags.project_tags".to_string(),
-                module: "project.templatetags.project_tags".to_string(),
-                doc: None,
-            }],
-            libraries: [(
-                "project_tags".to_string(),
-                "project.templatetags.project_tags".to_string(),
-            )]
-            .into(),
-            builtins: Vec::new(),
-        };
-
-        let libraries = TemplateLibraries::default()
-            .apply_active_snapshot(Some(first))
-            .apply_active_snapshot(Some(second));
-
-        let names: Vec<_> = libraries
-            .installed_symbol_candidates(TemplateSymbolKind::Tag)
-            .into_iter()
-            .map(|candidate| candidate.symbol.name().to_string())
-            .collect();
-
-        assert_eq!(names, vec!["new_tag"]);
-    }
-
-    #[test]
     fn registration_modules_keep_deterministic_precedence_order() {
-        let libraries =
-            TemplateLibraries::default().apply_active_snapshot(Some(TemplateLibrarySnapshot {
-                symbols: Vec::new(),
-                libraries: [("project_tags".to_string(), "project.tags".to_string())].into(),
-                builtins: vec![
-                    "z.templatetags.tags".to_string(),
-                    "django.template.defaulttags".to_string(),
-                    "z.templatetags.tags".to_string(),
-                ],
-            }));
+        let mut libraries = TemplateLibraries {
+            active_knowledge: StaticKnowledge::Known,
+            ..TemplateLibraries::default()
+        };
+        libraries
+            .loadable
+            .entry(library_name("project_tags"))
+            .or_default()
+            .push(active_library("project_tags", "project.tags"));
+        for module_name in [
+            "z.templatetags.tags",
+            "django.template.defaulttags",
+            "z.templatetags.tags",
+        ] {
+            let module = module(module_name);
+            push_unique_module(&mut libraries.builtin_order, module.clone());
+            libraries
+                .builtins
+                .entry(module.clone())
+                .or_insert_with(|| builtin_library("defaulttags", module.as_str(), Vec::new()));
+        }
 
         let modules: Vec<_> = libraries
             .registration_modules()
@@ -628,5 +474,26 @@ mod tests {
                 "django.template.defaulttags",
             ]
         );
+    }
+
+    #[test]
+    fn registration_modules_keep_known_partial_modules() {
+        let mut libraries = TemplateLibraries {
+            active_knowledge: StaticKnowledge::Partial,
+            ..TemplateLibraries::default()
+        };
+        libraries
+            .loadable
+            .entry(library_name("project_tags"))
+            .or_default()
+            .push(active_library("project_tags", "project.tags"));
+
+        let modules: Vec<_> = libraries
+            .registration_modules()
+            .into_iter()
+            .map(|module| module.as_str().to_string())
+            .collect();
+
+        assert_eq!(modules, vec!["project.tags"]);
     }
 }

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -173,7 +173,7 @@ pub struct InstalledSymbolCandidate {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TemplateLibraries {
-    pub active_knowledge: StaticKnowledge,
+    pub knowledge: StaticKnowledge,
     pub loadable: BTreeMap<LibraryName, Vec<TemplateLibrary>>,
     pub builtins: BTreeMap<PyModuleName, TemplateLibrary>,
     pub builtin_order: Vec<PyModuleName>,
@@ -182,7 +182,7 @@ pub struct TemplateLibraries {
 impl Default for TemplateLibraries {
     fn default() -> Self {
         Self {
-            active_knowledge: StaticKnowledge::Unknown,
+            knowledge: StaticKnowledge::Unknown,
             loadable: BTreeMap::new(),
             builtins: BTreeMap::new(),
             builtin_order: Vec::new(),
@@ -200,7 +200,7 @@ impl TemplateLibraries {
 
     #[must_use]
     pub fn registration_modules(&self) -> Vec<PyModuleName> {
-        if self.active_knowledge == StaticKnowledge::Unknown {
+        if self.knowledge == StaticKnowledge::Unknown {
             return Vec::new();
         }
 
@@ -400,7 +400,7 @@ mod tests {
     #[test]
     fn builtin_candidates_keep_last_builtin_symbol() {
         let mut libraries = TemplateLibraries {
-            active_knowledge: StaticKnowledge::Known,
+            knowledge: StaticKnowledge::Known,
             ..TemplateLibraries::default()
         };
         let z_first = module("z_first");
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn registration_modules_keep_deterministic_precedence_order() {
         let mut libraries = TemplateLibraries {
-            active_knowledge: StaticKnowledge::Known,
+            knowledge: StaticKnowledge::Known,
             ..TemplateLibraries::default()
         };
         libraries
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     fn registration_modules_keep_known_partial_modules() {
         let mut libraries = TemplateLibraries {
-            active_knowledge: StaticKnowledge::Partial,
+            knowledge: StaticKnowledge::Partial,
             ..TemplateLibraries::default()
         };
         libraries

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -175,8 +175,7 @@ pub struct InstalledSymbolCandidate {
 pub struct TemplateLibraries {
     pub knowledge: StaticKnowledge,
     pub loadable: BTreeMap<LibraryName, Vec<TemplateLibrary>>,
-    pub builtins: BTreeMap<PyModuleName, TemplateLibrary>,
-    pub builtin_order: Vec<PyModuleName>,
+    pub builtins: Vec<TemplateLibrary>,
 }
 
 impl Default for TemplateLibraries {
@@ -184,8 +183,7 @@ impl Default for TemplateLibraries {
         Self {
             knowledge: StaticKnowledge::Unknown,
             loadable: BTreeMap::new(),
-            builtins: BTreeMap::new(),
-            builtin_order: Vec::new(),
+            builtins: Vec::new(),
         }
     }
 }
@@ -218,21 +216,19 @@ impl TemplateLibraries {
     }
 
     pub fn builtin_modules(&self) -> impl Iterator<Item = &PyModuleName> + '_ {
-        self.builtin_order
-            .iter()
-            .filter(|module| self.builtins.contains_key(*module))
+        self.builtins.iter().map(TemplateLibrary::module)
     }
 
     pub fn builtin_libraries(&self) -> impl Iterator<Item = &TemplateLibrary> + '_ {
-        self.builtin_modules()
-            .filter_map(|module| self.builtins.get(module))
+        self.builtins.iter()
     }
 
     pub fn builtin_libraries_by_module(
         &self,
     ) -> impl Iterator<Item = (&PyModuleName, &TemplateLibrary)> + '_ {
-        self.builtin_modules()
-            .filter_map(|module| self.builtins.get(module).map(|library| (module, library)))
+        self.builtins
+            .iter()
+            .map(|library| (library.module(), library))
     }
 
     pub fn loadable_library_names(&self) -> impl Iterator<Item = &LibraryName> + '_ {
@@ -403,34 +399,25 @@ mod tests {
             knowledge: StaticKnowledge::Known,
             ..TemplateLibraries::default()
         };
-        let z_first = module("z_first");
         let a_second = module("a_second");
-        libraries.builtin_order.push(z_first.clone());
-        libraries.builtin_order.push(a_second.clone());
-        libraries.builtins.insert(
-            z_first,
-            builtin_library(
-                "z_first",
-                "z_first",
-                vec![symbol(
-                    TemplateSymbolKind::Filter,
-                    "duplicate",
-                    Some("first"),
-                )],
-            ),
-        );
-        libraries.builtins.insert(
-            a_second.clone(),
-            builtin_library(
-                "a_second",
-                "a_second",
-                vec![symbol(
-                    TemplateSymbolKind::Filter,
-                    "duplicate",
-                    Some("second"),
-                )],
-            ),
-        );
+        libraries.builtins.push(builtin_library(
+            "z_first",
+            "z_first",
+            vec![symbol(
+                TemplateSymbolKind::Filter,
+                "duplicate",
+                Some("first"),
+            )],
+        ));
+        libraries.builtins.push(builtin_library(
+            "a_second",
+            a_second.as_str(),
+            vec![symbol(
+                TemplateSymbolKind::Filter,
+                "duplicate",
+                Some("second"),
+            )],
+        ));
 
         let candidates = libraries.installed_symbol_candidates(TemplateSymbolKind::Filter);
 
@@ -459,11 +446,17 @@ mod tests {
             "z.templatetags.tags",
         ] {
             let module = module(module_name);
-            push_unique_module(&mut libraries.builtin_order, module.clone());
-            libraries
+            if !libraries
                 .builtins
-                .entry(module.clone())
-                .or_insert_with(|| builtin_library("defaulttags", module.as_str(), Vec::new()));
+                .iter()
+                .any(|library| library.module() == &module)
+            {
+                libraries.builtins.push(builtin_library(
+                    "defaulttags",
+                    module.as_str(),
+                    Vec::new(),
+                ));
+            }
         }
 
         let modules: Vec<_> = libraries

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -4,24 +4,11 @@
 //! Django, Python, and the filesystem for facts, then writes changed facts to
 //! the `Project` input. Pure semantic derivation stays in tracked queries.
 
-use std::fmt::Write;
-use std::fs;
-
-use camino::Utf8Path;
-use camino::Utf8PathBuf;
-use salsa::Setter;
-use serde::Deserialize;
-use serde::Serialize;
-use sha2::Digest;
-use sha2::Sha256;
-
 use crate::project::db::Db as ProjectDb;
 use crate::project::input::Project;
-use crate::project::introspector::IntrospectionRequest;
-use crate::project::python::Interpreter;
 use crate::project::resolve::model_modules;
 use crate::project::resolve::templatetag_modules;
-use crate::project::symbols::TemplateLibrarySnapshot;
+use crate::project::settings::settings_dependency_files;
 
 /// Refresh all external project data.
 ///
@@ -35,166 +22,7 @@ pub fn refresh_external_data(db: &mut dyn ProjectDb) {
     };
 
     project.refresh_source_roots(db);
-    refresh_template_libraries(db, project);
     refresh_python_modules(db, project);
-}
-
-/// Populate template libraries from the filesystem cache, if available.
-///
-/// This is a fast, synchronous startup path. It gives completions and
-/// diagnostics previously discovered library data while fresh project
-/// introspection runs in the background.
-pub fn load_template_library_cache(db: &mut dyn ProjectDb) -> bool {
-    let Some(project) = db.project() else {
-        return false;
-    };
-
-    let interpreter = project.interpreter(db).clone();
-    let root = project.root(db).clone();
-    let django_settings_module = project.django_settings_module(db).clone();
-    let pythonpath = project.pythonpath(db).clone();
-    let Some(dir) = cache_dir(
-        &root,
-        &interpreter,
-        django_settings_module.as_deref(),
-        &pythonpath,
-    ) else {
-        return false;
-    };
-    // Keep the legacy filename for on-disk cache compatibility.
-    let path = dir.join("inspector.json");
-
-    let Ok(content) = fs::read_to_string(path.as_std_path()) else {
-        return false;
-    };
-    let Ok(envelope) = serde_json::from_str::<CacheEnvelope>(&content) else {
-        return false;
-    };
-
-    if envelope.djls_version != env!("CARGO_PKG_VERSION") {
-        tracing::debug!(
-            "Template library snapshot cache version mismatch: cached={}, current={}",
-            envelope.djls_version,
-            env!("CARGO_PKG_VERSION"),
-        );
-        return false;
-    }
-
-    tracing::info!("Loaded template library snapshot from cache: {}", path);
-    apply_template_library_snapshot(db, project, envelope.response);
-    true
-}
-
-#[derive(Serialize)]
-struct TemplateLibrarySnapshotRequest;
-
-impl IntrospectionRequest for TemplateLibrarySnapshotRequest {
-    const NAME: &'static str = "template_libraries";
-    type Response = TemplateLibrarySnapshot;
-}
-
-fn refresh_template_libraries(db: &mut dyn ProjectDb, project: Project) {
-    let Some(snapshot) = db
-        .project_introspector()
-        .query(db, &TemplateLibrarySnapshotRequest)
-    else {
-        return;
-    };
-
-    let interpreter = project.interpreter(db).clone();
-    let root = project.root(db).clone();
-    let django_settings_module = project.django_settings_module(db).clone();
-    let pythonpath = project.pythonpath(db).clone();
-    if let Some(dir) = cache_dir(
-        &root,
-        &interpreter,
-        django_settings_module.as_deref(),
-        &pythonpath,
-    ) {
-        let envelope = CacheEnvelope {
-            djls_version: env!("CARGO_PKG_VERSION").to_string(),
-            response: snapshot.clone(),
-        };
-
-        if let Err(e) = fs::create_dir_all(dir.as_std_path()) {
-            tracing::warn!("Failed to create template library snapshot cache directory: {e}");
-        } else {
-            let path = dir.join("inspector.json");
-            match serde_json::to_string(&envelope) {
-                Ok(json) => {
-                    if let Err(e) = fs::write(path.as_std_path(), json) {
-                        tracing::warn!("Failed to write template library snapshot cache: {e}");
-                    } else {
-                        tracing::debug!("Saved template library snapshot to cache: {}", path);
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to serialize template library snapshot cache: {e}");
-                }
-            }
-        }
-    }
-
-    apply_template_library_snapshot(db, project, snapshot);
-}
-
-fn apply_template_library_snapshot(
-    db: &mut dyn ProjectDb,
-    project: Project,
-    snapshot: TemplateLibrarySnapshot,
-) -> bool {
-    let current = project.template_libraries(db).clone();
-    let next = current.apply_active_snapshot(Some(snapshot));
-    if project.template_libraries(db) == &next {
-        return false;
-    }
-
-    project.set_template_libraries(db).to(next);
-    true
-}
-
-#[derive(Serialize, Deserialize)]
-struct CacheEnvelope {
-    djls_version: String,
-    response: TemplateLibrarySnapshot,
-}
-
-fn cache_key(
-    root: &Utf8Path,
-    interpreter: &Interpreter,
-    django_settings_module: Option<&str>,
-    pythonpath: &[String],
-) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(root.as_str().as_bytes());
-    hasher.update(b"\0");
-    hasher.update(format!("{interpreter:?}").as_bytes());
-    hasher.update(b"\0");
-    hasher.update(django_settings_module.unwrap_or("").as_bytes());
-    hasher.update(b"\0");
-    for path in pythonpath {
-        hasher.update(path.as_bytes());
-        hasher.update(b"\0");
-    }
-    let digest = hasher.finalize();
-    let mut key = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        write!(&mut key, "{byte:02x}").expect("writing to String cannot fail");
-    }
-    key
-}
-
-fn cache_dir(
-    root: &Utf8Path,
-    interpreter: &Interpreter,
-    django_settings_module: Option<&str>,
-    pythonpath: &[String],
-) -> Option<Utf8PathBuf> {
-    let base = djls_conf::project_dirs()
-        .and_then(|dirs| Utf8PathBuf::from_path_buf(dirs.cache_dir().to_path_buf()).ok())?;
-    let key = cache_key(root, interpreter, django_settings_module, pythonpath);
-    // Keep the legacy `inspector` directory for on-disk cache compatibility.
-    Some(base.join("inspector").join(&key[..16]))
 }
 
 fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
@@ -209,6 +37,10 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
 
     for root in roots {
         db.bump_file_root_revision(root);
+    }
+
+    for file in settings_dependency_files(db, project) {
+        db.bump_file_revision(file);
     }
 
     let mut file_paths = Vec::new();
@@ -230,51 +62,5 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
     for path in file_paths {
         let file = db.get_or_create_file(&path);
         db.bump_file_revision(file);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cache_key_deterministic() {
-        let root = Utf8Path::new("/project");
-        let interpreter = Interpreter::VenvPath("/project/.venv".to_string());
-        let dsm = Some("myproject.settings");
-        let pythonpath = vec!["/extra".to_string()];
-
-        let key1 = cache_key(root, &interpreter, dsm, &pythonpath);
-        let key2 = cache_key(root, &interpreter, dsm, &pythonpath);
-        assert_eq!(key1, key2);
-    }
-
-    #[test]
-    fn cache_key_varies_with_inputs() {
-        let interpreter = Interpreter::VenvPath("/project/.venv".to_string());
-        let pythonpath: Vec<String> = vec![];
-
-        let key1 = cache_key(Utf8Path::new("/project-a"), &interpreter, None, &pythonpath);
-        let key2 = cache_key(Utf8Path::new("/project-b"), &interpreter, None, &pythonpath);
-        assert_ne!(key1, key2);
-    }
-
-    #[test]
-    fn cache_envelope_round_trips() {
-        let snapshot = TemplateLibrarySnapshot {
-            symbols: Vec::new(),
-            libraries: [("i18n".to_string(), "django.templatetags.i18n".to_string())].into(),
-            builtins: vec!["django.template.defaulttags".to_string()],
-        };
-        let envelope = CacheEnvelope {
-            djls_version: "test-version".to_string(),
-            response: snapshot.clone(),
-        };
-
-        let json = serde_json::to_string(&envelope).unwrap();
-        let decoded: CacheEnvelope = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(decoded.djls_version, "test-version");
-        assert_eq!(decoded.response, snapshot);
     }
 }

--- a/crates/djls-semantic/src/project/sync.rs
+++ b/crates/djls-semantic/src/project/sync.rs
@@ -8,7 +8,7 @@ use crate::project::db::Db as ProjectDb;
 use crate::project::input::Project;
 use crate::project::resolve::model_modules;
 use crate::project::resolve::templatetag_modules;
-use crate::project::settings::settings_dependency_files;
+use crate::project::settings::settings_source_files;
 
 /// Refresh all external project data.
 ///
@@ -39,7 +39,7 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
         db.bump_file_root_revision(root);
     }
 
-    for file in settings_dependency_files(db, project) {
+    for file in settings_source_files(db, project) {
         db.bump_file_revision(file);
     }
 

--- a/crates/djls-semantic/src/scoping/loads.rs
+++ b/crates/djls-semantic/src/scoping/loads.rs
@@ -4,6 +4,8 @@ use std::collections::HashSet;
 use djls_source::Span;
 use djls_templates::TagBit;
 
+use crate::project::TemplateLibraries;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LoadArgument {
     name: String,
@@ -198,6 +200,30 @@ impl LoadedLibraries {
     #[must_use]
     pub(crate) fn statements(&self) -> &[LoadStatement] {
         &self.statements
+    }
+
+    #[must_use]
+    pub(crate) fn has_unknown_load_that_can_shadow_symbol_before(
+        &self,
+        position: u32,
+        symbol: &str,
+        template_libraries: &TemplateLibraries,
+    ) -> bool {
+        self.statements.iter().any(|stmt| {
+            if stmt.span.end() > position {
+                return false;
+            }
+
+            match &stmt.kind {
+                LoadKind::FullLoad { libraries } => libraries
+                    .iter()
+                    .any(|library| !template_libraries.is_enabled_library_str(library.as_str())),
+                LoadKind::SelectiveImport { symbols, library } => {
+                    !template_libraries.is_enabled_library_str(library.as_str())
+                        && symbols.iter().any(|loaded| loaded.as_str() == symbol)
+                }
+            }
+        })
     }
 
     /// Compute the load state at a given byte position.

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -135,11 +135,15 @@ pub(crate) fn make_template_libraries(
         else {
             continue;
         };
-        push_unique_module(&mut result.builtin_order, module.clone());
-        result
+        if !result
             .builtins
-            .entry(module.clone())
-            .or_insert_with(|| TemplateLibrary::new_builtin(name, module));
+            .iter()
+            .any(|library| library.module() == &module)
+        {
+            result
+                .builtins
+                .push(TemplateLibrary::new_builtin(name, module));
+        }
     }
 
     for (load_name, module_name) in libraries {
@@ -179,7 +183,11 @@ pub(crate) fn make_template_libraries(
                 let Ok(module) = PyModuleName::parse(&fixture.library_module) else {
                     continue;
                 };
-                if let Some(library) = result.builtins.get_mut(&module) {
+                if let Some(library) = result
+                    .builtins
+                    .iter_mut()
+                    .find(|library| library.module() == &module)
+                {
                     library.merge_symbol(symbol);
                 }
             }
@@ -206,12 +214,6 @@ pub(crate) fn make_template_libraries(
     }
 
     result
-}
-
-fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
-    if !modules.contains(&module) {
-        modules.push(module);
-    }
 }
 
 pub(crate) fn make_template_libraries_tags_only(

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -1,7 +1,6 @@
 mod mdtest;
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -33,11 +32,16 @@ use crate::filters::FilterAritySpecs;
 use crate::project::Db as ProjectDb;
 #[cfg(test)]
 use crate::project::Interpreter;
+use crate::project::LibraryName;
 use crate::project::Project;
 use crate::project::ProjectIntrospector;
+use crate::project::PyModuleName;
+use crate::project::SymbolDefinition;
 use crate::project::TemplateLibraries;
-use crate::project::TemplateLibrarySnapshot;
-use crate::project::TemplateSymbolSnapshot;
+use crate::project::TemplateLibrary;
+use crate::project::TemplateSymbol;
+use crate::project::TemplateSymbolKind;
+use crate::project::TemplateSymbolName;
 #[cfg(test)]
 use crate::project::resolve::SearchPaths;
 use crate::python::ArgumentCountConstraint;
@@ -99,38 +103,115 @@ pub(crate) fn library_filter_json(name: &str, load_name: &str, module: &str) -> 
     })
 }
 
+#[derive(serde::Deserialize)]
+struct TemplateSymbolFixture {
+    kind: TemplateSymbolKind,
+    name: String,
+    #[serde(default)]
+    load_name: Option<String>,
+    library_module: String,
+    module: String,
+    #[serde(default)]
+    doc: Option<String>,
+}
+
 pub(crate) fn make_template_libraries(
     tags: &[serde_json::Value],
     filters: &[serde_json::Value],
     libraries: &HashMap<String, String, impl std::hash::BuildHasher>,
     builtins: &[String],
 ) -> TemplateLibraries {
-    let mut symbols: Vec<TemplateSymbolSnapshot> = tags
-        .iter()
-        .cloned()
-        .map(serde_json::from_value)
-        .collect::<Result<_, _>>()
-        .unwrap();
-
-    symbols.extend(
-        filters
-            .iter()
-            .cloned()
-            .map(serde_json::from_value)
-            .collect::<Result<Vec<TemplateSymbolSnapshot>, _>>()
-            .unwrap(),
-    );
-
-    let response = TemplateLibrarySnapshot {
-        symbols,
-        libraries: libraries
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect::<BTreeMap<_, _>>(),
-        builtins: builtins.to_vec(),
+    let mut result = TemplateLibraries {
+        active_knowledge: crate::project::StaticKnowledge::Known,
+        ..TemplateLibraries::default()
     };
 
-    TemplateLibraries::default().apply_active_snapshot(Some(response))
+    for module_name in builtins {
+        let Ok(module) = PyModuleName::parse(module_name) else {
+            continue;
+        };
+        let Ok(name) =
+            LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
+        else {
+            continue;
+        };
+        push_unique_module(&mut result.builtin_order, module.clone());
+        result
+            .builtins
+            .entry(module.clone())
+            .or_insert_with(|| TemplateLibrary::new_builtin(name, module));
+    }
+
+    for (load_name, module_name) in libraries {
+        let Ok(load_name) = LibraryName::parse(load_name) else {
+            continue;
+        };
+        let Ok(module) = PyModuleName::parse(module_name) else {
+            continue;
+        };
+        result
+            .loadable
+            .entry(load_name.clone())
+            .or_default()
+            .push(TemplateLibrary::new_active(load_name, module, None));
+    }
+
+    let symbols = tags.iter().chain(filters.iter()).cloned();
+    for fixture in symbols
+        .map(serde_json::from_value)
+        .collect::<Result<Vec<TemplateSymbolFixture>, _>>()
+        .unwrap()
+    {
+        let Ok(name) = TemplateSymbolName::parse(&fixture.name) else {
+            continue;
+        };
+        let definition = PyModuleName::parse(&fixture.module)
+            .map_or(SymbolDefinition::Unknown, SymbolDefinition::Module);
+        let symbol = TemplateSymbol {
+            kind: fixture.kind,
+            name,
+            definition,
+            doc: fixture.doc,
+        };
+
+        match fixture.load_name {
+            None => {
+                let Ok(module) = PyModuleName::parse(&fixture.library_module) else {
+                    continue;
+                };
+                if let Some(library) = result.builtins.get_mut(&module) {
+                    library.merge_symbol(symbol);
+                }
+            }
+            Some(load_name) => {
+                let Ok(load_name) = LibraryName::parse(&load_name) else {
+                    continue;
+                };
+                let Ok(module) = PyModuleName::parse(&fixture.library_module) else {
+                    continue;
+                };
+                let libraries = result.loadable.entry(load_name.clone()).or_default();
+                if let Some(library) = libraries
+                    .iter_mut()
+                    .find(|library| library.module() == &module)
+                {
+                    library.merge_symbol(symbol);
+                } else {
+                    let mut library = TemplateLibrary::new_active(load_name, module, None);
+                    library.merge_symbol(symbol);
+                    libraries.push(library);
+                }
+            }
+        }
+    }
+
+    result
+}
+
+fn push_unique_module(modules: &mut Vec<PyModuleName>, module: PyModuleName) {
+    if !modules.contains(&module) {
+        modules.push(module);
+    }
 }
 
 pub(crate) fn make_template_libraries_tags_only(
@@ -227,7 +308,6 @@ pub(crate) struct ProjectFixture {
     search_paths: Option<SearchPaths>,
     register_roots: bool,
     tag_specs: TagSpecDef,
-    template_libraries: TemplateLibraries,
 }
 
 #[cfg(test)]
@@ -245,7 +325,6 @@ impl ProjectFixture {
             search_paths: None,
             register_roots: true,
             tag_specs: settings.tagspecs().clone(),
-            template_libraries: TemplateLibraries::default(),
         }
     }
 
@@ -286,12 +365,6 @@ impl ProjectFixture {
     }
 
     #[must_use]
-    pub(crate) fn template_libraries(mut self, template_libraries: TemplateLibraries) -> Self {
-        self.template_libraries = template_libraries;
-        self
-    }
-
-    #[must_use]
     pub(crate) fn template_file(
         self,
         _name: impl Into<String>,
@@ -327,7 +400,6 @@ impl ProjectFixture {
             self.pythonpath,
             self.env_vars,
             self.tag_specs,
-            self.template_libraries,
         )
     }
 

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -122,7 +122,7 @@ pub(crate) fn make_template_libraries(
     builtins: &[String],
 ) -> TemplateLibraries {
     let mut result = TemplateLibraries {
-        active_knowledge: crate::project::StaticKnowledge::Known,
+        knowledge: crate::project::StaticKnowledge::Known,
         ..TemplateLibraries::default()
     };
 

--- a/crates/djls-semantic/src/validation.rs
+++ b/crates/djls-semantic/src/validation.rs
@@ -11,7 +11,9 @@ use djls_templates::walk_nodelist;
 
 use crate::db::Db;
 use crate::filters::FilterAritySpecs;
+use crate::project::StaticKnowledge;
 use crate::project::TemplateLibraries;
+use crate::scoping::LoadedLibraries;
 use crate::scoping::SymbolIndex;
 use crate::structure::OpaqueRegions;
 use crate::tags::TagSpecs;
@@ -46,6 +48,7 @@ pub(crate) struct TemplateValidator<'a> {
     db: &'a dyn Db,
     tag_specs: &'a TagSpecs,
     symbol_index: &'a SymbolIndex,
+    loaded_libraries: &'a LoadedLibraries,
     template_libraries: &'a TemplateLibraries,
     opaque_regions: &'a OpaqueRegions,
     filter_arity_specs: &'a FilterAritySpecs,
@@ -63,6 +66,7 @@ impl<'a> TemplateValidator<'a> {
     ) -> Self {
         let template_libraries = db.template_libraries();
         let tag_specs = db.tag_specs();
+        let loaded_libraries = crate::scoping::compute_loaded_libraries(db, nodelist);
         let symbol_index = crate::scoping::compute_symbol_index(db, nodelist);
         let filter_arity_specs = db.filter_arity_specs();
 
@@ -70,6 +74,7 @@ impl<'a> TemplateValidator<'a> {
             db,
             tag_specs,
             symbol_index,
+            loaded_libraries,
             template_libraries,
             opaque_regions,
             filter_arity_specs,
@@ -167,12 +172,23 @@ impl Visitor for TemplateValidator<'_> {
                 );
 
                 // 2. Filter Arity
-                filters::check_filter_arity_rule(
-                    self.db,
-                    filter,
-                    self.filter_arity_specs,
-                    self.template_libraries.active_knowledge,
-                );
+                let unknown_load_can_shadow_filter = self.template_libraries.active_knowledge
+                    == StaticKnowledge::Partial
+                    && self
+                        .loaded_libraries
+                        .has_unknown_load_that_can_shadow_symbol_before(
+                            span.start(),
+                            &filter.name,
+                            self.template_libraries,
+                        );
+                if !unknown_load_can_shadow_filter {
+                    filters::check_filter_arity_rule(
+                        self.db,
+                        filter,
+                        self.filter_arity_specs,
+                        self.template_libraries.active_knowledge,
+                    );
+                }
             }
         }
 

--- a/crates/djls-semantic/src/validation.rs
+++ b/crates/djls-semantic/src/validation.rs
@@ -135,7 +135,7 @@ impl Visitor for TemplateValidator<'_> {
                     name,
                     span,
                     symbols,
-                    self.template_libraries.active_knowledge,
+                    self.template_libraries.knowledge,
                 );
             }
 
@@ -168,11 +168,11 @@ impl Visitor for TemplateValidator<'_> {
                     self.db,
                     filter,
                     symbols,
-                    self.template_libraries.active_knowledge,
+                    self.template_libraries.knowledge,
                 );
 
                 // 2. Filter Arity
-                let unknown_load_can_shadow_filter = self.template_libraries.active_knowledge
+                let unknown_load_can_shadow_filter = self.template_libraries.knowledge
                     == StaticKnowledge::Partial
                     && self
                         .loaded_libraries
@@ -186,7 +186,7 @@ impl Visitor for TemplateValidator<'_> {
                         self.db,
                         filter,
                         self.filter_arity_specs,
-                        self.template_libraries.active_knowledge,
+                        self.template_libraries.knowledge,
                     );
                 }
             }

--- a/crates/djls-semantic/src/validation/filters.rs
+++ b/crates/djls-semantic/src/validation/filters.rs
@@ -12,9 +12,9 @@ pub(crate) fn check_filter_arity_rule(
     db: &dyn Db,
     filter: &Filter,
     arity_specs: &FilterAritySpecs,
-    active_knowledge: StaticKnowledge,
+    knowledge: StaticKnowledge,
 ) {
-    if active_knowledge == StaticKnowledge::Unknown {
+    if knowledge == StaticKnowledge::Unknown {
         return;
     }
 

--- a/crates/djls-semantic/src/validation/filters.rs
+++ b/crates/djls-semantic/src/validation/filters.rs
@@ -14,7 +14,7 @@ pub(crate) fn check_filter_arity_rule(
     arity_specs: &FilterAritySpecs,
     active_knowledge: StaticKnowledge,
 ) {
-    if active_knowledge != StaticKnowledge::Known {
+    if active_knowledge == StaticKnowledge::Unknown {
         return;
     }
 

--- a/crates/djls-semantic/src/validation/scoping.rs
+++ b/crates/djls-semantic/src/validation/scoping.rs
@@ -21,9 +21,9 @@ pub(crate) fn check_tag_scoping_rule(
     name: &str,
     span: Span,
     symbols: &AvailableSymbols,
-    active_knowledge: StaticKnowledge,
+    knowledge: StaticKnowledge,
 ) {
-    if active_knowledge == StaticKnowledge::Unknown {
+    if knowledge == StaticKnowledge::Unknown {
         return;
     }
 
@@ -31,7 +31,7 @@ pub(crate) fn check_tag_scoping_rule(
 
     match symbols.check(name) {
         TagAvailability::Available => {}
-        TagAvailability::Unknown if active_knowledge == StaticKnowledge::Partial => {}
+        TagAvailability::Unknown if knowledge == StaticKnowledge::Partial => {}
         TagAvailability::Unknown => {
             ValidationErrorAccumulator(ValidationError::UnknownTag {
                 tag: name.to_string(),
@@ -63,15 +63,15 @@ pub(crate) fn check_filter_scoping_rule(
     db: &dyn Db,
     filter: &Filter,
     symbols: &AvailableSymbols,
-    active_knowledge: StaticKnowledge,
+    knowledge: StaticKnowledge,
 ) {
-    if active_knowledge == StaticKnowledge::Unknown {
+    if knowledge == StaticKnowledge::Unknown {
         return;
     }
 
     match symbols.check_filter(&filter.name) {
         FilterAvailability::Available => {}
-        FilterAvailability::Unknown if active_knowledge == StaticKnowledge::Partial => {}
+        FilterAvailability::Unknown if knowledge == StaticKnowledge::Partial => {}
         FilterAvailability::Unknown => {
             ValidationErrorAccumulator(ValidationError::UnknownFilter {
                 filter: filter.name.clone(),
@@ -105,7 +105,7 @@ pub(crate) fn check_load_libraries_rule(
     bits: &[TagBit],
     template_libraries: &TemplateLibraries,
 ) {
-    if template_libraries.active_knowledge == StaticKnowledge::Unknown {
+    if template_libraries.knowledge == StaticKnowledge::Unknown {
         return;
     }
 
@@ -128,7 +128,7 @@ pub(crate) fn check_load_libraries_rule(
             continue;
         }
 
-        if template_libraries.active_knowledge == StaticKnowledge::Known {
+        if template_libraries.knowledge == StaticKnowledge::Known {
             ValidationErrorAccumulator(ValidationError::UnknownLibrary {
                 name: lib.as_str().to_string(),
                 span: lib.span(),

--- a/crates/djls-semantic/src/validation/scoping.rs
+++ b/crates/djls-semantic/src/validation/scoping.rs
@@ -23,7 +23,7 @@ pub(crate) fn check_tag_scoping_rule(
     symbols: &AvailableSymbols,
     active_knowledge: StaticKnowledge,
 ) {
-    if active_knowledge != StaticKnowledge::Known {
+    if active_knowledge == StaticKnowledge::Unknown {
         return;
     }
 
@@ -31,6 +31,7 @@ pub(crate) fn check_tag_scoping_rule(
 
     match symbols.check(name) {
         TagAvailability::Available => {}
+        TagAvailability::Unknown if active_knowledge == StaticKnowledge::Partial => {}
         TagAvailability::Unknown => {
             ValidationErrorAccumulator(ValidationError::UnknownTag {
                 tag: name.to_string(),
@@ -64,12 +65,13 @@ pub(crate) fn check_filter_scoping_rule(
     symbols: &AvailableSymbols,
     active_knowledge: StaticKnowledge,
 ) {
-    if active_knowledge != StaticKnowledge::Known {
+    if active_knowledge == StaticKnowledge::Unknown {
         return;
     }
 
     match symbols.check_filter(&filter.name) {
         FilterAvailability::Available => {}
+        FilterAvailability::Unknown if active_knowledge == StaticKnowledge::Partial => {}
         FilterAvailability::Unknown => {
             ValidationErrorAccumulator(ValidationError::UnknownFilter {
                 filter: filter.name.clone(),
@@ -103,7 +105,7 @@ pub(crate) fn check_load_libraries_rule(
     bits: &[TagBit],
     template_libraries: &TemplateLibraries,
 ) {
-    if template_libraries.active_knowledge != StaticKnowledge::Known {
+    if template_libraries.active_knowledge == StaticKnowledge::Unknown {
         return;
     }
 
@@ -126,11 +128,13 @@ pub(crate) fn check_load_libraries_rule(
             continue;
         }
 
-        ValidationErrorAccumulator(ValidationError::UnknownLibrary {
-            name: lib.as_str().to_string(),
-            span: lib.span(),
-        })
-        .accumulate(db);
+        if template_libraries.active_knowledge == StaticKnowledge::Known {
+            ValidationErrorAccumulator(ValidationError::UnknownLibrary {
+                name: lib.as_str().to_string(),
+                span: lib.span(),
+            })
+            .accumulate(db);
+        }
     }
 }
 

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 use std::sync::Arc;
 
 use djls_semantic::ProjectDb;
-use djls_semantic::load_template_library_cache;
 use djls_semantic::refresh_external_data;
 use djls_source::FileKind;
 use tokio::sync::Mutex;
@@ -190,28 +189,7 @@ impl LanguageServer for DjangoLanguageServer {
     async fn initialized(&self, _params: ls_types::InitializedParams) {
         tracing::info!("Server received initialized notification.");
 
-        // Phase 1: Load the cached template library snapshot for near-instant startup.
-        // This populates template_libraries from disk cache so completions and
-        // diagnostics work immediately while fresh project introspection runs.
-        let cache_loaded = self
-            .with_session_mut(|session| {
-                let t = std::time::Instant::now();
-                let loaded = load_template_library_cache(session.db_mut());
-                if loaded {
-                    tracing::info!(
-                        "Template library snapshot cache loaded in {:?}",
-                        t.elapsed()
-                    );
-                } else {
-                    tracing::info!("No template library snapshot cache available");
-                }
-                loaded
-            })
-            .await;
-
-        // Phase 2: Refresh project data in the background.
-        // This validates/refreshes the cached data, extracts external
-        // rules, and initializes the workspace.
+        // Refresh project data in the background and initialize the workspace.
         let rx = self
             .with_session_mut_task(|session| async move {
                 let start = std::time::Instant::now();
@@ -232,12 +210,7 @@ impl LanguageServer for DjangoLanguageServer {
             })
             .await;
 
-        // If we loaded from cache, the server is already functional — requests
-        // arriving during the background refresh will use cached data. If no
-        // cache was available, we wait for the full initialization like before.
-        if !cache_loaded {
-            let _ = rx.await;
-        }
+        let _ = rx.await;
     }
 
     async fn shutdown(&self) -> LspResult<()> {

--- a/noxfile.py
+++ b/noxfile.py
@@ -127,7 +127,7 @@ def e2e(session):
         "-q",
         "-p",
         "djls-semantic",
-        "template_dirs_match_django_facts_golden",
+        "django_facts_golden",
         "--",
         "--ignored",
         external=True,


### PR DESCRIPTION
## Summary

- Derive template tag libraries from source and `DjangoSettings` instead of the runtime inspector snapshot.
- Remove the template-library project input, inspector refresh/cache path, and startup cache-loading phase.
- Gate diagnostics under `StaticKnowledge::Partial`: keep evidence-backed unloaded/arity diagnostics, suppress unsafe absence claims, and account for unknown loads that can shadow filters.
- Add golden comparison for derived template libraries against `tests/fixtures/django-facts/django-5.2.json` in `just e2e`.

## Validation

- `cargo build -q`
- `cargo test -q -j 2 -- --test-threads=2`
- `cargo clippy --all-targets --all-features --benches -- -D warnings`
- `just fmt`
- `just fmt --check`
- `just test "-q -j 2 -- --test-threads=2"`
- `just e2e`
- `just clippy`
- `just lint`
- stale-plumbing guards:
  - `rg "refresh_template_libraries|load_template_library_cache|CacheEnvelope" crates/` returned no matches
  - `rg "set_template_libraries|load_template_library_cache|inspector\.json" crates/` returned no matches
  - `rg "project_introspector\(\)\.query" crates/` returned no matches
  - `rg "TemplateLibrarySnapshot|TemplateSymbolSnapshot|apply_active_snapshot" crates/` returned no matches
