### PR TITLE
Make project refresh non-blocking

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -571,6 +571,40 @@ mod invalidation_tests {
     }
 
     #[test]
+    fn tagspecs_settings_change_reports_semantic_change() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            r#"
+[tagspecs]
+version = "0.6.0"
+
+[[tagspecs.libraries]]
+module = "myapp.templatetags.custom"
+
+[[tagspecs.libraries.tags]]
+name = "switch"
+type = "block"
+"#,
+        )
+        .unwrap();
+
+        let mut db = DjangoDatabase::new(
+            Arc::new(InMemoryFileSystem::new()),
+            &Settings::default(),
+            Some(root.as_path()),
+        );
+        let settings = Settings::new(root.as_path(), None).unwrap();
+
+        let update = db.set_settings(settings);
+
+        assert!(!update.env_changed);
+        assert!(!update.diagnostics_changed);
+        assert!(update.semantic_changed);
+    }
+
+    #[test]
     fn tagspecs_change_invalidates_compute_tag_specs() {
         let (mut db, event_log) = test_db_with_project();
 

--- a/crates/djls-db/src/settings.rs
+++ b/crates/djls-db/src/settings.rs
@@ -11,6 +11,7 @@ use crate::db::DjangoDatabase;
 pub struct SettingsUpdate {
     pub env_changed: bool,
     pub diagnostics_changed: bool,
+    pub semantic_changed: bool,
 }
 
 impl DjangoDatabase {
@@ -37,20 +38,23 @@ impl DjangoDatabase {
         let previous = self.settings();
         *self.settings.lock().unwrap() = settings;
 
-        let diagnostics_changed = previous.diagnostics() != self.settings().diagnostics();
+        let current = self.settings();
+        let diagnostics_changed = previous.diagnostics() != current.diagnostics();
+        let semantic_changed = previous.tagspecs() != current.tagspecs();
 
         if self.project().is_some() {
-            let settings = self.settings();
-            let env_changed = self.update_project_from_settings(&settings);
+            let env_changed = self.update_project_from_settings(&current);
             return SettingsUpdate {
                 env_changed,
                 diagnostics_changed,
+                semantic_changed,
             };
         }
 
         SettingsUpdate {
             env_changed: false,
             diagnostics_changed,
+            semantic_changed,
         }
     }
 
@@ -58,8 +62,8 @@ impl DjangoDatabase {
     /// Salsa setters when values actually change (Ruff/RA pattern).
     ///
     /// Returns `true` if environment-related fields changed (`interpreter`,
-    /// `django_settings_module`, `pythonpath`), indicating project data should
-    /// be refreshed.
+    /// `django_settings_module`, `pythonpath`, `env_vars`), indicating project
+    /// data should be refreshed by the caller.
     pub(crate) fn update_project_from_settings(&mut self, settings: &Settings) -> bool {
         let Some(project) = self.project() else {
             return false;
@@ -104,10 +108,6 @@ impl DjangoDatabase {
         let new_tagspecs = settings.tagspecs().clone();
         if project.tagspecs(self) != &new_tagspecs {
             project.set_tagspecs(self).to(new_tagspecs);
-        }
-
-        if env_changed {
-            project.refresh_source_roots(self);
         }
 
         env_changed

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -84,6 +84,8 @@ pub use symbols::TemplateLibraries;
 pub use symbols::TemplateLibrary;
 pub use symbols::TemplateSymbol;
 pub use symbols::TemplateSymbolKind;
+pub use sync::apply_refresh;
+pub use sync::compute_refresh;
 pub use sync::refresh_external_data;
 pub use templates::FindTemplateResult;
 pub use templates::ProjectTemplateFile;

--- a/crates/djls-project/src/project.rs
+++ b/crates/djls-project/src/project.rs
@@ -7,7 +7,6 @@ use djls_conf::TagSpecDef;
 use djls_source::File;
 use djls_source::FileSystem;
 use salsa::Durability;
-use salsa::Setter;
 
 use crate::db::Db as ProjectDb;
 use crate::names::ModulePath;
@@ -88,19 +87,6 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn refresh_source_roots(self, db: &mut dyn ProjectDb) {
-        let search_paths = SearchPaths::from_project_settings(
-            db.file_system(),
-            self.root(db),
-            self.interpreter(db),
-            self.pythonpath(db),
-        );
-        search_paths.register_roots(db);
-        if self.search_paths(db) != &search_paths {
-            self.set_search_paths(db).to(search_paths);
-        }
-    }
-
     pub(crate) fn touch_search_path_roots(self, db: &dyn ProjectDb) {
         for search_path in self.search_paths(db).iter() {
             if let Some(root) = db.files().root(db, search_path.path()) {

--- a/crates/djls-project/src/sync.rs
+++ b/crates/djls-project/src/sync.rs
@@ -4,9 +4,12 @@
 //! Django, Python, and the filesystem for facts, then writes changed facts to
 //! the `Project` input. Pure semantic derivation stays in tracked queries.
 
+use camino::Utf8PathBuf;
+use salsa::Setter;
+
 use crate::db::Db as ProjectDb;
 use crate::environment::templatetag_candidate_paths;
-use crate::project::Project;
+use crate::resolve::SearchPaths;
 use crate::resolve::model_modules;
 use crate::resolve::templatetag_modules;
 use crate::settings::settings_source_files;
@@ -18,33 +21,32 @@ use crate::settings::settings_source_files;
 /// into the `Project` input, then lets tracked semantic queries handle editor
 /// file contents and downstream derivations.
 pub fn refresh_external_data(db: &mut dyn ProjectDb) {
-    let Some(project) = db.project() else {
+    let Some(refresh) = compute_refresh(db) else {
         return;
     };
-
-    project.refresh_source_roots(db);
-    refresh_python_modules(db, project);
+    apply_refresh(db, refresh);
 }
 
-fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
-    // The LSP currently has no watched-file stream for dependency roots. Treat
-    // an explicit refresh as the freshness boundary for module discovery and
-    // currently discovered Python files.
-    let roots: Vec<_> = project
-        .search_paths(db)
-        .iter()
-        .filter_map(|search_path| db.files().root(db, search_path.path()))
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RefreshData {
+    search_paths: SearchPaths,
+    file_paths: Vec<Utf8PathBuf>,
+}
+
+pub fn compute_refresh(db: &dyn ProjectDb) -> Option<RefreshData> {
+    let project = db.project()?;
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        project.root(db),
+        project.interpreter(db),
+        project.pythonpath(db),
+    );
+
+    let mut file_paths: Vec<_> = settings_source_files(db, project)
+        .into_iter()
+        .map(|file| file.path(db).to_path_buf())
         .collect();
 
-    for root in roots {
-        db.bump_file_root_revision(root);
-    }
-
-    for file in settings_source_files(db, project) {
-        db.bump_file_revision(file);
-    }
-
-    let mut file_paths = Vec::new();
     file_paths.extend(
         model_modules(db, project)
             .iter()
@@ -60,6 +62,39 @@ fn refresh_python_modules(db: &mut dyn ProjectDb, project: Project) {
 
     file_paths.sort();
     file_paths.dedup();
+
+    Some(RefreshData {
+        search_paths,
+        file_paths,
+    })
+}
+
+pub fn apply_refresh(db: &mut dyn ProjectDb, refresh: RefreshData) {
+    let Some(project) = db.project() else {
+        return;
+    };
+    let RefreshData {
+        search_paths,
+        file_paths,
+    } = refresh;
+
+    search_paths.register_roots(db);
+    if project.search_paths(db) != &search_paths {
+        project.set_search_paths(db).to(search_paths);
+    }
+
+    // The LSP currently has no watched-file stream for dependency roots. Treat
+    // an explicit refresh as the freshness boundary for module discovery and
+    // currently discovered Python files.
+    let roots: Vec<_> = project
+        .search_paths(db)
+        .iter()
+        .filter_map(|search_path| db.files().root(db, search_path.path()))
+        .collect();
+
+    for root in roots {
+        db.bump_file_root_revision(root);
+    }
 
     for path in file_paths {
         let file = db.get_or_create_file(&path);

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -694,6 +694,37 @@ fn refresh_external_data_discovers_site_packages_created_after_bootstrap() {
 }
 
 #[test]
+fn compute_and_apply_refresh_discovers_site_packages_created_after_bootstrap() {
+    let mut db = TestDatabase::new();
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &[],
+    );
+    search_paths.register_roots(&db);
+    let project = ProjectFixture::new("/project")
+        .search_paths(search_paths)
+        .interpreter(Interpreter::Auto)
+        .register_roots(false)
+        .install(&mut db);
+
+    db.add_file(
+        "/project/.venv/lib/python3.12/site-packages/blog/models.py",
+        "from django.db import models\nclass VenvArticle(models.Model):\n    pass\n",
+    );
+
+    let refresh = compute_refresh(&db).expect("project should be configured");
+    apply_refresh(&mut db, refresh);
+
+    assert!(project.search_paths(&db).iter().any(|search_path| {
+        search_path.path() == Utf8Path::new("/project/.venv/lib/python3.12/site-packages")
+    }));
+    let graph = compute_model_graph(&db, project);
+    assert!(graph.get("VenvArticle").is_some());
+}
+
+#[test]
 fn discover_external_model_files_finds_models() {
     let tmp = tempfile::TempDir::new().unwrap();
     let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();

--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -3,6 +3,7 @@ mod document;
 mod ext;
 mod logging;
 mod queue;
+mod refresh;
 mod server;
 mod session;
 mod workspace;

--- a/crates/djls-server/src/refresh.rs
+++ b/crates/djls-server/src/refresh.rs
@@ -1,0 +1,304 @@
+//! Background project refresh.
+//!
+//! Runs off the session lock as much as possible: compute the refresh on a
+//! database clone, apply it briefly under the lock, then warm derived queries
+//! and republish diagnostics from a snapshot. The session's refresh epoch is
+//! checked between stages so superseded work is dropped on the floor.
+
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use djls_project::Db as ProjectDb;
+use djls_project::apply_refresh;
+use djls_project::compute_refresh;
+use djls_project::project_template_files;
+use djls_semantic::Db as SemanticDb;
+use tokio::sync::Mutex;
+use tower_lsp_server::Client;
+use tower_lsp_server::ls_types;
+
+use crate::document::TextDocument;
+use crate::ext::UriExt;
+use crate::session::SNAPSHOT_CANCEL_RETRIES;
+use crate::session::Session;
+use crate::session::SessionSnapshot;
+
+fn refresh_is_stale(refresh_epoch: &AtomicU64, epoch: u64) -> bool {
+    refresh_epoch.load(Ordering::Acquire) != epoch
+}
+
+pub(crate) async fn run_project_refresh(
+    session: Arc<Mutex<Session>>,
+    client: Client,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    epoch: u64,
+    log_initialization: bool,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    let result = run_project_refresh_inner(
+        session,
+        client,
+        refresh_epoch,
+        diagnostic_publish_lock,
+        epoch,
+    )
+    .await;
+
+    if log_initialization {
+        tracing::info!("Server initialization completed in {:?}", start.elapsed());
+    } else if result.is_ok() {
+        tracing::info!("Environment refresh completed in {:?}", start.elapsed());
+    }
+
+    result
+}
+
+async fn run_project_refresh_inner(
+    session: Arc<Mutex<Session>>,
+    client: Client,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    epoch: u64,
+) -> anyhow::Result<()> {
+    if refresh_is_stale(&refresh_epoch, epoch) {
+        tracing::debug!(
+            epoch,
+            "Skipping stale project refresh before locking session"
+        );
+        return Ok(());
+    }
+
+    // Cancellation here usually means a document edit, not a config change:
+    // nothing bumps the epoch or resubmits, so dropping the compute would lose
+    // the refresh for good. Retry with a fresh database clone instead, like
+    // the snapshot reads do.
+    let mut refresh = None;
+    for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
+        let Some(compute_db) = ({
+            let session_lock = session.lock().await;
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                tracing::debug!(
+                    epoch,
+                    "Skipping stale project refresh after locking session"
+                );
+                return Ok(());
+            }
+
+            let db = session_lock.db();
+            db.project().map(|_| db.clone())
+        }) else {
+            tracing::info!("Task: No project configured, skipping initialization.");
+            return Ok(());
+        };
+
+        let result = tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(AssertUnwindSafe(|| compute_refresh(&compute_db)))
+        })
+        .await
+        .expect("project refresh compute task must not panic");
+
+        match result {
+            Ok(computed) => {
+                refresh = computed;
+                break;
+            }
+            Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
+                tracing::debug!(
+                    ?cancelled,
+                    attempt = attempt + 1,
+                    "Project refresh compute cancelled; retrying with fresh database clone"
+                );
+            }
+            Err(cancelled) => {
+                tracing::warn!(
+                    ?cancelled,
+                    retries = SNAPSHOT_CANCEL_RETRIES,
+                    "Project refresh compute cancelled repeatedly; project facts may be stale until the next refresh"
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    let Some(refresh) = refresh else {
+        return Ok(());
+    };
+
+    if refresh_is_stale(&refresh_epoch, epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh before apply");
+        return Ok(());
+    }
+
+    let (snapshot, documents) = {
+        let mut session_lock = session.lock().await;
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
+            return Ok(());
+        }
+
+        let db = session_lock.db_mut();
+        if db.project().is_none() {
+            return Ok(());
+        }
+
+        let t = std::time::Instant::now();
+        apply_refresh(db, refresh);
+        tracing::info!("External data refresh completed in {:?}", t.elapsed());
+
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale project refresh after apply");
+            return Ok(());
+        }
+
+        (session_lock.snapshot(), session_lock.open_documents())
+    };
+
+    warm_project_queries(snapshot.clone(), Arc::clone(&refresh_epoch), epoch).await;
+    republish_snapshot_diagnostics(
+        client,
+        snapshot,
+        documents,
+        refresh_epoch,
+        diagnostic_publish_lock,
+        epoch,
+    )
+    .await;
+
+    Ok(())
+}
+
+async fn warm_project_queries(
+    snapshot: SessionSnapshot,
+    refresh_epoch: Arc<AtomicU64>,
+    epoch: u64,
+) {
+    let result = tokio::task::spawn_blocking(move || {
+        salsa::Cancelled::catch(AssertUnwindSafe(|| {
+            let db = snapshot.db();
+            let Some(project) = db.project() else {
+                return;
+            };
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = db.tag_specs();
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = db.template_dirs();
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = db.template_libraries();
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = project_template_files(db, project);
+        }))
+    })
+    .await
+    .expect("project warm-up task must not panic");
+
+    if let Err(cancelled) = result {
+        tracing::debug!(
+            ?cancelled,
+            "Project refresh warm-up cancelled; newer inputs will re-warm queries"
+        );
+    }
+}
+
+async fn republish_snapshot_diagnostics(
+    client: Client,
+    snapshot: SessionSnapshot,
+    documents: Vec<TextDocument>,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    epoch: u64,
+) {
+    if snapshot.client_info().supports_pull_diagnostics() {
+        tracing::debug!("Client supports pull diagnostics, skipping refresh diagnostics push");
+        return;
+    }
+
+    for document in documents {
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale refresh diagnostics republish");
+            return;
+        }
+
+        let file = document.file();
+        let Some(diagnostics) = collect_snapshot_diagnostics(snapshot.clone(), file).await else {
+            continue;
+        };
+
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
+            return;
+        }
+
+        let Some(lsp_uri) = ls_types::Uri::from_path(document.path()) else {
+            continue;
+        };
+
+        let diagnostic_count = diagnostics.len();
+        let lsp_uri_text = lsp_uri.to_string();
+        let _publish_guard = diagnostic_publish_lock.lock().await;
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
+            return;
+        }
+        client
+            .publish_diagnostics(lsp_uri, diagnostics, Some(document.version()))
+            .await;
+
+        tracing::debug!(
+            "Published {} diagnostics for {}",
+            diagnostic_count,
+            lsp_uri_text
+        );
+    }
+}
+
+async fn collect_snapshot_diagnostics(
+    snapshot: SessionSnapshot,
+    file: djls_source::File,
+) -> Option<Vec<ls_types::Diagnostic>> {
+    for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
+        let snapshot = snapshot.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(AssertUnwindSafe(|| {
+                djls_ide::collect_diagnostics(snapshot.db(), file)
+            }))
+        })
+        .await
+        .expect("diagnostics snapshot task must not panic");
+
+        match result {
+            Ok(diagnostics) => return diagnostics,
+            Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
+                tracing::debug!(
+                    ?cancelled,
+                    attempt = attempt + 1,
+                    "Refresh diagnostics cancelled; retrying with same snapshot"
+                );
+            }
+            Err(cancelled) => {
+                tracing::debug!(
+                    ?cancelled,
+                    retries = SNAPSHOT_CANCEL_RETRIES,
+                    "Refresh diagnostics cancelled; skipping diagnostics republish"
+                );
+                return None;
+            }
+        }
+    }
+
+    unreachable!("diagnostics retry loop must return")
+}

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -1,9 +1,14 @@
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use djls_project::Db as ProjectDb;
-use djls_project::refresh_external_data;
+use djls_project::apply_refresh;
+use djls_project::compute_refresh;
+use djls_project::project_template_files;
+use djls_semantic::Db as SemanticDb;
 use djls_source::FileKind;
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
@@ -26,6 +31,8 @@ pub(crate) struct DjangoLanguageServer {
     client: Client,
     session: Arc<Mutex<Session>>,
     queue: Queue,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
     logging: LoggingGuard,
 }
 
@@ -36,6 +43,8 @@ impl DjangoLanguageServer {
             client,
             session: Arc::new(Mutex::new(Session::default())),
             queue: Queue::new(),
+            refresh_epoch: Arc::new(AtomicU64::new(0)),
+            diagnostic_publish_lock: Arc::new(Mutex::new(())),
             logging,
         }
     }
@@ -97,6 +106,31 @@ impl DjangoLanguageServer {
         unreachable!("snapshot retry loop must return")
     }
 
+    fn next_refresh_epoch(&self) -> u64 {
+        self.refresh_epoch.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    async fn submit_project_refresh(&self, epoch: u64, log_initialization: bool) {
+        let client = self.client.clone();
+        let refresh_epoch = Arc::clone(&self.refresh_epoch);
+        let diagnostic_publish_lock = Arc::clone(&self.diagnostic_publish_lock);
+
+        let rx = self
+            .with_session_mut_task(move |session| async move {
+                run_project_refresh_task(
+                    session,
+                    client,
+                    refresh_epoch,
+                    diagnostic_publish_lock,
+                    epoch,
+                    log_initialization,
+                )
+                .await
+            })
+            .await;
+        drop(rx);
+    }
+
     pub(crate) async fn with_session_mut_task<F, Fut>(
         &self,
         f: F,
@@ -151,6 +185,7 @@ impl DjangoLanguageServer {
 
         let diagnostic_count = diagnostics.len();
         let lsp_uri_text = lsp_uri.to_string();
+        let _publish_guard = self.diagnostic_publish_lock.lock().await;
         self.client
             .publish_diagnostics(lsp_uri, diagnostics, Some(document.version()))
             .await;
@@ -161,6 +196,264 @@ impl DjangoLanguageServer {
             lsp_uri_text
         );
     }
+}
+
+fn refresh_is_stale(refresh_epoch: &AtomicU64, epoch: u64) -> bool {
+    refresh_epoch.load(Ordering::Acquire) != epoch
+}
+
+async fn run_project_refresh_task(
+    session: Arc<Mutex<Session>>,
+    client: Client,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    epoch: u64,
+    log_initialization: bool,
+) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    let result = run_project_refresh_task_inner(
+        session,
+        client,
+        refresh_epoch,
+        diagnostic_publish_lock,
+        epoch,
+    )
+    .await;
+
+    if log_initialization {
+        tracing::info!("Server initialization completed in {:?}", start.elapsed());
+    } else if result.is_ok() {
+        tracing::info!("Environment refresh completed in {:?}", start.elapsed());
+    }
+
+    result
+}
+
+async fn run_project_refresh_task_inner(
+    session: Arc<Mutex<Session>>,
+    client: Client,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    epoch: u64,
+) -> anyhow::Result<()> {
+    if refresh_is_stale(&refresh_epoch, epoch) {
+        tracing::debug!(
+            epoch,
+            "Skipping stale project refresh before locking session"
+        );
+        return Ok(());
+    }
+
+    let Some(compute_db) = ({
+        let session_lock = session.lock().await;
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(
+                epoch,
+                "Skipping stale project refresh after locking session"
+            );
+            return Ok(());
+        }
+
+        let db = session_lock.db();
+        db.project().map(|_| db.clone())
+    }) else {
+        tracing::info!("Task: No project configured, skipping initialization.");
+        return Ok(());
+    };
+
+    let refresh = tokio::task::spawn_blocking(move || {
+        salsa::Cancelled::catch(AssertUnwindSafe(|| compute_refresh(&compute_db)))
+    })
+    .await
+    .expect("project refresh compute task must not panic");
+
+    let Some(refresh) = (match refresh {
+        Ok(refresh) => refresh,
+        Err(cancelled) => {
+            tracing::debug!(
+                ?cancelled,
+                "Project refresh compute cancelled; newer inputs will re-run refresh"
+            );
+            return Ok(());
+        }
+    }) else {
+        return Ok(());
+    };
+
+    if refresh_is_stale(&refresh_epoch, epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh before apply");
+        return Ok(());
+    }
+
+    let (snapshot, documents) = {
+        let mut session_lock = session.lock().await;
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
+            return Ok(());
+        }
+
+        let db = session_lock.db_mut();
+        if db.project().is_none() {
+            return Ok(());
+        }
+
+        let t = std::time::Instant::now();
+        apply_refresh(db, refresh);
+        tracing::info!("External data refresh completed in {:?}", t.elapsed());
+
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale project refresh after apply");
+            return Ok(());
+        }
+
+        (session_lock.snapshot(), session_lock.open_documents())
+    };
+
+    warm_project_queries(snapshot.clone(), Arc::clone(&refresh_epoch), epoch).await;
+    republish_snapshot_diagnostics(
+        client,
+        snapshot,
+        documents,
+        refresh_epoch,
+        diagnostic_publish_lock,
+        epoch,
+    )
+    .await;
+
+    Ok(())
+}
+
+async fn warm_project_queries(
+    snapshot: SessionSnapshot,
+    refresh_epoch: Arc<AtomicU64>,
+    epoch: u64,
+) {
+    let result = tokio::task::spawn_blocking(move || {
+        salsa::Cancelled::catch(AssertUnwindSafe(|| {
+            let db = snapshot.db();
+            let Some(project) = db.project() else {
+                return;
+            };
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = db.tag_specs();
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = db.template_dirs();
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = db.template_libraries();
+
+            if refresh_is_stale(&refresh_epoch, epoch) {
+                return;
+            }
+            let _ = project_template_files(db, project);
+        }))
+    })
+    .await
+    .expect("project warm-up task must not panic");
+
+    if let Err(cancelled) = result {
+        tracing::debug!(
+            ?cancelled,
+            "Project refresh warm-up cancelled; newer inputs will re-warm queries"
+        );
+    }
+}
+
+async fn republish_snapshot_diagnostics(
+    client: Client,
+    snapshot: SessionSnapshot,
+    documents: Vec<TextDocument>,
+    refresh_epoch: Arc<AtomicU64>,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    epoch: u64,
+) {
+    if snapshot.client_info().supports_pull_diagnostics() {
+        tracing::debug!("Client supports pull diagnostics, skipping refresh diagnostics push");
+        return;
+    }
+
+    for document in documents {
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale refresh diagnostics republish");
+            return;
+        }
+
+        let file = document.file();
+        let Some(diagnostics) = collect_snapshot_diagnostics(snapshot.clone(), file).await else {
+            continue;
+        };
+
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
+            return;
+        }
+
+        let Some(lsp_uri) = ls_types::Uri::from_path(document.path()) else {
+            continue;
+        };
+
+        let diagnostic_count = diagnostics.len();
+        let lsp_uri_text = lsp_uri.to_string();
+        let _publish_guard = diagnostic_publish_lock.lock().await;
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
+            return;
+        }
+        client
+            .publish_diagnostics(lsp_uri, diagnostics, Some(document.version()))
+            .await;
+
+        tracing::debug!(
+            "Published {} diagnostics for {}",
+            diagnostic_count,
+            lsp_uri_text
+        );
+    }
+}
+
+async fn collect_snapshot_diagnostics(
+    snapshot: SessionSnapshot,
+    file: djls_source::File,
+) -> Option<Vec<ls_types::Diagnostic>> {
+    for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
+        let snapshot = snapshot.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(AssertUnwindSafe(|| {
+                djls_ide::collect_diagnostics(snapshot.db(), file)
+            }))
+        })
+        .await
+        .expect("diagnostics snapshot task must not panic");
+
+        match result {
+            Ok(diagnostics) => return diagnostics,
+            Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
+                tracing::debug!(
+                    ?cancelled,
+                    attempt = attempt + 1,
+                    "Refresh diagnostics cancelled; retrying with same snapshot"
+                );
+            }
+            Err(cancelled) => {
+                tracing::debug!(
+                    ?cancelled,
+                    retries = SNAPSHOT_CANCEL_RETRIES,
+                    "Refresh diagnostics cancelled; skipping diagnostics republish"
+                );
+                return None;
+            }
+        }
+    }
+
+    unreachable!("diagnostics retry loop must return")
 }
 
 impl LanguageServer for DjangoLanguageServer {
@@ -236,27 +529,8 @@ impl LanguageServer for DjangoLanguageServer {
         tracing::info!("Server received initialized notification.");
 
         // Refresh project data in the background and initialize the workspace.
-        let rx = self
-            .with_session_mut_task(|session| async move {
-                let start = std::time::Instant::now();
-
-                let mut session_lock = session.lock().await;
-                let db = session_lock.db_mut();
-
-                let t = std::time::Instant::now();
-                refresh_external_data(db);
-                tracing::info!("External data refresh completed in {:?}", t.elapsed());
-
-                if db.project().is_none() {
-                    tracing::info!("Task: No project configured, skipping initialization.");
-                }
-
-                tracing::info!("Server initialization completed in {:?}", start.elapsed());
-                Ok(())
-            })
-            .await;
-
-        let _ = rx.await;
+        let epoch = self.next_refresh_epoch();
+        self.submit_project_refresh(epoch, true).await;
     }
 
     async fn shutdown(&self) -> LspResult<()> {
@@ -542,36 +816,18 @@ impl LanguageServer for DjangoLanguageServer {
             })
             .await;
 
-        if !settings_update.env_changed && !settings_update.diagnostics_changed {
+        if !settings_update.env_changed
+            && !settings_update.diagnostics_changed
+            && !settings_update.semantic_changed
+        {
             return;
         }
 
         if settings_update.env_changed {
-            let rx = self
-                .with_session_mut_task(|session| async move {
-                    let start = std::time::Instant::now();
-
-                    let mut session_lock = session.lock().await;
-                    let db = session_lock.db_mut();
-
-                    if db.project().is_none() {
-                        return Ok(());
-                    }
-
-                    let t = std::time::Instant::now();
-                    refresh_external_data(db);
-                    tracing::info!("External data refresh completed in {:?}", t.elapsed());
-
-                    tracing::info!("Environment refresh completed in {:?}", start.elapsed());
-                    Ok(())
-                })
-                .await;
-
-            // Wait for environment update to complete before republishing diagnostics
-            let _ = rx.await;
-        }
-
-        if settings_update.env_changed || settings_update.diagnostics_changed {
+            let epoch = self.next_refresh_epoch();
+            self.submit_project_refresh(epoch, false).await;
+        } else if settings_update.diagnostics_changed || settings_update.semantic_changed {
+            let _epoch = self.next_refresh_epoch();
             let documents = self.with_session(Session::open_documents).await;
 
             for document in documents {

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -1,14 +1,8 @@
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 
 use djls_project::Db as ProjectDb;
-use djls_project::apply_refresh;
-use djls_project::compute_refresh;
-use djls_project::project_template_files;
-use djls_semantic::Db as SemanticDb;
 use djls_source::FileKind;
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
@@ -22,17 +16,15 @@ use crate::ext::PositionEncodingExt;
 use crate::ext::UriExt;
 use crate::logging::LoggingGuard;
 use crate::queue::Queue;
+use crate::refresh;
+use crate::session::SNAPSHOT_CANCEL_RETRIES;
 use crate::session::Session;
 use crate::session::SessionSnapshot;
-
-const SNAPSHOT_CANCEL_RETRIES: usize = 2;
 
 pub(crate) struct DjangoLanguageServer {
     client: Client,
     session: Arc<Mutex<Session>>,
     queue: Queue,
-    refresh_epoch: Arc<AtomicU64>,
-    diagnostic_publish_lock: Arc<Mutex<()>>,
     logging: LoggingGuard,
 }
 
@@ -43,8 +35,6 @@ impl DjangoLanguageServer {
             client,
             session: Arc::new(Mutex::new(Session::default())),
             queue: Queue::new(),
-            refresh_epoch: Arc::new(AtomicU64::new(0)),
-            diagnostic_publish_lock: Arc::new(Mutex::new(())),
             logging,
         }
     }
@@ -106,18 +96,23 @@ impl DjangoLanguageServer {
         unreachable!("snapshot retry loop must return")
     }
 
-    fn next_refresh_epoch(&self) -> u64 {
-        self.refresh_epoch.fetch_add(1, Ordering::AcqRel) + 1
-    }
-
-    async fn submit_project_refresh(&self, epoch: u64, log_initialization: bool) {
+    /// Bump the session's refresh epoch and queue a refresh task for the new
+    /// epoch. The task body lives in [`crate::refresh`].
+    async fn submit_project_refresh(&self, log_initialization: bool) {
         let client = self.client.clone();
-        let refresh_epoch = Arc::clone(&self.refresh_epoch);
-        let diagnostic_publish_lock = Arc::clone(&self.diagnostic_publish_lock);
+        let (epoch, refresh_epoch, diagnostic_publish_lock) = self
+            .with_session(|session| {
+                (
+                    session.bump_refresh_epoch(),
+                    session.refresh_epoch(),
+                    session.diagnostic_publish_lock(),
+                )
+            })
+            .await;
 
         let rx = self
             .with_session_mut_task(move |session| async move {
-                run_project_refresh_task(
+                refresh::run_project_refresh(
                     session,
                     client,
                     refresh_epoch,
@@ -185,7 +180,8 @@ impl DjangoLanguageServer {
 
         let diagnostic_count = diagnostics.len();
         let lsp_uri_text = lsp_uri.to_string();
-        let _publish_guard = self.diagnostic_publish_lock.lock().await;
+        let publish_lock = self.with_session(Session::diagnostic_publish_lock).await;
+        let _publish_guard = publish_lock.lock().await;
         self.client
             .publish_diagnostics(lsp_uri, diagnostics, Some(document.version()))
             .await;
@@ -196,264 +192,6 @@ impl DjangoLanguageServer {
             lsp_uri_text
         );
     }
-}
-
-fn refresh_is_stale(refresh_epoch: &AtomicU64, epoch: u64) -> bool {
-    refresh_epoch.load(Ordering::Acquire) != epoch
-}
-
-async fn run_project_refresh_task(
-    session: Arc<Mutex<Session>>,
-    client: Client,
-    refresh_epoch: Arc<AtomicU64>,
-    diagnostic_publish_lock: Arc<Mutex<()>>,
-    epoch: u64,
-    log_initialization: bool,
-) -> anyhow::Result<()> {
-    let start = std::time::Instant::now();
-    let result = run_project_refresh_task_inner(
-        session,
-        client,
-        refresh_epoch,
-        diagnostic_publish_lock,
-        epoch,
-    )
-    .await;
-
-    if log_initialization {
-        tracing::info!("Server initialization completed in {:?}", start.elapsed());
-    } else if result.is_ok() {
-        tracing::info!("Environment refresh completed in {:?}", start.elapsed());
-    }
-
-    result
-}
-
-async fn run_project_refresh_task_inner(
-    session: Arc<Mutex<Session>>,
-    client: Client,
-    refresh_epoch: Arc<AtomicU64>,
-    diagnostic_publish_lock: Arc<Mutex<()>>,
-    epoch: u64,
-) -> anyhow::Result<()> {
-    if refresh_is_stale(&refresh_epoch, epoch) {
-        tracing::debug!(
-            epoch,
-            "Skipping stale project refresh before locking session"
-        );
-        return Ok(());
-    }
-
-    let Some(compute_db) = ({
-        let session_lock = session.lock().await;
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(
-                epoch,
-                "Skipping stale project refresh after locking session"
-            );
-            return Ok(());
-        }
-
-        let db = session_lock.db();
-        db.project().map(|_| db.clone())
-    }) else {
-        tracing::info!("Task: No project configured, skipping initialization.");
-        return Ok(());
-    };
-
-    let refresh = tokio::task::spawn_blocking(move || {
-        salsa::Cancelled::catch(AssertUnwindSafe(|| compute_refresh(&compute_db)))
-    })
-    .await
-    .expect("project refresh compute task must not panic");
-
-    let Some(refresh) = (match refresh {
-        Ok(refresh) => refresh,
-        Err(cancelled) => {
-            tracing::debug!(
-                ?cancelled,
-                "Project refresh compute cancelled; newer inputs will re-run refresh"
-            );
-            return Ok(());
-        }
-    }) else {
-        return Ok(());
-    };
-
-    if refresh_is_stale(&refresh_epoch, epoch) {
-        tracing::debug!(epoch, "Skipping stale project refresh before apply");
-        return Ok(());
-    }
-
-    let (snapshot, documents) = {
-        let mut session_lock = session.lock().await;
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
-            return Ok(());
-        }
-
-        let db = session_lock.db_mut();
-        if db.project().is_none() {
-            return Ok(());
-        }
-
-        let t = std::time::Instant::now();
-        apply_refresh(db, refresh);
-        tracing::info!("External data refresh completed in {:?}", t.elapsed());
-
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale project refresh after apply");
-            return Ok(());
-        }
-
-        (session_lock.snapshot(), session_lock.open_documents())
-    };
-
-    warm_project_queries(snapshot.clone(), Arc::clone(&refresh_epoch), epoch).await;
-    republish_snapshot_diagnostics(
-        client,
-        snapshot,
-        documents,
-        refresh_epoch,
-        diagnostic_publish_lock,
-        epoch,
-    )
-    .await;
-
-    Ok(())
-}
-
-async fn warm_project_queries(
-    snapshot: SessionSnapshot,
-    refresh_epoch: Arc<AtomicU64>,
-    epoch: u64,
-) {
-    let result = tokio::task::spawn_blocking(move || {
-        salsa::Cancelled::catch(AssertUnwindSafe(|| {
-            let db = snapshot.db();
-            let Some(project) = db.project() else {
-                return;
-            };
-
-            if refresh_is_stale(&refresh_epoch, epoch) {
-                return;
-            }
-            let _ = db.tag_specs();
-
-            if refresh_is_stale(&refresh_epoch, epoch) {
-                return;
-            }
-            let _ = db.template_dirs();
-
-            if refresh_is_stale(&refresh_epoch, epoch) {
-                return;
-            }
-            let _ = db.template_libraries();
-
-            if refresh_is_stale(&refresh_epoch, epoch) {
-                return;
-            }
-            let _ = project_template_files(db, project);
-        }))
-    })
-    .await
-    .expect("project warm-up task must not panic");
-
-    if let Err(cancelled) = result {
-        tracing::debug!(
-            ?cancelled,
-            "Project refresh warm-up cancelled; newer inputs will re-warm queries"
-        );
-    }
-}
-
-async fn republish_snapshot_diagnostics(
-    client: Client,
-    snapshot: SessionSnapshot,
-    documents: Vec<TextDocument>,
-    refresh_epoch: Arc<AtomicU64>,
-    diagnostic_publish_lock: Arc<Mutex<()>>,
-    epoch: u64,
-) {
-    if snapshot.client_info().supports_pull_diagnostics() {
-        tracing::debug!("Client supports pull diagnostics, skipping refresh diagnostics push");
-        return;
-    }
-
-    for document in documents {
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale refresh diagnostics republish");
-            return;
-        }
-
-        let file = document.file();
-        let Some(diagnostics) = collect_snapshot_diagnostics(snapshot.clone(), file).await else {
-            continue;
-        };
-
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
-            return;
-        }
-
-        let Some(lsp_uri) = ls_types::Uri::from_path(document.path()) else {
-            continue;
-        };
-
-        let diagnostic_count = diagnostics.len();
-        let lsp_uri_text = lsp_uri.to_string();
-        let _publish_guard = diagnostic_publish_lock.lock().await;
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
-            return;
-        }
-        client
-            .publish_diagnostics(lsp_uri, diagnostics, Some(document.version()))
-            .await;
-
-        tracing::debug!(
-            "Published {} diagnostics for {}",
-            diagnostic_count,
-            lsp_uri_text
-        );
-    }
-}
-
-async fn collect_snapshot_diagnostics(
-    snapshot: SessionSnapshot,
-    file: djls_source::File,
-) -> Option<Vec<ls_types::Diagnostic>> {
-    for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
-        let snapshot = snapshot.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            salsa::Cancelled::catch(AssertUnwindSafe(|| {
-                djls_ide::collect_diagnostics(snapshot.db(), file)
-            }))
-        })
-        .await
-        .expect("diagnostics snapshot task must not panic");
-
-        match result {
-            Ok(diagnostics) => return diagnostics,
-            Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
-                tracing::debug!(
-                    ?cancelled,
-                    attempt = attempt + 1,
-                    "Refresh diagnostics cancelled; retrying with same snapshot"
-                );
-            }
-            Err(cancelled) => {
-                tracing::debug!(
-                    ?cancelled,
-                    retries = SNAPSHOT_CANCEL_RETRIES,
-                    "Refresh diagnostics cancelled; skipping diagnostics republish"
-                );
-                return None;
-            }
-        }
-    }
-
-    unreachable!("diagnostics retry loop must return")
 }
 
 impl LanguageServer for DjangoLanguageServer {
@@ -529,8 +267,7 @@ impl LanguageServer for DjangoLanguageServer {
         tracing::info!("Server received initialized notification.");
 
         // Refresh project data in the background and initialize the workspace.
-        let epoch = self.next_refresh_epoch();
-        self.submit_project_refresh(epoch, true).await;
+        self.submit_project_refresh(true).await;
     }
 
     async fn shutdown(&self) -> LspResult<()> {
@@ -816,23 +553,16 @@ impl LanguageServer for DjangoLanguageServer {
             })
             .await;
 
-        if !settings_update.env_changed
-            && !settings_update.diagnostics_changed
-            && !settings_update.semantic_changed
+        // Any relevant change submits a refresh: the epoch bump supersedes
+        // in-flight refresh work (so a stale republish cannot overwrite newer
+        // settings), and the new task re-applies and republishes diagnostics
+        // for open documents. Bumping without resubmitting would drop a
+        // superseded refresh's apply on the floor.
+        if settings_update.env_changed
+            || settings_update.diagnostics_changed
+            || settings_update.semantic_changed
         {
-            return;
-        }
-
-        if settings_update.env_changed {
-            let epoch = self.next_refresh_epoch();
-            self.submit_project_refresh(epoch, false).await;
-        } else if settings_update.diagnostics_changed || settings_update.semantic_changed {
-            let _epoch = self.next_refresh_epoch();
-            let documents = self.with_session(Session::open_documents).await;
-
-            for document in documents {
-                self.maybe_push_diagnostics(&document).await;
-            }
+            self.submit_project_refresh(false).await;
         }
     }
 }

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -3,6 +3,10 @@
 //! This module implements the LSP session abstraction that manages project-specific
 //! state and the Salsa database for incremental computation.
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
 #[cfg(test)]
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
@@ -12,6 +16,7 @@ use djls_project::Db as ProjectDb;
 use djls_source::Db as SourceDb;
 use djls_source::File;
 use djls_source::Offset;
+use tokio::sync::Mutex;
 use tower_lsp_server::ls_types;
 
 use crate::client::ClientInfo;
@@ -22,6 +27,10 @@ use crate::ext::TextDocumentContentChangeEventExt;
 use crate::ext::TextDocumentItemExt;
 use crate::ext::UriExt;
 use crate::workspace::Workspace;
+
+/// How many times snapshot-based reads retry after Salsa cancellation before
+/// giving up and returning a fallback.
+pub(crate) const SNAPSHOT_CANCEL_RETRIES: usize = 2;
 
 /// LSP Session managing project-specific state and database operations.
 ///
@@ -44,6 +53,16 @@ pub(crate) struct Session {
 
     /// The Salsa database for incremental computation
     db: DjangoDatabase,
+
+    /// Generation counter for project refreshes. Background refresh tasks
+    /// capture the value at submission and drop their work when it no longer
+    /// matches — a later bump supersedes any in-flight refresh.
+    refresh_epoch: Arc<AtomicU64>,
+
+    /// Serializes `publishDiagnostics` sends so a refresh-originated republish
+    /// can re-check the epoch under the lock and never overwrite a newer
+    /// publish.
+    diagnostic_publish_lock: Arc<Mutex<()>>,
 }
 
 impl Session {
@@ -83,11 +102,27 @@ impl Session {
             workspace,
             client_info,
             db,
+            refresh_epoch: Arc::new(AtomicU64::new(0)),
+            diagnostic_publish_lock: Arc::new(Mutex::new(())),
         }
     }
 
     pub(crate) fn snapshot(&self) -> SessionSnapshot {
         SessionSnapshot::new(self.db.clone(), self.client_info.clone())
+    }
+
+    /// Advance the refresh epoch, superseding any in-flight refresh task.
+    /// Returns the new epoch for the work that follows the bump.
+    pub(crate) fn bump_refresh_epoch(&self) -> u64 {
+        self.refresh_epoch.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    pub(crate) fn refresh_epoch(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.refresh_epoch)
+    }
+
+    pub(crate) fn diagnostic_publish_lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.diagnostic_publish_lock)
     }
 
     pub(crate) fn client_info(&self) -> &ClientInfo {


### PR DESCRIPTION
## Summary

- make project refresh compute search paths and bump targets off the session lock, then briefly apply the resulting inputs under lock
- add a refresh epoch plus snapshot warm-up for tag specs, template dirs/libraries, and project template files
- republish refresh diagnostics through an epoch-aware publish path, and report tagspec-only settings changes as semantic changes
- remove the now-dead `Project::refresh_source_roots` helper

## Validation

- `cargo build -q`
- `cargo test -q -p djls-server`
- `cargo test -q -p djls-project`
- `cargo test -q -p djls-db tagspecs_settings_change_reports_semantic_change`
- `cargo test -q`
- `just test`
- `just e2e`
- `cargo clippy --all-targets --all-features --benches -- -D warnings`
- clean-tree `just clippy`
- clean-tree `just fmt`
- clean-tree `just lint`
