### PR TITLE
Report startup stages as independent progress

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -1089,7 +1089,7 @@ def my_filter(value, arg):
         let project = Project::bootstrap(&db, root.as_path(), &settings);
         db.project = Some(project);
 
-        let refresh = djls_project::compute_refresh(&db).expect("project refresh data");
+        let refresh = djls_project::compute_refresh(&db, |_| {}).expect("project refresh data");
         let file_paths: Vec<_> = refresh.file_paths().to_vec();
         assert!(!file_paths.is_empty());
         djls_project::apply_refresh(&mut db, refresh);
@@ -1112,7 +1112,7 @@ def my_filter(value, arg):
             .collect();
         assert!(!root_revisions.is_empty());
 
-        let refresh = djls_project::compute_refresh(&db).expect("project refresh data");
+        let refresh = djls_project::compute_refresh(&db, |_| {}).expect("project refresh data");
         djls_project::apply_refresh(&mut db, refresh);
 
         let unchanged_file_revisions: Vec<_> = file_paths

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -85,6 +85,7 @@ pub use symbols::TemplateLibrary;
 pub use symbols::TemplateSymbol;
 pub use symbols::TemplateSymbolKind;
 pub use sync::RefreshData;
+pub use sync::RefreshStage;
 pub use sync::apply_refresh;
 pub use sync::compute_refresh;
 pub use sync::refresh_external_data;

--- a/crates/djls-project/src/sync.rs
+++ b/crates/djls-project/src/sync.rs
@@ -21,7 +21,7 @@ use crate::settings::settings_source_files;
 /// into the `Project` input, then lets tracked semantic queries handle editor
 /// file contents and downstream derivations.
 pub fn refresh_external_data(db: &mut dyn ProjectDb) {
-    let Some(refresh) = compute_refresh(db) else {
+    let Some(refresh) = compute_refresh(db, |_| {}) else {
         return;
     };
     apply_refresh(db, refresh);
@@ -40,8 +40,35 @@ impl RefreshData {
     }
 }
 
-pub fn compute_refresh(db: &dyn ProjectDb) -> Option<RefreshData> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RefreshStage {
+    ResolveEnvironment,
+    ScanSettings,
+    DiscoverModelModules,
+    DiscoverTemplateLibraries,
+    DiscoverTemplateTagCandidates,
+}
+
+impl RefreshStage {
+    #[must_use]
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::ResolveEnvironment => "Resolving environment",
+            Self::ScanSettings => "Scanning settings",
+            Self::DiscoverModelModules => "Discovering model modules",
+            Self::DiscoverTemplateLibraries => "Discovering template libraries",
+            Self::DiscoverTemplateTagCandidates => "Discovering template tag candidates",
+        }
+    }
+}
+
+pub fn compute_refresh(
+    db: &dyn ProjectDb,
+    mut report_stage: impl FnMut(RefreshStage),
+) -> Option<RefreshData> {
     let project = db.project()?;
+
+    report_stage(RefreshStage::ResolveEnvironment);
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         project.root(db),
@@ -49,22 +76,27 @@ pub fn compute_refresh(db: &dyn ProjectDb) -> Option<RefreshData> {
         project.pythonpath(db),
     );
 
+    report_stage(RefreshStage::ScanSettings);
     let mut file_paths: Vec<_> = settings_source_files(db, project)
         .into_iter()
         .map(|file| file.path(db).to_path_buf())
         .collect();
 
+    report_stage(RefreshStage::DiscoverModelModules);
     file_paths.extend(
         model_modules(db, project)
             .iter()
             .map(|module| module.path().to_path_buf()),
     );
 
+    report_stage(RefreshStage::DiscoverTemplateLibraries);
     file_paths.extend(
         templatetag_modules(db, project)
             .iter()
             .map(|module| module.path().to_path_buf()),
     );
+
+    report_stage(RefreshStage::DiscoverTemplateTagCandidates);
     file_paths.extend(templatetag_candidate_paths(db, project));
 
     file_paths.sort();

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -714,8 +714,21 @@ fn compute_and_apply_refresh_discovers_site_packages_created_after_bootstrap() {
         "from django.db import models\nclass VenvArticle(models.Model):\n    pass\n",
     );
 
-    let refresh = compute_refresh(&db).expect("project should be configured");
+    let mut stages = Vec::new();
+    let refresh =
+        compute_refresh(&db, |stage| stages.push(stage)).expect("project should be configured");
     apply_refresh(&mut db, refresh);
+
+    assert_eq!(
+        stages,
+        vec![
+            RefreshStage::ResolveEnvironment,
+            RefreshStage::ScanSettings,
+            RefreshStage::DiscoverModelModules,
+            RefreshStage::DiscoverTemplateLibraries,
+            RefreshStage::DiscoverTemplateTagCandidates,
+        ]
+    );
 
     assert!(project.search_paths(&db).iter().any(|search_path| {
         search_path.path() == Utf8Path::new("/project/.venv/lib/python3.12/site-packages")

--- a/crates/djls-server/src/progress.rs
+++ b/crates/djls-server/src/progress.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types;
@@ -7,9 +8,17 @@ use tower_lsp_server::ls_types::notification::Progress as ProgressNotification;
 
 use crate::client::ClientInfo;
 
+const CREATE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
+
 static NEXT_PROGRESS_TOKEN: AtomicU64 = AtomicU64::new(1);
 
-pub(crate) struct LoadProgress {
+#[derive(Clone)]
+pub(crate) struct ProgressReporter {
+    client: Client,
+    info: ClientInfo,
+}
+
+pub(crate) struct ProgressItem {
     title: String,
     state: Option<ProgressState>,
 }
@@ -22,16 +31,17 @@ enum ProgressState {
     Log,
 }
 
-impl LoadProgress {
-    pub(crate) async fn begin(client: Client, info: &ClientInfo, title: &str) -> Self {
+impl ProgressReporter {
+    pub(crate) fn new(client: Client, info: ClientInfo) -> Self {
+        Self { client, info }
+    }
+
+    pub(crate) async fn begin(&self, title: &str) -> ProgressItem {
         let title = title.to_string();
 
-        if !info.supports_work_done_progress() {
+        if !self.info.supports_work_done_progress() {
             tracing::info!("{title}");
-            return Self {
-                title,
-                state: Some(ProgressState::Log),
-            };
+            return ProgressItem::log(title);
         }
 
         let token = ls_types::ProgressToken::String(format!(
@@ -41,27 +51,53 @@ impl LoadProgress {
             NEXT_PROGRESS_TOKEN.fetch_add(1, Ordering::Relaxed)
         ));
 
-        // This awaits the client's response, gating the (sequential) refresh
-        // queue on it. tower-lsp-server requests have no timeout, so a client
-        // that advertises the capability but never answers would stall the
-        // refresh — accepted because clients answer create requests
-        // immediately, and a hung client breaks far more than progress.
-        match client.create_work_done_progress(token.clone()).await {
-            Ok(()) => {
-                send_begin(&client, token.clone(), title.clone()).await;
-                Self {
+        let (created_tx, created_rx) = tokio::sync::oneshot::channel();
+        let create_client = self.client.clone();
+        let create_token = token.clone();
+        tokio::spawn(async move {
+            let result = create_client.create_work_done_progress(create_token).await;
+            let _ = created_tx.send(result);
+        });
+
+        match tokio::time::timeout(CREATE_PROGRESS_TIMEOUT, created_rx).await {
+            Ok(Ok(Ok(()))) => {
+                send_begin(&self.client, token.clone(), title.clone()).await;
+                ProgressItem {
                     title,
-                    state: Some(ProgressState::Lsp { client, token }),
+                    state: Some(ProgressState::Lsp {
+                        client: self.client.clone(),
+                        token,
+                    }),
                 }
             }
-            Err(error) => {
-                tracing::debug!(?error, "Falling back to log-only project load progress");
+            Ok(Ok(Err(error))) => {
+                tracing::debug!(?error, title, "Falling back to log-only progress");
                 tracing::info!("{title}");
-                Self {
-                    title,
-                    state: Some(ProgressState::Log),
-                }
+                ProgressItem::log(title)
             }
+            Ok(Err(_)) => {
+                tracing::debug!(title, "Progress creation task was cancelled");
+                tracing::info!("{title}");
+                ProgressItem::log(title)
+            }
+            Err(_) => {
+                tracing::debug!(
+                    title,
+                    timeout_ms = CREATE_PROGRESS_TIMEOUT.as_millis(),
+                    "Timed out creating work-done progress; falling back to log-only progress"
+                );
+                tracing::info!("{title}");
+                ProgressItem::log(title)
+            }
+        }
+    }
+}
+
+impl ProgressItem {
+    fn log(title: String) -> Self {
+        Self {
+            title,
+            state: Some(ProgressState::Log),
         }
     }
 
@@ -89,14 +125,15 @@ impl LoadProgress {
     }
 }
 
-impl Drop for LoadProgress {
+impl Drop for ProgressItem {
     fn drop(&mut self) {
         let Some(ProgressState::Lsp { client, token }) = self.state.take() else {
             return;
         };
 
-        // Drop without finish() means the refresh future itself was dropped
-        // (cancellation or unwind), not a normal supersede.
+        // Only LSP items that sent Begin owe the client an End. Drop without
+        // finish() means the refresh future itself was dropped (cancellation or
+        // unwind), not a normal supersede.
         tokio::spawn(async move {
             send_end(&client, token, Some("cancelled".to_string())).await;
         });

--- a/crates/djls-server/src/refresh.rs
+++ b/crates/djls-server/src/refresh.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use djls_conf::Settings;
 use djls_project::Db as ProjectDb;
 use djls_project::RefreshData;
+use djls_project::RefreshStage;
 use djls_project::apply_refresh;
 use djls_project::compute_refresh;
 use djls_project::project_template_files;
@@ -23,7 +24,8 @@ use tower_lsp_server::ls_types;
 use crate::client::ClientInfo;
 use crate::document::TextDocument;
 use crate::ext::UriExt;
-use crate::progress::LoadProgress;
+use crate::progress::ProgressItem;
+use crate::progress::ProgressReporter;
 use crate::session::ProjectRefreshState;
 use crate::session::SNAPSHOT_CANCEL_RETRIES;
 use crate::session::Session;
@@ -54,13 +56,6 @@ pub(crate) enum ProjectRefreshReason {
 }
 
 impl ProjectRefreshReason {
-    fn progress_title(self) -> &'static str {
-        match self {
-            Self::Startup => "Loading Django project",
-            Self::ConfigurationChanged => "Refreshing Django project",
-        }
-    }
-
     fn completion_log(self) -> &'static str {
         match self {
             Self::Startup => "Server initialization completed",
@@ -95,18 +90,18 @@ impl ProjectRefreshRequest {
     }
 }
 
+const RESOLVE_ENVIRONMENT_TITLE: &str = "Resolving Django environment";
+const DISCOVER_PROJECT_FACTS_TITLE: &str = "Discovering Django project facts";
+const WARM_CACHES_TITLE: &str = "Warming Django caches";
+const PUBLISH_DIAGNOSTICS_TITLE: &str = "Publishing diagnostics";
+
 pub(crate) async fn run_project_refresh(
     session: Arc<Mutex<Session>>,
     client: Client,
     request: ProjectRefreshRequest,
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
-    let progress = LoadProgress::begin(
-        client.clone(),
-        &request.client_info,
-        request.reason.progress_title(),
-    )
-    .await;
+    let progress = ProgressReporter::new(client.clone(), request.client_info.clone());
     let result = run_project_refresh_inner(
         session,
         client,
@@ -116,21 +111,6 @@ pub(crate) async fn run_project_refresh(
         request.epoch,
     )
     .await;
-
-    match &result {
-        Ok(RefreshOutcome::Complete) => {
-            progress.finish("complete").await;
-        }
-        Ok(RefreshOutcome::Skipped) => {
-            progress.finish("skipped").await;
-        }
-        Ok(RefreshOutcome::Superseded) => {
-            progress.finish("superseded").await;
-        }
-        Err(_) => {
-            progress.finish("failed").await;
-        }
-    }
 
     if result.is_ok() {
         tracing::info!(
@@ -148,7 +128,7 @@ async fn run_project_refresh_inner(
     client: Client,
     project_refresh: &ProjectRefreshState,
     diagnostic_publish_lock: Arc<Mutex<()>>,
-    progress: &LoadProgress,
+    progress: &ProgressReporter,
     epoch: u64,
 ) -> anyhow::Result<RefreshOutcome> {
     if project_refresh.is_stale(epoch) {
@@ -159,36 +139,32 @@ async fn run_project_refresh_inner(
         return Ok(RefreshOutcome::Superseded);
     }
 
-    progress.report("Resolving environment").await;
-
-    let settings = match load_project_settings(&session, project_refresh, epoch).await {
-        LoadOutcome::Loaded(settings) => *settings,
-        LoadOutcome::Skipped => return Ok(RefreshOutcome::Skipped),
-        LoadOutcome::Superseded => return Ok(RefreshOutcome::Superseded),
-    };
-
-    if project_refresh.is_stale(epoch) {
-        tracing::debug!(
-            epoch,
-            "Skipping stale project refresh before settings apply"
-        );
-        return Ok(RefreshOutcome::Superseded);
+    // Start visible progress before touching the session. Clients often send
+    // didOpen/completion immediately after initialized; progress setup should
+    // not sit behind a session snapshot in that race.
+    let mut environment_progress = Some(progress.begin(RESOLVE_ENVIRONMENT_TITLE).await);
+    if let Some(progress) = environment_progress.as_ref() {
+        progress.report("Resolving environment").await;
     }
 
-    progress.report("Applying project settings").await;
-
-    if let Err(outcome) = apply_project_settings(&session, project_refresh, epoch, settings).await {
+    if let Err(outcome) =
+        load_and_apply_project_settings(&session, project_refresh, epoch, &mut environment_progress)
+            .await
+    {
         return Ok(outcome);
     }
 
-    if project_refresh.is_stale(epoch) {
-        tracing::debug!(epoch, "Skipping stale project refresh after settings apply");
-        return Ok(RefreshOutcome::Superseded);
-    }
-
-    progress.report("Computing project facts").await;
-
-    let refresh = match compute_project_refresh(&session, project_refresh, epoch).await {
+    let mut facts_progress = None;
+    let refresh = match compute_project_refresh(
+        &session,
+        project_refresh,
+        epoch,
+        progress,
+        &mut environment_progress,
+        &mut facts_progress,
+    )
+    .await
+    {
         ComputeOutcome::Computed(refresh) => refresh,
         ComputeOutcome::Skipped => return Ok(RefreshOutcome::Skipped),
         ComputeOutcome::Superseded => return Ok(RefreshOutcome::Superseded),
@@ -196,26 +172,47 @@ async fn run_project_refresh_inner(
 
     if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh before apply");
+        finish_progress(&mut facts_progress, "superseded").await;
         return Ok(RefreshOutcome::Superseded);
     }
 
-    progress.report("Applying project facts").await;
+    if facts_progress.is_none() {
+        facts_progress = Some(progress.begin(DISCOVER_PROJECT_FACTS_TITLE).await);
+    }
+    if let Some(progress) = facts_progress.as_ref() {
+        progress.report("Applying project facts").await;
+    }
 
     let (snapshot, documents) =
         match apply_project_facts(&session, project_refresh, epoch, refresh).await {
-            Ok(snapshot) => snapshot,
-            Err(outcome) => return Ok(outcome),
+            Ok(snapshot) => {
+                finish_progress(&mut facts_progress, "complete").await;
+                snapshot
+            }
+            Err(outcome) => {
+                finish_progress(&mut facts_progress, outcome.progress_message()).await;
+                return Ok(outcome);
+            }
         };
 
-    progress.report("Warming caches").await;
-    warm_project_queries(snapshot.clone(), project_refresh.clone(), epoch).await;
+    let warm_progress = progress.begin(WARM_CACHES_TITLE).await;
+    warm_project_queries(
+        snapshot.clone(),
+        project_refresh.clone(),
+        epoch,
+        &warm_progress,
+    )
+    .await;
 
     if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh after warm-up");
+        warm_progress.finish("superseded").await;
         return Ok(RefreshOutcome::Superseded);
     }
+    warm_progress.finish("complete").await;
 
-    progress.report("Publishing diagnostics").await;
+    let diagnostics_progress = progress.begin(PUBLISH_DIAGNOSTICS_TITLE).await;
+    diagnostics_progress.report("Publishing diagnostics").await;
     if !republish_snapshot_diagnostics(
         client,
         snapshot,
@@ -226,10 +223,67 @@ async fn run_project_refresh_inner(
     )
     .await
     {
+        diagnostics_progress.finish("superseded").await;
         return Ok(RefreshOutcome::Superseded);
     }
+    diagnostics_progress.finish("complete").await;
 
     Ok(RefreshOutcome::Complete)
+}
+
+impl RefreshOutcome {
+    fn progress_message(&self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Skipped => "skipped",
+            Self::Superseded => "superseded",
+        }
+    }
+}
+
+async fn load_and_apply_project_settings(
+    session: &Arc<Mutex<Session>>,
+    project_refresh: &ProjectRefreshState,
+    epoch: u64,
+    progress: &mut Option<ProgressItem>,
+) -> Result<(), RefreshOutcome> {
+    let settings = match load_project_settings(session, project_refresh, epoch).await {
+        LoadOutcome::Loaded(settings) => *settings,
+        LoadOutcome::Skipped => {
+            finish_progress(progress, "skipped").await;
+            return Err(RefreshOutcome::Skipped);
+        }
+        LoadOutcome::Superseded => {
+            finish_progress(progress, "superseded").await;
+            return Err(RefreshOutcome::Superseded);
+        }
+    };
+
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(
+            epoch,
+            "Skipping stale project refresh before settings apply"
+        );
+        finish_progress(progress, "superseded").await;
+        return Err(RefreshOutcome::Superseded);
+    }
+
+    if let Some(progress) = progress.as_ref() {
+        progress.report("Applying project settings").await;
+    }
+
+    if let Err(outcome) = apply_project_settings(session, project_refresh, epoch, settings).await {
+        finish_progress(progress, outcome.progress_message()).await;
+        return Err(outcome);
+    }
+
+    if project_refresh.is_stale(epoch) {
+        tracing::debug!(epoch, "Skipping stale project refresh after settings apply");
+        finish_progress(progress, "superseded").await;
+        return Err(RefreshOutcome::Superseded);
+    }
+
+    Ok(())
 }
 
 async fn apply_project_settings(
@@ -337,6 +391,9 @@ async fn compute_project_refresh(
     session: &Arc<Mutex<Session>>,
     project_refresh: &ProjectRefreshState,
     epoch: u64,
+    progress: &ProgressReporter,
+    environment_progress: &mut Option<ProgressItem>,
+    facts_progress: &mut Option<ProgressItem>,
 ) -> ComputeOutcome {
     // Cancellation here usually means a document edit, not a config change:
     // nothing bumps the epoch or resubmits, so dropping the compute would lose
@@ -350,6 +407,8 @@ async fn compute_project_refresh(
                     epoch,
                     "Skipping stale project refresh after locking session"
                 );
+                finish_progress(environment_progress, "superseded").await;
+                finish_progress(facts_progress, "superseded").await;
                 return ComputeOutcome::Superseded;
             }
 
@@ -357,19 +416,58 @@ async fn compute_project_refresh(
             db.project().map(|_| db.clone())
         }) else {
             tracing::info!("Task: No project configured, skipping initialization.");
+            finish_progress(environment_progress, "skipped").await;
+            finish_progress(facts_progress, "skipped").await;
             return ComputeOutcome::Skipped;
         };
 
-        let result = tokio::task::spawn_blocking(move || {
-            salsa::Cancelled::catch(AssertUnwindSafe(|| compute_refresh(&compute_db)))
-        })
-        .await
-        .expect("project refresh compute task must not panic");
+        let (stage_tx, mut stage_rx) = tokio::sync::mpsc::unbounded_channel::<RefreshStage>();
+        let mut task = tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(AssertUnwindSafe(|| {
+                compute_refresh(&compute_db, |stage| {
+                    let _ = stage_tx.send(stage);
+                })
+            }))
+        });
+
+        let result = loop {
+            tokio::select! {
+                maybe_stage = stage_rx.recv() => {
+                    if let Some(stage) = maybe_stage {
+                        report_refresh_stage(
+                            stage,
+                            progress,
+                            environment_progress,
+                            facts_progress,
+                        )
+                        .await;
+                    } else {
+                        break task.await.expect("project refresh compute task must not panic");
+                    }
+                }
+                result = &mut task => {
+                    break result.expect("project refresh compute task must not panic");
+                }
+            }
+        };
+
+        while let Ok(stage) = stage_rx.try_recv() {
+            report_refresh_stage(stage, progress, environment_progress, facts_progress).await;
+        }
 
         match result {
-            Ok(Some(refresh)) => return ComputeOutcome::Computed(refresh),
-            Ok(None) => return ComputeOutcome::Skipped,
+            Ok(Some(refresh)) => {
+                finish_progress(environment_progress, "complete").await;
+                return ComputeOutcome::Computed(refresh);
+            }
+            Ok(None) => {
+                finish_progress(environment_progress, "skipped").await;
+                finish_progress(facts_progress, "skipped").await;
+                return ComputeOutcome::Skipped;
+            }
             Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
+                finish_progress(environment_progress, "retrying").await;
+                finish_progress(facts_progress, "retrying").await;
                 tracing::debug!(
                     ?cancelled,
                     attempt = attempt + 1,
@@ -377,6 +475,8 @@ async fn compute_project_refresh(
                 );
             }
             Err(cancelled) => {
+                finish_progress(environment_progress, "cancelled").await;
+                finish_progress(facts_progress, "cancelled").await;
                 tracing::warn!(
                     ?cancelled,
                     retries = SNAPSHOT_CANCEL_RETRIES,
@@ -390,12 +490,68 @@ async fn compute_project_refresh(
     unreachable!("project refresh retry loop must return")
 }
 
+async fn report_refresh_stage(
+    stage: RefreshStage,
+    reporter: &ProgressReporter,
+    environment_progress: &mut Option<ProgressItem>,
+    facts_progress: &mut Option<ProgressItem>,
+) {
+    match stage {
+        RefreshStage::ResolveEnvironment | RefreshStage::ScanSettings => {
+            if environment_progress.is_none() {
+                *environment_progress = Some(reporter.begin(RESOLVE_ENVIRONMENT_TITLE).await);
+            }
+            if let Some(progress) = environment_progress.as_ref() {
+                progress.report(stage.message()).await;
+            }
+        }
+        RefreshStage::DiscoverModelModules
+        | RefreshStage::DiscoverTemplateLibraries
+        | RefreshStage::DiscoverTemplateTagCandidates => {
+            finish_progress(environment_progress, "complete").await;
+            if facts_progress.is_none() {
+                *facts_progress = Some(reporter.begin(DISCOVER_PROJECT_FACTS_TITLE).await);
+            }
+            if let Some(progress) = facts_progress.as_ref() {
+                progress.report(stage.message()).await;
+            }
+        }
+    }
+}
+
+async fn finish_progress(progress: &mut Option<ProgressItem>, message: &str) {
+    if let Some(progress) = progress.take() {
+        progress.finish(message).await;
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WarmStage {
+    BuildTagSpecs,
+    ResolveTemplateDirs,
+    IndexTemplateLibraries,
+    IndexTemplates,
+}
+
+impl WarmStage {
+    fn message(self) -> &'static str {
+        match self {
+            Self::BuildTagSpecs => "Building tag specs",
+            Self::ResolveTemplateDirs => "Resolving template directories",
+            Self::IndexTemplateLibraries => "Indexing template libraries",
+            Self::IndexTemplates => "Indexing templates",
+        }
+    }
+}
+
 async fn warm_project_queries(
     snapshot: SessionSnapshot,
     project_refresh: ProjectRefreshState,
     epoch: u64,
+    progress: &ProgressItem,
 ) {
-    let result = tokio::task::spawn_blocking(move || {
+    let (stage_tx, mut stage_rx) = tokio::sync::mpsc::unbounded_channel::<WarmStage>();
+    let mut task = tokio::task::spawn_blocking(move || {
         salsa::Cancelled::catch(AssertUnwindSafe(|| {
             let db = snapshot.db();
             let Some(project) = db.project() else {
@@ -405,26 +561,47 @@ async fn warm_project_queries(
             if project_refresh.is_stale(epoch) {
                 return;
             }
+            let _ = stage_tx.send(WarmStage::BuildTagSpecs);
             let _ = db.tag_specs();
 
             if project_refresh.is_stale(epoch) {
                 return;
             }
+            let _ = stage_tx.send(WarmStage::ResolveTemplateDirs);
             let _ = db.template_dirs();
 
             if project_refresh.is_stale(epoch) {
                 return;
             }
+            let _ = stage_tx.send(WarmStage::IndexTemplateLibraries);
             let _ = db.template_libraries();
 
             if project_refresh.is_stale(epoch) {
                 return;
             }
+            let _ = stage_tx.send(WarmStage::IndexTemplates);
             let _ = project_template_files(db, project);
         }))
-    })
-    .await
-    .expect("project warm-up task must not panic");
+    });
+
+    let result = loop {
+        tokio::select! {
+            maybe_stage = stage_rx.recv() => {
+                if let Some(stage) = maybe_stage {
+                    progress.report(stage.message()).await;
+                } else {
+                    break task.await.expect("project warm-up task must not panic");
+                }
+            }
+            result = &mut task => {
+                break result.expect("project warm-up task must not panic");
+            }
+        }
+    };
+
+    while let Ok(stage) = stage_rx.try_recv() {
+        progress.report(stage.message()).await;
+    }
 
     if let Err(cancelled) = result {
         tracing::debug!(

--- a/tests/e2e/test_startup.py
+++ b/tests/e2e/test_startup.py
@@ -14,6 +14,12 @@ from .conftest import TEST_WORKSPACE
 from .utils import position_after
 
 BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+EXPECTED_STARTUP_PROGRESS_TITLES = {
+    "Resolving Django environment",
+    "Discovering Django project facts",
+    "Warming Django caches",
+    "Publishing diagnostics",
+}
 
 
 @pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
@@ -71,24 +77,38 @@ async def wait_for_log_message(client: LanguageClient, prefix: str) -> None:
         )
 
 
-async def wait_for_progress_events(
+async def wait_for_progress_titles(
     client: LanguageClient,
-) -> list[
-    types.WorkDoneProgressBegin
-    | types.WorkDoneProgressReport
-    | types.WorkDoneProgressEnd
-]:
-    def events() -> list[
+    expected_titles: set[str],
+) -> dict[
+    object,
+    list[
         types.WorkDoneProgressBegin
         | types.WorkDoneProgressReport
         | types.WorkDoneProgressEnd
-    ]:
-        return [event for events in client.progress_reports.values() for event in events]
+    ],
+]:
+    def completed_titles() -> set[str]:
+        titles = set()
+        for events in client.progress_reports.values():
+            begin = next(
+                (
+                    event
+                    for event in events
+                    if isinstance(event, types.WorkDoneProgressBegin)
+                ),
+                None,
+            )
+            if begin is None:
+                continue
+            if any(isinstance(event, types.WorkDoneProgressEnd) for event in events):
+                titles.add(begin.title)
+        return titles
 
-    while not any(event.kind == "end" for event in events()):
+    while not expected_titles <= completed_titles():
         await asyncio.wait_for(client.wait_for_notification(types.PROGRESS), timeout=5)
 
-    return events()
+    return client.progress_reports
 
 
 @pytest.mark.asyncio
@@ -108,7 +128,7 @@ async def test_initialize_returns_protocol_capabilities_without_project_loading(
 async def test_server_accepts_template_requests_after_startup_load(
     startup_client: LanguageClient,
 ):
-    await wait_for_progress_events(startup_client)
+    await wait_for_progress_titles(startup_client, EXPECTED_STARTUP_PROGRESS_TITLES)
 
     startup_client.text_document_did_open(
         types.DidOpenTextDocumentParams(
@@ -135,31 +155,84 @@ async def test_server_accepts_template_requests_after_startup_load(
 async def test_supported_client_receives_startup_progress_begin_report_end(
     startup_client: LanguageClient,
 ):
-    events = await wait_for_progress_events(startup_client)
-
-    assert startup_client.progress_reports, "window/workDoneProgress/create was not observed"
-    assert [event.kind for event in events][0] == "begin"
-    assert any(event.kind == "report" for event in events)
-    assert [event.kind for event in events][-1] == "end"
-    assert any(
-        isinstance(event, types.WorkDoneProgressBegin)
-        and event.title == "Loading Django project"
-        for event in events
+    progress_reports = await wait_for_progress_titles(
+        startup_client,
+        EXPECTED_STARTUP_PROGRESS_TITLES,
     )
+    events = [event for events in progress_reports.values() for event in events]
+
+    assert progress_reports, "window/workDoneProgress/create was not observed"
+    assert len(progress_reports) >= 2
+    assert any(event.kind == "report" for event in events)
+
+    titles_by_token = {}
+    for token, token_events in progress_reports.items():
+        begin_index = next(
+            (
+                index
+                for index, event in enumerate(token_events)
+                if isinstance(event, types.WorkDoneProgressBegin)
+            ),
+            None,
+        )
+        if begin_index is None:
+            continue
+        end_index = next(
+            (
+                index
+                for index, event in enumerate(token_events)
+                if isinstance(event, types.WorkDoneProgressEnd)
+            ),
+            None,
+        )
+        assert end_index is not None
+        assert begin_index < end_index
+        titles_by_token[token] = token_events[begin_index].title
+
+    observed_titles = set(titles_by_token.values())
+    assert EXPECTED_STARTUP_PROGRESS_TITLES <= observed_titles
+    assert "Loading Django project" not in observed_titles
+
+    report_messages = [
+        event.message
+        for event in events
+        if isinstance(event, types.WorkDoneProgressReport)
+    ]
+    for expected in [
+        "Resolving environment",
+        "Scanning settings",
+        "Discovering model modules",
+        "Discovering template libraries",
+        "Discovering template tag candidates",
+        "Applying project facts",
+        "Building tag specs",
+        "Resolving template directories",
+        "Indexing template libraries",
+        "Indexing templates",
+        "Publishing diagnostics",
+    ]:
+        assert expected in report_messages
 
 
 @pytest.mark.asyncio
 async def test_unsupported_client_receives_log_fallback(
     no_progress_client: LanguageClient,
 ):
-    await wait_for_log_message(no_progress_client, "Loading Django project")
+    await wait_for_log_message(no_progress_client, "Resolving Django environment")
     await wait_for_log_message(no_progress_client, "Server initialization completed")
 
     messages = [message.message for message in no_progress_client.log_messages]
 
     assert not no_progress_client.progress_reports
-    assert "Loading Django project" in messages
+    for expected in EXPECTED_STARTUP_PROGRESS_TITLES:
+        assert expected in messages
     assert any(
-        message.startswith("Loading Django project: Warming caches")
+        message.startswith(
+            "Discovering Django project facts: Discovering template libraries"
+        )
+        for message in messages
+    )
+    assert any(
+        message.startswith("Warming Django caches: Indexing templates")
         for message in messages
     )


### PR DESCRIPTION
## Summary
- split startup refresh into independent work-done progress items
- report refresh/warm-up stages through per-stage progress tokens and log fallback
- add RA-style follow-up plans for parallel refresh, counted progress, and durable status

## Validation
- cargo test -q -p djls-server
- just fmt --check
- just e2e tests/e2e/test_startup.py
- cargo clippy --all-targets --all-features --benches -- -D warnings
- cargo test -q