### PR TITLE
Report startup progress and cover startup contract

### DIFF
--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -84,6 +84,7 @@ pub use symbols::TemplateLibraries;
 pub use symbols::TemplateLibrary;
 pub use symbols::TemplateSymbol;
 pub use symbols::TemplateSymbolKind;
+pub use sync::RefreshData;
 pub use sync::apply_refresh;
 pub use sync::compute_refresh;
 pub use sync::refresh_external_data;

--- a/crates/djls-server/src/client.rs
+++ b/crates/djls-server/src/client.rs
@@ -75,6 +75,11 @@ impl ClientInfo {
     }
 
     #[must_use]
+    pub(crate) fn supports_work_done_progress(&self) -> bool {
+        self.capabilities.work_done_progress
+    }
+
+    #[must_use]
     pub(crate) fn supports_snippets(&self) -> bool {
         self.capabilities.snippets
     }
@@ -96,6 +101,7 @@ pub(crate) enum Client {
 pub(crate) struct ClientCapabilities {
     pull_diagnostics: bool,
     snippets: bool,
+    work_done_progress: bool,
 }
 
 impl ClientCapabilities {
@@ -115,9 +121,16 @@ impl ClientCapabilities {
             .and_then(|completion_item| completion_item.snippet_support)
             .unwrap_or(false);
 
+        let work_done_progress = capabilities
+            .window
+            .as_ref()
+            .and_then(|window| window.work_done_progress)
+            .unwrap_or(false);
+
         Self {
             pull_diagnostics,
             snippets,
+            work_done_progress,
         }
     }
 }

--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -2,6 +2,7 @@ mod client;
 mod document;
 mod ext;
 mod logging;
+mod progress;
 mod queue;
 mod refresh;
 mod server;

--- a/crates/djls-server/src/progress.rs
+++ b/crates/djls-server/src/progress.rs
@@ -1,0 +1,139 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use tower_lsp_server::Client;
+use tower_lsp_server::ls_types;
+use tower_lsp_server::ls_types::notification::Progress as ProgressNotification;
+
+use crate::client::ClientInfo;
+
+static NEXT_PROGRESS_TOKEN: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) struct LoadProgress {
+    title: String,
+    state: Option<ProgressState>,
+}
+
+enum ProgressState {
+    Lsp {
+        client: Client,
+        token: ls_types::ProgressToken,
+    },
+    Log,
+}
+
+impl LoadProgress {
+    pub(crate) async fn begin(client: Client, info: &ClientInfo, title: &str) -> Self {
+        let title = title.to_string();
+
+        if !info.supports_work_done_progress() {
+            tracing::info!("{title}");
+            return Self {
+                title,
+                state: Some(ProgressState::Log),
+            };
+        }
+
+        let token = ls_types::ProgressToken::String(format!(
+            "djls-load-{}",
+            // Uniqueness is the only invariant; no cross-thread data is
+            // synchronized through this counter.
+            NEXT_PROGRESS_TOKEN.fetch_add(1, Ordering::Relaxed)
+        ));
+
+        match client.create_work_done_progress(token.clone()).await {
+            Ok(()) => {
+                send_begin(&client, token.clone(), title.clone()).await;
+                Self {
+                    title,
+                    state: Some(ProgressState::Lsp { client, token }),
+                }
+            }
+            Err(error) => {
+                tracing::debug!(?error, "Falling back to log-only project load progress");
+                tracing::info!("{title}");
+                Self {
+                    title,
+                    state: Some(ProgressState::Log),
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn report(&self, message: &str) {
+        match self.state.as_ref() {
+            Some(ProgressState::Lsp { client, token }) => {
+                send_report(client, token.clone(), message.to_string()).await;
+            }
+            Some(ProgressState::Log) | None => {
+                tracing::info!("{}: {message}", self.title);
+            }
+        }
+    }
+
+    pub(crate) async fn finish(mut self, message: &str) {
+        let state = self.state.take();
+        match state {
+            Some(ProgressState::Lsp { client, token }) => {
+                send_end(&client, token, Some(message.to_string())).await;
+            }
+            Some(ProgressState::Log) | None => {
+                tracing::info!("{}: {message}", self.title);
+            }
+        }
+    }
+}
+
+impl Drop for LoadProgress {
+    fn drop(&mut self) {
+        let Some(ProgressState::Lsp { client, token }) = self.state.take() else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            send_end(&client, token, Some("superseded".to_string())).await;
+        });
+    }
+}
+
+async fn send_begin(client: &Client, token: ls_types::ProgressToken, title: String) {
+    client
+        .send_notification::<ProgressNotification>(ls_types::ProgressParams {
+            token,
+            value: ls_types::ProgressParamsValue::WorkDone(ls_types::WorkDoneProgress::Begin(
+                ls_types::WorkDoneProgressBegin {
+                    title,
+                    cancellable: Some(false),
+                    message: None,
+                    percentage: None,
+                },
+            )),
+        })
+        .await;
+}
+
+async fn send_report(client: &Client, token: ls_types::ProgressToken, message: String) {
+    client
+        .send_notification::<ProgressNotification>(ls_types::ProgressParams {
+            token,
+            value: ls_types::ProgressParamsValue::WorkDone(ls_types::WorkDoneProgress::Report(
+                ls_types::WorkDoneProgressReport {
+                    cancellable: None,
+                    message: Some(message),
+                    percentage: None,
+                },
+            )),
+        })
+        .await;
+}
+
+async fn send_end(client: &Client, token: ls_types::ProgressToken, message: Option<String>) {
+    client
+        .send_notification::<ProgressNotification>(ls_types::ProgressParams {
+            token,
+            value: ls_types::ProgressParamsValue::WorkDone(ls_types::WorkDoneProgress::End(
+                ls_types::WorkDoneProgressEnd { message },
+            )),
+        })
+        .await;
+}

--- a/crates/djls-server/src/progress.rs
+++ b/crates/djls-server/src/progress.rs
@@ -41,6 +41,11 @@ impl LoadProgress {
             NEXT_PROGRESS_TOKEN.fetch_add(1, Ordering::Relaxed)
         ));
 
+        // This awaits the client's response, gating the (sequential) refresh
+        // queue on it. tower-lsp-server requests have no timeout, so a client
+        // that advertises the capability but never answers would stall the
+        // refresh — accepted because clients answer create requests
+        // immediately, and a hung client breaks far more than progress.
         match client.create_work_done_progress(token.clone()).await {
             Ok(()) => {
                 send_begin(&client, token.clone(), title.clone()).await;
@@ -90,8 +95,10 @@ impl Drop for LoadProgress {
             return;
         };
 
+        // Drop without finish() means the refresh future itself was dropped
+        // (cancellation or unwind), not a normal supersede.
         tokio::spawn(async move {
-            send_end(&client, token, Some("superseded".to_string())).await;
+            send_end(&client, token, Some("cancelled".to_string())).await;
         });
     }
 }

--- a/crates/djls-server/src/refresh.rs
+++ b/crates/djls-server/src/refresh.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use djls_project::Db as ProjectDb;
+use djls_project::RefreshData;
 use djls_project::apply_refresh;
 use djls_project::compute_refresh;
 use djls_project::project_template_files;
@@ -19,11 +20,19 @@ use tokio::sync::Mutex;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types;
 
+use crate::client::ClientInfo;
 use crate::document::TextDocument;
 use crate::ext::UriExt;
+use crate::progress::LoadProgress;
 use crate::session::SNAPSHOT_CANCEL_RETRIES;
 use crate::session::Session;
 use crate::session::SessionSnapshot;
+
+enum RefreshOutcome {
+    Complete,
+    Skipped,
+    Superseded,
+}
 
 fn refresh_is_stale(refresh_epoch: &AtomicU64, epoch: u64) -> bool {
     refresh_epoch.load(Ordering::Acquire) != epoch
@@ -34,18 +43,37 @@ pub(crate) async fn run_project_refresh(
     client: Client,
     refresh_epoch: Arc<AtomicU64>,
     diagnostic_publish_lock: Arc<Mutex<()>>,
+    client_info: ClientInfo,
     epoch: u64,
     log_initialization: bool,
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
+    let progress =
+        LoadProgress::begin(client.clone(), &client_info, "Loading Django project").await;
     let result = run_project_refresh_inner(
         session,
         client,
         refresh_epoch,
         diagnostic_publish_lock,
+        &progress,
         epoch,
     )
     .await;
+
+    match &result {
+        Ok(RefreshOutcome::Complete) => {
+            progress.finish("complete").await;
+        }
+        Ok(RefreshOutcome::Skipped) => {
+            progress.finish("skipped").await;
+        }
+        Ok(RefreshOutcome::Superseded) => {
+            progress.finish("superseded").await;
+        }
+        Err(_) => {
+            progress.finish("failed").await;
+        }
+    }
 
     if log_initialization {
         tracing::info!("Server initialization completed in {:?}", start.elapsed());
@@ -53,7 +81,7 @@ pub(crate) async fn run_project_refresh(
         tracing::info!("Environment refresh completed in {:?}", start.elapsed());
     }
 
-    result
+    result.map(|_| ())
 }
 
 async fn run_project_refresh_inner(
@@ -61,37 +89,104 @@ async fn run_project_refresh_inner(
     client: Client,
     refresh_epoch: Arc<AtomicU64>,
     diagnostic_publish_lock: Arc<Mutex<()>>,
+    progress: &LoadProgress,
     epoch: u64,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<RefreshOutcome> {
     if refresh_is_stale(&refresh_epoch, epoch) {
         tracing::debug!(
             epoch,
             "Skipping stale project refresh before locking session"
         );
-        return Ok(());
+        return Ok(RefreshOutcome::Superseded);
     }
 
+    progress.report("Resolving environment").await;
+
+    let Some(refresh) = compute_project_refresh(&session, &refresh_epoch, epoch).await? else {
+        return Ok(RefreshOutcome::Skipped);
+    };
+
+    if refresh_is_stale(&refresh_epoch, epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh before apply");
+        return Ok(RefreshOutcome::Superseded);
+    }
+
+    progress.report("Applying project facts").await;
+
+    let (snapshot, documents) = {
+        let mut session_lock = session.lock().await;
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
+            return Ok(RefreshOutcome::Superseded);
+        }
+
+        let db = session_lock.db_mut();
+        if db.project().is_none() {
+            return Ok(RefreshOutcome::Skipped);
+        }
+
+        let t = std::time::Instant::now();
+        apply_refresh(db, refresh);
+        tracing::info!("External data refresh completed in {:?}", t.elapsed());
+
+        if refresh_is_stale(&refresh_epoch, epoch) {
+            tracing::debug!(epoch, "Skipping stale project refresh after apply");
+            return Ok(RefreshOutcome::Superseded);
+        }
+
+        (session_lock.snapshot(), session_lock.open_documents())
+    };
+
+    progress.report("Warming caches").await;
+    warm_project_queries(snapshot.clone(), Arc::clone(&refresh_epoch), epoch).await;
+
+    if refresh_is_stale(&refresh_epoch, epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh after warm-up");
+        return Ok(RefreshOutcome::Superseded);
+    }
+
+    progress.report("Publishing diagnostics").await;
+    if !republish_snapshot_diagnostics(
+        client,
+        snapshot,
+        documents,
+        refresh_epoch,
+        diagnostic_publish_lock,
+        epoch,
+    )
+    .await
+    {
+        return Ok(RefreshOutcome::Superseded);
+    }
+
+    Ok(RefreshOutcome::Complete)
+}
+
+async fn compute_project_refresh(
+    session: &Arc<Mutex<Session>>,
+    refresh_epoch: &Arc<AtomicU64>,
+    epoch: u64,
+) -> anyhow::Result<Option<RefreshData>> {
     // Cancellation here usually means a document edit, not a config change:
     // nothing bumps the epoch or resubmits, so dropping the compute would lose
     // the refresh for good. Retry with a fresh database clone instead, like
     // the snapshot reads do.
-    let mut refresh = None;
     for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
         let Some(compute_db) = ({
             let session_lock = session.lock().await;
-            if refresh_is_stale(&refresh_epoch, epoch) {
+            if refresh_is_stale(refresh_epoch, epoch) {
                 tracing::debug!(
                     epoch,
                     "Skipping stale project refresh after locking session"
                 );
-                return Ok(());
+                return Ok(None);
             }
 
             let db = session_lock.db();
             db.project().map(|_| db.clone())
         }) else {
             tracing::info!("Task: No project configured, skipping initialization.");
-            return Ok(());
+            return Ok(None);
         };
 
         let result = tokio::task::spawn_blocking(move || {
@@ -101,10 +196,7 @@ async fn run_project_refresh_inner(
         .expect("project refresh compute task must not panic");
 
         match result {
-            Ok(computed) => {
-                refresh = computed;
-                break;
-            }
+            Ok(refresh) => return Ok(refresh),
             Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
                 tracing::debug!(
                     ?cancelled,
@@ -118,56 +210,12 @@ async fn run_project_refresh_inner(
                     retries = SNAPSHOT_CANCEL_RETRIES,
                     "Project refresh compute cancelled repeatedly; project facts may be stale until the next refresh"
                 );
-                return Ok(());
+                return Ok(None);
             }
         }
     }
 
-    let Some(refresh) = refresh else {
-        return Ok(());
-    };
-
-    if refresh_is_stale(&refresh_epoch, epoch) {
-        tracing::debug!(epoch, "Skipping stale project refresh before apply");
-        return Ok(());
-    }
-
-    let (snapshot, documents) = {
-        let mut session_lock = session.lock().await;
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
-            return Ok(());
-        }
-
-        let db = session_lock.db_mut();
-        if db.project().is_none() {
-            return Ok(());
-        }
-
-        let t = std::time::Instant::now();
-        apply_refresh(db, refresh);
-        tracing::info!("External data refresh completed in {:?}", t.elapsed());
-
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale project refresh after apply");
-            return Ok(());
-        }
-
-        (session_lock.snapshot(), session_lock.open_documents())
-    };
-
-    warm_project_queries(snapshot.clone(), Arc::clone(&refresh_epoch), epoch).await;
-    republish_snapshot_diagnostics(
-        client,
-        snapshot,
-        documents,
-        refresh_epoch,
-        diagnostic_publish_lock,
-        epoch,
-    )
-    .await;
-
-    Ok(())
+    unreachable!("project refresh retry loop must return")
 }
 
 async fn warm_project_queries(
@@ -221,16 +269,16 @@ async fn republish_snapshot_diagnostics(
     refresh_epoch: Arc<AtomicU64>,
     diagnostic_publish_lock: Arc<Mutex<()>>,
     epoch: u64,
-) {
+) -> bool {
     if snapshot.client_info().supports_pull_diagnostics() {
         tracing::debug!("Client supports pull diagnostics, skipping refresh diagnostics push");
-        return;
+        return true;
     }
 
     for document in documents {
         if refresh_is_stale(&refresh_epoch, epoch) {
             tracing::debug!(epoch, "Skipping stale refresh diagnostics republish");
-            return;
+            return false;
         }
 
         let file = document.file();
@@ -240,7 +288,7 @@ async fn republish_snapshot_diagnostics(
 
         if refresh_is_stale(&refresh_epoch, epoch) {
             tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
-            return;
+            return false;
         }
 
         let Some(lsp_uri) = ls_types::Uri::from_path(document.path()) else {
@@ -252,7 +300,7 @@ async fn republish_snapshot_diagnostics(
         let _publish_guard = diagnostic_publish_lock.lock().await;
         if refresh_is_stale(&refresh_epoch, epoch) {
             tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
-            return;
+            return false;
         }
         client
             .publish_diagnostics(lsp_uri, diagnostics, Some(document.version()))
@@ -264,6 +312,8 @@ async fn republish_snapshot_diagnostics(
             lsp_uri_text
         );
     }
+
+    true
 }
 
 async fn collect_snapshot_diagnostics(

--- a/crates/djls-server/src/refresh.rs
+++ b/crates/djls-server/src/refresh.rs
@@ -34,6 +34,12 @@ enum RefreshOutcome {
     Superseded,
 }
 
+enum ComputeOutcome {
+    Computed(RefreshData),
+    Skipped,
+    Superseded,
+}
+
 fn refresh_is_stale(refresh_epoch: &AtomicU64, epoch: u64) -> bool {
     refresh_epoch.load(Ordering::Acquire) != epoch
 }
@@ -102,8 +108,10 @@ async fn run_project_refresh_inner(
 
     progress.report("Resolving environment").await;
 
-    let Some(refresh) = compute_project_refresh(&session, &refresh_epoch, epoch).await? else {
-        return Ok(RefreshOutcome::Skipped);
+    let refresh = match compute_project_refresh(&session, &refresh_epoch, epoch).await {
+        ComputeOutcome::Computed(refresh) => refresh,
+        ComputeOutcome::Skipped => return Ok(RefreshOutcome::Skipped),
+        ComputeOutcome::Superseded => return Ok(RefreshOutcome::Superseded),
     };
 
     if refresh_is_stale(&refresh_epoch, epoch) {
@@ -166,7 +174,7 @@ async fn compute_project_refresh(
     session: &Arc<Mutex<Session>>,
     refresh_epoch: &Arc<AtomicU64>,
     epoch: u64,
-) -> anyhow::Result<Option<RefreshData>> {
+) -> ComputeOutcome {
     // Cancellation here usually means a document edit, not a config change:
     // nothing bumps the epoch or resubmits, so dropping the compute would lose
     // the refresh for good. Retry with a fresh database clone instead, like
@@ -179,14 +187,14 @@ async fn compute_project_refresh(
                     epoch,
                     "Skipping stale project refresh after locking session"
                 );
-                return Ok(None);
+                return ComputeOutcome::Superseded;
             }
 
             let db = session_lock.db();
             db.project().map(|_| db.clone())
         }) else {
             tracing::info!("Task: No project configured, skipping initialization.");
-            return Ok(None);
+            return ComputeOutcome::Skipped;
         };
 
         let result = tokio::task::spawn_blocking(move || {
@@ -196,7 +204,8 @@ async fn compute_project_refresh(
         .expect("project refresh compute task must not panic");
 
         match result {
-            Ok(refresh) => return Ok(refresh),
+            Ok(Some(refresh)) => return ComputeOutcome::Computed(refresh),
+            Ok(None) => return ComputeOutcome::Skipped,
             Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
                 tracing::debug!(
                     ?cancelled,
@@ -210,7 +219,7 @@ async fn compute_project_refresh(
                     retries = SNAPSHOT_CANCEL_RETRIES,
                     "Project refresh compute cancelled repeatedly; project facts may be stale until the next refresh"
                 );
-                return Ok(None);
+                return ComputeOutcome::Skipped;
             }
         }
     }

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -100,12 +100,13 @@ impl DjangoLanguageServer {
     /// epoch. The task body lives in [`crate::refresh`].
     async fn submit_project_refresh(&self, log_initialization: bool) {
         let client = self.client.clone();
-        let (epoch, refresh_epoch, diagnostic_publish_lock) = self
+        let (epoch, refresh_epoch, diagnostic_publish_lock, client_info) = self
             .with_session(|session| {
                 (
                     session.bump_refresh_epoch(),
                     session.refresh_epoch(),
                     session.diagnostic_publish_lock(),
+                    session.client_info().clone(),
                 )
             })
             .await;
@@ -117,6 +118,7 @@ impl DjangoLanguageServer {
                     client,
                     refresh_epoch,
                     diagnostic_publish_lock,
+                    client_info,
                     epoch,
                     log_initialization,
                 )

--- a/tests/e2e/test_startup.py
+++ b/tests/e2e/test_startup.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_lsp
+from lsprotocol import types
+from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import client_capabilities
+
+from .conftest import SERVER_COMMAND
+from .conftest import TEST_WORKSPACE
+from .utils import position_after
+
+BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+
+
+@pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
+async def startup_client(lsp_client: LanguageClient):
+    initialize_result = await lsp_client.initialize_session(
+        types.InitializeParams(
+            capabilities=client_capabilities("visual-studio-code"),
+            workspace_folders=[
+                types.WorkspaceFolder(
+                    uri=TEST_WORKSPACE.as_uri(),
+                    name="test_project",
+                )
+            ],
+        )
+    )
+    lsp_client.djls_initialize_result = initialize_result
+
+    yield lsp_client
+
+    await lsp_client.shutdown_session()
+
+
+def no_progress_capabilities() -> types.ClientCapabilities:
+    capabilities = client_capabilities("visual-studio-code")
+    if capabilities.window is None:
+        capabilities.window = types.WindowClientCapabilities()
+    capabilities.window.work_done_progress = False
+    return capabilities
+
+
+@pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
+async def no_progress_client(lsp_client: LanguageClient):
+    await lsp_client.initialize_session(
+        types.InitializeParams(
+            capabilities=no_progress_capabilities(),
+            workspace_folders=[
+                types.WorkspaceFolder(
+                    uri=TEST_WORKSPACE.as_uri(),
+                    name="test_project",
+                )
+            ],
+        )
+    )
+
+    yield lsp_client
+
+    await lsp_client.shutdown_session()
+
+
+async def wait_for_log_message(client: LanguageClient, prefix: str) -> None:
+    while not any(message.message.startswith(prefix) for message in client.log_messages):
+        await asyncio.wait_for(
+            client.wait_for_notification(types.WINDOW_LOG_MESSAGE),
+            timeout=5,
+        )
+
+
+async def wait_for_progress_events(
+    client: LanguageClient,
+) -> list[
+    types.WorkDoneProgressBegin
+    | types.WorkDoneProgressReport
+    | types.WorkDoneProgressEnd
+]:
+    def events() -> list[
+        types.WorkDoneProgressBegin
+        | types.WorkDoneProgressReport
+        | types.WorkDoneProgressEnd
+    ]:
+        return [event for events in client.progress_reports.values() for event in events]
+
+    while not any(event.kind == "end" for event in events()):
+        await asyncio.wait_for(client.wait_for_notification(types.PROGRESS), timeout=5)
+
+    return events()
+
+
+@pytest.mark.asyncio
+async def test_initialize_returns_capabilities_before_project_load_finishes(
+    startup_client: LanguageClient,
+):
+    capabilities = startup_client.djls_initialize_result.capabilities
+
+    assert startup_client.error is None
+    assert capabilities is not None
+    assert capabilities.text_document_sync is not None
+    assert capabilities.completion_provider is not None
+    assert capabilities.diagnostic_provider is not None
+
+
+@pytest.mark.asyncio
+async def test_server_accepts_template_requests_after_initialized(
+    startup_client: LanguageClient,
+):
+    startup_client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=BASE_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=BASE_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    result = await startup_client.text_document_completion_async(
+        types.CompletionParams(
+            text_document=types.TextDocumentIdentifier(uri=BASE_TEMPLATE.as_uri()),
+            position=position_after(BASE_TEMPLATE, "{% sta"),
+        )
+    )
+
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_supported_client_receives_startup_progress_begin_report_end(
+    startup_client: LanguageClient,
+):
+    events = await wait_for_progress_events(startup_client)
+
+    assert startup_client.progress_reports, "window/workDoneProgress/create was not observed"
+    assert [event.kind for event in events][0] == "begin"
+    assert any(event.kind == "report" for event in events)
+    assert [event.kind for event in events][-1] == "end"
+    assert any(
+        isinstance(event, types.WorkDoneProgressBegin)
+        and event.title == "Loading Django project"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsupported_client_receives_log_fallback(
+    no_progress_client: LanguageClient,
+):
+    await wait_for_log_message(no_progress_client, "Loading Django project")
+    await wait_for_log_message(no_progress_client, "Server initialization completed")
+
+    messages = [message.message for message in no_progress_client.log_messages]
+
+    assert not no_progress_client.progress_reports
+    assert "Loading Django project" in messages
+    assert any(
+        message.startswith("Loading Django project: Warming caches")
+        for message in messages
+    )


### PR DESCRIPTION
## Summary

- Add startup load progress reporting around the project refresh flow, using server-initiated `window/workDoneProgress/create` when the client supports it.
- Fall back to tracing/log messages when work-done progress is unavailable or rejected.
- Add pytest-lsp startup contract coverage for initialize responsiveness, post-initialized requests, progress Begin/Report/End, and log fallback.
- Re-export `RefreshData` from `djls-project` because `compute_refresh` already exposes it in its public return type and the server now names it in a small retry helper.

## Validation

- `cargo build -q -p djls-server`
- `cargo test -q -p djls-server`
- `uv run pytest tests/e2e/test_startup.py -q -x`
- `cargo test -q`
- `just test`
- `just e2e` (31 passed)
- `cargo clippy --all-targets --all-features --benches -- -D warnings`
- clean-tree `just clippy`
- `just fmt`
- `just lint`

Note: the first full `cargo test -q` needed `just corpus sync` because the corpus had not been synced at the post-plan-016 `djls-testing` location; after syncing, the targeted corpus test and full suites passed.