### PR TITLE
Reshape template library model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Changed template tag library discovery to derive libraries from project source and Django settings instead of the runtime inspector.
 - Bumped Rust toolchain from 1.95 to 1.96.
+- **Internal**: Reshaped template tag library storage around loadable and builtin mounts.
 
 ### Removed
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -326,7 +326,7 @@ _Avoid_: Template Tree, document symbol, syntax tree
 - "Project model", "project context", "project knowledge", and "project state" are not canonical terms; resolved: use **Project Facts**.
 - "Django Environment" is a path-scoped Django analysis context, not a Python environment, virtual environment, or OS environment.
 - "Template Library" can mean a collection of templates; resolved: use **Template Tag Library** for Django tag/filter libraries.
-- "Installed Template Tag Library" is ambiguous between pip-installed packages and Django `INSTALLED_APPS`; resolved: describe a **Template Tag Library** as discovered, active, or builtin.
+- "Installed Template Tag Library" is ambiguous between pip-installed packages and Django `INSTALLED_APPS`; resolved: describe a **Template Tag Library** as loadable (requires `{% load %}`) or builtin (preloaded). "Active" and "discovered" are not library availability states.
 - "Tag" can mean source syntax, a known definition, structural behavior, or semantic role; resolved: use **Template Tag**, **Tag Definition**, **Tag Spec**, and **Tag Role** for those different contexts.
 - "Definition" can mean the Python source that implements a tag or DJLS's model of a known tag; resolved: use **Definition Source** for provenance or navigation targets and **Tag Definition** or **Filter Definition** for the language server model.
 - "Block" is overloaded by Django syntax, Django inheritance, parser internals, and tree structure; resolved: use **Block Tag** for the structural definition category, **Block Template Tag** for the named `block` tag, **Inheritance Block** for the thing it defines, and **Template Branch** for the tree structure.

--- a/crates/djls-bench/src/specs.rs
+++ b/crates/djls-bench/src/specs.rs
@@ -161,10 +161,7 @@ fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
 
     for module_name in [DEFAULTTAGS, DEFAULTFILTERS] {
         let module = PyModuleName::parse(module_name).unwrap();
-        let name = LibraryName::parse(module.as_str().split('.').next_back().unwrap()).unwrap();
-        libraries
-            .builtins
-            .push(TemplateLibrary::new_builtin(name, module));
+        libraries.builtins.push(TemplateLibrary::new(module));
     }
 
     for (load_name, module_name) in [("i18n", I18N), ("static", STATIC)] {
@@ -172,9 +169,7 @@ fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
         let module = PyModuleName::parse(module_name).unwrap();
         libraries
             .loadable
-            .entry(load_name.clone())
-            .or_default()
-            .push(TemplateLibrary::new_active(load_name, module, None));
+            .insert(load_name, TemplateLibrary::new(module));
     }
 
     for bench_symbol in symbols {
@@ -192,10 +187,8 @@ fn build_template_libraries(symbols: Vec<BenchSymbol>) -> TemplateLibraries {
             Some(load_name) => {
                 let load_name = LibraryName::parse(load_name).unwrap();
                 let module = PyModuleName::parse(bench_symbol.module).unwrap();
-                if let Some(libraries) = libraries.loadable.get_mut(&load_name)
-                    && let Some(library) = libraries
-                        .iter_mut()
-                        .find(|library| library.module() == &module)
+                if let Some(library) = libraries.loadable.get_mut(&load_name)
+                    && library.module() == &module
                 {
                     library.merge_symbol(bench_symbol.symbol);
                 }

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -821,7 +821,7 @@ def my_filter(value, arg):
     fn assert_custom_library_module(db: &DjangoDatabase, module_path: &str) {
         assert_eq!(
             db.template_libraries()
-                .best_loadable_library_str("custom")
+                .loadable_library_str("custom")
                 .unwrap()
                 .module()
                 .as_str(),
@@ -947,7 +947,7 @@ def my_filter(value, arg):
 
         assert!(
             db.template_libraries()
-                .best_loadable_library_str("custom")
+                .loadable_library_str("custom")
                 .is_none()
         );
         let extra_file = djls_source::Db::get_or_create_file(&db, &extra_settings_path);
@@ -1003,7 +1003,7 @@ def my_filter(value, arg):
 
         let libraries = db.template_libraries();
         let custom = libraries
-            .best_loadable_library_str("custom")
+            .loadable_library_str("custom")
             .expect("custom library should be derived");
         assert_eq!(custom.module().as_str(), "blog.templatetags.custom");
         assert!(custom.symbols.iter().any(|symbol| symbol.name() == "hello"));
@@ -1055,7 +1055,7 @@ def my_filter(value, arg):
         db.project = Some(project);
 
         let libraries = db.template_libraries();
-        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        let custom = libraries.loadable_library_str("custom").unwrap();
         assert!(
             custom
                 .symbols
@@ -1072,7 +1072,7 @@ def my_filter(value, arg):
         db.bump_file_revision(tag_file);
 
         let libraries = db.template_libraries();
-        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        let custom = libraries.loadable_library_str("custom").unwrap();
         assert!(
             custom
                 .symbols

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -651,7 +651,7 @@ fn generate_load_symbol_candidates(
         return Vec::new();
     }
 
-    let Some(library) = library.and_then(|name| template_libraries.best_loadable_library_str(name))
+    let Some(library) = library.and_then(|name| template_libraries.loadable_library_str(name))
     else {
         return Vec::new();
     };
@@ -750,10 +750,7 @@ mod tests {
         for (name, module) in libraries {
             let name = LibraryName::parse(name).unwrap();
             let module = PyModuleName::parse(module).unwrap();
-            loadable.insert(
-                name.clone(),
-                vec![TemplateLibrary::new_active(name, module, None)],
-            );
+            loadable.insert(name, TemplateLibrary::new(module));
         }
 
         TemplateLibraries {
@@ -780,7 +777,7 @@ mod tests {
     fn filter_libraries() -> TemplateLibraries {
         let library_name = LibraryName::parse("i18n").unwrap();
         let module = PyModuleName::parse("django.templatetags.i18n").unwrap();
-        let mut library = TemplateLibrary::new_active(library_name.clone(), module.clone(), None);
+        let mut library = TemplateLibrary::new(module.clone());
         library.symbols.push(template_symbol(
             TemplateSymbolKind::Filter,
             "trans",
@@ -790,17 +787,14 @@ mod tests {
 
         TemplateLibraries {
             knowledge: StaticKnowledge::Known,
-            loadable: BTreeMap::from([(library_name, vec![library])]),
+            loadable: BTreeMap::from([(library_name, library)]),
             builtins: Vec::new(),
         }
     }
 
     fn tag_libraries() -> TemplateLibraries {
         let builtin_module = PyModuleName::parse("django.template.defaulttags").unwrap();
-        let mut builtin = TemplateLibrary::new_builtin(
-            LibraryName::parse("defaulttags").unwrap(),
-            builtin_module.clone(),
-        );
+        let mut builtin = TemplateLibrary::new(builtin_module.clone());
         builtin.symbols.push(template_symbol(
             TemplateSymbolKind::Tag,
             "if",
@@ -810,7 +804,7 @@ mod tests {
 
         let i18n_name = LibraryName::parse("i18n").unwrap();
         let i18n_module = PyModuleName::parse("django.templatetags.i18n").unwrap();
-        let mut i18n = TemplateLibrary::new_active(i18n_name.clone(), i18n_module.clone(), None);
+        let mut i18n = TemplateLibrary::new(i18n_module.clone());
         i18n.symbols.push(template_symbol(
             TemplateSymbolKind::Tag,
             "trans",
@@ -826,7 +820,7 @@ mod tests {
 
         TemplateLibraries {
             knowledge: StaticKnowledge::Known,
-            loadable: BTreeMap::from([(i18n_name, vec![i18n])]),
+            loadable: BTreeMap::from([(i18n_name, i18n)]),
             builtins: vec![builtin],
         }
     }

--- a/crates/djls-ide/src/hover.rs
+++ b/crates/djls-ide/src/hover.rs
@@ -46,7 +46,7 @@ pub fn hover(db: &dyn djls_semantic::Db, file: File, offset: Offset) -> Option<l
             Some((sections.join("\n---\n"), span))
         }
         SemanticOffsetContext::LoadLibrary { name, span } => {
-            let library = db.template_libraries().best_loadable_library_str(&name)?;
+            let library = db.template_libraries().loadable_library_str(&name)?;
             Some((
                 format!(
                     "```text\n(library) {name}\n```\n---\n```python\n{}\n```",

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -25,7 +25,6 @@ pub use project::InstalledSymbolCandidate;
 pub use project::InstalledSymbolOrigin;
 pub use project::Interpreter;
 pub use project::LibraryName;
-pub use project::LibraryOrigin;
 pub use project::Project;
 pub use project::ProjectIntrospector;
 pub use project::PyModuleName;
@@ -126,10 +125,10 @@ mod tests {
     use crate::ValidationError;
     use crate::filters::FilterAritySpecs;
     use crate::testing::TestDatabase;
-    use crate::testing::builtin_filter_json;
-    use crate::testing::builtin_tag_json;
+    use crate::testing::builtin_filter;
+    use crate::testing::builtin_tag;
     use crate::testing::collect_errors;
-    use crate::testing::library_tag_json;
+    use crate::testing::library_tag;
     use crate::testing::make_template_libraries;
 
     fn default_builtins_module() -> &'static str {
@@ -142,22 +141,22 @@ mod tests {
 
     fn standard_inventory() -> TemplateLibraries {
         let tags = vec![
-            builtin_tag_json("if", default_builtins_module()),
-            builtin_tag_json("for", default_builtins_module()),
-            builtin_tag_json("block", default_builtins_module()),
-            builtin_tag_json("verbatim", default_builtins_module()),
-            builtin_tag_json("comment", default_builtins_module()),
-            builtin_tag_json("load", default_builtins_module()),
-            builtin_tag_json("csrf_token", default_builtins_module()),
-            builtin_tag_json("with", default_builtins_module()),
-            library_tag_json("trans", "i18n", "django.templatetags.i18n"),
+            builtin_tag("if", default_builtins_module()),
+            builtin_tag("for", default_builtins_module()),
+            builtin_tag("block", default_builtins_module()),
+            builtin_tag("verbatim", default_builtins_module()),
+            builtin_tag("comment", default_builtins_module()),
+            builtin_tag("load", default_builtins_module()),
+            builtin_tag("csrf_token", default_builtins_module()),
+            builtin_tag("with", default_builtins_module()),
+            library_tag("trans", "i18n", "django.templatetags.i18n"),
         ];
         let filters = vec![
-            builtin_filter_json("title", default_filters_module()),
-            builtin_filter_json("lower", default_filters_module()),
-            builtin_filter_json("default", default_filters_module()),
-            builtin_filter_json("truncatewords", default_filters_module()),
-            builtin_filter_json("date", default_filters_module()),
+            builtin_filter("title", default_filters_module()),
+            builtin_filter("lower", default_filters_module()),
+            builtin_filter("default", default_filters_module()),
+            builtin_filter("truncatewords", default_filters_module()),
+            builtin_filter("date", default_filters_module()),
         ];
         let mut libraries = HashMap::new();
         libraries.insert("i18n".to_string(), "django.templatetags.i18n".to_string());
@@ -224,9 +223,9 @@ mod tests {
 
     fn partial_ambiguous_db() -> TestDatabase {
         let tags = vec![
-            builtin_tag_json("load", default_builtins_module()),
-            library_tag_json("shared", "alpha", "project.alpha_tags"),
-            library_tag_json("shared", "beta", "project.beta_tags"),
+            builtin_tag("load", default_builtins_module()),
+            library_tag("shared", "alpha", "project.alpha_tags"),
+            library_tag("shared", "beta", "project.beta_tags"),
         ];
         let filters = Vec::new();
         let libraries = HashMap::from([

--- a/crates/djls-semantic/src/project.rs
+++ b/crates/djls-semantic/src/project.rs
@@ -27,7 +27,6 @@ pub use crate::project::settings::template_dirs;
 pub use crate::project::settings::template_libraries;
 pub use crate::project::symbols::InstalledSymbolCandidate;
 pub use crate::project::symbols::InstalledSymbolOrigin;
-pub use crate::project::symbols::LibraryOrigin;
 pub use crate::project::symbols::SymbolDefinition;
 pub use crate::project::symbols::TemplateLibraries;
 pub use crate::project::symbols::TemplateLibrary;

--- a/crates/djls-semantic/src/project/settings.rs
+++ b/crates/djls-semantic/src/project/settings.rs
@@ -25,8 +25,6 @@ use crate::project::names::LibraryName;
 use crate::project::names::PyModuleName;
 use crate::project::names::TemplateSymbolName;
 use crate::project::resolve::module_file_in_search_path;
-use crate::project::symbols::LibraryOrigin;
-use crate::project::symbols::LibraryStatus;
 use crate::project::symbols::SymbolDefinition;
 use crate::project::symbols::TemplateLibraries;
 use crate::project::symbols::TemplateLibrary;
@@ -164,14 +162,22 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         libraries.knowledge = libraries.knowledge.demoted_to_partial();
     }
 
-    libraries.apply_derived(templatetag_package_libraries(&resolver, "django"));
+    let (knowledge, discovered_libraries) = templatetag_package_libraries(&resolver, "django");
+    libraries.knowledge = libraries.knowledge.weakened_by(knowledge);
+    for (load_name, library) in discovered_libraries {
+        libraries.insert_loadable(load_name, library);
+    }
 
     if settings.installed_apps.knowledge != StaticKnowledge::Unknown {
         for installed_app in &settings.installed_apps.values {
-            libraries.apply_derived(templatetag_package_libraries(
+            let (knowledge, discovered_libraries) = templatetag_package_libraries(
                 &resolver,
                 installed_app_package_module(installed_app),
-            ));
+            );
+            libraries.knowledge = libraries.knowledge.weakened_by(knowledge);
+            for (load_name, library) in discovered_libraries {
+                libraries.insert_loadable(load_name, library);
+            }
         }
     }
 
@@ -184,114 +190,51 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
     {
         libraries.knowledge = libraries.knowledge.weakened_by(backend.knowledge);
 
-        let configured = backend.libraries.iter().map(|(load_name, module_path)| {
-            SettingsLibraryDeclaration::Loadable {
-                load_name,
-                module_path,
+        for (load_name, module_path) in &backend.libraries {
+            let Ok(load_name) = LibraryName::parse(load_name) else {
+                libraries.knowledge = libraries.knowledge.demoted_to_partial();
+                continue;
+            };
+            let (knowledge, library) = library_from_module_path(&resolver, module_path);
+            libraries.knowledge = libraries.knowledge.weakened_by(knowledge);
+            if let Some(library) = library {
+                libraries.insert_loadable(load_name, library);
             }
-        });
-        let builtins = DEFAULT_TEMPLATE_BUILTINS
+        }
+
+        for module_path in DEFAULT_TEMPLATE_BUILTINS
             .iter()
             .copied()
             .chain(backend.builtins.iter().map(String::as_str))
-            .map(|module_path| SettingsLibraryDeclaration::Builtin { module_path });
-
-        for declaration in configured.chain(builtins) {
-            libraries.apply_derived(declaration.derive(&resolver));
+        {
+            let (knowledge, library) = library_from_module_path(&resolver, module_path);
+            libraries.knowledge = libraries.knowledge.weakened_by(knowledge);
+            if let Some(library) = library {
+                libraries.push_builtin(library);
+            }
         }
     }
 
     libraries
 }
 
-impl TemplateLibraries {
-    fn apply_derived(&mut self, derived: DerivedTemplateLibraries) {
-        self.knowledge = self.knowledge.weakened_by(derived.knowledge);
-        for library in derived.libraries {
-            match &library.status {
-                LibraryStatus::Active { .. } => self.set_loadable(library),
-                LibraryStatus::Builtin { .. } => self.push_builtin(library),
-            }
-        }
-    }
-}
-
-struct DerivedTemplateLibraries {
-    knowledge: StaticKnowledge,
-    libraries: Vec<TemplateLibrary>,
-}
-
-impl Default for DerivedTemplateLibraries {
-    fn default() -> Self {
-        Self {
-            knowledge: StaticKnowledge::Known,
-            libraries: Vec::new(),
-        }
-    }
-}
-
-impl DerivedTemplateLibraries {
-    fn known(library: TemplateLibrary) -> Self {
-        Self {
-            knowledge: StaticKnowledge::Known,
-            libraries: vec![library],
-        }
-    }
-
-    fn partial(library: Option<TemplateLibrary>) -> Self {
-        Self {
-            knowledge: StaticKnowledge::Partial,
-            libraries: library.into_iter().collect(),
-        }
-    }
-
-    fn demote_to_partial(&mut self) {
-        self.knowledge = self.knowledge.demoted_to_partial();
-    }
-}
-
-#[derive(Clone, Copy)]
-enum SettingsLibraryDeclaration<'a> {
-    Loadable {
-        load_name: &'a str,
-        module_path: &'a str,
-    },
-    Builtin {
-        module_path: &'a str,
-    },
-}
-
-impl SettingsLibraryDeclaration<'_> {
-    fn derive(self, resolver: &SalsaSettingsResolver<'_>) -> DerivedTemplateLibraries {
-        match self {
-            Self::Loadable {
-                load_name,
-                module_path,
-            } => configured_library(resolver, load_name, module_path),
-            Self::Builtin { module_path } => builtin_library(resolver, module_path),
-        }
-    }
-}
-
 fn templatetag_package_libraries(
     resolver: &SalsaSettingsResolver<'_>,
     package_module: &str,
-) -> DerivedTemplateLibraries {
-    let mut derived = DerivedTemplateLibraries::default();
+) -> (StaticKnowledge, Vec<(LibraryName, TemplateLibrary)>) {
+    let mut knowledge = StaticKnowledge::Known;
+    let mut libraries = Vec::new();
 
     if package_module.is_empty() {
-        derived.demote_to_partial();
-        return derived;
+        return (knowledge.demoted_to_partial(), libraries);
     }
 
-    let Ok(app_module) = PyModuleName::parse(package_module) else {
-        derived.demote_to_partial();
-        return derived;
-    };
+    if PyModuleName::parse(package_module).is_err() {
+        return (knowledge.demoted_to_partial(), libraries);
+    }
 
     let Some(package_dir) = package_dir(resolver.db, resolver.project, package_module) else {
-        derived.demote_to_partial();
-        return derived;
+        return (knowledge.demoted_to_partial(), libraries);
     };
 
     let templatetags_dir = package_dir.join("templatetags");
@@ -299,7 +242,7 @@ fn templatetag_package_libraries(
         .db
         .path_is_file(&templatetags_dir.join("__init__.py"))
     {
-        return derived;
+        return (knowledge, libraries);
     }
 
     let entries = match resolver
@@ -309,8 +252,7 @@ fn templatetag_package_libraries(
         Ok(entries) => entries,
         Err(err) => {
             tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
-            derived.demote_to_partial();
-            return derived;
+            return (knowledge.demoted_to_partial(), libraries);
         }
     };
 
@@ -327,12 +269,12 @@ fn templatetag_package_libraries(
         }
 
         let Ok(load_name) = LibraryName::parse(stem) else {
-            derived.demote_to_partial();
+            knowledge = knowledge.demoted_to_partial();
             continue;
         };
         let module_path = format!("{package_module}.templatetags.{stem}");
         let Ok(module) = PyModuleName::parse(&module_path) else {
-            derived.demote_to_partial();
+            knowledge = knowledge.demoted_to_partial();
             continue;
         };
 
@@ -342,61 +284,28 @@ fn templatetag_package_libraries(
             continue;
         }
 
-        let origin = LibraryOrigin {
-            app: app_module.clone(),
-            module: module.clone(),
-            path: entry.path,
-        };
-        let mut library = TemplateLibrary::new_active(load_name, module, Some(origin));
+        let mut library = TemplateLibrary::new(module);
         library.merge_symbols(analysis.symbols);
-        derived.libraries.push(library);
+        libraries.push((load_name, library));
     }
 
-    derived
+    (knowledge, libraries)
 }
 
-fn configured_library(
-    resolver: &SalsaSettingsResolver<'_>,
-    load_name: &str,
-    module_path: &str,
-) -> DerivedTemplateLibraries {
-    let Ok(load_name) = LibraryName::parse(load_name) else {
-        return DerivedTemplateLibraries::partial(None);
-    };
-    let Ok(module) = PyModuleName::parse(module_path) else {
-        return DerivedTemplateLibraries::partial(None);
-    };
-
-    library_with_symbols(
-        resolver,
-        TemplateLibrary::new_active(load_name, module, None),
-    )
-}
-
-fn builtin_library(
+fn library_from_module_path(
     resolver: &SalsaSettingsResolver<'_>,
     module_path: &str,
-) -> DerivedTemplateLibraries {
+) -> (StaticKnowledge, Option<TemplateLibrary>) {
     let Ok(module) = PyModuleName::parse(module_path) else {
-        return DerivedTemplateLibraries::partial(None);
-    };
-    let Ok(name) = LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
-    else {
-        return DerivedTemplateLibraries::partial(None);
+        return (StaticKnowledge::Partial, None);
     };
 
-    library_with_symbols(resolver, TemplateLibrary::new_builtin(name, module))
-}
-
-fn library_with_symbols(
-    resolver: &SalsaSettingsResolver<'_>,
-    mut library: TemplateLibrary,
-) -> DerivedTemplateLibraries {
+    let mut library = TemplateLibrary::new(module);
     if let Some(file) = module_file(resolver.db, resolver.project, library.module().as_str()) {
         library.merge_symbols(TemplateLibraryAnalysis::from_file(resolver.db, file).symbols);
-        DerivedTemplateLibraries::known(library)
+        (StaticKnowledge::Known, Some(library))
     } else {
-        DerivedTemplateLibraries::partial(Some(library))
+        (StaticKnowledge::Partial, Some(library))
     }
 }
 
@@ -921,7 +830,7 @@ mod tests {
 
         assert_eq!(libraries.knowledge, StaticKnowledge::Known);
         let custom = libraries
-            .best_loadable_library_str("custom")
+            .loadable_library_str("custom")
             .expect("custom library should be discovered");
         assert_eq!(custom.module().as_str(), "blog.templatetags.custom");
         assert!(custom.symbols.iter().any(|symbol| symbol.name() == "hello"));
@@ -971,7 +880,7 @@ mod tests {
 
         let libraries = template_libraries(&db, project);
 
-        let empty = libraries.best_loadable_library_str("empty").unwrap();
+        let empty = libraries.loadable_library_str("empty").unwrap();
         assert_eq!(empty.module().as_str(), "blog.templatetags.empty");
         assert!(empty.symbols.is_empty());
     }
@@ -1029,7 +938,7 @@ mod tests {
 
         let libraries = template_libraries(&db, project);
 
-        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        let custom = libraries.loadable_library_str("custom").unwrap();
         assert_eq!(custom.module().as_str(), "custom_tags");
         assert!(
             custom
@@ -1078,7 +987,7 @@ mod tests {
         let libraries = template_libraries(&db, project);
 
         assert_eq!(libraries.knowledge, StaticKnowledge::Partial);
-        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        let custom = libraries.loadable_library_str("custom").unwrap();
         assert_eq!(custom.module().as_str(), "project_tags");
         assert!(
             custom
@@ -1125,7 +1034,7 @@ mod tests {
 
         let libraries = template_libraries(&db, project);
 
-        let custom = libraries.best_loadable_library_str("custom").unwrap();
+        let custom = libraries.loadable_library_str("custom").unwrap();
         assert_eq!(custom.module().as_str(), "project_tags");
         assert!(
             custom

--- a/crates/djls-semantic/src/project/symbols.rs
+++ b/crates/djls-semantic/src/project/symbols.rs
@@ -16,7 +16,7 @@ pub enum TemplateSymbolKind {
     Filter,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SymbolDefinition {
     Exact { file: Utf8PathBuf },
     Module(PyModuleName),
@@ -35,12 +35,11 @@ impl SymbolDefinition {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TemplateSymbol {
     pub kind: TemplateSymbolKind,
     pub name: TemplateSymbolName,
     pub definition: SymbolDefinition,
-    #[serde(default)]
     pub doc: Option<String>,
 }
 
@@ -56,76 +55,24 @@ impl TemplateSymbol {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LibraryOrigin {
-    pub app: PyModuleName,
-    pub module: PyModuleName,
-    pub path: Utf8PathBuf,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LibraryStatus {
-    Active {
-        module: PyModuleName,
-        origin: Option<LibraryOrigin>,
-    },
-    Builtin {
-        module: PyModuleName,
-    },
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TemplateLibrary {
-    pub name: LibraryName,
-    pub status: LibraryStatus,
-    #[serde(default)]
+    pub module: PyModuleName,
     pub symbols: Vec<TemplateSymbol>,
 }
 
 impl TemplateLibrary {
     #[must_use]
-    pub fn new_active(
-        name: LibraryName,
-        module: PyModuleName,
-        origin: Option<LibraryOrigin>,
-    ) -> Self {
+    pub fn new(module: PyModuleName) -> Self {
         Self {
-            name,
-            status: LibraryStatus::Active { module, origin },
-            symbols: Vec::new(),
-        }
-    }
-
-    #[must_use]
-    pub fn new_builtin(name: LibraryName, module: PyModuleName) -> Self {
-        Self {
-            name,
-            status: LibraryStatus::Builtin { module },
+            module,
             symbols: Vec::new(),
         }
     }
 
     #[must_use]
     pub fn module(&self) -> &PyModuleName {
-        match &self.status {
-            LibraryStatus::Active { module, .. } | LibraryStatus::Builtin { module } => module,
-        }
-    }
-
-    #[must_use]
-    pub fn origin(&self) -> Option<&LibraryOrigin> {
-        match &self.status {
-            LibraryStatus::Active { origin, .. } => origin.as_ref(),
-            LibraryStatus::Builtin { .. } => None,
-        }
-    }
-
-    #[must_use]
-    pub fn is_active(&self) -> bool {
-        matches!(
-            self.status,
-            LibraryStatus::Active { .. } | LibraryStatus::Builtin { .. }
-        )
+        &self.module
     }
 
     pub fn merge_symbol(&mut self, new_symbol: TemplateSymbol) {
@@ -171,10 +118,10 @@ pub struct InstalledSymbolCandidate {
     pub origin: InstalledSymbolOrigin,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TemplateLibraries {
     pub knowledge: StaticKnowledge,
-    pub loadable: BTreeMap<LibraryName, Vec<TemplateLibrary>>,
+    pub loadable: BTreeMap<LibraryName, TemplateLibrary>,
     pub builtins: Vec<TemplateLibrary>,
 }
 
@@ -204,7 +151,7 @@ impl TemplateLibraries {
 
         let mut modules = Vec::new();
 
-        for (_name, library) in self.enabled_loadable_libraries() {
+        for (_name, library) in self.loadable_libraries() {
             push_unique_module(&mut modules, library.module().clone());
         }
 
@@ -237,11 +184,7 @@ impl TemplateLibraries {
 
     #[must_use]
     pub fn completion_library_names(&self) -> Vec<LibraryName> {
-        let mut names: Vec<LibraryName> = self
-            .loadable_library_names()
-            .filter(|name| self.is_enabled_library(name))
-            .cloned()
-            .collect();
+        let mut names: Vec<LibraryName> = self.loadable_library_names().cloned().collect();
 
         names.sort();
         names.dedup();
@@ -251,13 +194,11 @@ impl TemplateLibraries {
     pub fn loadable_libraries(
         &self,
     ) -> impl Iterator<Item = (&LibraryName, &TemplateLibrary)> + '_ {
-        self.loadable
-            .iter()
-            .flat_map(|(name, libraries)| libraries.iter().map(move |library| (name, library)))
+        self.loadable.iter()
     }
 
-    pub(crate) fn set_loadable(&mut self, library: TemplateLibrary) {
-        self.loadable.insert(library.name.clone(), vec![library]);
+    pub(crate) fn insert_loadable(&mut self, name: LibraryName, library: TemplateLibrary) {
+        self.loadable.insert(name, library);
     }
 
     pub(crate) fn push_builtin(&mut self, library: TemplateLibrary) {
@@ -268,13 +209,6 @@ impl TemplateLibraries {
         {
             self.builtins.push(library);
         }
-    }
-
-    pub fn enabled_loadable_libraries(
-        &self,
-    ) -> impl Iterator<Item = (&LibraryName, &TemplateLibrary)> + '_ {
-        self.loadable_libraries()
-            .filter(|(_name, library)| library.is_active())
     }
 
     #[must_use]
@@ -304,7 +238,7 @@ impl TemplateLibraries {
         }
         candidates.extend(builtin_candidates.into_values());
 
-        for (name, library) in self.enabled_loadable_libraries() {
+        for (name, library) in self.loadable_libraries() {
             for symbol in &library.symbols {
                 if symbol.kind != kind {
                     continue;
@@ -323,26 +257,19 @@ impl TemplateLibraries {
     }
 
     #[must_use]
-    pub fn best_loadable_library(&self, name: &LibraryName) -> Option<&TemplateLibrary> {
-        let libraries = self.loadable.get(name)?;
-
-        libraries
-            .iter()
-            .find(|library| library.is_active())
-            .or_else(|| libraries.iter().find(|library| library.origin().is_some()))
-            .or_else(|| libraries.first())
+    pub fn loadable_library(&self, name: &LibraryName) -> Option<&TemplateLibrary> {
+        self.loadable.get(name)
     }
 
     #[must_use]
-    pub fn best_loadable_library_str(&self, name: &str) -> Option<&TemplateLibrary> {
+    pub fn loadable_library_str(&self, name: &str) -> Option<&TemplateLibrary> {
         let name = LibraryName::parse(name).ok()?;
-        self.best_loadable_library(&name)
+        self.loadable_library(&name)
     }
 
     #[must_use]
     pub fn loadable_library_module(&self, name: &LibraryName) -> Option<&PyModuleName> {
-        self.best_loadable_library(name)
-            .map(TemplateLibrary::module)
+        self.loadable_library(name).map(TemplateLibrary::module)
     }
 
     #[must_use]
@@ -352,15 +279,13 @@ impl TemplateLibraries {
     }
 
     #[must_use]
-    pub fn is_enabled_library(&self, name: &LibraryName) -> bool {
-        self.loadable
-            .get(name)
-            .is_some_and(|libraries| libraries.iter().any(TemplateLibrary::is_active))
+    pub fn is_loadable(&self, name: &LibraryName) -> bool {
+        self.loadable.contains_key(name)
     }
 
     #[must_use]
-    pub fn is_enabled_library_str(&self, name: &str) -> bool {
-        LibraryName::parse(name).is_ok_and(|name| self.is_enabled_library(&name))
+    pub fn is_loadable_str(&self, name: &str) -> bool {
+        LibraryName::parse(name).is_ok_and(|name| self.is_loadable(&name))
     }
 }
 
@@ -391,20 +316,16 @@ mod tests {
         }
     }
 
-    fn builtin_library(
-        name: &str,
-        module_name: &str,
-        symbols: Vec<TemplateSymbol>,
-    ) -> TemplateLibrary {
-        let mut library = TemplateLibrary::new_builtin(library_name(name), module(module_name));
+    fn builtin_library(module_name: &str, symbols: Vec<TemplateSymbol>) -> TemplateLibrary {
+        let mut library = TemplateLibrary::new(module(module_name));
         for symbol in symbols {
             library.merge_symbol(symbol);
         }
         library
     }
 
-    fn active_library(name: &str, module_name: &str) -> TemplateLibrary {
-        TemplateLibrary::new_active(library_name(name), module(module_name), None)
+    fn loadable_library(module_name: &str) -> TemplateLibrary {
+        TemplateLibrary::new(module(module_name))
     }
 
     #[test]
@@ -416,7 +337,6 @@ mod tests {
         let a_second = module("a_second");
         libraries.builtins.push(builtin_library(
             "z_first",
-            "z_first",
             vec![symbol(
                 TemplateSymbolKind::Filter,
                 "duplicate",
@@ -424,7 +344,6 @@ mod tests {
             )],
         ));
         libraries.builtins.push(builtin_library(
-            "a_second",
             a_second.as_str(),
             vec![symbol(
                 TemplateSymbolKind::Filter,
@@ -449,11 +368,10 @@ mod tests {
             knowledge: StaticKnowledge::Known,
             ..TemplateLibraries::default()
         };
-        libraries
-            .loadable
-            .entry(library_name("project_tags"))
-            .or_default()
-            .push(active_library("project_tags", "project.tags"));
+        libraries.loadable.insert(
+            library_name("project_tags"),
+            loadable_library("project.tags"),
+        );
         for module_name in [
             "z.templatetags.tags",
             "django.template.defaulttags",
@@ -465,11 +383,9 @@ mod tests {
                 .iter()
                 .any(|library| library.module() == &module)
             {
-                libraries.builtins.push(builtin_library(
-                    "defaulttags",
-                    module.as_str(),
-                    Vec::new(),
-                ));
+                libraries
+                    .builtins
+                    .push(builtin_library(module.as_str(), Vec::new()));
             }
         }
 
@@ -495,11 +411,10 @@ mod tests {
             knowledge: StaticKnowledge::Partial,
             ..TemplateLibraries::default()
         };
-        libraries
-            .loadable
-            .entry(library_name("project_tags"))
-            .or_default()
-            .push(active_library("project_tags", "project.tags"));
+        libraries.loadable.insert(
+            library_name("project_tags"),
+            loadable_library("project.tags"),
+        );
 
         let modules: Vec<_> = libraries
             .registration_modules()

--- a/crates/djls-semantic/src/scoping/loads.rs
+++ b/crates/djls-semantic/src/scoping/loads.rs
@@ -217,9 +217,9 @@ impl LoadedLibraries {
             match &stmt.kind {
                 LoadKind::FullLoad { libraries } => libraries
                     .iter()
-                    .any(|library| !template_libraries.is_enabled_library_str(library.as_str())),
+                    .any(|library| !template_libraries.is_loadable_str(library.as_str())),
                 LoadKind::SelectiveImport { symbols, library } => {
-                    !template_libraries.is_enabled_library_str(library.as_str())
+                    !template_libraries.is_loadable_str(library.as_str())
                         && symbols.iter().any(|loaded| loaded.as_str() == symbol)
                 }
             }

--- a/crates/djls-semantic/src/scoping/symbols.rs
+++ b/crates/djls-semantic/src/scoping/symbols.rs
@@ -22,8 +22,8 @@ pub enum TagAvailability {
     /// The tag is known but defined in multiple unloaded libraries. Contains
     /// all candidate library names, sorted alphabetically.
     AmbiguousUnloaded { libraries: Vec<String> },
-    /// The tag is completely unknown — not in builtins and not in the inspector
-    /// inventory.
+    /// The tag is completely unknown — not builtin and not in any known
+    /// loadable library.
     Unknown,
 }
 
@@ -38,8 +38,8 @@ pub enum FilterAvailability {
     /// The filter is known but defined in multiple unloaded libraries. Contains
     /// all candidate library names, sorted alphabetically.
     AmbiguousUnloaded { libraries: Vec<String> },
-    /// The filter is completely unknown — not in builtins and not in the inspector
-    /// inventory.
+    /// The filter is completely unknown — not builtin and not in any known
+    /// loadable library.
     Unknown,
 }
 
@@ -97,7 +97,7 @@ impl AvailableSymbols {
             });
 
         let (loadable_tag_count, loadable_filter_count) = template_libraries
-            .enabled_loadable_libraries()
+            .loadable_libraries()
             .flat_map(|(_, lib)| &lib.symbols)
             .fold((0usize, 0usize), |(tags, filters), sym| match sym.kind {
                 TemplateSymbolKind::Tag => (tags + 1, filters),
@@ -133,8 +133,8 @@ impl AvailableSymbols {
             }
         }
 
-        // Build reverse indices for enabled, loadable libraries.
-        for (name, library) in template_libraries.enabled_loadable_libraries() {
+        // Build reverse indices for loadable libraries.
+        for (name, library) in template_libraries.loadable_libraries() {
             let load_name = name.as_str();
 
             for symbol in &library.symbols {
@@ -338,10 +338,10 @@ mod tests {
     use super::super::LoadKind;
     use super::super::LoadStatement;
     use super::*;
-    use crate::testing::builtin_filter_json;
-    use crate::testing::builtin_tag_json;
-    use crate::testing::library_filter_json;
-    use crate::testing::library_tag_json;
+    use crate::testing::builtin_filter;
+    use crate::testing::builtin_tag;
+    use crate::testing::library_filter;
+    use crate::testing::library_tag;
     use crate::testing::make_template_libraries;
     use crate::testing::make_template_libraries_tags_only;
 
@@ -351,13 +351,13 @@ mod tests {
 
     fn test_inventory() -> TemplateLibraries {
         let tags = vec![
-            builtin_tag_json("if", "django.template.defaulttags"),
-            builtin_tag_json("for", "django.template.defaulttags"),
-            builtin_tag_json("block", "django.template.loader_tags"),
-            library_tag_json("trans", "i18n", "django.templatetags.i18n"),
-            library_tag_json("blocktrans", "i18n", "django.templatetags.i18n"),
-            library_tag_json("static", "static", "django.templatetags.static"),
-            library_tag_json("get_static_prefix", "static", "django.templatetags.static"),
+            builtin_tag("if", "django.template.defaulttags"),
+            builtin_tag("for", "django.template.defaulttags"),
+            builtin_tag("block", "django.template.loader_tags"),
+            library_tag("trans", "i18n", "django.templatetags.i18n"),
+            library_tag("blocktrans", "i18n", "django.templatetags.i18n"),
+            library_tag("static", "static", "django.templatetags.static"),
+            library_tag("get_static_prefix", "static", "django.templatetags.static"),
         ];
 
         let mut libraries = FxHashMap::default();
@@ -491,9 +491,9 @@ mod tests {
     fn tag_in_multiple_libraries_produces_ambiguous() {
         // Create inventory with a tag defined in two libraries
         let tags = vec![
-            builtin_tag_json("if", "django.template.defaulttags"),
-            library_tag_json("mytag", "lib_a", "app.templatetags.lib_a"),
-            library_tag_json("mytag", "lib_b", "app.templatetags.lib_b"),
+            builtin_tag("if", "django.template.defaulttags"),
+            library_tag("mytag", "lib_a", "app.templatetags.lib_a"),
+            library_tag("mytag", "lib_b", "app.templatetags.lib_b"),
         ];
 
         let mut libraries = FxHashMap::default();
@@ -516,8 +516,8 @@ mod tests {
     #[test]
     fn ambiguous_resolved_by_loading_one_library() {
         let tags = vec![
-            library_tag_json("mytag", "lib_a", "app.templatetags.lib_a"),
-            library_tag_json("mytag", "lib_b", "app.templatetags.lib_b"),
+            library_tag("mytag", "lib_a", "app.templatetags.lib_a"),
+            library_tag("mytag", "lib_b", "app.templatetags.lib_b"),
         ];
 
         let mut libraries = FxHashMap::default();
@@ -657,8 +657,8 @@ mod tests {
     fn selective_import_with_ambiguous_tag() {
         // Tag "shared" exists in both lib_a and lib_b
         let tags = vec![
-            library_tag_json("shared", "lib_a", "app.templatetags.lib_a"),
-            library_tag_json("shared", "lib_b", "app.templatetags.lib_b"),
+            library_tag("shared", "lib_a", "app.templatetags.lib_a"),
+            library_tag("shared", "lib_b", "app.templatetags.lib_b"),
         ];
 
         let mut libraries = FxHashMap::default();
@@ -683,16 +683,16 @@ mod tests {
     }
 
     fn test_inventory_with_filters() -> TemplateLibraries {
-        let tags = vec![builtin_tag_json("if", "django.template.defaulttags")];
+        let tags = vec![builtin_tag("if", "django.template.defaulttags")];
         let filters = vec![
-            builtin_filter_json("title", "django.template.defaultfilters"),
-            builtin_filter_json("lower", "django.template.defaultfilters"),
-            library_filter_json(
+            builtin_filter("title", "django.template.defaultfilters"),
+            builtin_filter("lower", "django.template.defaultfilters"),
+            library_filter(
                 "apnumber",
                 "humanize",
                 "django.contrib.humanize.templatetags.humanize",
             ),
-            library_filter_json(
+            library_filter(
                 "intcomma",
                 "humanize",
                 "django.contrib.humanize.templatetags.humanize",
@@ -780,8 +780,8 @@ mod tests {
     #[test]
     fn filter_in_multiple_libraries_produces_ambiguous() {
         let filters = vec![
-            library_filter_json("shared", "lib_a", "app.templatetags.lib_a"),
-            library_filter_json("shared", "lib_b", "app.templatetags.lib_b"),
+            library_filter("shared", "lib_a", "app.templatetags.lib_a"),
+            library_filter("shared", "lib_b", "app.templatetags.lib_b"),
         ];
         let mut libraries = FxHashMap::default();
         libraries.insert("lib_a".to_string(), "app.templatetags.lib_a".to_string());

--- a/crates/djls-semantic/src/testing.rs
+++ b/crates/djls-semantic/src/testing.rs
@@ -59,7 +59,7 @@ use crate::tags::TagSpec;
 use crate::tags::TagSpecs;
 use crate::tags::builtin_tag_specs;
 
-pub(crate) fn builtin_tag_json(name: &str, module: &str) -> serde_json::Value {
+pub(crate) fn builtin_tag(name: &str, module: &str) -> serde_json::Value {
     serde_json::json!({
         "kind": "tag",
         "name": name,
@@ -70,7 +70,7 @@ pub(crate) fn builtin_tag_json(name: &str, module: &str) -> serde_json::Value {
     })
 }
 
-pub(crate) fn library_tag_json(name: &str, load_name: &str, module: &str) -> serde_json::Value {
+pub(crate) fn library_tag(name: &str, load_name: &str, module: &str) -> serde_json::Value {
     serde_json::json!({
         "kind": "tag",
         "name": name,
@@ -81,7 +81,7 @@ pub(crate) fn library_tag_json(name: &str, load_name: &str, module: &str) -> ser
     })
 }
 
-pub(crate) fn builtin_filter_json(name: &str, module: &str) -> serde_json::Value {
+pub(crate) fn builtin_filter(name: &str, module: &str) -> serde_json::Value {
     serde_json::json!({
         "kind": "filter",
         "name": name,
@@ -92,7 +92,7 @@ pub(crate) fn builtin_filter_json(name: &str, module: &str) -> serde_json::Value
     })
 }
 
-pub(crate) fn library_filter_json(name: &str, load_name: &str, module: &str) -> serde_json::Value {
+pub(crate) fn library_filter(name: &str, load_name: &str, module: &str) -> serde_json::Value {
     serde_json::json!({
         "kind": "filter",
         "name": name,
@@ -130,19 +130,12 @@ pub(crate) fn make_template_libraries(
         let Ok(module) = PyModuleName::parse(module_name) else {
             continue;
         };
-        let Ok(name) =
-            LibraryName::parse(module.as_str().split('.').next_back().unwrap_or("builtin"))
-        else {
-            continue;
-        };
         if !result
             .builtins
             .iter()
             .any(|library| library.module() == &module)
         {
-            result
-                .builtins
-                .push(TemplateLibrary::new_builtin(name, module));
+            result.builtins.push(TemplateLibrary::new(module));
         }
     }
 
@@ -155,9 +148,7 @@ pub(crate) fn make_template_libraries(
         };
         result
             .loadable
-            .entry(load_name.clone())
-            .or_default()
-            .push(TemplateLibrary::new_active(load_name, module, None));
+            .insert(load_name, TemplateLibrary::new(module));
     }
 
     let symbols = tags.iter().chain(filters.iter()).cloned();
@@ -198,16 +189,12 @@ pub(crate) fn make_template_libraries(
                 let Ok(module) = PyModuleName::parse(&fixture.library_module) else {
                     continue;
                 };
-                let libraries = result.loadable.entry(load_name.clone()).or_default();
-                if let Some(library) = libraries
-                    .iter_mut()
-                    .find(|library| library.module() == &module)
-                {
+                let library = result
+                    .loadable
+                    .entry(load_name)
+                    .or_insert_with(|| TemplateLibrary::new(module.clone()));
+                if library.module() == &module {
                     library.merge_symbol(symbol);
-                } else {
-                    let mut library = TemplateLibrary::new_active(load_name, module, None);
-                    library.merge_symbol(symbol);
-                    libraries.push(library);
                 }
             }
         }
@@ -815,61 +802,61 @@ fn choice_message(
 
 fn standard_template_libraries() -> TemplateLibraries {
     let tags = vec![
-        builtin_tag_json("autoescape", default_builtins_module()),
-        builtin_tag_json("block", default_loader_tags_module()),
-        builtin_tag_json("comment", default_builtins_module()),
-        builtin_tag_json("csrf_token", default_builtins_module()),
-        builtin_tag_json("cycle", default_builtins_module()),
-        builtin_tag_json("debug", default_builtins_module()),
-        builtin_tag_json("extends", default_loader_tags_module()),
-        builtin_tag_json("filter", default_builtins_module()),
-        builtin_tag_json("firstof", default_builtins_module()),
-        builtin_tag_json("for", default_builtins_module()),
-        builtin_tag_json("if", default_builtins_module()),
-        builtin_tag_json("ifchanged", default_builtins_module()),
-        builtin_tag_json("include", default_loader_tags_module()),
-        builtin_tag_json("load", default_builtins_module()),
-        builtin_tag_json("lorem", default_builtins_module()),
-        builtin_tag_json("now", default_builtins_module()),
-        builtin_tag_json("one_arg_tag", "example.templatetags.custom"),
-        builtin_tag_json("regroup", default_builtins_module()),
-        builtin_tag_json("spaceless", default_builtins_module()),
-        builtin_tag_json("templatetag", default_builtins_module()),
-        builtin_tag_json("url", default_builtins_module()),
-        builtin_tag_json("verbatim", default_builtins_module()),
-        builtin_tag_json("widthratio", default_builtins_module()),
-        builtin_tag_json("with", default_builtins_module()),
-        library_tag_json("ambiguous_tag", "alpha", "example.alpha.templatetags.alpha"),
-        library_tag_json("ambiguous_tag", "beta", "example.beta.templatetags.beta"),
-        library_tag_json("blocktrans", "i18n", "django.templatetags.i18n"),
-        library_tag_json("blocktranslate", "i18n", "django.templatetags.i18n"),
-        library_tag_json("cache", "cache", "django.templatetags.cache"),
-        library_tag_json("localize", "l10n", "django.templatetags.l10n"),
-        library_tag_json("localtime", "tz", "django.templatetags.tz"),
-        library_tag_json("static", "static", "django.templatetags.static"),
-        library_tag_json("timezone", "tz", "django.templatetags.tz"),
-        library_tag_json("trans", "i18n", "django.templatetags.i18n"),
-        library_tag_json("translate", "i18n", "django.templatetags.i18n"),
+        builtin_tag("autoescape", default_builtins_module()),
+        builtin_tag("block", default_loader_tags_module()),
+        builtin_tag("comment", default_builtins_module()),
+        builtin_tag("csrf_token", default_builtins_module()),
+        builtin_tag("cycle", default_builtins_module()),
+        builtin_tag("debug", default_builtins_module()),
+        builtin_tag("extends", default_loader_tags_module()),
+        builtin_tag("filter", default_builtins_module()),
+        builtin_tag("firstof", default_builtins_module()),
+        builtin_tag("for", default_builtins_module()),
+        builtin_tag("if", default_builtins_module()),
+        builtin_tag("ifchanged", default_builtins_module()),
+        builtin_tag("include", default_loader_tags_module()),
+        builtin_tag("load", default_builtins_module()),
+        builtin_tag("lorem", default_builtins_module()),
+        builtin_tag("now", default_builtins_module()),
+        builtin_tag("one_arg_tag", "example.templatetags.custom"),
+        builtin_tag("regroup", default_builtins_module()),
+        builtin_tag("spaceless", default_builtins_module()),
+        builtin_tag("templatetag", default_builtins_module()),
+        builtin_tag("url", default_builtins_module()),
+        builtin_tag("verbatim", default_builtins_module()),
+        builtin_tag("widthratio", default_builtins_module()),
+        builtin_tag("with", default_builtins_module()),
+        library_tag("ambiguous_tag", "alpha", "example.alpha.templatetags.alpha"),
+        library_tag("ambiguous_tag", "beta", "example.beta.templatetags.beta"),
+        library_tag("blocktrans", "i18n", "django.templatetags.i18n"),
+        library_tag("blocktranslate", "i18n", "django.templatetags.i18n"),
+        library_tag("cache", "cache", "django.templatetags.cache"),
+        library_tag("localize", "l10n", "django.templatetags.l10n"),
+        library_tag("localtime", "tz", "django.templatetags.tz"),
+        library_tag("static", "static", "django.templatetags.static"),
+        library_tag("timezone", "tz", "django.templatetags.tz"),
+        library_tag("trans", "i18n", "django.templatetags.i18n"),
+        library_tag("translate", "i18n", "django.templatetags.i18n"),
     ];
     let filters = vec![
-        builtin_filter_json("title", default_filters_module()),
-        builtin_filter_json("lower", default_filters_module()),
-        builtin_filter_json("length", default_filters_module()),
-        builtin_filter_json("default", default_filters_module()),
-        builtin_filter_json("truncatewords", default_filters_module()),
-        builtin_filter_json("date", default_filters_module()),
-        builtin_filter_json("upper", default_filters_module()),
-        library_filter_json(
+        builtin_filter("title", default_filters_module()),
+        builtin_filter("lower", default_filters_module()),
+        builtin_filter("length", default_filters_module()),
+        builtin_filter("default", default_filters_module()),
+        builtin_filter("truncatewords", default_filters_module()),
+        builtin_filter("date", default_filters_module()),
+        builtin_filter("upper", default_filters_module()),
+        library_filter(
             "intcomma",
             "humanize",
             "django.contrib.humanize.templatetags.humanize",
         ),
-        library_filter_json(
+        library_filter(
             "ambiguous_filter",
             "alpha",
             "example.alpha.templatetags.alpha",
         ),
-        library_filter_json("ambiguous_filter", "beta", "example.beta.templatetags.beta"),
+        library_filter("ambiguous_filter", "beta", "example.beta.templatetags.beta"),
     ];
     let mut libraries = HashMap::new();
     libraries.insert("cache".to_string(), "django.templatetags.cache".to_string());


### PR DESCRIPTION
## Summary

- Made template tag library availability positional: loadable libraries are keyed by load name, builtins are stored as ordered preloaded libraries.
- Deleted vestigial `LibraryStatus`, `LibraryOrigin`, fabricated builtin names, one-element loadable vectors, and constant-true enabled/active helpers.
- Updated fixtures, docs terminology, and the internal changelog note without changing diagnostics/completion/hover behavior.
- Follow-up review cleanup collapsed the configured/builtin helper split into a single module-path library constructor.

## Validation

Initial implementation:

- `cargo build -q`
- `cargo test -q`
- `cargo insta test --check`
- `cargo test -q -j 2 -- --test-threads=2`
- `just e2e`
- `just clippy --allow-dirty`
- `just fmt --check`
- `just lint`
- stale guard: no Rust-code matches for `LibraryStatus|LibraryOrigin|new_builtin|new_active|is_active|best_loadable|is_enabled_library|enabled_loadable`
- shape guards confirmed `TemplateLibraries.loadable: BTreeMap<LibraryName, TemplateLibrary>` and `TemplateLibrary { module, symbols }`
- no `.snap.new` files

Follow-up review cleanup:

- `just fmt`
- `cargo test -q -p djls-semantic project::settings`
- `cargo test -q -p djls-semantic -p djls-ide -p djls-db`
- `cargo clippy --all-targets --all-features --benches -- -D warnings`
- `just fmt --check`
