### PR TITLE
Stabilize validation rendering benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,5 +49,5 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd
         with:
-          mode: instrumentation
+          mode: simulation
           run: cargo codspeed run -p djls-bench

--- a/crates/djls-bench/benches/diagnostics.rs
+++ b/crates/djls-bench/benches/diagnostics.rs
@@ -207,23 +207,21 @@ fn render_validation(bencher: Bencher) {
     let renderer = DiagnosticRenderer::plain();
 
     bencher.bench_local(move || {
-        let mut rendered_count = 0;
+        let mut rendered_bytes = 0;
         for fixture in &fixtures {
             for error in &fixture.check.validation_errors {
-                if djls_bench::render_validation_error(
+                if let Some(output) = djls_bench::render_validation_error(
                     fixture.source,
                     fixture.path,
                     error,
                     &config,
                     &renderer,
-                )
-                .is_some()
-                {
-                    rendered_count += 1;
+                ) {
+                    rendered_bytes += output.len();
                 }
             }
         }
-        divan::black_box(rendered_count);
+        divan::black_box(rendered_bytes);
     });
 }
 
@@ -242,22 +240,20 @@ fn render_validation_synthetic(bencher: Bencher) {
     let renderer = DiagnosticRenderer::plain();
 
     bencher.bench_local(move || {
-        let mut rendered_count = 0;
+        let mut rendered_bytes = 0;
         for _ in 0..DIAGNOSTICS_INNER_ITERS {
             for error in &check.validation_errors {
-                if djls_bench::render_validation_error(
+                if let Some(output) = djls_bench::render_validation_error(
                     MANY_ERRORS_SOURCE,
                     "bench.html",
                     error,
                     &config,
                     &renderer,
-                )
-                .is_some()
-                {
-                    rendered_count += 1;
+                ) {
+                    rendered_bytes += output.len();
                 }
             }
         }
-        divan::black_box(rendered_count);
+        divan::black_box(rendered_bytes);
     });
 }

--- a/crates/djls-bench/benches/diagnostics.rs
+++ b/crates/djls-bench/benches/diagnostics.rs
@@ -198,7 +198,7 @@ fn validation_render_fixture(fixture: &ValidationErrorFixture) -> ValidationRend
 }
 
 #[divan::bench]
-fn render_validation(bencher: Bencher) {
+fn render_validation_output(bencher: Bencher) {
     let fixtures: Vec<_> = validation_error_fixtures()
         .iter()
         .map(validation_render_fixture)
@@ -207,7 +207,7 @@ fn render_validation(bencher: Bencher) {
     let renderer = DiagnosticRenderer::plain();
 
     bencher.bench_local(move || {
-        let mut rendered_bytes = 0;
+        let mut rendered_count = 0;
         for fixture in &fixtures {
             for error in &fixture.check.validation_errors {
                 if let Some(output) = djls_bench::render_validation_error(
@@ -217,16 +217,17 @@ fn render_validation(bencher: Bencher) {
                     &config,
                     &renderer,
                 ) {
-                    rendered_bytes += output.len();
+                    divan::black_box_drop(output);
+                    rendered_count += 1;
                 }
             }
         }
-        divan::black_box(rendered_bytes);
+        divan::black_box(rendered_count);
     });
 }
 
 #[divan::bench]
-fn render_validation_synthetic(bencher: Bencher) {
+fn render_validation_synthetic_output(bencher: Bencher) {
     let mut db = realistic_db();
     let file = db.file_with_contents("bench.html", MANY_ERRORS_SOURCE);
 
@@ -240,7 +241,7 @@ fn render_validation_synthetic(bencher: Bencher) {
     let renderer = DiagnosticRenderer::plain();
 
     bencher.bench_local(move || {
-        let mut rendered_bytes = 0;
+        let mut rendered_count = 0;
         for _ in 0..DIAGNOSTICS_INNER_ITERS {
             for error in &check.validation_errors {
                 if let Some(output) = djls_bench::render_validation_error(
@@ -250,10 +251,11 @@ fn render_validation_synthetic(bencher: Bencher) {
                     &config,
                     &renderer,
                 ) {
-                    rendered_bytes += output.len();
+                    divan::black_box_drop(output);
+                    rendered_count += 1;
                 }
             }
         }
-        divan::black_box(rendered_bytes);
+        divan::black_box(rendered_count);
     });
 }


### PR DESCRIPTION
## Summary
- use CodSpeed simulation mode for hardware-agnostic benchmark runs
- consume rendered diagnostic output bytes in validation rendering benchmarks

Closes #650

## Validation
- just fmt --check
- cargo bench -p djls-bench --bench diagnostics render_validation -- --sample-count 10
- cargo test -p djls-bench