### PR TITLE
remove stale runtime inspector references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We adhere to a version of Django's Code of Conduct in all interactions and expec
 
 For a detailed look at how the codebase works — data flow, the Salsa database, the template pipeline — see [ARCHITECTURE.md](ARCHITECTURE.md).
 
-The project is written in Rust with a Python subprocess for Django introspection. It uses a [Cargo workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html) with all crates under `crates/`. A few conventions to be aware of:
+The project is written in Rust and uses static analysis to introspect Django projects. It uses a [Cargo workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html) with all crates under `crates/`. A few conventions to be aware of:
 
 - **Dependency versions** are centralized in `[workspace.dependencies]` in the root [`Cargo.toml`](./Cargo.toml). Individual crates reference them with `dep.workspace = true` and never specify versions directly.
 - **Internal crates are listed before third-party crates** in each crate's `[dependencies]`, separated by a blank line. Both groups are kept in alphabetical order.

--- a/docs/clients/sublime-text.md
+++ b/docs/clients/sublime-text.md
@@ -9,7 +9,7 @@
 
 ## Configuration
 
-To use Django Language Server with Sublime Text, you'll need to configure two things: the LSP client settings to enable and run the server, and your Python environment and Django project settings so the server can introspect your project.
+To use Django Language Server with Sublime Text, you'll need to configure two things: the LSP client settings to enable and run the server, and your Python environment and Django project settings so the server can statically introspect your project.
 
 ### LSP client
 
@@ -46,7 +46,7 @@ The language server requires two settings to provide full functionality:
 - `django_settings_module` **(required)**: Your Django settings module (e.g., `"myproject.settings"`)
 - `venv_path` **(optional)**: Path to your virtual environment
 
-Without these, the language server can't introspect your Django project and will only provide basic built-in template tag completions. The language server attempts to auto-detect these settings from the `DJANGO_SETTINGS_MODULE` and `VIRTUAL_ENV` environment variables, and will also search for standard virtual environment directories (`.venv`, `venv`, `env`, `.env`) in your project root.
+Without these, the language server may not be able to fully introspect your Django project and will only provide basic built-in template tag completions. The language server attempts to auto-detect these settings from the `DJANGO_SETTINGS_MODULE` and `VIRTUAL_ENV` environment variables, and will also search for standard virtual environment directories (`.venv`, `venv`, `env`, `.env`) in your project root.
 
 However, **Sublime Text launches language servers as subprocesses that don't inherit your terminal's environment**, so you must explicitly configure at least `django_settings_module`, and likely `venv_path` as well unless your venv uses a standard name.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -6,36 +6,23 @@ Django Language Server auto-detects your project configuration in most cases. It
 
 ## Handling environment variables
 
-DJLS does not start Django or execute your settings module. That means missing
-application secrets usually do not break the language server the way they
-would break `django.setup()`.
+Environment variables matter when they identify project configuration.
 
-Environment variables still matter for the language server process itself. If
-`django_settings_module` is not configured, DJLS reads
-`DJANGO_SETTINGS_MODULE` from the environment inherited from your editor.
-Editors launched from desktop environments (app launchers, dock icons) often
-do not inherit shell variables set in `.bashrc`, `.zshrc`, or similar files.
+If `django_settings_module` is not configured, the language server reads `DJANGO_SETTINGS_MODULE` from the environment inherited from your editor. Editors launched from desktop environments (app launchers, dock icons) often do not inherit shell variables set in `.bashrc`, `.zshrc`, or similar files.
 
-For a language server, the most reliable setup is to configure the Django
-settings module explicitly:
+The most reliable setup is to configure the Django settings module explicitly:
 
 ```toml
 [tool.djls]
 django_settings_module = "myproject.settings"
 ```
 
-DJLS also reads `.env` in the project root, or the file configured by
-[`env_file`](#env_file), during static project introspection. The file uses the
-same format as `python-dotenv` and similar tools.
+The language server also reads `.env` in the project root, or the file configured by [`env_file`](#env_file), during static project introspection. The file uses the same format as `python-dotenv` and similar tools.
 
 ```toml
 [tool.djls]
 env_file = ".env.local"
 ```
-
-The env file is not forwarded to a subprocess, and DJLS does not use it to
-execute arbitrary settings code. Prefer explicit static configuration when
-possible.
 
 ## Options
 
@@ -45,9 +32,7 @@ possible.
 
 Your Django settings module path (e.g., `"myproject.settings"`).
 
-The server uses this to statically introspect your Django project for template
-tag completions, diagnostics, and navigation. If not explicitly configured, the
-server reads the `DJANGO_SETTINGS_MODULE` environment variable.
+The server uses this to statically introspect your Django project for template tag completions, diagnostics, and navigation. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
 
 **When to configure:**
 
@@ -71,10 +56,7 @@ The server needs access to your virtual environment to discover installed Django
 
 **Default:** `[]` (empty list)
 
-Additional directories to add to the Python import search paths used for
-static project introspection. These paths are searched alongside the project
-root when DJLS resolves settings modules, installed apps, template tag
-libraries, and Python sources.
+Additional directories to add to the Python import search paths used for static project introspection. These paths are searched alongside the project root when the server resolves settings modules, installed apps, template tag libraries, and Python sources.
 
 **When to configure:**
 
@@ -87,13 +69,9 @@ libraries, and Python sources.
 
 **Default:** `.env` in the project root (auto-detected, no error if missing)
 
-Path to an environment file (relative to the project root) whose variables are
-read during static project introspection.
+Path to an environment file (relative to the project root) whose variables are read during static project introspection.
 
-Many Django projects keep local configuration in `.env` files. DJLS parses the
-configured file and records the variables with the project state used by static
-analysis. It does not execute Django settings with those variables and does not
-modify the language server process environment.
+Many Django projects keep local configuration in `.env` files. The language server parses the configured file and records the variables with the project state used by static analysis.
 
 If no `env_file` is configured, the server looks for a `.env` file in the project root automatically. If the file doesn't exist, nothing happens. When `env_file` is set explicitly and the file is missing, a warning is logged.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -6,47 +6,36 @@ Django Language Server auto-detects your project configuration in most cases. It
 
 ## Handling environment variables
 
-Django projects commonly read secrets and configuration from environment variables — whether through `os.environ`, `django-environ`, `environs`, `python-decouple`, or similar libraries.
+DJLS does not start Django or execute your settings module. That means missing
+application secrets usually do not break the language server the way they
+would break `django.setup()`.
 
-When a required variable is missing, the language server's inspector process fails to initialize Django and you'll see an error like:
+Environment variables still matter for the language server process itself. If
+`django_settings_module` is not configured, DJLS reads
+`DJANGO_SETTINGS_MODULE` from the environment inherited from your editor.
+Editors launched from desktop environments (app launchers, dock icons) often
+do not inherit shell variables set in `.bashrc`, `.zshrc`, or similar files.
 
-> Missing required environment variable: DJANGO_SECRET_KEY. Django settings failed to load because 'DJANGO_SECRET_KEY' is not set in the editor's environment.
+For a language server, the most reliable setup is to configure the Django
+settings module explicitly:
 
-This happens because editors launched from desktop environments (app launchers, dock icons) don't inherit shell variables set in `.bashrc`, `.zshrc`, or similar.
-
-### How environment variables reach the inspector
-
-The inspector subprocess inherits the full environment of its parent process (the language server, which inherits from the editor). Variables set in your shell are available automatically **if the editor was launched from that shell**. The [`env_file`](#env_file) option exists for cases where that inheritance doesn't work.
-
-### Recommended setup
-
-If your Django settings depend on environment variables, create a `.env` file in your project root:
-
-```shell
-# .env
-DJANGO_SECRET_KEY=not-a-real-secret
-DATABASE_URL=postgres://localhost/mydb
+```toml
+[tool.djls]
+django_settings_module = "myproject.settings"
 ```
 
-The server automatically detects `.env` in the project root and loads its variables into the inspector process — no configuration needed. This is the same format used by `python-dotenv` and similar tools.
-
-!!! tip
-    The values only need to be valid enough for Django to initialize. For a language server, a placeholder `SECRET_KEY` works fine.
-
-If your env file has a different name or location, point to it explicitly:
+DJLS also reads `.env` in the project root, or the file configured by
+[`env_file`](#env_file), during static project introspection. The file uses the
+same format as `python-dotenv` and similar tools.
 
 ```toml
 [tool.djls]
 env_file = ".env.local"
 ```
 
-### Other approaches
-
-If you prefer not to use an env file:
-
-- **Launch your editor from the terminal** where the variables are already set. Most editors inherit the shell's environment when started this way.
-- **Configure your editor** to set environment variables before starting language servers. See your editor's documentation for details.
-- **Set `django_settings_module`** in your djls config if the only missing variable is `DJANGO_SETTINGS_MODULE`.
+The env file is not forwarded to a subprocess, and DJLS does not use it to
+execute arbitrary settings code. Prefer explicit static configuration when
+possible.
 
 ## Options
 
@@ -56,7 +45,9 @@ If you prefer not to use an env file:
 
 Your Django settings module path (e.g., `"myproject.settings"`).
 
-The server uses this to introspect your Django project and provide template tag completions, diagnostics, and navigation. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
+The server uses this to statically introspect your Django project for template
+tag completions, diagnostics, and navigation. If not explicitly configured, the
+server reads the `DJANGO_SETTINGS_MODULE` environment variable.
 
 **When to configure:**
 
@@ -80,22 +71,29 @@ The server needs access to your virtual environment to discover installed Django
 
 **Default:** `[]` (empty list)
 
-Additional directories to add to Python's import search path when the inspector process runs. These paths are added to `PYTHONPATH` alongside the project root and any existing `PYTHONPATH` environment variable.
+Additional directories to add to the Python import search paths used for
+static project introspection. These paths are searched alongside the project
+root when DJLS resolves settings modules, installed apps, template tag
+libraries, and Python sources.
 
 **When to configure:**
 
 - Your project has a non-standard structure where Django code imports from directories outside the project root
 - You're working in a monorepo where Django imports shared packages from other directories
 - Your project depends on internal libraries in non-standard locations
-- You need to make additional packages importable for Django introspection
+- You need to make additional packages visible to static introspection
 
 ### `env_file`
 
 **Default:** `.env` in the project root (auto-detected, no error if missing)
 
-Path to an environment file (relative to the project root) whose variables are injected into the inspector subprocess.
+Path to an environment file (relative to the project root) whose variables are
+read during static project introspection.
 
-Many Django projects read secrets and configuration from environment variables at settings load time. When the editor is launched from a desktop environment rather than a terminal, those variables aren't available and the inspector fails. This option tells the server to read a `.env` file and forward the variables to the inspector process, so Django settings load correctly without duplicating secrets into config files.
+Many Django projects keep local configuration in `.env` files. DJLS parses the
+configured file and records the variables with the project state used by static
+analysis. It does not execute Django settings with those variables and does not
+modify the language server process environment.
 
 If no `env_file` is configured, the server looks for a `.env` file in the project root automatically. If the file doesn't exist, nothing happens. When `env_file` is set explicitly and the file is missing, a warning is logged.
 
@@ -171,13 +169,13 @@ Map diagnostic codes or prefixes to severity levels. Supports:
     S108 = "warning" # New
     ```
 
-*Tag Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
+*Tag Scoping (requires complete [static knowledge](../template-validation.md#static-knowledge-availability)):*
 
 - `S108` - Unknown tag (not found in any active library)
 - `S109` - Unloaded tag (requires `{% load %}` for a specific library)
 - `S110` - Ambiguous unloaded tag (defined in multiple libraries)
 
-*Filter Scoping (requires [inspector](../template-validation.md#inspector-availability)):*
+*Filter Scoping (requires complete [static knowledge](../template-validation.md#static-knowledge-availability)):*
 
 - `S111` - Unknown filter (not found in any active library)
 - `S112` - Unloaded filter (requires `{% load %}` for a specific library)
@@ -193,9 +191,9 @@ Map diagnostic codes or prefixes to severity levels. Supports:
 
 - `S117` - Tag argument rule violation (e.g., wrong number of arguments, missing required keyword)
 
-*Library Resolution (requires [inspector](../template-validation.md#inspector-availability)):*
+*Library Resolution (requires complete [static knowledge](../template-validation.md#static-knowledge-availability)):*
 
-- `S120` - Unknown template tag library (not found in inspector inventory)
+- `S120` - Unknown template tag library (not found among known template tag libraries)
 
 *Extends Validation:*
 

--- a/tests/project/djls_app/templates/djls_app/tags/scoping.html
+++ b/tests/project/djls_app/templates/djls_app/tags/scoping.html
@@ -1,4 +1,4 @@
-{# Scoping diagnostics — requires Python runtime (inspector inventory) #}
+{# Scoping diagnostics — requires static project introspection #}
 {# Load resolution is position-aware: {% load %} only affects what comes AFTER it. #}
 
 


### PR DESCRIPTION
## Summary

Removes stale documentation that still referred to the deleted runtime inspector path while keeping normal introspection language where it is still accurate.

- Replaces Python subprocess / inspector process wording with static introspection language.
- Updates configuration docs so environment variables, `pythonpath`, and `env_file` are described as static discovery inputs.
- Updates the scoping fixture comment to remove the old Python runtime / inspector inventory requirement.

## Validation

- `just fmt`
- `just clippy --allow-dirty`
- `just lint`
- Style check: `rg -n "\\bDJLS\\b|does not start|doesn't start|not forwarded|django\\.setup|PYTHONPATH|can'tmay" docs/configuration/index.md docs/clients/sublime-text.md CONTRIBUTING.md tests/project/djls_app/templates/djls_app/tags/scoping.html`
  - No hits in the touched docs for the overcorrected wording or shorthand.