### PR TITLE
Publish durable server status

### DIFF
--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -7,6 +7,7 @@ mod queue;
 mod refresh;
 mod server;
 mod session;
+mod status;
 mod workspace;
 
 use std::io::IsTerminal;

--- a/crates/djls-server/src/refresh.rs
+++ b/crates/djls-server/src/refresh.rs
@@ -38,23 +38,40 @@ use crate::session::ProjectRefreshState;
 use crate::session::SNAPSHOT_CANCEL_RETRIES;
 use crate::session::Session;
 use crate::session::SessionSnapshot;
+use crate::status::ServerStatusHealth;
+use crate::status::ServerStatusNotification;
+use crate::status::ServerStatusParams;
 
 enum RefreshOutcome {
     Complete,
-    Skipped,
+    NoProjectConfigured,
     Superseded,
+    Failed(anyhow::Error),
+}
+
+impl RefreshOutcome {
+    fn progress_message(&self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::NoProjectConfigured => "skipped",
+            Self::Superseded => "superseded",
+            Self::Failed(_) => "failed",
+        }
+    }
 }
 
 enum LoadOutcome {
     Loaded(Box<Settings>),
-    Skipped,
+    NoProjectConfigured,
     Superseded,
+    Failed(anyhow::Error),
 }
 
 enum ComputeOutcome {
     Computed(RefreshData),
-    Skipped,
+    NoProjectConfigured,
     Superseded,
+    Failed(anyhow::Error),
 }
 
 enum CaptureOutcome {
@@ -62,7 +79,7 @@ enum CaptureOutcome {
         db: DjangoDatabase,
         project: Project,
     },
-    Skipped,
+    NoProjectConfigured,
     Superseded,
 }
 
@@ -121,7 +138,7 @@ pub(crate) async fn run_project_refresh(
     let progress = ProgressReporter::new(client.clone(), request.client_info.clone());
     let result = run_project_refresh_inner(
         session,
-        client,
+        client.clone(),
         &request.project_refresh,
         request.diagnostic_publish_lock,
         &progress,
@@ -129,7 +146,7 @@ pub(crate) async fn run_project_refresh(
     )
     .await;
 
-    if result.is_ok() {
+    if !matches!(&result, RefreshOutcome::Failed(_)) {
         tracing::info!(
             "{} in {:?}",
             request.reason.completion_log(),
@@ -137,7 +154,39 @@ pub(crate) async fn run_project_refresh(
         );
     }
 
-    result.map(|_| ())
+    match result {
+        RefreshOutcome::Complete => {
+            client
+                .send_notification::<ServerStatusNotification>(ServerStatusParams {
+                    health: ServerStatusHealth::Ok,
+                    quiescent: true,
+                    message: "Ready".to_string(),
+                })
+                .await;
+            Ok(())
+        }
+        RefreshOutcome::NoProjectConfigured => {
+            client
+                .send_notification::<ServerStatusNotification>(ServerStatusParams {
+                    health: ServerStatusHealth::Warning,
+                    quiescent: true,
+                    message: "No Django project configured".to_string(),
+                })
+                .await;
+            Ok(())
+        }
+        RefreshOutcome::Superseded => Ok(()),
+        RefreshOutcome::Failed(error) => {
+            client
+                .send_notification::<ServerStatusNotification>(ServerStatusParams {
+                    health: ServerStatusHealth::Error,
+                    quiescent: true,
+                    message: format!("Project refresh failed: {error}"),
+                })
+                .await;
+            Err(error)
+        }
+    }
 }
 
 async fn run_project_refresh_inner(
@@ -147,13 +196,13 @@ async fn run_project_refresh_inner(
     diagnostic_publish_lock: Arc<Mutex<()>>,
     progress: &ProgressReporter,
     epoch: u64,
-) -> anyhow::Result<RefreshOutcome> {
+) -> RefreshOutcome {
     if project_refresh.is_stale(epoch) {
         tracing::debug!(
             epoch,
             "Skipping stale project refresh before locking session"
         );
-        return Ok(RefreshOutcome::Superseded);
+        return RefreshOutcome::Superseded;
     }
 
     // Start visible progress before touching the session. Clients often send
@@ -168,7 +217,7 @@ async fn run_project_refresh_inner(
         load_and_apply_project_settings(&session, project_refresh, epoch, &mut environment_progress)
             .await
     {
-        return Ok(outcome);
+        return outcome;
     }
 
     let mut facts_progress = None;
@@ -183,14 +232,15 @@ async fn run_project_refresh_inner(
     .await
     {
         ComputeOutcome::Computed(refresh) => refresh,
-        ComputeOutcome::Skipped => return Ok(RefreshOutcome::Skipped),
-        ComputeOutcome::Superseded => return Ok(RefreshOutcome::Superseded),
+        ComputeOutcome::NoProjectConfigured => return RefreshOutcome::NoProjectConfigured,
+        ComputeOutcome::Superseded => return RefreshOutcome::Superseded,
+        ComputeOutcome::Failed(error) => return RefreshOutcome::Failed(error),
     };
 
     if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh before apply");
         finish_progress(&mut facts_progress, "superseded").await;
-        return Ok(RefreshOutcome::Superseded);
+        return RefreshOutcome::Superseded;
     }
 
     if facts_progress.is_none() {
@@ -208,13 +258,13 @@ async fn run_project_refresh_inner(
             }
             Err(outcome) => {
                 finish_progress(&mut facts_progress, outcome.progress_message()).await;
-                return Ok(outcome);
+                return outcome;
             }
         };
 
     if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh before warm-up");
-        return Ok(RefreshOutcome::Superseded);
+        return RefreshOutcome::Superseded;
     }
 
     let warm_progress = progress.begin(WARM_CACHES_TITLE).await;
@@ -229,20 +279,18 @@ async fn run_project_refresh_inner(
     if project_refresh.is_stale(epoch) {
         tracing::debug!(epoch, "Skipping stale project refresh after warm-up");
         warm_progress.finish("superseded").await;
-        return Ok(RefreshOutcome::Superseded);
+        return RefreshOutcome::Superseded;
     }
     warm_progress.finish(warm_outcome.progress_message()).await;
 
     let diagnostics_progress = progress.begin(PUBLISH_DIAGNOSTICS_TITLE).await;
     diagnostics_progress.report("Publishing diagnostics").await;
+    let units = CountUnits {
+        singular: "diagnostics document",
+        plural: "diagnostics documents",
+    };
     diagnostics_progress
-        .report(&count_message(
-            documents.len(),
-            CountUnits {
-                singular: "diagnostics document",
-                plural: "diagnostics documents",
-            },
-        ))
+        .report(&count_message(documents.len(), units))
         .await;
     if !republish_snapshot_diagnostics(
         client,
@@ -255,21 +303,11 @@ async fn run_project_refresh_inner(
     .await
     {
         diagnostics_progress.finish("superseded").await;
-        return Ok(RefreshOutcome::Superseded);
+        return RefreshOutcome::Superseded;
     }
     diagnostics_progress.finish("complete").await;
 
-    Ok(RefreshOutcome::Complete)
-}
-
-impl RefreshOutcome {
-    fn progress_message(&self) -> &'static str {
-        match self {
-            Self::Complete => "complete",
-            Self::Skipped => "skipped",
-            Self::Superseded => "superseded",
-        }
-    }
+    RefreshOutcome::Complete
 }
 
 async fn load_and_apply_project_settings(
@@ -280,13 +318,17 @@ async fn load_and_apply_project_settings(
 ) -> Result<(), RefreshOutcome> {
     let settings = match load_project_settings(session, project_refresh, epoch).await {
         LoadOutcome::Loaded(settings) => *settings,
-        LoadOutcome::Skipped => {
+        LoadOutcome::NoProjectConfigured => {
             finish_progress(progress, "skipped").await;
-            return Err(RefreshOutcome::Skipped);
+            return Err(RefreshOutcome::NoProjectConfigured);
         }
         LoadOutcome::Superseded => {
             finish_progress(progress, "superseded").await;
             return Err(RefreshOutcome::Superseded);
+        }
+        LoadOutcome::Failed(error) => {
+            finish_progress(progress, "failed").await;
+            return Err(RefreshOutcome::Failed(error));
         }
     };
 
@@ -334,7 +376,7 @@ async fn apply_project_settings(
 
     let db = session_lock.db_mut();
     if db.project().is_none() {
-        return Err(RefreshOutcome::Skipped);
+        return Err(RefreshOutcome::NoProjectConfigured);
     }
 
     db.apply_project_settings(settings);
@@ -355,7 +397,7 @@ async fn apply_project_facts(
 
     let db = session_lock.db_mut();
     if db.project().is_none() {
-        return Err(RefreshOutcome::Skipped);
+        return Err(RefreshOutcome::NoProjectConfigured);
     }
 
     let t = std::time::Instant::now();
@@ -394,7 +436,7 @@ async fn load_project_settings(
         })
     }) else {
         tracing::info!("Task: No project configured, skipping settings load.");
-        return LoadOutcome::Skipped;
+        return LoadOutcome::NoProjectConfigured;
     };
 
     let settings =
@@ -406,7 +448,7 @@ async fn load_project_settings(
         Ok(settings) => settings,
         Err(err) => {
             tracing::error!("Error loading settings: {}", err);
-            return LoadOutcome::Skipped;
+            return LoadOutcome::Failed(err.into());
         }
     };
 
@@ -452,10 +494,10 @@ async fn compute_project_refresh(
         let (compute_db, project) = match capture_refresh_db(session, project_refresh, epoch).await
         {
             CaptureOutcome::Captured { db, project } => (db, project),
-            CaptureOutcome::Skipped => {
+            CaptureOutcome::NoProjectConfigured => {
                 finish_progress(environment_progress, "skipped").await;
                 finish_progress(facts_progress, "skipped").await;
-                return ComputeOutcome::Skipped;
+                return ComputeOutcome::NoProjectConfigured;
             }
             CaptureOutcome::Superseded => {
                 finish_progress(environment_progress, "superseded").await;
@@ -510,7 +552,9 @@ async fn compute_project_refresh(
                     retries = SNAPSHOT_CANCEL_RETRIES,
                     "Project refresh compute cancelled repeatedly; project facts may be stale until the next refresh"
                 );
-                return ComputeOutcome::Skipped;
+                return ComputeOutcome::Failed(anyhow::anyhow!(
+                    "project refresh compute cancelled after {SNAPSHOT_CANCEL_RETRIES} retries"
+                ));
             }
         }
     }
@@ -535,7 +579,7 @@ async fn capture_refresh_db(
     let db = session_lock.db();
     let Some(project) = db.project() else {
         tracing::info!("Task: No project configured, skipping initialization.");
-        return CaptureOutcome::Skipped;
+        return CaptureOutcome::NoProjectConfigured;
     };
 
     CaptureOutcome::Captured {
@@ -1232,7 +1276,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn project_settings_load_error_skips_refresh_inputs() {
+    async fn project_settings_load_error_fails_refresh() {
         let tempdir = tempdir().unwrap();
         let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
         std::fs::write(
@@ -1255,6 +1299,6 @@ mod tests {
 
         let outcome = load_project_settings(&session, &project_refresh, epoch).await;
 
-        assert!(matches!(outcome, LoadOutcome::Skipped));
+        assert!(matches!(outcome, LoadOutcome::Failed(_)));
     }
 }

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -17,6 +17,9 @@ use crate::refresh;
 use crate::session::SNAPSHOT_CANCEL_RETRIES;
 use crate::session::Session;
 use crate::session::SessionSnapshot;
+use crate::status::ServerStatusHealth;
+use crate::status::ServerStatusNotification;
+use crate::status::ServerStatusParams;
 
 pub(crate) struct DjangoLanguageServer {
     client: Client,
@@ -120,6 +123,18 @@ impl DjangoLanguageServer {
             reason,
         );
 
+        let message = match reason {
+            refresh::ProjectRefreshReason::Startup => "Loading Django project",
+            refresh::ProjectRefreshReason::ConfigurationChanged => "Refreshing Django project",
+        };
+        self.client
+            .send_notification::<ServerStatusNotification>(ServerStatusParams {
+                health: ServerStatusHealth::Ok,
+                quiescent: false,
+                message: message.to_string(),
+            })
+            .await;
+
         let submit_result = self
             .queue
             .submit(async move { refresh::run_project_refresh(session, client, request).await })
@@ -131,6 +146,13 @@ impl DjangoLanguageServer {
             }
             Err(e) => {
                 tracing::error!("Failed to submit task: {}", e);
+                self.client
+                    .send_notification::<ServerStatusNotification>(ServerStatusParams {
+                        health: ServerStatusHealth::Error,
+                        quiescent: true,
+                        message: format!("Project refresh failed: {e}"),
+                    })
+                    .await;
             }
         }
     }

--- a/crates/djls-server/src/status.rs
+++ b/crates/djls-server/src/status.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+use serde::Serialize;
+use tower_lsp_server::ls_types::notification::Notification;
+
+pub(crate) struct ServerStatusNotification;
+
+impl Notification for ServerStatusNotification {
+    type Params = ServerStatusParams;
+    const METHOD: &'static str = "djls/serverStatus";
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct ServerStatusParams {
+    pub(crate) health: ServerStatusHealth,
+    pub(crate) quiescent: bool,
+    pub(crate) message: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ServerStatusHealth {
+    Ok,
+    Warning,
+    Error,
+}

--- a/tests/e2e/test_startup.py
+++ b/tests/e2e/test_startup.py
@@ -14,6 +14,7 @@ from .conftest import TEST_WORKSPACE
 from .utils import position_after
 
 BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+SERVER_STATUS = "djls/serverStatus"
 EXPECTED_STARTUP_PROGRESS_TITLES = {
     "Resolving Django environment",
     "Discovering Django project facts",
@@ -58,6 +59,18 @@ def has_counted_unit(messages: list[str], units: tuple[str, str]) -> bool:
 
 @pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
 async def startup_client(lsp_client: LanguageClient):
+    lsp_client.djls_server_statuses = []
+
+    @lsp_client.feature(SERVER_STATUS)
+    def server_status(client: LanguageClient, params):
+        client.djls_server_statuses.append(
+            {
+                "health": params.health,
+                "quiescent": params.quiescent,
+                "message": params.message,
+            }
+        )
+
     initialize_result = await lsp_client.initialize_session(
         types.InitializeParams(
             capabilities=client_capabilities("visual-studio-code"),
@@ -86,6 +99,18 @@ def no_progress_capabilities() -> types.ClientCapabilities:
 
 @pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
 async def no_progress_client(lsp_client: LanguageClient):
+    lsp_client.djls_server_statuses = []
+
+    @lsp_client.feature(SERVER_STATUS)
+    def server_status(client: LanguageClient, params):
+        client.djls_server_statuses.append(
+            {
+                "health": params.health,
+                "quiescent": params.quiescent,
+                "message": params.message,
+            }
+        )
+
     await lsp_client.initialize_session(
         types.InitializeParams(
             capabilities=no_progress_capabilities(),
@@ -93,6 +118,40 @@ async def no_progress_client(lsp_client: LanguageClient):
                 types.WorkspaceFolder(
                     uri=TEST_WORKSPACE.as_uri(),
                     name="test_project",
+                )
+            ],
+        )
+    )
+
+    yield lsp_client
+
+    await lsp_client.shutdown_session()
+
+
+@pytest_lsp.fixture(config=ClientServerConfig(server_command=SERVER_COMMAND))
+async def bad_settings_client(lsp_client: LanguageClient, tmp_path):
+    workspace = tmp_path / "bad_settings"
+    workspace.mkdir()
+    (workspace / "djls.toml").write_text("debug = not_a_boolean", encoding="utf-8")
+    lsp_client.djls_server_statuses = []
+
+    @lsp_client.feature(SERVER_STATUS)
+    def server_status(client: LanguageClient, params):
+        client.djls_server_statuses.append(
+            {
+                "health": params.health,
+                "quiescent": params.quiescent,
+                "message": params.message,
+            }
+        )
+
+    await lsp_client.initialize_session(
+        types.InitializeParams(
+            capabilities=client_capabilities("visual-studio-code"),
+            workspace_folders=[
+                types.WorkspaceFolder(
+                    uri=workspace.as_uri(),
+                    name="bad_settings",
                 )
             ],
         )
@@ -178,6 +237,82 @@ async def test_initialize_returns_protocol_capabilities_without_project_loading(
     assert capabilities.text_document_sync is not None
     assert capabilities.completion_provider is not None
     assert capabilities.diagnostic_provider is not None
+
+
+@pytest.mark.asyncio
+async def test_server_publishes_loading_and_ready_status(startup_client: LanguageClient):
+    while not any(
+        status.get("health") == "ok"
+        and status.get("quiescent") is True
+        and status.get("message") == "Ready"
+        for status in startup_client.djls_server_statuses
+    ):
+        await wait_for_notification(startup_client, SERVER_STATUS)
+
+    statuses = startup_client.djls_server_statuses
+    loading_index = next(
+        (
+            index
+            for index, status in enumerate(statuses)
+            if status.get("health") == "ok"
+            and status.get("quiescent") is False
+            and status.get("message") == "Loading Django project"
+        ),
+        None,
+    )
+    ready_index = next(
+        (
+            index
+            for index, status in enumerate(statuses)
+            if status.get("health") == "ok"
+            and status.get("quiescent") is True
+            and status.get("message") == "Ready"
+        ),
+        None,
+    )
+
+    assert loading_index is not None
+    assert ready_index is not None
+    assert loading_index < ready_index
+
+
+@pytest.mark.asyncio
+async def test_server_publishes_error_status_for_failed_refresh(
+    bad_settings_client: LanguageClient,
+):
+    while not any(
+        status.get("health") == "error"
+        and status.get("quiescent") is True
+        and str(status.get("message", "")).startswith("Project refresh failed")
+        for status in bad_settings_client.djls_server_statuses
+    ):
+        await wait_for_notification(bad_settings_client, SERVER_STATUS)
+
+    statuses = bad_settings_client.djls_server_statuses
+    loading_index = next(
+        (
+            index
+            for index, status in enumerate(statuses)
+            if status.get("health") == "ok"
+            and status.get("quiescent") is False
+            and status.get("message") == "Loading Django project"
+        ),
+        None,
+    )
+    error_index = next(
+        (
+            index
+            for index, status in enumerate(statuses)
+            if status.get("health") == "error"
+            and status.get("quiescent") is True
+            and str(status.get("message", "")).startswith("Project refresh failed")
+        ),
+        None,
+    )
+
+    assert loading_index is not None
+    assert error_index is not None
+    assert loading_index < error_index
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a typed `djls/serverStatus` notification with `health`, `quiescent`, and `message`
- publish non-quiescent status before queued refresh work and terminal ready/warning/error status from refresh outcomes
- treat settings-load failures as refresh failures so clients receive `health=error`
- cover ready and failed startup status order in e2e tests

## Tests
- cargo test -q -p djls-server
- just e2e tests/e2e/test_startup.py
- just fmt --check
- cargo clippy --all-targets --all-features --benches -- -D warnings
- cargo test -q
- just e2e
- just lint