### PR TITLE
Restore not-in-INSTALLED_APPS diagnostics from static facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
-- Restored S118/S119/S121 diagnostics for template tags, filters, and libraries that exist on Python search paths but whose app is not in `INSTALLED_APPS`.
 - Fixed settings refreshes for star imports inside `try` and `if` blocks.
 
 ## [6.0.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Restored S118/S119/S121 diagnostics for template tags, filters, and libraries that exist on Python search paths but whose app is not in `INSTALLED_APPS`.
 - Fixed settings refreshes for star imports inside `try` and `if` blocks.
 
 ## [6.0.3]

--- a/crates/djls-project/src/environment.rs
+++ b/crates/djls-project/src/environment.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
@@ -16,7 +17,6 @@ use crate::names::PyModuleName;
 use crate::project::Project;
 use crate::settings::TemplateLibraryAnalysis;
 use crate::settings::template_libraries;
-use crate::symbols::TemplateLibraries;
 use crate::symbols::TemplateSymbolKind;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -26,6 +26,52 @@ pub struct InactiveLibrary {
     pub module: PyModuleName,
     pub tags: Vec<String>,
     pub filters: Vec<String>,
+}
+
+impl InactiveLibrary {
+    fn from_candidate(
+        db: &dyn ProjectDb,
+        candidate: TemplateTagCandidate,
+        active_modules: &BTreeSet<PyModuleName>,
+    ) -> Option<Self> {
+        if active_modules.contains(&candidate.module) {
+            return None;
+        }
+
+        let file = db.get_or_create_file(&candidate.path);
+        let analysis = TemplateLibraryAnalysis::from_file(db, file);
+        if !analysis.defines_library && analysis.symbols.is_empty() {
+            return None;
+        }
+
+        let mut tags = Vec::new();
+        let mut filters = Vec::new();
+        for symbol in analysis.symbols {
+            match symbol.kind {
+                TemplateSymbolKind::Tag => tags.push(symbol.name.as_str().to_string()),
+                TemplateSymbolKind::Filter => filters.push(symbol.name.as_str().to_string()),
+            }
+        }
+        tags.sort();
+        tags.dedup();
+        filters.sort();
+        filters.dedup();
+
+        Some(Self {
+            name: candidate.name,
+            app: candidate.app,
+            module: candidate.module,
+            tags,
+            filters,
+        })
+    }
+
+    fn cmp_by_app_name_module(&self, other: &Self) -> Ordering {
+        self.app
+            .cmp(&other.app)
+            .then_with(|| self.name.cmp(&other.name))
+            .then_with(|| self.module.cmp(&other.module))
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -38,6 +84,20 @@ impl InactiveLibraries {
     pub fn empty_ref() -> &'static Self {
         static EMPTY: LazyLock<InactiveLibraries> = LazyLock::new(InactiveLibraries::default);
         &EMPTY
+    }
+
+    fn push(&mut self, library: InactiveLibrary) {
+        self.by_name
+            .entry(library.name.clone())
+            .or_default()
+            .push(library);
+    }
+
+    fn sort_and_dedup(&mut self) {
+        for libraries in self.by_name.values_mut() {
+            libraries.sort_by(InactiveLibrary::cmp_by_app_name_module);
+            libraries.dedup_by(|left, right| left.app == right.app && left.module == right.module);
+        }
     }
 
     #[must_use]
@@ -53,7 +113,7 @@ impl InactiveLibraries {
             .flat_map(|libraries| libraries.iter())
             .filter(|library| library.tags.iter().any(|candidate| candidate == tag))
             .collect();
-        sort_candidates(&mut candidates);
+        candidates.sort_by(|left, right| left.cmp_by_app_name_module(right));
         candidates
     }
 
@@ -65,45 +125,65 @@ impl InactiveLibraries {
             .flat_map(|libraries| libraries.iter())
             .filter(|library| library.filters.iter().any(|candidate| candidate == filter))
             .collect();
-        sort_candidates(&mut candidates);
+        candidates.sort_by(|left, right| left.cmp_by_app_name_module(right));
         candidates
     }
 }
 
-fn sort_candidates(candidates: &mut [&InactiveLibrary]) {
-    candidates.sort_by(|left, right| {
-        left.app
-            .cmp(&right.app)
-            .then_with(|| left.name.cmp(&right.name))
-            .then_with(|| left.module.cmp(&right.module))
-    });
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct TemplateTagFile {
+struct TemplateTagCandidate {
     app: PyModuleName,
     name: LibraryName,
     module: PyModuleName,
     path: Utf8PathBuf,
 }
 
-#[salsa::tracked(returns(ref))]
-pub fn inactive_template_libraries(db: &dyn ProjectDb, project: Project) -> InactiveLibraries {
-    let active_modules = active_template_library_modules(template_libraries(db, project));
-    let mut inactive = InactiveLibraries::default();
+impl TemplateTagCandidate {
+    fn new(app: PyModuleName, name: LibraryName, path: Utf8PathBuf) -> Option<Self> {
+        let module =
+            PyModuleName::parse(&format!("{}.templatetags.{}", app.as_str(), name.as_str()))
+                .ok()?;
 
-    for candidate in discover_project_templatetag_files(db, project) {
-        let Some(library) = inactive_library_from_candidate(db, candidate, &active_modules) else {
-            continue;
-        };
-        inactive
-            .by_name
-            .entry(library.name.clone())
-            .or_default()
-            .push(library);
+        Some(Self {
+            app,
+            name,
+            module,
+            path,
+        })
     }
 
-    sort_inactive_libraries(&mut inactive);
+    fn into_path(self) -> Utf8PathBuf {
+        self.path
+    }
+
+    fn cmp_by_app_name_path(&self, other: &Self) -> Ordering {
+        self.app
+            .cmp(&other.app)
+            .then_with(|| self.name.cmp(&other.name))
+            .then_with(|| self.path.cmp(&other.path))
+    }
+}
+
+#[salsa::tracked(returns(ref))]
+pub fn inactive_template_libraries(db: &dyn ProjectDb, project: Project) -> InactiveLibraries {
+    project.touch_search_path_roots(db);
+
+    let template_libraries = template_libraries(db, project);
+    let active_modules: BTreeSet<_> = template_libraries
+        .loadable
+        .values()
+        .map(|library| library.module().clone())
+        .chain(template_libraries.builtin_modules().cloned())
+        .collect();
+
+    let mut inactive = InactiveLibraries::default();
+    for candidate in discover_project_templatetag_candidates(db, project) {
+        if let Some(library) = InactiveLibrary::from_candidate(db, candidate, &active_modules) {
+            inactive.push(library);
+        }
+    }
+
+    inactive.sort_and_dedup();
     inactive
 }
 
@@ -111,167 +191,66 @@ pub(crate) fn templatetag_candidate_paths(
     db: &dyn ProjectDb,
     project: Project,
 ) -> Vec<Utf8PathBuf> {
-    discover_project_templatetag_files(db, project)
+    discover_project_templatetag_candidates(db, project)
         .into_iter()
-        .map(|file| file.path)
+        .map(TemplateTagCandidate::into_path)
         .collect()
 }
 
-fn discover_project_templatetag_files(
+fn discover_project_templatetag_candidates(
     db: &dyn ProjectDb,
     project: Project,
-) -> Vec<TemplateTagFile> {
+) -> Vec<TemplateTagCandidate> {
     let search_paths = project.search_paths(db);
-    let mut files_by_path: Vec<(usize, TemplateTagFile)> = Vec::new();
+    let mut candidates_by_path: Vec<(usize, TemplateTagCandidate)> = Vec::new();
     let mut path_indexes: FxHashMap<Utf8PathBuf, usize> = FxHashMap::default();
 
     for search_path in search_paths.iter() {
-        touch_search_path_root(db, search_path.path());
         let excluded_paths = if search_path.is_first_party() {
-            nested_non_first_party_paths(project, db, search_path.path())
+            search_paths
+                .iter()
+                .filter(|other| {
+                    !other.is_first_party() && other.path().starts_with(search_path.path())
+                })
+                .map(|other| other.path().to_path_buf())
+                .collect()
         } else {
             Vec::new()
         };
         let search_path_len = search_path.path().as_str().len();
 
-        for (app, name, path) in discover_templatetag_files(
+        for candidate in discover_templatetag_candidates(
             db.file_system(),
             search_path.path(),
             search_path.root_kind(),
             &excluded_paths,
         ) {
-            let Some(module) = module_from_app_and_library(&app, &name) else {
-                continue;
-            };
-            let file = TemplateTagFile {
-                app,
-                name,
-                module,
-                path: path.clone(),
-            };
-            record_longest_search_path_file(
-                &mut files_by_path,
-                &mut path_indexes,
-                search_path_len,
-                path,
-                file,
-            );
+            let path = candidate.path.clone();
+            if let Some(index) = path_indexes.get(&path).copied() {
+                let (existing_search_path_len, existing) = &mut candidates_by_path[index];
+                if search_path_len > *existing_search_path_len {
+                    *existing_search_path_len = search_path_len;
+                    *existing = candidate;
+                }
+            } else {
+                path_indexes.insert(path, candidates_by_path.len());
+                candidates_by_path.push((search_path_len, candidate));
+            }
         }
     }
 
-    files_by_path
+    candidates_by_path
         .into_iter()
-        .map(|(_search_path_len, file)| file)
+        .map(|(_search_path_len, candidate)| candidate)
         .collect()
 }
 
-fn touch_search_path_root(db: &dyn ProjectDb, path: &Utf8Path) {
-    if let Some(root) = db.files().root(db, path) {
-        let _ = root.revision(db);
-    } else {
-        tracing::warn!("Search path has no registered source root: {}", path);
-    }
-}
-
-fn nested_non_first_party_paths(
-    project: Project,
-    db: &dyn ProjectDb,
-    search_path: &Utf8Path,
-) -> Vec<Utf8PathBuf> {
-    project
-        .search_paths(db)
-        .iter()
-        .filter(|other| !other.is_first_party() && other.path().starts_with(search_path))
-        .map(|other| other.path().to_path_buf())
-        .collect()
-}
-
-fn record_longest_search_path_file(
-    files_by_path: &mut Vec<(usize, TemplateTagFile)>,
-    path_indexes: &mut FxHashMap<Utf8PathBuf, usize>,
-    search_path_len: usize,
-    path: Utf8PathBuf,
-    file: TemplateTagFile,
-) {
-    if let Some(index) = path_indexes.get(&path).copied() {
-        let (existing_search_path_len, existing) = &mut files_by_path[index];
-        if search_path_len > *existing_search_path_len {
-            *existing_search_path_len = search_path_len;
-            *existing = file;
-        }
-    } else {
-        path_indexes.insert(path, files_by_path.len());
-        files_by_path.push((search_path_len, file));
-    }
-}
-
-fn active_template_library_modules(libraries: &TemplateLibraries) -> BTreeSet<PyModuleName> {
-    libraries
-        .loadable
-        .values()
-        .map(|library| library.module().clone())
-        .chain(libraries.builtin_modules().cloned())
-        .collect()
-}
-
-fn inactive_library_from_candidate(
-    db: &dyn ProjectDb,
-    candidate: TemplateTagFile,
-    active_modules: &BTreeSet<PyModuleName>,
-) -> Option<InactiveLibrary> {
-    if active_modules.contains(&candidate.module) {
-        return None;
-    }
-
-    let file = db.get_or_create_file(&candidate.path);
-    let analysis = TemplateLibraryAnalysis::from_file(db, file);
-    if !analysis.defines_library && analysis.symbols.is_empty() {
-        return None;
-    }
-
-    let (tags, filters) = sorted_symbol_names(analysis);
-    Some(InactiveLibrary {
-        name: candidate.name,
-        app: candidate.app,
-        module: candidate.module,
-        tags,
-        filters,
-    })
-}
-
-fn sorted_symbol_names(analysis: TemplateLibraryAnalysis) -> (Vec<String>, Vec<String>) {
-    let mut tags = Vec::new();
-    let mut filters = Vec::new();
-    for symbol in analysis.symbols {
-        match symbol.kind {
-            TemplateSymbolKind::Tag => tags.push(symbol.name.as_str().to_string()),
-            TemplateSymbolKind::Filter => filters.push(symbol.name.as_str().to_string()),
-        }
-    }
-    tags.sort();
-    tags.dedup();
-    filters.sort();
-    filters.dedup();
-    (tags, filters)
-}
-
-fn sort_inactive_libraries(inactive: &mut InactiveLibraries) {
-    for libraries in inactive.by_name.values_mut() {
-        libraries.sort_by(|left, right| {
-            left.app
-                .cmp(&right.app)
-                .then_with(|| left.module.cmp(&right.module))
-        });
-        libraries.dedup_by(|left, right| left.app == right.app && left.module == right.module);
-    }
-}
-
-fn discover_templatetag_files(
+fn discover_templatetag_candidates(
     fs: &dyn FileSystem,
     base_dir: &Utf8Path,
     root_kind: FileRootKind,
     excluded_roots: &[Utf8PathBuf],
-) -> Vec<(PyModuleName, LibraryName, Utf8PathBuf)> {
+) -> Vec<TemplateTagCandidate> {
     let options = match root_kind {
         FileRootKind::Project => WalkOptions::project(),
         FileRootKind::SearchPath => WalkOptions::library_search_path(),
@@ -336,23 +315,15 @@ fn discover_templatetag_files(
         let Ok(name) = LibraryName::parse(stem) else {
             continue;
         };
+        let Some(candidate) = TemplateTagCandidate::new(app, name, path) else {
+            continue;
+        };
 
-        results.push((app, name, path));
+        results.push(candidate);
     }
 
-    results.sort_by(
-        |(left_app, left_name, left_path), (right_app, right_name, right_path)| {
-            left_app
-                .cmp(right_app)
-                .then_with(|| left_name.cmp(right_name))
-                .then_with(|| left_path.cmp(right_path))
-        },
-    );
+    results.sort_by(TemplateTagCandidate::cmp_by_app_name_path);
     results
-}
-
-fn module_from_app_and_library(app: &PyModuleName, name: &LibraryName) -> Option<PyModuleName> {
-    PyModuleName::parse(&format!("{}.templatetags.{}", app.as_str(), name.as_str())).ok()
 }
 
 #[cfg(test)]
@@ -363,7 +334,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn discover_templatetag_files_requires_django_package_shape() {
+    fn discover_templatetag_candidates_requires_django_package_shape() {
         let mut fs = InMemoryFileSystem::new();
         fs.add_file("/root/pkg_a/__init__.py".into(), String::new());
         fs.add_file("/root/pkg_a/templatetags/__init__.py".into(), String::new());
@@ -374,13 +345,18 @@ mod tests {
         fs.add_file("/root/loose/templatetags/__init__.py".into(), String::new());
         fs.add_file("/root/loose/templatetags/baz.py".into(), String::new());
 
-        let discovered =
-            discover_templatetag_files(&fs, Utf8Path::new("/root"), FileRootKind::Project, &[]);
+        let discovered = discover_templatetag_candidates(
+            &fs,
+            Utf8Path::new("/root"),
+            FileRootKind::Project,
+            &[],
+        );
 
         assert_eq!(discovered.len(), 1);
-        let (app, name, path) = &discovered[0];
-        assert_eq!(app.as_str(), "pkg_a");
-        assert_eq!(name.as_str(), "foo");
-        assert_eq!(path.as_str(), "/root/pkg_a/templatetags/foo.py");
+        let candidate = &discovered[0];
+        assert_eq!(candidate.app.as_str(), "pkg_a");
+        assert_eq!(candidate.name.as_str(), "foo");
+        assert_eq!(candidate.module.as_str(), "pkg_a.templatetags.foo");
+        assert_eq!(candidate.path.as_str(), "/root/pkg_a/templatetags/foo.py");
     }
 }

--- a/crates/djls-project/src/environment.rs
+++ b/crates/djls-project/src/environment.rs
@@ -1,0 +1,386 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
+
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use djls_source::FileRootKind;
+use djls_source::FileSystem;
+use djls_source::WalkEntryKind;
+use djls_source::WalkOptions;
+use rustc_hash::FxHashMap;
+
+use crate::db::Db as ProjectDb;
+use crate::names::LibraryName;
+use crate::names::PyModuleName;
+use crate::project::Project;
+use crate::settings::TemplateLibraryAnalysis;
+use crate::settings::template_libraries;
+use crate::symbols::TemplateLibraries;
+use crate::symbols::TemplateSymbolKind;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InactiveLibrary {
+    pub name: LibraryName,
+    pub app: PyModuleName,
+    pub module: PyModuleName,
+    pub tags: Vec<String>,
+    pub filters: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct InactiveLibraries {
+    pub by_name: BTreeMap<LibraryName, Vec<InactiveLibrary>>,
+}
+
+impl InactiveLibraries {
+    #[must_use]
+    pub fn empty_ref() -> &'static Self {
+        static EMPTY: LazyLock<InactiveLibraries> = LazyLock::new(InactiveLibraries::default);
+        &EMPTY
+    }
+
+    #[must_use]
+    pub fn library_candidates(&self, name: &LibraryName) -> &[InactiveLibrary] {
+        self.by_name.get(name).map_or(&[], Vec::as_slice)
+    }
+
+    #[must_use]
+    pub fn tag_candidates(&self, tag: &str) -> Vec<&InactiveLibrary> {
+        let mut candidates: Vec<_> = self
+            .by_name
+            .values()
+            .flat_map(|libraries| libraries.iter())
+            .filter(|library| library.tags.iter().any(|candidate| candidate == tag))
+            .collect();
+        sort_candidates(&mut candidates);
+        candidates
+    }
+
+    #[must_use]
+    pub fn filter_candidates(&self, filter: &str) -> Vec<&InactiveLibrary> {
+        let mut candidates: Vec<_> = self
+            .by_name
+            .values()
+            .flat_map(|libraries| libraries.iter())
+            .filter(|library| library.filters.iter().any(|candidate| candidate == filter))
+            .collect();
+        sort_candidates(&mut candidates);
+        candidates
+    }
+}
+
+fn sort_candidates(candidates: &mut [&InactiveLibrary]) {
+    candidates.sort_by(|left, right| {
+        left.app
+            .cmp(&right.app)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.module.cmp(&right.module))
+    });
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TemplateTagFile {
+    app: PyModuleName,
+    name: LibraryName,
+    module: PyModuleName,
+    path: Utf8PathBuf,
+}
+
+#[salsa::tracked(returns(ref))]
+pub fn inactive_template_libraries(db: &dyn ProjectDb, project: Project) -> InactiveLibraries {
+    let active_modules = active_template_library_modules(template_libraries(db, project));
+    let mut inactive = InactiveLibraries::default();
+
+    for candidate in discover_project_templatetag_files(db, project) {
+        let Some(library) = inactive_library_from_candidate(db, candidate, &active_modules) else {
+            continue;
+        };
+        inactive
+            .by_name
+            .entry(library.name.clone())
+            .or_default()
+            .push(library);
+    }
+
+    sort_inactive_libraries(&mut inactive);
+    inactive
+}
+
+pub(crate) fn templatetag_candidate_paths(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> Vec<Utf8PathBuf> {
+    discover_project_templatetag_files(db, project)
+        .into_iter()
+        .map(|file| file.path)
+        .collect()
+}
+
+fn discover_project_templatetag_files(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> Vec<TemplateTagFile> {
+    let search_paths = project.search_paths(db);
+    let mut files_by_path: Vec<(usize, TemplateTagFile)> = Vec::new();
+    let mut path_indexes: FxHashMap<Utf8PathBuf, usize> = FxHashMap::default();
+
+    for search_path in search_paths.iter() {
+        touch_search_path_root(db, search_path.path());
+        let excluded_paths = if search_path.is_first_party() {
+            nested_non_first_party_paths(project, db, search_path.path())
+        } else {
+            Vec::new()
+        };
+        let search_path_len = search_path.path().as_str().len();
+
+        for (app, name, path) in discover_templatetag_files(
+            db.file_system(),
+            search_path.path(),
+            search_path.root_kind(),
+            &excluded_paths,
+        ) {
+            let Some(module) = module_from_app_and_library(&app, &name) else {
+                continue;
+            };
+            let file = TemplateTagFile {
+                app,
+                name,
+                module,
+                path: path.clone(),
+            };
+            record_longest_search_path_file(
+                &mut files_by_path,
+                &mut path_indexes,
+                search_path_len,
+                path,
+                file,
+            );
+        }
+    }
+
+    files_by_path
+        .into_iter()
+        .map(|(_search_path_len, file)| file)
+        .collect()
+}
+
+fn touch_search_path_root(db: &dyn ProjectDb, path: &Utf8Path) {
+    if let Some(root) = db.files().root(db, path) {
+        let _ = root.revision(db);
+    } else {
+        tracing::warn!("Search path has no registered source root: {}", path);
+    }
+}
+
+fn nested_non_first_party_paths(
+    project: Project,
+    db: &dyn ProjectDb,
+    search_path: &Utf8Path,
+) -> Vec<Utf8PathBuf> {
+    project
+        .search_paths(db)
+        .iter()
+        .filter(|other| !other.is_first_party() && other.path().starts_with(search_path))
+        .map(|other| other.path().to_path_buf())
+        .collect()
+}
+
+fn record_longest_search_path_file(
+    files_by_path: &mut Vec<(usize, TemplateTagFile)>,
+    path_indexes: &mut FxHashMap<Utf8PathBuf, usize>,
+    search_path_len: usize,
+    path: Utf8PathBuf,
+    file: TemplateTagFile,
+) {
+    if let Some(index) = path_indexes.get(&path).copied() {
+        let (existing_search_path_len, existing) = &mut files_by_path[index];
+        if search_path_len > *existing_search_path_len {
+            *existing_search_path_len = search_path_len;
+            *existing = file;
+        }
+    } else {
+        path_indexes.insert(path, files_by_path.len());
+        files_by_path.push((search_path_len, file));
+    }
+}
+
+fn active_template_library_modules(libraries: &TemplateLibraries) -> BTreeSet<PyModuleName> {
+    libraries
+        .loadable
+        .values()
+        .map(|library| library.module().clone())
+        .chain(libraries.builtin_modules().cloned())
+        .collect()
+}
+
+fn inactive_library_from_candidate(
+    db: &dyn ProjectDb,
+    candidate: TemplateTagFile,
+    active_modules: &BTreeSet<PyModuleName>,
+) -> Option<InactiveLibrary> {
+    if active_modules.contains(&candidate.module) {
+        return None;
+    }
+
+    let file = db.get_or_create_file(&candidate.path);
+    let analysis = TemplateLibraryAnalysis::from_file(db, file);
+    if !analysis.defines_library && analysis.symbols.is_empty() {
+        return None;
+    }
+
+    let (tags, filters) = sorted_symbol_names(analysis);
+    Some(InactiveLibrary {
+        name: candidate.name,
+        app: candidate.app,
+        module: candidate.module,
+        tags,
+        filters,
+    })
+}
+
+fn sorted_symbol_names(analysis: TemplateLibraryAnalysis) -> (Vec<String>, Vec<String>) {
+    let mut tags = Vec::new();
+    let mut filters = Vec::new();
+    for symbol in analysis.symbols {
+        match symbol.kind {
+            TemplateSymbolKind::Tag => tags.push(symbol.name.as_str().to_string()),
+            TemplateSymbolKind::Filter => filters.push(symbol.name.as_str().to_string()),
+        }
+    }
+    tags.sort();
+    tags.dedup();
+    filters.sort();
+    filters.dedup();
+    (tags, filters)
+}
+
+fn sort_inactive_libraries(inactive: &mut InactiveLibraries) {
+    for libraries in inactive.by_name.values_mut() {
+        libraries.sort_by(|left, right| {
+            left.app
+                .cmp(&right.app)
+                .then_with(|| left.module.cmp(&right.module))
+        });
+        libraries.dedup_by(|left, right| left.app == right.app && left.module == right.module);
+    }
+}
+
+fn discover_templatetag_files(
+    fs: &dyn FileSystem,
+    base_dir: &Utf8Path,
+    root_kind: FileRootKind,
+    excluded_roots: &[Utf8PathBuf],
+) -> Vec<(PyModuleName, LibraryName, Utf8PathBuf)> {
+    let options = match root_kind {
+        FileRootKind::Project => WalkOptions::project(),
+        FileRootKind::SearchPath => WalkOptions::library_search_path(),
+    };
+
+    let mut results = Vec::new();
+
+    let entries = match fs.walk_entries(base_dir, &options) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!("Failed to walk Python source root {}: {}", base_dir, err);
+            return results;
+        }
+    };
+
+    for entry in entries {
+        if entry.kind != WalkEntryKind::File {
+            continue;
+        }
+        let path = entry.path;
+
+        if path.extension() != Some("py") {
+            continue;
+        }
+        let Some(stem) = path.file_stem() else {
+            continue;
+        };
+        if stem.starts_with('_') {
+            continue;
+        }
+
+        if excluded_roots
+            .iter()
+            .any(|excluded| path.starts_with(excluded))
+        {
+            continue;
+        }
+
+        let Some(templatetags_dir) = path.parent() else {
+            continue;
+        };
+        if templatetags_dir.file_name() != Some("templatetags") {
+            continue;
+        }
+        if !fs.exists(&templatetags_dir.join("__init__.py")) {
+            continue;
+        }
+
+        let Some(app_dir) = templatetags_dir.parent() else {
+            continue;
+        };
+        if app_dir == base_dir || !fs.exists(&app_dir.join("__init__.py")) {
+            continue;
+        }
+
+        let Some(app_rel) = app_dir.strip_prefix(base_dir).ok() else {
+            continue;
+        };
+        let Ok(app) = PyModuleName::from_relative_package(app_rel) else {
+            continue;
+        };
+        let Ok(name) = LibraryName::parse(stem) else {
+            continue;
+        };
+
+        results.push((app, name, path));
+    }
+
+    results.sort_by(
+        |(left_app, left_name, left_path), (right_app, right_name, right_path)| {
+            left_app
+                .cmp(right_app)
+                .then_with(|| left_name.cmp(right_name))
+                .then_with(|| left_path.cmp(right_path))
+        },
+    );
+    results
+}
+
+fn module_from_app_and_library(app: &PyModuleName, name: &LibraryName) -> Option<PyModuleName> {
+    PyModuleName::parse(&format!("{}.templatetags.{}", app.as_str(), name.as_str())).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use djls_source::InMemoryFileSystem;
+
+    use super::*;
+
+    #[test]
+    fn discover_templatetag_files_requires_django_package_shape() {
+        let mut fs = InMemoryFileSystem::new();
+        fs.add_file("/root/pkg_a/__init__.py".into(), String::new());
+        fs.add_file("/root/pkg_a/templatetags/__init__.py".into(), String::new());
+        fs.add_file("/root/pkg_a/templatetags/foo.py".into(), String::new());
+        fs.add_file("/root/pkg_a/templatetags/_private.py".into(), String::new());
+        fs.add_file("/root/pkg_b/__init__.py".into(), String::new());
+        fs.add_file("/root/pkg_b/templatetags/bar.py".into(), String::new());
+        fs.add_file("/root/loose/templatetags/__init__.py".into(), String::new());
+        fs.add_file("/root/loose/templatetags/baz.py".into(), String::new());
+
+        let discovered =
+            discover_templatetag_files(&fs, Utf8Path::new("/root"), FileRootKind::Project, &[]);
+
+        assert_eq!(discovered.len(), 1);
+        let (app, name, path) = &discovered[0];
+        assert_eq!(app.as_str(), "pkg_a");
+        assert_eq!(name.as_str(), "foo");
+        assert_eq!(path.as_str(), "/root/pkg_a/templatetags/foo.py");
+    }
+}

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -1,4 +1,5 @@
 mod db;
+mod environment;
 mod extraction;
 mod names;
 mod parse;
@@ -13,6 +14,9 @@ mod system;
 mod templates;
 
 pub use db::Db;
+pub use environment::InactiveLibraries;
+pub use environment::InactiveLibrary;
+pub use environment::inactive_template_libraries;
 pub use extraction::DjangoSettings;
 pub use extraction::ExprExt;
 pub use extraction::InstalledAppsSetting;

--- a/crates/djls-project/src/resolve.rs
+++ b/crates/djls-project/src/resolve.rs
@@ -62,7 +62,7 @@ impl SearchPath {
         matches!(self, Self::FirstParty(_))
     }
 
-    fn root_kind(&self) -> FileRootKind {
+    pub(crate) fn root_kind(&self) -> FileRootKind {
         match self {
             // Extra pythonpath entries are user-edited code, so they get the
             // same low-durability treatment as project files.

--- a/crates/djls-project/src/settings.rs
+++ b/crates/djls-project/src/settings.rs
@@ -309,13 +309,13 @@ fn library_from_module_path(
     }
 }
 
-struct TemplateLibraryAnalysis {
-    defines_library: bool,
-    symbols: Vec<TemplateSymbol>,
+pub(crate) struct TemplateLibraryAnalysis {
+    pub(crate) defines_library: bool,
+    pub(crate) symbols: Vec<TemplateSymbol>,
 }
 
 impl TemplateLibraryAnalysis {
-    fn from_file(db: &dyn ProjectDb, file: File) -> Self {
+    pub(crate) fn from_file(db: &dyn ProjectDb, file: File) -> Self {
         let Some(parsed) = parse_python_module(db, file) else {
             return Self {
                 defines_library: false,

--- a/crates/djls-project/src/sync.rs
+++ b/crates/djls-project/src/sync.rs
@@ -5,6 +5,7 @@
 //! the `Project` input. Pure semantic derivation stays in tracked queries.
 
 use crate::db::Db as ProjectDb;
+use crate::environment::templatetag_candidate_paths;
 use crate::project::Project;
 use crate::resolve::model_modules;
 use crate::resolve::templatetag_modules;
@@ -55,6 +56,7 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
             .iter()
             .map(|module| module.path().to_path_buf()),
     );
+    file_paths.extend(templatetag_candidate_paths(db, project));
 
     file_paths.sort();
     file_paths.dedup();

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -343,6 +343,143 @@ fn template_libraries_include_empty_registered_modules() {
 }
 
 #[test]
+fn inactive_template_libraries_collect_uninstalled_templatetags() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            ("/proj/myapp/__init__.py", ""),
+            ("/proj/myapp/templatetags/__init__.py", ""),
+            (
+                "/proj/myapp/templatetags/myapp_tags.py",
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef active_tag():\n    pass\n",
+            ),
+            ("/proj/crispy/__init__.py", ""),
+            ("/proj/crispy/templatetags/__init__.py", ""),
+            (
+                "/proj/crispy/templatetags/crispy.py",
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef crispy_tag():\n    pass\n@register.filter\ndef crispy_filter(value):\n    return value\n",
+            ),
+            (
+                "/proj/myproject/settings.py",
+                "INSTALLED_APPS = ['myapp']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+            ),
+        ],
+    );
+
+    let inactive = inactive_template_libraries(&db, project);
+
+    let crispy = LibraryName::parse("crispy").unwrap();
+    let candidates = inactive.library_candidates(&crispy);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].name.as_str(), "crispy");
+    assert_eq!(candidates[0].app.as_str(), "crispy");
+    assert_eq!(candidates[0].module.as_str(), "crispy.templatetags.crispy");
+    assert_eq!(candidates[0].tags, vec!["crispy_tag"]);
+    assert_eq!(candidates[0].filters, vec!["crispy_filter"]);
+    assert!(
+        inactive
+            .library_candidates(&LibraryName::parse("myapp_tags").unwrap())
+            .is_empty(),
+        "installed app libraries must be subtracted from inactive candidates"
+    );
+}
+
+#[test]
+fn inactive_template_libraries_rerun_after_search_root_revision_bump() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            ("/proj/myapp/__init__.py", ""),
+            ("/proj/myapp/templatetags/__init__.py", ""),
+            (
+                "/proj/myapp/templatetags/myapp_tags.py",
+                "from django import template\nregister = template.Library()\n",
+            ),
+            (
+                "/proj/myproject/settings.py",
+                "INSTALLED_APPS = ['myapp']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+            ),
+        ],
+    );
+
+    assert!(
+        inactive_template_libraries(&db, project)
+            .library_candidates(&LibraryName::parse("crispy").unwrap())
+            .is_empty()
+    );
+
+    db.add_file("/proj/crispy/__init__.py", "");
+    db.add_file("/proj/crispy/templatetags/__init__.py", "");
+    db.add_file(
+        "/proj/crispy/templatetags/crispy.py",
+        "from django import template\nregister = template.Library()\n@register.simple_tag\ndef crispy_tag():\n    pass\n",
+    );
+    let root = db
+        .files()
+        .expect_root(&db, Utf8Path::new("/proj/crispy/templatetags/crispy.py"));
+    db.bump_file_root_revision(root);
+
+    let inactive = inactive_template_libraries(&db, project);
+
+    assert_eq!(
+        inactive
+            .library_candidates(&LibraryName::parse("crispy").unwrap())
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn refresh_external_data_updates_inactive_template_library_symbols() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            ("/proj/myapp/__init__.py", ""),
+            ("/proj/myapp/templatetags/__init__.py", ""),
+            (
+                "/proj/myapp/templatetags/myapp_tags.py",
+                "from django import template\nregister = template.Library()\n",
+            ),
+            ("/proj/crispy/__init__.py", ""),
+            ("/proj/crispy/templatetags/__init__.py", ""),
+            (
+                "/proj/crispy/templatetags/crispy.py",
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef old_tag():\n    pass\n",
+            ),
+            (
+                "/proj/myproject/settings.py",
+                "INSTALLED_APPS = ['myapp']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+            ),
+        ],
+    );
+
+    assert!(
+        inactive_template_libraries(&db, project)
+            .tag_candidates("new_tag")
+            .is_empty()
+    );
+
+    db.add_file(
+        "/proj/crispy/templatetags/crispy.py",
+        "from django import template\nregister = template.Library()\n@register.simple_tag\ndef new_tag():\n    pass\n",
+    );
+    refresh_external_data(&mut db);
+
+    assert_eq!(
+        inactive_template_libraries(&db, project)
+            .tag_candidates("new_tag")
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn template_libraries_demote_unresolved_app_to_partial() {
     let mut db = TestDatabase::new();
     let project = project_with_settings(

--- a/crates/djls-semantic/src/errors.rs
+++ b/crates/djls-semantic/src/errors.rs
@@ -39,6 +39,14 @@ pub enum ValidationError {
     #[error("Unknown tag '{tag}'")]
     UnknownTag { tag: String, span: Span },
 
+    #[error("Add '{app}' to INSTALLED_APPS to use tag '{tag}'")]
+    TagNotInInstalledApps {
+        tag: String,
+        app: String,
+        load_name: String,
+        span: Span,
+    },
+
     #[error("Tag '{tag}' requires the '{library}' tag library")]
     UnloadedTag {
         tag: String,
@@ -58,6 +66,14 @@ pub enum ValidationError {
 
     #[error("Unknown filter '{filter}'")]
     UnknownFilter { filter: String, span: Span },
+
+    #[error("Add '{app}' to INSTALLED_APPS to use filter '{filter}'")]
+    FilterNotInInstalledApps {
+        filter: String,
+        app: String,
+        load_name: String,
+        span: Span,
+    },
 
     #[error("Filter '{filter}' requires the '{library}' tag library")]
     UnloadedFilter {
@@ -99,6 +115,14 @@ pub enum ValidationError {
     #[error("Unknown template tag library '{name}'")]
     UnknownLibrary { name: String, span: Span },
 
+    #[error("Add '{app}' to INSTALLED_APPS to use template tag library '{name}'")]
+    LibraryNotInInstalledApps {
+        name: String,
+        app: String,
+        candidates: Vec<String>,
+        span: Span,
+    },
+
     #[error("The 'extends' tag must be the first tag in the template")]
     ExtendsMustBeFirst { span: Span },
 
@@ -132,7 +156,10 @@ impl ValidationError {
             Self::FilterMissingArgument { .. } => "S115",
             Self::FilterUnexpectedArgument { .. } => "S116",
             Self::ExtractedRuleViolation { .. } => "S117",
+            Self::TagNotInInstalledApps { .. } => "S118",
+            Self::FilterNotInInstalledApps { .. } => "S119",
             Self::UnknownLibrary { .. } => "S120",
+            Self::LibraryNotInInstalledApps { .. } => "S121",
             Self::ExtendsMustBeFirst { .. } => "S122",
             Self::MultipleExtends { .. } => "S123",
         }
@@ -147,9 +174,11 @@ impl ValidationError {
             | Self::OrphanedClosingTag { span, .. }
             | Self::UnmatchedBlockName { span, .. }
             | Self::UnknownTag { span, .. }
+            | Self::TagNotInInstalledApps { span, .. }
             | Self::UnloadedTag { span, .. }
             | Self::AmbiguousUnloadedTag { span, .. }
             | Self::UnknownFilter { span, .. }
+            | Self::FilterNotInInstalledApps { span, .. }
             | Self::UnloadedFilter { span, .. }
             | Self::AmbiguousUnloadedFilter { span, .. }
             | Self::ExpressionSyntaxError { span, .. }
@@ -157,6 +186,7 @@ impl ValidationError {
             | Self::FilterUnexpectedArgument { span, .. }
             | Self::ExtractedRuleViolation { span, .. }
             | Self::UnknownLibrary { span, .. }
+            | Self::LibraryNotInInstalledApps { span, .. }
             | Self::ExtendsMustBeFirst { span, .. }
             | Self::MultipleExtends { span, .. } => Some(*span),
         }

--- a/crates/djls-semantic/src/validation.rs
+++ b/crates/djls-semantic/src/validation.rs
@@ -3,8 +3,10 @@ pub(crate) mod filters;
 pub(crate) mod if_expressions;
 pub(crate) mod scoping;
 
+use djls_project::InactiveLibraries;
 use djls_project::StaticKnowledge;
 use djls_project::TemplateLibraries;
+use djls_project::inactive_template_libraries;
 use djls_source::Span;
 use djls_templates::Filter;
 use djls_templates::Node;
@@ -50,6 +52,7 @@ pub(crate) struct TemplateValidator<'a> {
     symbol_index: &'a SymbolIndex,
     loaded_libraries: &'a LoadedLibraries,
     template_libraries: &'a TemplateLibraries,
+    inactive_libraries: &'a InactiveLibraries,
     opaque_regions: &'a OpaqueRegions,
     filter_arity_specs: &'a FilterAritySpecs,
 
@@ -65,6 +68,11 @@ impl<'a> TemplateValidator<'a> {
         opaque_regions: &'a OpaqueRegions,
     ) -> Self {
         let template_libraries = db.template_libraries();
+        let inactive_libraries = db
+            .project()
+            .map_or(InactiveLibraries::empty_ref(), |project| {
+                inactive_template_libraries(db, project)
+            });
         let tag_specs = db.tag_specs();
         let loaded_libraries = crate::scoping::compute_loaded_libraries(db, nodelist);
         let symbol_index = crate::scoping::compute_symbol_index(db, nodelist);
@@ -76,6 +84,7 @@ impl<'a> TemplateValidator<'a> {
             symbol_index,
             loaded_libraries,
             template_libraries,
+            inactive_libraries,
             opaque_regions,
             filter_arity_specs,
             extends_position: ExtendsPosition::default(),
@@ -135,6 +144,7 @@ impl Visitor for TemplateValidator<'_> {
                     name,
                     span,
                     symbols,
+                    self.inactive_libraries,
                     self.template_libraries.knowledge,
                 );
             }
@@ -147,7 +157,13 @@ impl Visitor for TemplateValidator<'_> {
             }
 
             // 4. Load library validation
-            scoping::check_load_libraries_rule(self.db, name, bits, self.template_libraries);
+            scoping::check_load_libraries_rule(
+                self.db,
+                name,
+                bits,
+                self.template_libraries,
+                self.inactive_libraries,
+            );
 
             // 5. If expression validation
             if name == "if" || name == "elif" {
@@ -168,6 +184,7 @@ impl Visitor for TemplateValidator<'_> {
                     self.db,
                     filter,
                     symbols,
+                    self.inactive_libraries,
                     self.template_libraries.knowledge,
                 );
 

--- a/crates/djls-semantic/src/validation/scoping.rs
+++ b/crates/djls-semantic/src/validation/scoping.rs
@@ -1,3 +1,4 @@
+use djls_project::InactiveLibraries;
 use djls_project::LibraryName;
 use djls_project::StaticKnowledge;
 use djls_project::TemplateLibraries;
@@ -21,6 +22,7 @@ pub(crate) fn check_tag_scoping_rule(
     name: &str,
     span: Span,
     symbols: &AvailableSymbols,
+    inactive_libraries: &InactiveLibraries,
     knowledge: StaticKnowledge,
 ) {
     if knowledge == StaticKnowledge::Unknown {
@@ -33,11 +35,21 @@ pub(crate) fn check_tag_scoping_rule(
         TagAvailability::Available => {}
         TagAvailability::Unknown if knowledge == StaticKnowledge::Partial => {}
         TagAvailability::Unknown => {
-            ValidationErrorAccumulator(ValidationError::UnknownTag {
-                tag: name.to_string(),
-                span: full_span,
-            })
-            .accumulate(db);
+            if let Some(candidate) = inactive_libraries.tag_candidates(name).first() {
+                ValidationErrorAccumulator(ValidationError::TagNotInInstalledApps {
+                    tag: name.to_string(),
+                    app: candidate.app.as_str().to_string(),
+                    load_name: candidate.name.as_str().to_string(),
+                    span: full_span,
+                })
+                .accumulate(db);
+            } else {
+                ValidationErrorAccumulator(ValidationError::UnknownTag {
+                    tag: name.to_string(),
+                    span: full_span,
+                })
+                .accumulate(db);
+            }
         }
         TagAvailability::Unloaded { library } => {
             ValidationErrorAccumulator(ValidationError::UnloadedTag {
@@ -63,6 +75,7 @@ pub(crate) fn check_filter_scoping_rule(
     db: &dyn Db,
     filter: &Filter,
     symbols: &AvailableSymbols,
+    inactive_libraries: &InactiveLibraries,
     knowledge: StaticKnowledge,
 ) {
     if knowledge == StaticKnowledge::Unknown {
@@ -73,11 +86,21 @@ pub(crate) fn check_filter_scoping_rule(
         FilterAvailability::Available => {}
         FilterAvailability::Unknown if knowledge == StaticKnowledge::Partial => {}
         FilterAvailability::Unknown => {
-            ValidationErrorAccumulator(ValidationError::UnknownFilter {
-                filter: filter.name.clone(),
-                span: filter.span,
-            })
-            .accumulate(db);
+            if let Some(candidate) = inactive_libraries.filter_candidates(&filter.name).first() {
+                ValidationErrorAccumulator(ValidationError::FilterNotInInstalledApps {
+                    filter: filter.name.clone(),
+                    app: candidate.app.as_str().to_string(),
+                    load_name: candidate.name.as_str().to_string(),
+                    span: filter.span,
+                })
+                .accumulate(db);
+            } else {
+                ValidationErrorAccumulator(ValidationError::UnknownFilter {
+                    filter: filter.name.clone(),
+                    span: filter.span,
+                })
+                .accumulate(db);
+            }
         }
         FilterAvailability::Unloaded { library } => {
             ValidationErrorAccumulator(ValidationError::UnloadedFilter {
@@ -104,6 +127,7 @@ pub(crate) fn check_load_libraries_rule(
     name: &str,
     bits: &[TagBit],
     template_libraries: &TemplateLibraries,
+    inactive_libraries: &InactiveLibraries,
 ) {
     if template_libraries.knowledge == StaticKnowledge::Unknown {
         return;
@@ -119,21 +143,36 @@ pub(crate) fn check_load_libraries_rule(
     };
 
     for lib in libs {
-        if let Ok(name) = LibraryName::parse(lib.as_str()) {
-            if template_libraries.loadable.contains_key(&name) {
-                continue;
-            }
-        } else {
+        let Ok(load_name) = LibraryName::parse(lib.as_str()) else {
             // Invalid library name string (shouldn't happen given LoadKind parser, but safety first)
+            continue;
+        };
+        if template_libraries.loadable.contains_key(&load_name) {
             continue;
         }
 
         if template_libraries.knowledge == StaticKnowledge::Known {
-            ValidationErrorAccumulator(ValidationError::UnknownLibrary {
-                name: lib.as_str().to_string(),
-                span: lib.span(),
-            })
-            .accumulate(db);
+            let candidates = inactive_libraries.library_candidates(&load_name);
+            if let Some(first) = candidates.first() {
+                let mut apps: Vec<_> = candidates
+                    .iter()
+                    .map(|candidate| candidate.app.as_str().to_string())
+                    .collect();
+                apps.dedup();
+                ValidationErrorAccumulator(ValidationError::LibraryNotInInstalledApps {
+                    name: lib.as_str().to_string(),
+                    app: first.app.as_str().to_string(),
+                    candidates: apps,
+                    span: lib.span(),
+                })
+                .accumulate(db);
+            } else {
+                ValidationErrorAccumulator(ValidationError::UnknownLibrary {
+                    name: lib.as_str().to_string(),
+                    span: lib.span(),
+                })
+                .accumulate(db);
+            }
         }
     }
 }

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -9,6 +9,7 @@ use djls_project::SymbolKey;
 use djls_project::TemplateLibraries;
 use djls_semantic::FilterAritySpecs;
 use djls_semantic::ValidationError;
+use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use djls_testing::builtin_filter;
 use djls_testing::builtin_tag;
@@ -121,6 +122,49 @@ fn partial_ambiguous_db() -> TestDatabase {
     let mut libraries = make_template_libraries(&tags, &filters, &libraries, &builtins);
     libraries.knowledge = StaticKnowledge::Partial;
     TestDatabase::new().with_template_libraries(libraries)
+}
+
+fn db_with_project_files(
+    template_libraries: TemplateLibraries,
+    files: &[(&str, &str)],
+) -> TestDatabase {
+    let mut db = TestDatabase::new()
+        .with_template_libraries(template_libraries)
+        .with_arity_specs(standard_arities());
+    let mut fixture = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file(
+            "/proj/myproject/settings.py",
+            "INSTALLED_APPS = ['myapp']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+        )
+        .file("/proj/myapp/__init__.py", "")
+        .file("/proj/myapp/templatetags/__init__.py", "");
+    for (path, source) in files {
+        fixture = fixture.file(*path, *source);
+    }
+    fixture.install(&mut db);
+    db
+}
+
+fn standard_db_with_inactive_files(files: &[(&str, &str)]) -> TestDatabase {
+    db_with_project_files(standard_inventory(), files)
+}
+
+fn partial_db_with_inactive_files(files: &[(&str, &str)]) -> TestDatabase {
+    let mut libraries = standard_inventory();
+    libraries.knowledge = StaticKnowledge::Partial;
+    db_with_project_files(libraries, files)
+}
+
+fn crispy_inactive_files() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("/proj/crispy/__init__.py", ""),
+        ("/proj/crispy/templatetags/__init__.py", ""),
+        (
+            "/proj/crispy/templatetags/crispy.py",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef crispy_tag():\n    pass\n@register.filter\ndef crispy_filter(value):\n    return value\n",
+        ),
+    ]
 }
 
 fn collect_all_errors(db: &TestDatabase, source: &str) -> Vec<ValidationError> {
@@ -241,6 +285,173 @@ fn partial_knowledge_keeps_filter_arity_after_unrelated_unknown_selective_load()
             ValidationError::FilterMissingArgument { filter, .. } if filter == "truncatewords"
         )),
         "unknown selective loads should only shadow named filters: {errors:?}"
+    );
+}
+
+#[test]
+fn unknown_load_name_with_inactive_candidate_reports_not_in_installed_apps() {
+    let files = crispy_inactive_files();
+    let db = standard_db_with_inactive_files(&files);
+    let errors = collect_all_errors(&db, "{% load crispy %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::LibraryNotInInstalledApps { name, app, candidates, .. }
+                if name == "crispy"
+                    && app == "crispy"
+                    && candidates == &vec!["crispy".to_string()]
+        )),
+        "inactive library should produce S121: {errors:?}"
+    );
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, ValidationError::UnknownLibrary { name, .. } if name == "crispy")),
+        "S121 should replace S120 when inactive evidence exists: {errors:?}"
+    );
+}
+
+#[test]
+fn unknown_load_name_without_inactive_candidate_stays_unknown_library() {
+    let db = standard_db();
+    let errors = collect_all_errors(&db, "{% load missing_library %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnknownLibrary { name, .. } if name == "missing_library"
+        )),
+        "missing library should keep S120: {errors:?}"
+    );
+}
+
+#[test]
+fn unknown_tag_with_inactive_candidate_reports_not_in_installed_apps() {
+    let files = crispy_inactive_files();
+    let db = standard_db_with_inactive_files(&files);
+    let errors = collect_all_errors(&db, "{% crispy_tag %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::TagNotInInstalledApps { tag, app, load_name, .. }
+                if tag == "crispy_tag" && app == "crispy" && load_name == "crispy"
+        )),
+        "inactive tag should produce S118 naming app and load name: {errors:?}"
+    );
+    assert!(
+        !errors.iter().any(
+            |error| matches!(error, ValidationError::UnknownTag { tag, .. } if tag == "crispy_tag")
+        ),
+        "S118 should replace S108 when inactive evidence exists: {errors:?}"
+    );
+}
+
+#[test]
+fn unknown_tag_without_inactive_candidate_stays_unknown_tag() {
+    let db = standard_db();
+    let errors = collect_all_errors(&db, "{% definitely_unknown %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnknownTag { tag, .. } if tag == "definitely_unknown"
+        )),
+        "unknown tag should keep S108: {errors:?}"
+    );
+}
+
+#[test]
+fn unknown_filter_with_inactive_candidate_reports_not_in_installed_apps() {
+    let files = crispy_inactive_files();
+    let db = standard_db_with_inactive_files(&files);
+    let errors = collect_all_errors(&db, "{{ value|crispy_filter }}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::FilterNotInInstalledApps { filter, app, load_name, .. }
+                if filter == "crispy_filter" && app == "crispy" && load_name == "crispy"
+        )),
+        "inactive filter should produce S119: {errors:?}"
+    );
+}
+
+#[test]
+fn active_unloaded_tag_wins_over_inactive_candidate() {
+    let files = [
+        ("/proj/otherapp/__init__.py", ""),
+        ("/proj/otherapp/templatetags/__init__.py", ""),
+        (
+            "/proj/otherapp/templatetags/other_tags.py",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef trans():\n    pass\n",
+        ),
+    ];
+    let db = standard_db_with_inactive_files(&files);
+    let errors = collect_all_errors(&db, "{% trans \"hello\" %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnloadedTag { tag, library, .. }
+                if tag == "trans" && library == "i18n"
+        )),
+        "active unloaded library should win: {errors:?}"
+    );
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, ValidationError::TagNotInInstalledApps { tag, .. } if tag == "trans")),
+        "inactive candidates must not override active unloaded symbols: {errors:?}"
+    );
+}
+
+#[test]
+fn partial_knowledge_suppresses_inactive_absence_claim() {
+    let files = crispy_inactive_files();
+    let db = partial_db_with_inactive_files(&files);
+    let errors = collect_all_errors(&db, "{% load crispy %}\n");
+
+    assert!(
+        !errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnknownLibrary { name, .. }
+                | ValidationError::LibraryNotInInstalledApps { name, .. }
+                if name == "crispy"
+        )),
+        "partial knowledge should suppress S120 and S121: {errors:?}"
+    );
+}
+
+#[test]
+fn inactive_library_candidates_are_sorted_for_deterministic_s121() {
+    let files = [
+        ("/proj/beta/__init__.py", ""),
+        ("/proj/beta/templatetags/__init__.py", ""),
+        (
+            "/proj/beta/templatetags/shared.py",
+            "from django import template\nregister = template.Library()\n",
+        ),
+        ("/proj/alpha/__init__.py", ""),
+        ("/proj/alpha/templatetags/__init__.py", ""),
+        (
+            "/proj/alpha/templatetags/shared.py",
+            "from django import template\nregister = template.Library()\n",
+        ),
+    ];
+    let db = standard_db_with_inactive_files(&files);
+    let errors = collect_all_errors(&db, "{% load shared %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::LibraryNotInInstalledApps { name, app, candidates, .. }
+                if name == "shared"
+                    && app == "alpha"
+                    && candidates == &vec!["alpha".to_string(), "beta".to_string()]
+        )),
+        "S121 should use the first sorted candidate and include all apps: {errors:?}"
     );
 }
 

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -6,15 +6,16 @@ Django Language Server validates your Django templates as you write them, catchi
 
 Template validation relies on three systems working together:
 
-### Inspector
+### Static project discovery
 
-The **inspector** is a Python process that introspects your running Django project to discover:
+DJLS statically reads your Django settings and Python search paths to discover:
 
-- Which template tags and filters exist
-- Which libraries they belong to (builtins vs third-party)
-- Which library load-name maps to which module
+- Which apps are listed in `INSTALLED_APPS`
+- Which template tag libraries are active for this project
+- Which template tag libraries exist on the search paths but are not active
+- Which tags and filters each library registers
 
-This gives djls an accurate picture of your project's template tag ecosystem — the same tags Django would see at runtime. The inspector reflects your `INSTALLED_APPS` configuration, so it only reports tags and filters from apps that are actually activated.
+This gives djls an evidence-backed picture of your project's template tag ecosystem without starting Django. The active inventory reflects `INSTALLED_APPS`, so tags and filters from packages outside the active app list are reported separately.
 
 ### Extraction
 
@@ -25,7 +26,7 @@ The **extraction engine** analyzes Python source code (using static AST analysis
 - **Filter arity** — whether a filter expects an argument (e.g., `{{ value|default:"nothing" }}`)
 - **Expression syntax** — valid operator usage in `{% if %}` / `{% elif %}` expressions
 
-Together, the inspector tells djls *what's active in your project*, and extraction tells djls *how to validate usage*.
+Together, static project discovery tells djls *what's active in your project*, and extraction tells djls *how to validate usage*.
 
 ## Template Symbol Resolution
 
@@ -40,12 +41,13 @@ Each layer has a different failure mode and a different fix:
 
 | Layer | Failure | Diagnostic | Fix |
 |---|---|---|---|
-| Not active in the Django project | Package not installed or app not activated | S108/S111 (Unknown) | Install the package and add the app to `INSTALLED_APPS` |
+| Not found in active or inactive libraries | Unknown package, library, tag, or filter | S108/S111/S120 (Unknown) | Check the name or install the package |
+| Found on the Python search paths, not active in this project | App missing from `INSTALLED_APPS` | S118/S119/S121 (Not in `INSTALLED_APPS`) | Add the app to `INSTALLED_APPS` |
 | Active, not loaded | No `{% load %}` | S109/S112 (Unloaded) | Add `{% load <library> %}` |
 
-`{% load %}` library names are checked against the active inspector inventory. A library name not reported by the active Django project is reported as S120 (unknown library).
+`{% load %}` library names are checked against the active static inventory first. If the library exists on the project's Python search paths but its app is not in `INSTALLED_APPS`, djls reports S121. If no inactive-library evidence exists, djls reports S120.
 
-This gives you diagnostics based on the same template tag inventory Django would use at runtime.
+This gives you diagnostics based on the same template tag inventory Django would use at runtime, while distinguishing "not installed or misspelled" from "installed but not activated".
 
 ## What djls Validates
 
@@ -58,27 +60,30 @@ Validates that block tags are properly opened, closed, and nested:
 - **S102** — Orphaned tag (intermediate tag like `{% else %}` without a parent `{% if %}`)
 - **S103** — Unmatched block name (e.g., `{% endblock foo %}` doesn't match `{% block bar %}`)
 
-### Tag Scoping (S108–S110)
+### Tag Scoping (S108–S110, S118)
 
 Validates that template tags are available at their point of use, using [template symbol resolution](#template-symbol-resolution):
 
-- **S108** — Unknown tag (not found in any active library)
-- **S109** — Unloaded tag (defined in a library that hasn't been loaded via `{% load %}`)
-- **S110** — Ambiguous unloaded tag (defined in multiple libraries — load the correct one to resolve)
+- **S108** — Unknown tag (not found in any active or inactive library)
+- **S109** — Unloaded tag (defined in an active library that hasn't been loaded via `{% load %}`)
+- **S110** — Ambiguous unloaded tag (defined in multiple active libraries — load the correct one to resolve)
+- **S118** — Tag exists in a library whose app is not in `INSTALLED_APPS`
 
-### Filter Scoping (S111–S113)
+### Filter Scoping (S111–S113, S119)
 
 Validates that template filters are available at their point of use, with the same resolution layers as tags:
 
-- **S111** — Unknown filter (not found in any active library)
-- **S112** — Unloaded filter (defined in a library that hasn't been loaded)
-- **S113** — Ambiguous unloaded filter (defined in multiple libraries)
+- **S111** — Unknown filter (not found in any active or inactive library)
+- **S112** — Unloaded filter (defined in an active library that hasn't been loaded)
+- **S113** — Ambiguous unloaded filter (defined in multiple active libraries)
+- **S119** — Filter exists in a library whose app is not in `INSTALLED_APPS`
 
-### Library Validation (S120)
+### Library Validation (S120–S121)
 
 Validates that `{% load %}` library names refer to known template tag libraries:
 
-- **S120** — Unknown library (not found in the inspector inventory)
+- **S120** — Unknown library (not found in active or inactive libraries)
+- **S121** — Library exists on the project's Python search paths, but its app is not in `INSTALLED_APPS`
 
 ### Extends Validation (S122–S123)
 
@@ -118,25 +123,26 @@ Django templates are deeply dynamic — many things can only be checked at runti
 - **Dynamic tag behavior** — Tags whose validation depends on runtime state
 - **Format strings** — Whether date/time format strings are valid
 
-## Inspector Availability
+## Static Knowledge Availability
 
-The inspector requires a working Django environment (correct `DJANGO_SETTINGS_MODULE`, virtual environment with Django installed, no import errors during Django setup).
+Static discovery can be complete, partial, or unavailable. It is complete only when djls can resolve the active settings, installed apps, template backends, and relevant Python modules.
 
-When the inspector is **healthy**:
+When static discovery is **complete**:
 
 - Full validation is active — all current validation diagnostics are emitted
 - Completions are scoped to loaded libraries at cursor position
 
-When the inspector is **unavailable** (Django init failed, Python not configured, etc.):
+When static discovery is **partial or unavailable**:
 
-- **S108–S113 and S120 are suppressed** — Without knowing which tags/filters and libraries exist, djls cannot determine whether something is unknown or unloaded
-- **S115–S116 are suppressed** — Filter arity rules come from extraction, which depends on knowing the source modules
-- **S117 is suppressed** — Tag argument rules come from extraction, which depends on the inspector discovering tag source modules
+- **Absence-claim diagnostics are suppressed** — S108, S111, S118, S119, S120, and S121 require a complete active set, so djls does not emit them from partial evidence
+- **Known unloaded diagnostics can still appear under partial knowledge** — S109, S110, S112, and S113 are based on positive active-library evidence
+- **S115–S116 are suppressed when filter arity rules are unavailable** — Filter arity rules come from extraction, which depends on knowing source modules
+- **S117 is suppressed when tag argument rules are unavailable** — Tag argument rules come from extraction, which depends on discovering tag source modules
 - **S100–S103 still work** — Block structure validation uses built-in tag specs
 - **S114 still works** — Expression syntax validation is purely structural
-- **Inspector-backed completions are unavailable** — Tag, filter, and library completions that depend on active inventory are suppressed; syntax-only completions may still appear
+- **Project-backed completions are unavailable** when the active inventory is unknown; syntax-only completions may still appear
 
-This design avoids false positives when the Python environment isn't available.
+This design avoids false positives when djls cannot prove whether a tag, filter, or library is absent from the active project.
 
 ## Configuring Diagnostic Severity
 

--- a/tests/e2e/test_diagnostics.py
+++ b/tests/e2e/test_diagnostics.py
@@ -17,6 +17,7 @@ FIRST_PARTY_UNLOADED_TEMPLATE = (
     / "tags"
     / "first_party_unloaded.html"
 )
+NOT_IN_INSTALLED_APPS_TEMPLATE = TEST_WORKSPACE / "templates" / "not_in_installed_apps.html"
 EXPECTED_DIAGNOSTICS = {"S108", "S109", "S111", "S112", "S115", "S116"}
 
 
@@ -66,6 +67,39 @@ async def test_publish_diagnostics_for_unloaded_first_party_tag(
         for diagnostic in client.diagnostics[FIRST_PARTY_UNLOADED_TEMPLATE.as_uri()]
         if diagnostic.code
     } == {"S109"}
+
+
+@pytest.mark.asyncio
+async def test_publish_diagnostics_for_inactive_django_contrib_library(
+    client: LanguageClient,
+):
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=NOT_IN_INSTALLED_APPS_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=NOT_IN_INSTALLED_APPS_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    while not client.diagnostics.get(NOT_IN_INSTALLED_APPS_TEMPLATE.as_uri()):
+        await client.wait_for_notification(types.TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
+
+    diagnostics = client.diagnostics[NOT_IN_INSTALLED_APPS_TEMPLATE.as_uri()]
+    load_diagnostics = [
+        diagnostic for diagnostic in diagnostics if diagnostic.range.start.line == 0
+    ]
+    tag_diagnostics = [
+        diagnostic for diagnostic in diagnostics if diagnostic.range.start.line == 2
+    ]
+
+    assert [str(diagnostic.code) for diagnostic in load_diagnostics] == ["S121"]
+    assert "django.contrib.flatpages" in load_diagnostics[0].message
+    assert [str(diagnostic.code) for diagnostic in tag_diagnostics] == ["S118"]
+    assert "django.contrib.flatpages" in tag_diagnostics[0].message
+    assert "S108" not in {str(diagnostic.code) for diagnostic in diagnostics}
 
 
 @pytest.mark.asyncio

--- a/tests/project/templates/not_in_installed_apps.html
+++ b/tests/project/templates/not_in_installed_apps.html
@@ -1,0 +1,3 @@
+{% load flatpages %}
+
+{% get_flatpages as pages %}


### PR DESCRIPTION
## Summary

- add a static inactive template-library scan over Python search paths
- restore S118/S119/S121 diagnostics for tags, filters, and libraries whose app is not in `INSTALLED_APPS`
- cover inactive library diagnostics with unit tests, refresh invalidation coverage, e2e flatpages assertions, docs, and changelog

## Notes

The inactive facts stay separate from `TemplateLibraries`: the scan collects positive evidence from `templatetags/*.py` files, subtracts active library modules, and validation only upgrades unknown diagnostics when `TemplateLibraries::knowledge == StaticKnowledge::Known`.

A review found a stale-refresh risk for inactive library file contents. This PR fixes that by including inactive templatetag candidate paths in `refresh_external_data` file-revision bumps, with a regression test for changed inactive symbols.

## Validation

- `cargo test -q`
- `just test`
- `just e2e`
- `just clippy`
- `just fmt --check`
- `just lint`
- `cargo test -q -p djls-project inactive`
- `cargo test -q -p djls-project discover_templatetag`
- `cargo test -q -p djls-project refresh_external_data_updates_inactive_template_library_symbols`
- `cargo test -q -p djls-semantic`

## Scope check

Plan 018 invariants:

- S118/S119/S121 code arms restored in `crates/djls-semantic/src/errors.rs`
- no `Knowledge` field on `InactiveLibraries`
- no `TemplateLibraries` fields or library-status variants added
- partial/unknown knowledge still suppresses absence-claim diagnostics
- inactive candidates are sorted deterministically
- e2e fixture proves `django.contrib.flatpages` reports S121/S118 when absent from `INSTALLED_APPS`
