### PR TITLE
Defer project loading from initialize

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -46,8 +46,8 @@ pub struct DjangoDatabase {
     /// tracked queries branch on the untracked `db.project()` read, so
     /// replacing the handle (or flipping None→Some after queries have run)
     /// changes results outside Salsa's dependency graph. Set once during
-    /// construction; reloads mutate fields via Salsa setters
-    /// (see `update_project_from_settings`). Same invariant as ty's
+    /// construction; reloads mutate fields via Salsa setters through
+    /// `Project::reload_from_settings`. Same invariant as ty's
     /// `ProjectDatabase` (`ty_project/src/db.rs`).
     pub(crate) project: Option<Project>,
 
@@ -94,6 +94,12 @@ impl Default for DjangoDatabase {
 
 impl DjangoDatabase {
     /// Create a new [`DjangoDatabase`] with the given file system handle.
+    ///
+    /// The constructor creates protocol state only. When a project path is
+    /// present, it installs a stable initial `Project` handle with root-only
+    /// search paths and settings values that are already in memory. Applying
+    /// project settings reloads disk-derived project fields onto the same
+    /// stable handle.
     pub fn new(
         file_system: Arc<dyn FileSystem>,
         settings: &Settings,
@@ -117,7 +123,7 @@ impl DjangoDatabase {
     }
 
     fn set_project(&mut self, root: &Utf8Path, settings: &Settings) {
-        let project = Project::bootstrap(self, root, settings);
+        let project = Project::initial(self, root, settings);
         self.project = Some(project);
     }
 }
@@ -208,12 +214,14 @@ mod invalidation_tests {
     use camino::Utf8Path;
     use camino::Utf8PathBuf;
     use djls_conf::Settings;
+    use djls_project::Db as ProjectDb;
     use djls_project::Project;
     use djls_semantic::Db as SemanticDb;
     use djls_semantic::SemanticOffsetContext;
     use djls_source::Db as SourceDb;
     use djls_source::InMemoryFileSystem;
     use djls_source::Offset;
+    use djls_source::OsFileSystem;
     use djls_source::SourceFiles;
     use salsa::Database;
     use salsa::Setter;
@@ -247,7 +255,7 @@ mod invalidation_tests {
 
     /// Create a test database with event logging and a pre-configured project.
     ///
-    /// Uses `Interpreter::discover(None)` to match what `update_project_from_settings`
+    /// Uses `Interpreter::discover(None)` to match what `Project::bootstrap`
     /// produces, avoiding spurious interpreter mismatches from `$VIRTUAL_ENV`.
     fn test_db_with_project() -> (DjangoDatabase, EventLog) {
         let event_log = EventLog::default();
@@ -597,11 +605,75 @@ type = "block"
         );
         let settings = Settings::new(root.as_path(), None).unwrap();
 
-        let update = db.set_settings(settings);
+        db.apply_project_settings(settings);
 
-        assert!(!update.env_changed);
-        assert!(!update.diagnostics_changed);
-        assert!(update.semantic_changed);
+        let project = db.project().expect("project should exist");
+        assert!(
+            project
+                .tagspecs(&db)
+                .libraries
+                .iter()
+                .any(|library| library.module == "myapp.templatetags.custom")
+        );
+    }
+
+    #[test]
+    fn initial_project_loads_disk_facts_into_same_handle() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        let extra_path = root.join("extra_python");
+        std::fs::create_dir_all(extra_path.as_std_path()).unwrap();
+        std::fs::write(root.join(".env.local").as_std_path(), "FROM_ENV=loaded\n").unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            format!(
+                r#"
+django_settings_module = "config.settings"
+pythonpath = ["{extra_path}"]
+env_file = ".env.local"
+"#
+            ),
+        )
+        .unwrap();
+
+        let mut db = DjangoDatabase::new(
+            Arc::new(OsFileSystem),
+            &Settings::default(),
+            Some(root.as_path()),
+        );
+        let project = db.project().expect("initial project should exist");
+
+        assert_eq!(project.root(&db), root.as_path());
+        assert_eq!(project.django_settings_module(&db).as_deref(), None);
+        assert!(project.pythonpath(&db).is_empty());
+        assert!(project.env_vars(&db).is_empty());
+        let initial_paths: Vec<_> = project
+            .search_paths(&db)
+            .iter()
+            .map(|search_path| search_path.path().to_path_buf())
+            .collect();
+        assert_eq!(initial_paths, vec![root.clone()]);
+
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        db.apply_project_settings(settings);
+
+        assert_eq!(db.project(), Some(project));
+        assert_eq!(
+            project.django_settings_module(&db).as_deref(),
+            Some("config.settings")
+        );
+        assert_eq!(project.pythonpath(&db), &vec![extra_path.to_string()]);
+        assert_eq!(
+            project.env_vars(&db),
+            &vec![("FROM_ENV".to_string(), "loaded".to_string())]
+        );
+        let loaded_paths: Vec<_> = project
+            .search_paths(&db)
+            .iter()
+            .map(|search_path| search_path.path().to_path_buf())
+            .collect();
+        assert_eq!(loaded_paths.first(), Some(&root));
+        assert!(loaded_paths.contains(&extra_path));
     }
 
     #[test]
@@ -671,20 +743,18 @@ type = "block"
     }
 
     #[test]
-    fn update_project_from_settings_unchanged_no_invalidation() {
+    fn project_settings_unchanged_no_invalidation() {
         let (mut db, event_log) = test_db_with_project();
 
         // Prime the cache
         let _specs = db.tag_specs();
         event_log.take();
 
-        // Call update_project_from_settings with default settings (same as project was created with)
+        // Apply default project settings, matching what the project was created with.
         let settings = Settings::default();
-        let env_changed = db.update_project_from_settings(&settings);
-        assert!(
-            !env_changed,
-            "env should not have changed with default settings"
-        );
+        db.project()
+            .expect("project should exist")
+            .reload_from_settings(&mut db, &settings);
 
         // Access tag_specs — should still be cached
         let _specs = db.tag_specs();
@@ -982,6 +1052,89 @@ def my_filter(value, arg):
         djls_project::refresh_external_data(&mut db);
 
         assert_custom_library_module(&db, "new_tags");
+    }
+
+    #[test]
+    fn apply_refresh_bumps_roots_but_not_unchanged_file_contents() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "django_settings_module = \"settings\"\n",
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        let tag_path = root.join("blog/templatetags/custom.py");
+
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(root.join("manage.py"), String::new());
+            fs.add_file(
+                root.join("settings.py"),
+                "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n".to_string(),
+            );
+            fs.add_file(root.join("blog/templatetags/__init__.py"), String::new());
+            fs.add_file(tag_path, template_tag_library_source("custom_tag"));
+        }
+
+        let mut db = DjangoDatabase {
+            fs,
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            storage: salsa::Storage::default(),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
+
+        let refresh = djls_project::compute_refresh(&db).expect("project refresh data");
+        let file_paths: Vec<_> = refresh.file_paths().to_vec();
+        assert!(!file_paths.is_empty());
+        djls_project::apply_refresh(&mut db, refresh);
+
+        let project = db.project().expect("project should exist");
+        let file_revisions: Vec<_> = file_paths
+            .iter()
+            .map(|path| {
+                let file = db.get_or_create_file(path);
+                (path.clone(), file.revision(&db))
+            })
+            .collect();
+        assert!(!file_revisions.is_empty());
+
+        let root_revisions: Vec<_> = project
+            .search_paths(&db)
+            .iter()
+            .filter_map(|search_path| db.files().root(&db, search_path.path()))
+            .map(|root| (root.path(&db).clone(), root.revision(&db)))
+            .collect();
+        assert!(!root_revisions.is_empty());
+
+        let refresh = djls_project::compute_refresh(&db).expect("project refresh data");
+        djls_project::apply_refresh(&mut db, refresh);
+
+        let unchanged_file_revisions: Vec<_> = file_paths
+            .iter()
+            .map(|path| {
+                let file = db.get_or_create_file(path);
+                (path.clone(), file.revision(&db))
+            })
+            .collect();
+        let unchanged_root_revisions: Vec<_> = project
+            .search_paths(&db)
+            .iter()
+            .filter_map(|search_path| db.files().root(&db, search_path.path()))
+            .map(|root| (root.path(&db).clone(), root.revision(&db)))
+            .collect();
+
+        assert_eq!(unchanged_file_revisions, file_revisions);
+        assert!(unchanged_root_revisions.iter().zip(root_revisions).all(
+            |((new_path, new_revision), (old_path, old_revision))| {
+                new_path == &old_path && *new_revision > old_revision
+            }
+        ));
     }
 
     #[test]

--- a/crates/djls-db/src/lib.rs
+++ b/crates/djls-db/src/lib.rs
@@ -9,4 +9,3 @@ mod db;
 mod settings;
 
 pub use db::DjangoDatabase;
-pub use settings::SettingsUpdate;

--- a/crates/djls-db/src/settings.rs
+++ b/crates/djls-db/src/settings.rs
@@ -1,18 +1,7 @@
 use djls_conf::Settings;
 use djls_project::Db as ProjectDb;
-use djls_project::Interpreter;
-use djls_project::load_env_file;
-use djls_source::Db as _;
-use salsa::Setter;
 
 use crate::db::DjangoDatabase;
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct SettingsUpdate {
-    pub env_changed: bool,
-    pub diagnostics_changed: bool,
-    pub semantic_changed: bool,
-}
 
 impl DjangoDatabase {
     /// Get a clone of the current settings.
@@ -24,92 +13,16 @@ impl DjangoDatabase {
         self.settings.lock().unwrap().clone()
     }
 
-    /// Update the settings, updating the existing project's fields via manual
-    /// comparison (Ruff/RA pattern) to avoid unnecessary Salsa invalidation.
-    ///
-    /// When a project exists, delegates to `update_project_from_settings` to
-    /// surgically update only the fields that changed, keeping project identity
-    /// stable. When no project exists, the settings are stored for future use.
+    /// Store project settings and update the stable project handle.
     ///
     /// # Panics
     ///
-    /// Panics if the settings mutex is poisoned (another thread panicked while holding the lock)
-    pub fn set_settings(&mut self, settings: Settings) -> SettingsUpdate {
-        let previous = self.settings();
+    /// Panics if the settings mutex is poisoned.
+    pub fn apply_project_settings(&mut self, settings: Settings) {
+        if let Some(project) = self.project() {
+            project.reload_from_settings(self, &settings);
+        }
+
         *self.settings.lock().unwrap() = settings;
-
-        let current = self.settings();
-        let diagnostics_changed = previous.diagnostics() != current.diagnostics();
-        let semantic_changed = previous.tagspecs() != current.tagspecs();
-
-        if self.project().is_some() {
-            let env_changed = self.update_project_from_settings(&current);
-            return SettingsUpdate {
-                env_changed,
-                diagnostics_changed,
-                semantic_changed,
-            };
-        }
-
-        SettingsUpdate {
-            env_changed: false,
-            diagnostics_changed,
-            semantic_changed,
-        }
-    }
-
-    /// Update an existing project's fields from new settings, only calling
-    /// Salsa setters when values actually change (Ruff/RA pattern).
-    ///
-    /// Returns `true` if environment-related fields changed (`interpreter`,
-    /// `django_settings_module`, `pythonpath`, `env_vars`), indicating project
-    /// data should be refreshed by the caller.
-    pub(crate) fn update_project_from_settings(&mut self, settings: &Settings) -> bool {
-        let Some(project) = self.project() else {
-            return false;
-        };
-
-        let mut env_changed = false;
-
-        let new_interpreter = Interpreter::discover(settings.venv_path());
-        if project.interpreter(self) != &new_interpreter {
-            project.set_interpreter(self).to(new_interpreter);
-            env_changed = true;
-        }
-
-        let new_dsm = settings
-            .django_settings_module()
-            .map(String::from)
-            .or_else(|| {
-                std::env::var("DJANGO_SETTINGS_MODULE")
-                    .ok()
-                    .filter(|s| !s.is_empty())
-            });
-        if project.django_settings_module(self) != &new_dsm {
-            project.set_django_settings_module(self).to(new_dsm);
-            env_changed = true;
-        }
-
-        let new_pythonpath = settings.pythonpath().to_vec();
-        if project.pythonpath(self) != &new_pythonpath {
-            project.set_pythonpath(self).to(new_pythonpath);
-            env_changed = true;
-        }
-
-        // Re-parse the env file when settings change. The env_file path may
-        // have changed, or the file contents may differ after a reload.
-        let root = project.root(self).clone();
-        let new_env_vars = load_env_file(self.file_system(), &root, settings);
-        if project.env_vars(self) != &new_env_vars {
-            project.set_env_vars(self).to(new_env_vars);
-            env_changed = true;
-        }
-
-        let new_tagspecs = settings.tagspecs().clone();
-        if project.tagspecs(self) != &new_tagspecs {
-            project.set_tagspecs(self).to(new_tagspecs);
-        }
-
-        env_changed
     }
 }

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -253,6 +253,32 @@ impl CompletionCandidate {
         }
     }
 
+    fn tag_name_from_spec(
+        name: &str,
+        prefix: &OffsetPrefix<'_>,
+        needs_leading_space: bool,
+        close: TagClose,
+        spec: &djls_semantic::TagSpec,
+        supports_snippets: bool,
+    ) -> Self {
+        let edit = if supports_snippets {
+            CompletionEdit::tag_snippet(name, spec, prefix, needs_leading_space, close)
+                .unwrap_or_else(|| {
+                    CompletionEdit::tag_plain(name, prefix, needs_leading_space, close)
+                })
+        } else {
+            CompletionEdit::tag_plain(name, prefix, needs_leading_space, close)
+        };
+
+        Self {
+            label: name.to_string(),
+            kind: CompletionCandidateKind::TagName,
+            edit,
+            detail: Some("Django template tag".to_string()),
+            documentation: None,
+        }
+    }
+
     fn end_tag(
         opener_name: &str,
         name: &str,
@@ -408,7 +434,9 @@ pub fn completion(
     let context = CompletionOffsetContext::new(*source.kind(), source.as_str(), tokens, offset);
     let template_libraries = db.template_libraries();
 
-    let available_symbols = if template_libraries.knowledge == StaticKnowledge::Known {
+    let available_symbols = if template_libraries.knowledge == StaticKnowledge::Unknown {
+        None
+    } else {
         match &context {
             CompletionOffsetContext::Template(
                 TemplateCompletionContext::TagName { .. }
@@ -423,8 +451,6 @@ pub fn completion(
             )
             | CompletionOffsetContext::None => None,
         }
-    } else {
-        None
     };
 
     let mut candidates = match &context {
@@ -503,10 +529,6 @@ fn generate_tag_name_candidates(
 ) -> Vec<CompletionCandidate> {
     let mut candidates = Vec::new();
 
-    if template_libraries.knowledge != StaticKnowledge::Known {
-        return candidates;
-    }
-
     if prefix.text.starts_with("end") {
         for (opener_name, spec) in tag_specs {
             let Some(end_tag) = &spec.end_tag else {
@@ -523,6 +545,27 @@ fn generate_tag_name_candidates(
                 ));
             }
         }
+    }
+
+    if template_libraries.knowledge == StaticKnowledge::Unknown {
+        for (name, spec) in tag_specs {
+            if !name.starts_with(prefix.text) {
+                continue;
+            }
+
+            candidates.push(CompletionCandidate::tag_name_from_spec(
+                name,
+                prefix,
+                needs_leading_space,
+                close,
+                spec,
+                supports_snippets,
+            ));
+        }
+
+        candidates.sort_by(CompletionCandidate::cmp_rank);
+        candidates.dedup_by(|left, right| left.label == right.label);
+        return candidates;
     }
 
     for candidate in template_libraries.installed_symbol_candidates(TemplateSymbolKind::Tag) {
@@ -1077,6 +1120,62 @@ mod tests {
 
         assert_eq!(labels(&before_candidates), vec!["if"]);
         assert_eq!(after_labels, vec!["blocktrans", "if", "trans"]);
+    }
+
+    #[test]
+    fn tag_candidates_fall_back_to_specs_when_libraries_are_unknown() {
+        let mut specs = TagSpecs::default();
+        specs.insert(
+            "static".to_string(),
+            TagSpec::new(
+                Cow::Borrowed("django.templatetags.static"),
+                None,
+                Cow::Borrowed(&[]),
+                false,
+            ),
+        );
+
+        let candidates = generate_tag_name_candidates(
+            &prefix("sta"),
+            false,
+            full_close(),
+            TemplateLibraries::empty_ref(),
+            &specs,
+            None,
+            false,
+        );
+
+        assert_eq!(labels(&candidates), vec!["static"]);
+        assert_eq!(candidates[0].detail.as_deref(), Some("Django template tag"));
+    }
+
+    #[test]
+    fn partial_tag_candidates_use_known_libraries_not_raw_specs() {
+        let mut libraries = tag_libraries();
+        libraries.knowledge = StaticKnowledge::Partial;
+        let mut specs = TagSpecs::default();
+        specs.insert(
+            "project_only".to_string(),
+            TagSpec::new(
+                Cow::Borrowed("project.templatetags.project_only"),
+                None,
+                Cow::Borrowed(&[]),
+                false,
+            ),
+        );
+        let available_symbols = AvailableSymbols::from_loads(Vec::new(), &libraries, 0);
+
+        let candidates = generate_tag_name_candidates(
+            &prefix("project"),
+            false,
+            full_close(),
+            &libraries,
+            &specs,
+            Some(&available_symbols),
+            false,
+        );
+
+        assert!(candidates.is_empty());
     }
 
     #[test]

--- a/crates/djls-project/src/project.rs
+++ b/crates/djls-project/src/project.rs
@@ -7,6 +7,7 @@ use djls_conf::TagSpecDef;
 use djls_source::File;
 use djls_source::FileSystem;
 use salsa::Durability;
+use salsa::Setter;
 
 use crate::db::Db as ProjectDb;
 use crate::names::ModulePath;
@@ -100,32 +101,99 @@ impl Project {
         }
     }
 
+    pub fn initial(db: &dyn ProjectDb, root: &Utf8Path, settings: &Settings) -> Project {
+        let search_paths = SearchPaths::root_only(root);
+        let interpreter = settings.venv_path().map_or(Interpreter::Auto, |path| {
+            Interpreter::VenvPath(path.to_string())
+        });
+        let django_settings_module = settings.django_settings_module().map(String::from);
+        let pythonpath = settings.pythonpath().to_vec();
+        let env_vars = Vec::new();
+        let tagspecs = settings.tagspecs().clone();
+
+        search_paths.register_roots(db);
+        Project::builder(
+            root.to_path_buf(),
+            search_paths,
+            interpreter,
+            django_settings_module,
+            pythonpath,
+            env_vars,
+            tagspecs,
+        )
+        .durability(Durability::MEDIUM)
+        .root_durability(Durability::HIGH)
+        .new(db)
+    }
+
     pub fn bootstrap(db: &dyn ProjectDb, root: &Utf8Path, settings: &Settings) -> Project {
         let interpreter = Interpreter::discover(settings.venv_path());
-        let resolved_django_settings_module =
-            resolve_django_settings(db.file_system(), root, settings);
+        let django_settings_module = resolve_django_settings(db.file_system(), root, settings);
         let env_vars = load_env_file(db.file_system(), root, settings);
-
         let search_paths = SearchPaths::from_project_settings(
             db.file_system(),
             root,
             &interpreter,
             settings.pythonpath(),
         );
-        search_paths.register_roots(db);
+        let pythonpath = settings.pythonpath().to_vec();
+        let tagspecs = settings.tagspecs().clone();
 
+        search_paths.register_roots(db);
         Project::builder(
             root.to_path_buf(),
             search_paths,
             interpreter,
-            resolved_django_settings_module,
-            settings.pythonpath().to_vec(),
+            django_settings_module,
+            pythonpath,
             env_vars,
-            settings.tagspecs().clone(),
+            tagspecs,
         )
         .durability(Durability::MEDIUM)
         .root_durability(Durability::HIGH)
         .new(db)
+    }
+
+    /// Reload settings-derived project fields on this stable Salsa input.
+    pub fn reload_from_settings(self, db: &mut dyn ProjectDb, settings: &Settings) {
+        let root = self.root(db).clone();
+        let interpreter = Interpreter::discover(settings.venv_path());
+        let django_settings_module = resolve_django_settings(db.file_system(), &root, settings);
+        let env_vars = load_env_file(db.file_system(), &root, settings);
+        let search_paths = SearchPaths::from_project_settings(
+            db.file_system(),
+            &root,
+            &interpreter,
+            settings.pythonpath(),
+        );
+        let pythonpath = settings.pythonpath().to_vec();
+        let tagspecs = settings.tagspecs().clone();
+
+        if self.search_paths(db) != &search_paths {
+            search_paths.register_roots(db);
+            self.set_search_paths(db).to(search_paths);
+        }
+
+        if self.interpreter(db) != &interpreter {
+            self.set_interpreter(db).to(interpreter);
+        }
+
+        if self.django_settings_module(db) != &django_settings_module {
+            self.set_django_settings_module(db)
+                .to(django_settings_module);
+        }
+
+        if self.pythonpath(db) != &pythonpath {
+            self.set_pythonpath(db).to(pythonpath);
+        }
+
+        if self.env_vars(db) != &env_vars {
+            self.set_env_vars(db).to(env_vars);
+        }
+
+        if self.tagspecs(db) != &tagspecs {
+            self.set_tagspecs(db).to(tagspecs);
+        }
     }
 }
 

--- a/crates/djls-project/src/resolve.rs
+++ b/crates/djls-project/src/resolve.rs
@@ -84,6 +84,13 @@ pub struct SearchPaths {
 
 impl SearchPaths {
     #[must_use]
+    pub fn root_only(root: &Utf8Path) -> Self {
+        let mut search_paths = Self::default();
+        search_paths.push(SearchPath::first_party(root.to_path_buf()));
+        search_paths
+    }
+
+    #[must_use]
     pub fn from_project_settings(
         fs: &dyn FileSystem,
         root: &Utf8Path,

--- a/crates/djls-project/src/sync.rs
+++ b/crates/djls-project/src/sync.rs
@@ -33,6 +33,13 @@ pub struct RefreshData {
     file_paths: Vec<Utf8PathBuf>,
 }
 
+impl RefreshData {
+    #[must_use]
+    pub fn file_paths(&self) -> &[Utf8PathBuf] {
+        &self.file_paths
+    }
+}
+
 pub fn compute_refresh(db: &dyn ProjectDb) -> Option<RefreshData> {
     let project = db.project()?;
     let search_paths = SearchPaths::from_project_settings(
@@ -78,14 +85,12 @@ pub fn apply_refresh(db: &mut dyn ProjectDb, refresh: RefreshData) {
         file_paths,
     } = refresh;
 
-    search_paths.register_roots(db);
-    if project.search_paths(db) != &search_paths {
+    let search_paths_changed = project.search_paths(db) != &search_paths;
+    if search_paths_changed {
+        search_paths.register_roots(db);
         project.set_search_paths(db).to(search_paths);
     }
 
-    // The LSP currently has no watched-file stream for dependency roots. Treat
-    // an explicit refresh as the freshness boundary for module discovery and
-    // currently discovered Python files.
     let roots: Vec<_> = project
         .search_paths(db)
         .iter()
@@ -98,6 +103,11 @@ pub fn apply_refresh(db: &mut dyn ProjectDb, refresh: RefreshData) {
 
     for path in file_paths {
         let file = db.get_or_create_file(&path);
-        db.bump_file_revision(file);
+        let current = file.source(db);
+        let latest = db.read_file(&path).unwrap_or_default();
+
+        if current.as_str() != latest {
+            db.bump_file_revision(file);
+        }
     }
 }

--- a/crates/djls-server/src/refresh.rs
+++ b/crates/djls-server/src/refresh.rs
@@ -1,15 +1,15 @@
 //! Background project refresh.
 //!
-//! Runs off the session lock as much as possible: compute the refresh on a
-//! database clone, apply it briefly under the lock, then warm derived queries
-//! and republish diagnostics from a snapshot. The session's refresh epoch is
-//! checked between stages so superseded work is dropped on the floor.
+//! Runs expensive refresh work off the session lock: load settings on a
+//! blocking task, compute project facts on a database clone, apply the results
+//! under the lock, then warm derived queries and republish diagnostics from a
+//! snapshot. The session's refresh epoch is checked between stages so
+//! superseded work is dropped on the floor.
 
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 
+use djls_conf::Settings;
 use djls_project::Db as ProjectDb;
 use djls_project::RefreshData;
 use djls_project::apply_refresh;
@@ -24,6 +24,7 @@ use crate::client::ClientInfo;
 use crate::document::TextDocument;
 use crate::ext::UriExt;
 use crate::progress::LoadProgress;
+use crate::session::ProjectRefreshState;
 use crate::session::SNAPSHOT_CANCEL_RETRIES;
 use crate::session::Session;
 use crate::session::SessionSnapshot;
@@ -34,35 +35,85 @@ enum RefreshOutcome {
     Superseded,
 }
 
+enum LoadOutcome {
+    Loaded(Box<Settings>),
+    Skipped,
+    Superseded,
+}
+
 enum ComputeOutcome {
     Computed(RefreshData),
     Skipped,
     Superseded,
 }
 
-fn refresh_is_stale(refresh_epoch: &AtomicU64, epoch: u64) -> bool {
-    refresh_epoch.load(Ordering::Acquire) != epoch
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ProjectRefreshReason {
+    Startup,
+    ConfigurationChanged,
+}
+
+impl ProjectRefreshReason {
+    fn progress_title(self) -> &'static str {
+        match self {
+            Self::Startup => "Loading Django project",
+            Self::ConfigurationChanged => "Refreshing Django project",
+        }
+    }
+
+    fn completion_log(self) -> &'static str {
+        match self {
+            Self::Startup => "Server initialization completed",
+            Self::ConfigurationChanged => "Project refresh completed",
+        }
+    }
+}
+
+pub(crate) struct ProjectRefreshRequest {
+    project_refresh: ProjectRefreshState,
+    diagnostic_publish_lock: Arc<Mutex<()>>,
+    client_info: ClientInfo,
+    epoch: u64,
+    reason: ProjectRefreshReason,
+}
+
+impl ProjectRefreshRequest {
+    pub(crate) fn new(
+        project_refresh: ProjectRefreshState,
+        diagnostic_publish_lock: Arc<Mutex<()>>,
+        client_info: ClientInfo,
+        epoch: u64,
+        reason: ProjectRefreshReason,
+    ) -> Self {
+        Self {
+            project_refresh,
+            diagnostic_publish_lock,
+            client_info,
+            epoch,
+            reason,
+        }
+    }
 }
 
 pub(crate) async fn run_project_refresh(
     session: Arc<Mutex<Session>>,
     client: Client,
-    refresh_epoch: Arc<AtomicU64>,
-    diagnostic_publish_lock: Arc<Mutex<()>>,
-    client_info: ClientInfo,
-    epoch: u64,
-    log_initialization: bool,
+    request: ProjectRefreshRequest,
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
-    let progress =
-        LoadProgress::begin(client.clone(), &client_info, "Loading Django project").await;
+    let progress = LoadProgress::begin(
+        client.clone(),
+        &request.client_info,
+        request.reason.progress_title(),
+    )
+    .await;
     let result = run_project_refresh_inner(
         session,
         client,
-        refresh_epoch,
-        diagnostic_publish_lock,
+        &request.project_refresh,
+        request.diagnostic_publish_lock,
         &progress,
-        epoch,
+        request.epoch,
     )
     .await;
 
@@ -81,10 +132,12 @@ pub(crate) async fn run_project_refresh(
         }
     }
 
-    if log_initialization {
-        tracing::info!("Server initialization completed in {:?}", start.elapsed());
-    } else if result.is_ok() {
-        tracing::info!("Environment refresh completed in {:?}", start.elapsed());
+    if result.is_ok() {
+        tracing::info!(
+            "{} in {:?}",
+            request.reason.completion_log(),
+            start.elapsed()
+        );
     }
 
     result.map(|_| ())
@@ -93,12 +146,12 @@ pub(crate) async fn run_project_refresh(
 async fn run_project_refresh_inner(
     session: Arc<Mutex<Session>>,
     client: Client,
-    refresh_epoch: Arc<AtomicU64>,
+    project_refresh: &ProjectRefreshState,
     diagnostic_publish_lock: Arc<Mutex<()>>,
     progress: &LoadProgress,
     epoch: u64,
 ) -> anyhow::Result<RefreshOutcome> {
-    if refresh_is_stale(&refresh_epoch, epoch) {
+    if project_refresh.is_stale(epoch) {
         tracing::debug!(
             epoch,
             "Skipping stale project refresh before locking session"
@@ -108,47 +161,56 @@ async fn run_project_refresh_inner(
 
     progress.report("Resolving environment").await;
 
-    let refresh = match compute_project_refresh(&session, &refresh_epoch, epoch).await {
+    let settings = match load_project_settings(&session, project_refresh, epoch).await {
+        LoadOutcome::Loaded(settings) => *settings,
+        LoadOutcome::Skipped => return Ok(RefreshOutcome::Skipped),
+        LoadOutcome::Superseded => return Ok(RefreshOutcome::Superseded),
+    };
+
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(
+            epoch,
+            "Skipping stale project refresh before settings apply"
+        );
+        return Ok(RefreshOutcome::Superseded);
+    }
+
+    progress.report("Applying project settings").await;
+
+    if let Err(outcome) = apply_project_settings(&session, project_refresh, epoch, settings).await {
+        return Ok(outcome);
+    }
+
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh after settings apply");
+        return Ok(RefreshOutcome::Superseded);
+    }
+
+    progress.report("Computing project facts").await;
+
+    let refresh = match compute_project_refresh(&session, project_refresh, epoch).await {
         ComputeOutcome::Computed(refresh) => refresh,
         ComputeOutcome::Skipped => return Ok(RefreshOutcome::Skipped),
         ComputeOutcome::Superseded => return Ok(RefreshOutcome::Superseded),
     };
 
-    if refresh_is_stale(&refresh_epoch, epoch) {
+    if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh before apply");
         return Ok(RefreshOutcome::Superseded);
     }
 
     progress.report("Applying project facts").await;
 
-    let (snapshot, documents) = {
-        let mut session_lock = session.lock().await;
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
-            return Ok(RefreshOutcome::Superseded);
-        }
-
-        let db = session_lock.db_mut();
-        if db.project().is_none() {
-            return Ok(RefreshOutcome::Skipped);
-        }
-
-        let t = std::time::Instant::now();
-        apply_refresh(db, refresh);
-        tracing::info!("External data refresh completed in {:?}", t.elapsed());
-
-        if refresh_is_stale(&refresh_epoch, epoch) {
-            tracing::debug!(epoch, "Skipping stale project refresh after apply");
-            return Ok(RefreshOutcome::Superseded);
-        }
-
-        (session_lock.snapshot(), session_lock.open_documents())
-    };
+    let (snapshot, documents) =
+        match apply_project_facts(&session, project_refresh, epoch, refresh).await {
+            Ok(snapshot) => snapshot,
+            Err(outcome) => return Ok(outcome),
+        };
 
     progress.report("Warming caches").await;
-    warm_project_queries(snapshot.clone(), Arc::clone(&refresh_epoch), epoch).await;
+    warm_project_queries(snapshot.clone(), project_refresh.clone(), epoch).await;
 
-    if refresh_is_stale(&refresh_epoch, epoch) {
+    if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh after warm-up");
         return Ok(RefreshOutcome::Superseded);
     }
@@ -158,7 +220,7 @@ async fn run_project_refresh_inner(
         client,
         snapshot,
         documents,
-        refresh_epoch,
+        project_refresh.clone(),
         diagnostic_publish_lock,
         epoch,
     )
@@ -170,9 +232,110 @@ async fn run_project_refresh_inner(
     Ok(RefreshOutcome::Complete)
 }
 
+async fn apply_project_settings(
+    session: &Arc<Mutex<Session>>,
+    project_refresh: &ProjectRefreshState,
+    epoch: u64,
+    settings: Settings,
+) -> Result<(), RefreshOutcome> {
+    let mut session_lock = session.lock().await;
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(
+            epoch,
+            "Skipping stale project refresh after settings apply lock"
+        );
+        return Err(RefreshOutcome::Superseded);
+    }
+
+    let db = session_lock.db_mut();
+    if db.project().is_none() {
+        return Err(RefreshOutcome::Skipped);
+    }
+
+    db.apply_project_settings(settings);
+    Ok(())
+}
+
+async fn apply_project_facts(
+    session: &Arc<Mutex<Session>>,
+    project_refresh: &ProjectRefreshState,
+    epoch: u64,
+    refresh: RefreshData,
+) -> Result<(SessionSnapshot, Vec<TextDocument>), RefreshOutcome> {
+    let mut session_lock = session.lock().await;
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh after apply lock");
+        return Err(RefreshOutcome::Superseded);
+    }
+
+    let db = session_lock.db_mut();
+    if db.project().is_none() {
+        return Err(RefreshOutcome::Skipped);
+    }
+
+    let t = std::time::Instant::now();
+    apply_refresh(db, refresh);
+    tracing::info!("External data refresh completed in {:?}", t.elapsed());
+
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh after apply");
+        return Err(RefreshOutcome::Superseded);
+    }
+
+    Ok((session_lock.snapshot(), session_lock.open_documents()))
+}
+
+async fn load_project_settings(
+    session: &Arc<Mutex<Session>>,
+    project_refresh: &ProjectRefreshState,
+    epoch: u64,
+) -> LoadOutcome {
+    let Some((project_root, config_overrides)) = ({
+        let session_lock = session.lock().await;
+        if project_refresh.is_stale(epoch) {
+            tracing::debug!(
+                epoch,
+                "Skipping stale project settings load after locking session"
+            );
+            return LoadOutcome::Superseded;
+        }
+
+        let db = session_lock.db();
+        db.project().map(|project| {
+            (
+                project.root(db).clone(),
+                session_lock.client_info().config_overrides().clone(),
+            )
+        })
+    }) else {
+        tracing::info!("Task: No project configured, skipping settings load.");
+        return LoadOutcome::Skipped;
+    };
+
+    let settings =
+        tokio::task::spawn_blocking(move || Settings::new(&project_root, Some(config_overrides)))
+            .await
+            .expect("project settings load task must not panic");
+
+    let settings = match settings {
+        Ok(settings) => settings,
+        Err(err) => {
+            tracing::error!("Error loading settings: {}", err);
+            return LoadOutcome::Skipped;
+        }
+    };
+
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh after settings load");
+        return LoadOutcome::Superseded;
+    }
+
+    LoadOutcome::Loaded(Box::new(settings))
+}
+
 async fn compute_project_refresh(
     session: &Arc<Mutex<Session>>,
-    refresh_epoch: &Arc<AtomicU64>,
+    project_refresh: &ProjectRefreshState,
     epoch: u64,
 ) -> ComputeOutcome {
     // Cancellation here usually means a document edit, not a config change:
@@ -182,7 +345,7 @@ async fn compute_project_refresh(
     for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
         let Some(compute_db) = ({
             let session_lock = session.lock().await;
-            if refresh_is_stale(refresh_epoch, epoch) {
+            if project_refresh.is_stale(epoch) {
                 tracing::debug!(
                     epoch,
                     "Skipping stale project refresh after locking session"
@@ -229,7 +392,7 @@ async fn compute_project_refresh(
 
 async fn warm_project_queries(
     snapshot: SessionSnapshot,
-    refresh_epoch: Arc<AtomicU64>,
+    project_refresh: ProjectRefreshState,
     epoch: u64,
 ) {
     let result = tokio::task::spawn_blocking(move || {
@@ -239,22 +402,22 @@ async fn warm_project_queries(
                 return;
             };
 
-            if refresh_is_stale(&refresh_epoch, epoch) {
+            if project_refresh.is_stale(epoch) {
                 return;
             }
             let _ = db.tag_specs();
 
-            if refresh_is_stale(&refresh_epoch, epoch) {
+            if project_refresh.is_stale(epoch) {
                 return;
             }
             let _ = db.template_dirs();
 
-            if refresh_is_stale(&refresh_epoch, epoch) {
+            if project_refresh.is_stale(epoch) {
                 return;
             }
             let _ = db.template_libraries();
 
-            if refresh_is_stale(&refresh_epoch, epoch) {
+            if project_refresh.is_stale(epoch) {
                 return;
             }
             let _ = project_template_files(db, project);
@@ -275,7 +438,7 @@ async fn republish_snapshot_diagnostics(
     client: Client,
     snapshot: SessionSnapshot,
     documents: Vec<TextDocument>,
-    refresh_epoch: Arc<AtomicU64>,
+    project_refresh: ProjectRefreshState,
     diagnostic_publish_lock: Arc<Mutex<()>>,
     epoch: u64,
 ) -> bool {
@@ -285,7 +448,7 @@ async fn republish_snapshot_diagnostics(
     }
 
     for document in documents {
-        if refresh_is_stale(&refresh_epoch, epoch) {
+        if project_refresh.is_stale(epoch) {
             tracing::debug!(epoch, "Skipping stale refresh diagnostics republish");
             return false;
         }
@@ -295,7 +458,7 @@ async fn republish_snapshot_diagnostics(
             continue;
         };
 
-        if refresh_is_stale(&refresh_epoch, epoch) {
+        if project_refresh.is_stale(epoch) {
             tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
             return false;
         }
@@ -307,7 +470,7 @@ async fn republish_snapshot_diagnostics(
         let diagnostic_count = diagnostics.len();
         let lsp_uri_text = lsp_uri.to_string();
         let _publish_guard = diagnostic_publish_lock.lock().await;
-        if refresh_is_stale(&refresh_epoch, epoch) {
+        if project_refresh.is_stale(epoch) {
             tracing::debug!(epoch, "Skipping stale refresh diagnostics publish");
             return false;
         }
@@ -360,4 +523,39 @@ async fn collect_snapshot_diagnostics(
     }
 
     unreachable!("diagnostics retry loop must return")
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn project_settings_load_error_skips_refresh_inputs() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "debug = not_a_boolean",
+        )
+        .unwrap();
+
+        let params = ls_types::InitializeParams {
+            workspace_folders: Some(vec![ls_types::WorkspaceFolder {
+                uri: ls_types::Uri::from_file_path(root.as_std_path()).unwrap(),
+                name: "test_project".to_string(),
+            }]),
+            ..Default::default()
+        };
+        let session = Session::new(&params);
+        let project_refresh = session.project_refresh().clone();
+        let epoch = project_refresh.begin_refresh();
+        let session = Arc::new(Mutex::new(session));
+
+        let outcome = load_project_settings(&session, &project_refresh, epoch).await;
+
+        assert!(matches!(outcome, LoadOutcome::Skipped));
+    }
 }

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -1,11 +1,8 @@
-use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
-use djls_project::Db as ProjectDb;
 use djls_source::FileKind;
 use tokio::sync::Mutex;
-use tokio::sync::oneshot;
 use tower_lsp_server::Client;
 use tower_lsp_server::LanguageServer;
 use tower_lsp_server::jsonrpc::Result as LspResult;
@@ -98,54 +95,34 @@ impl DjangoLanguageServer {
 
     /// Bump the session's refresh epoch and queue a refresh task for the new
     /// epoch. The task body lives in [`crate::refresh`].
-    async fn submit_project_refresh(&self, log_initialization: bool) {
+    async fn submit_project_refresh(&self, reason: refresh::ProjectRefreshReason) {
         let client = self.client.clone();
-        let (epoch, refresh_epoch, diagnostic_publish_lock, client_info) = self
+        let (epoch, project_refresh, diagnostic_publish_lock, client_info) = self
             .with_session(|session| {
+                let project_refresh = session.project_refresh().clone();
+                let epoch = project_refresh.begin_refresh();
+
                 (
-                    session.bump_refresh_epoch(),
-                    session.refresh_epoch(),
+                    epoch,
+                    project_refresh,
                     session.diagnostic_publish_lock(),
                     session.client_info().clone(),
                 )
             })
             .await;
 
-        let rx = self
-            .with_session_mut_task(move |session| async move {
-                refresh::run_project_refresh(
-                    session,
-                    client,
-                    refresh_epoch,
-                    diagnostic_publish_lock,
-                    client_info,
-                    epoch,
-                    log_initialization,
-                )
-                .await
-            })
-            .await;
-        drop(rx);
-    }
-
-    pub(crate) async fn with_session_mut_task<F, Fut>(
-        &self,
-        f: F,
-    ) -> oneshot::Receiver<anyhow::Result<()>>
-    where
-        F: FnOnce(Arc<Mutex<Session>>) -> Fut + Send + 'static,
-        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
-    {
         let session = Arc::clone(&self.session);
-        let (tx, rx) = oneshot::channel();
+        let request = refresh::ProjectRefreshRequest::new(
+            project_refresh,
+            diagnostic_publish_lock,
+            client_info,
+            epoch,
+            reason,
+        );
 
         let submit_result = self
             .queue
-            .submit(async move {
-                let res = f(session).await;
-                let _ = tx.send(res);
-                Ok(())
-            })
+            .submit(async move { refresh::run_project_refresh(session, client, request).await })
             .await;
 
         match submit_result {
@@ -156,21 +133,20 @@ impl DjangoLanguageServer {
                 tracing::error!("Failed to submit task: {}", e);
             }
         }
-
-        rx
     }
 
     async fn maybe_push_diagnostics(&self, document: &TextDocument) {
+        if self
+            .with_session(|session| session.client_info().supports_pull_diagnostics())
+            .await
+        {
+            tracing::debug!("Client supports pull diagnostics, skipping push");
+            return;
+        }
+
         let file = document.file();
         let Some(diagnostics) = self
-            .with_snapshot(move |snapshot| {
-                if snapshot.client_info().supports_pull_diagnostics() {
-                    tracing::debug!("Client supports pull diagnostics, skipping push");
-                    return None;
-                }
-
-                djls_ide::collect_diagnostics(snapshot.db(), file)
-            })
+            .with_snapshot(move |snapshot| djls_ide::collect_diagnostics(snapshot.db(), file))
             .await
         else {
             return;
@@ -269,7 +245,8 @@ impl LanguageServer for DjangoLanguageServer {
         tracing::info!("Server received initialized notification.");
 
         // Refresh project data in the background and initialize the workspace.
-        self.submit_project_refresh(true).await;
+        self.submit_project_refresh(refresh::ProjectRefreshReason::Startup)
+            .await;
     }
 
     async fn shutdown(&self) -> LspResult<()> {
@@ -532,39 +509,8 @@ impl LanguageServer for DjangoLanguageServer {
     }
 
     async fn did_change_configuration(&self, _params: ls_types::DidChangeConfigurationParams) {
-        tracing::info!("Configuration change detected. Reloading settings...");
-
-        let settings_update = self
-            .with_session_mut(|session| {
-                if session.project().is_none() {
-                    return djls_db::SettingsUpdate::default();
-                }
-
-                let project_root = session.db().project_root_or_cwd();
-
-                match djls_conf::Settings::new(
-                    &project_root,
-                    Some(session.client_info().config_overrides().clone()),
-                ) {
-                    Ok(new_settings) => session.set_settings(new_settings),
-                    Err(e) => {
-                        tracing::error!("Error loading settings: {}", e);
-                        djls_db::SettingsUpdate::default()
-                    }
-                }
-            })
+        tracing::info!("Configuration change detected. Queuing configuration refresh...");
+        self.submit_project_refresh(refresh::ProjectRefreshReason::ConfigurationChanged)
             .await;
-
-        // Any relevant change submits a refresh: the epoch bump supersedes
-        // in-flight refresh work (so a stale republish cannot overwrite newer
-        // settings), and the new task re-applies and republishes diagnostics
-        // for open documents. Bumping without resubmitting would drop a
-        // superseded refresh's apply on the floor.
-        if settings_update.env_changed
-            || settings_update.diagnostics_changed
-            || settings_update.semantic_changed
-        {
-            self.submit_project_refresh(false).await;
-        }
     }
 }

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -10,9 +10,7 @@ use std::sync::atomic::Ordering;
 #[cfg(test)]
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_conf::Settings;
 use djls_db::DjangoDatabase;
-use djls_project::Db as ProjectDb;
 use djls_source::Db as SourceDb;
 use djls_source::File;
 use djls_source::Offset;
@@ -31,6 +29,27 @@ use crate::workspace::Workspace;
 /// How many times snapshot-based reads retry after Salsa cancellation before
 /// giving up and returning a fallback.
 pub(crate) const SNAPSHOT_CANCEL_RETRIES: usize = 2;
+
+#[derive(Clone)]
+pub(crate) struct ProjectRefreshState {
+    epoch: Arc<AtomicU64>,
+}
+
+impl ProjectRefreshState {
+    fn new() -> Self {
+        Self {
+            epoch: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub(crate) fn begin_refresh(&self) -> u64 {
+        self.epoch.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    pub(crate) fn is_stale(&self, epoch: u64) -> bool {
+        self.epoch.load(Ordering::Acquire) != epoch
+    }
+}
 
 /// LSP Session managing project-specific state and database operations.
 ///
@@ -54,10 +73,10 @@ pub(crate) struct Session {
     /// The Salsa database for incremental computation
     db: DjangoDatabase,
 
-    /// Generation counter for project refreshes. Background refresh tasks
+    /// Tracks the current project refresh generation. Background refresh tasks
     /// capture the value at submission and drop their work when it no longer
-    /// matches — a later bump supersedes any in-flight refresh.
-    refresh_epoch: Arc<AtomicU64>,
+    /// matches; a later bump supersedes any in-flight refresh.
+    project_refresh: ProjectRefreshState,
 
     /// Serializes `publishDiagnostics` sends so a refresh-originated republish
     /// can re-check the epoch under the lock and never overwrite a newer
@@ -85,12 +104,11 @@ impl Session {
         let client_settings = client_options.settings.clone();
 
         let workspace = Workspace::new();
-        let settings = project_path
-            .as_ref()
-            .and_then(|path| djls_conf::Settings::new(path, Some(client_settings.clone())).ok())
-            .unwrap_or(client_settings);
-
-        let db = DjangoDatabase::new(workspace.overlay(), &settings, project_path.as_deref());
+        let db = DjangoDatabase::new(
+            workspace.overlay(),
+            &client_settings,
+            project_path.as_deref(),
+        );
 
         let client_info = ClientInfo::new(
             &params.capabilities,
@@ -102,7 +120,7 @@ impl Session {
             workspace,
             client_info,
             db,
-            refresh_epoch: Arc::new(AtomicU64::new(0)),
+            project_refresh: ProjectRefreshState::new(),
             diagnostic_publish_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -111,14 +129,8 @@ impl Session {
         SessionSnapshot::new(self.db.clone(), self.client_info.clone())
     }
 
-    /// Advance the refresh epoch, superseding any in-flight refresh task.
-    /// Returns the new epoch for the work that follows the bump.
-    pub(crate) fn bump_refresh_epoch(&self) -> u64 {
-        self.refresh_epoch.fetch_add(1, Ordering::AcqRel) + 1
-    }
-
-    pub(crate) fn refresh_epoch(&self) -> Arc<AtomicU64> {
-        Arc::clone(&self.refresh_epoch)
+    pub(crate) fn project_refresh(&self) -> &ProjectRefreshState {
+        &self.project_refresh
     }
 
     pub(crate) fn diagnostic_publish_lock(&self) -> Arc<Mutex<()>> {
@@ -135,15 +147,6 @@ impl Session {
 
     pub(crate) fn db_mut(&mut self) -> &mut DjangoDatabase {
         &mut self.db
-    }
-
-    pub(crate) fn set_settings(&mut self, settings: Settings) -> djls_db::SettingsUpdate {
-        self.db.set_settings(settings)
-    }
-
-    /// Get the current project for this session
-    pub(crate) fn project(&self) -> Option<djls_project::Project> {
-        self.db.project()
     }
 
     /// Open a document in the session.
@@ -332,7 +335,10 @@ impl SessionSnapshot {
 
 #[cfg(test)]
 mod tests {
+    use djls_project::Db as ProjectDb;
+    use djls_project::Interpreter;
     use djls_source::Db as SourceDb;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -415,8 +421,70 @@ mod tests {
             snapshot.client_info().position_encoding()
         );
         assert_eq!(
-            session.project().is_some(),
+            session.db().project().is_some(),
             snapshot.db().project().is_some()
         );
+    }
+
+    #[test]
+    fn session_new_uses_initial_project_until_refresh_loads_settings() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        let config_extra_path = root.join("config_extra");
+        let client_extra_path = root.join("client_extra");
+        let venv_path = root.join(".venv");
+        std::fs::create_dir_all(config_extra_path.as_std_path()).unwrap();
+        std::fs::create_dir_all(client_extra_path.as_std_path()).unwrap();
+        std::fs::write(
+            root.join(".env").as_std_path(),
+            "FROM_ENV=should_not_load\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            format!(
+                r#"
+django_settings_module = "config.settings"
+pythonpath = ["{config_extra_path}"]
+"#
+            ),
+        )
+        .unwrap();
+
+        let params = ls_types::InitializeParams {
+            workspace_folders: Some(vec![ls_types::WorkspaceFolder {
+                uri: ls_types::Uri::from_file_path(root.as_std_path()).unwrap(),
+                name: "test_project".to_string(),
+            }]),
+            initialization_options: Some(serde_json::json!({
+                "django_settings_module": "client.settings",
+                "pythonpath": [client_extra_path.to_string()],
+                "venv_path": venv_path.to_string(),
+            })),
+            ..Default::default()
+        };
+
+        let session = Session::new(&params);
+        let db = session.db();
+        let project = db.project().expect("initialize should create a project");
+
+        assert_eq!(project.root(db), root.as_path());
+        assert_eq!(
+            project.django_settings_module(db).as_deref(),
+            Some("client.settings")
+        );
+        assert_eq!(project.pythonpath(db), &vec![client_extra_path.to_string()]);
+        assert_eq!(
+            project.interpreter(db),
+            &Interpreter::VenvPath(venv_path.to_string())
+        );
+        assert!(project.env_vars(db).is_empty());
+
+        let search_paths: Vec<_> = project
+            .search_paths(db)
+            .iter()
+            .map(|search_path| search_path.path().to_path_buf())
+            .collect();
+        assert_eq!(search_paths, vec![root]);
     }
 }

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -154,7 +154,8 @@ impl Command for Check {
         }
 
         let fs: Arc<dyn FileSystem> = Arc::new(OsFileSystem);
-        let db = DjangoDatabase::new(fs, &settings, Some(&project_root));
+        let mut db = DjangoDatabase::new(fs, &settings, Some(&project_root));
+        db.apply_project_settings(settings);
 
         let walk_options = WalkOptions {
             hidden: self.hidden,
@@ -252,7 +253,8 @@ fn check_stdin(
     let stdin_path = Utf8PathBuf::from("<stdin>.html");
     mem_fs.add_file(stdin_path.clone(), source);
     let fs: Arc<dyn FileSystem> = Arc::new(mem_fs);
-    let db = DjangoDatabase::new(fs, settings, Some(project_root));
+    let mut db = DjangoDatabase::new(fs, settings, Some(project_root));
+    db.apply_project_settings(settings.clone());
 
     let result = check_file_with_source(&db, &stdin_path);
     if quiet {

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest_asyncio
 import pytest_lsp
+from lsprotocol import types
 from lsprotocol.types import InitializeParams
 from lsprotocol.types import WorkspaceFolder
 from pytest_lsp import ClientServerConfig
@@ -25,6 +27,18 @@ TEST_DIR = Path(__file__).parent.parent
 TEST_WORKSPACE = TEST_DIR / "project"
 
 
+async def wait_for_project_load(client: LanguageClient) -> None:
+    def progress_done() -> bool:
+        return any(
+            event.kind == "end"
+            for events in client.progress_reports.values()
+            for event in events
+        )
+
+    while not progress_done():
+        await asyncio.wait_for(client.wait_for_notification(types.PROGRESS), timeout=5)
+
+
 @pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
 async def emacs_client(lsp_client: LanguageClient):
     await lsp_client.initialize_session(
@@ -35,6 +49,7 @@ async def emacs_client(lsp_client: LanguageClient):
             ],
         )
     )
+    await wait_for_project_load(lsp_client)
 
     yield
 
@@ -51,6 +66,7 @@ async def neovim_client(lsp_client: LanguageClient):
             ],
         )
     )
+    await wait_for_project_load(lsp_client)
 
     yield
 
@@ -67,6 +83,7 @@ async def vscode_client(lsp_client: LanguageClient):
             ],
         )
     )
+    await wait_for_project_load(lsp_client)
 
     yield
 

--- a/tests/e2e/test_startup.py
+++ b/tests/e2e/test_startup.py
@@ -92,7 +92,7 @@ async def wait_for_progress_events(
 
 
 @pytest.mark.asyncio
-async def test_initialize_returns_capabilities_before_project_load_finishes(
+async def test_initialize_returns_protocol_capabilities_without_project_loading(
     startup_client: LanguageClient,
 ):
     capabilities = startup_client.djls_initialize_result.capabilities
@@ -105,9 +105,11 @@ async def test_initialize_returns_capabilities_before_project_load_finishes(
 
 
 @pytest.mark.asyncio
-async def test_server_accepts_template_requests_after_initialized(
+async def test_server_accepts_template_requests_after_startup_load(
     startup_client: LanguageClient,
 ):
+    await wait_for_progress_events(startup_client)
+
     startup_client.text_document_did_open(
         types.DidOpenTextDocumentParams(
             text_document=types.TextDocumentItem(


### PR DESCRIPTION
## Summary
- Make `DjangoDatabase::new` create only protocol/initial project state, with full project settings loaded later through refresh or explicit CLI application.
- Move LSP startup/config refresh onto off-lock settings/project-input loading with short epoch-checked apply.
- Keep early startup completions useful by falling back to builtin tag specs while template-library facts are still loading.
- Update `djls check` to explicitly apply loaded settings after DB construction and add startup/DB/completion coverage.

## Validation
- `cargo build -q -p djls-server`
- `cargo build -q -p djls`
- `cargo test -q`
- `cargo test -q -p djls-server`
- `cargo test -q -p djls-db -p djls-project`
- `cargo test -q -p djls-ide`
- `cargo test -q -p djls --test check`
- `uv run pytest tests/e2e/test_startup.py -q -x`
- `just test`
- `just e2e`
- `just clippy --allow-dirty`
- `just fmt`
- `just lint`