### PR TITLE
Unify opaque region computation with template tree

### DIFF
--- a/crates/djls-ide/src/folding.rs
+++ b/crates/djls-ide/src/folding.rs
@@ -30,6 +30,13 @@ pub fn collect_folding_ranges(
 #[derive(Default)]
 struct FoldSpans(Vec<FoldSpan>);
 
+struct FoldFrame {
+    opener_name: String,
+    opener_span: Span,
+    closer_name: Option<String>,
+    opaque: bool,
+}
+
 impl FoldSpans {
     fn collect(nodes: &[Node], source: &str, tag_index: &TagIndex) -> Self {
         let mut folds = Self::default();
@@ -39,33 +46,56 @@ impl FoldSpans {
     }
 
     fn collect_semantic(&mut self, nodes: &[Node], tag_index: &TagIndex) {
-        let mut stack = Vec::new();
+        let mut stack: Vec<FoldFrame> = Vec::new();
 
         for node in nodes {
             let Node::Tag { name, .. } = node else {
                 continue;
             };
 
+            if let Some(frame) = stack
+                .pop_if(|frame| frame.opaque && frame.closer_name.as_deref() == Some(name.as_str()))
+            {
+                self.push_bounds(
+                    frame.opener_span.start(),
+                    node.full_span().end(),
+                    FoldKind::from_semantic_tag_name(&frame.opener_name),
+                );
+                continue;
+            }
+            if stack.last().is_some_and(|frame| frame.opaque) {
+                continue;
+            }
+
+            if let Some(possible_openers) = tag_index.closer_openers(name)
+                && let Some(open_idx) = stack.iter().rposition(|frame| {
+                    possible_openers
+                        .iter()
+                        .any(|opener| opener == &frame.opener_name)
+                })
+            {
+                while stack.len() > open_idx + 1 {
+                    stack.pop();
+                }
+                let frame = stack.pop().expect("matched opener should remain on stack");
+                self.push_bounds(
+                    frame.opener_span.start(),
+                    node.full_span().end(),
+                    FoldKind::from_semantic_tag_name(&frame.opener_name),
+                );
+                continue;
+            }
+
             match tag_index.classify(name) {
                 TagClass::Opener => {
-                    stack.push((name.as_str(), node.full_span()));
+                    stack.push(FoldFrame {
+                        opener_name: name.clone(),
+                        opener_span: node.full_span(),
+                        closer_name: tag_index.closer_name(name).map(str::to_string),
+                        opaque: tag_index.is_opaque(name),
+                    });
                 }
-                TagClass::Closer { opener_name } => {
-                    let Some(open_idx) = stack
-                        .iter()
-                        .rposition(|(stacked_opener_name, _)| *stacked_opener_name == opener_name)
-                    else {
-                        continue;
-                    };
-
-                    let (matched_opener_name, opener_span) = stack.remove(open_idx);
-                    self.push_bounds(
-                        opener_span.start(),
-                        node.full_span().end(),
-                        FoldKind::from_semantic_tag_name(matched_opener_name),
-                    );
-                }
-                TagClass::Intermediate { .. } | TagClass::Unknown => {}
+                TagClass::Closer { .. } | TagClass::Intermediate { .. } | TagClass::Unknown => {}
             }
         }
     }

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -43,6 +43,7 @@ pub use tags::TagSpecs;
 pub use tags::builtin_tag_specs;
 pub use tags::compute_tag_specs;
 
+use crate::structure::opaque_regions_from_tree;
 use crate::validation::TemplateValidator;
 
 /// Validate a Django template file.
@@ -76,10 +77,10 @@ pub fn validate_nodelist(db: &dyn Db, nodelist: djls_templates::NodeList<'_>) {
     }
 
     // 1. Structural analysis accumulates block-structure diagnostics.
-    let _template_tree = build_template_tree(db, nodelist);
+    let template_tree = build_template_tree(db, nodelist);
 
     // 2. Perform all other validations in a single walk.
-    let opaque_regions = compute_opaque_regions(db, nodelist);
+    let opaque_regions = opaque_regions_from_tree(template_tree.regions(db));
     let validator = TemplateValidator::new(db, nodelist, &opaque_regions);
     validator.validate(nodes);
 }

--- a/crates/djls-semantic/src/structure.rs
+++ b/crates/djls-semantic/src/structure.rs
@@ -22,6 +22,7 @@ pub use crate::structure::grammar::TagIndex;
 pub use crate::structure::grammar::compute_tag_index;
 pub use crate::structure::opaque::OpaqueRegions;
 pub use crate::structure::opaque::compute_opaque_regions;
+pub(crate) use crate::structure::opaque::opaque_regions_from_tree;
 pub use crate::structure::outline::OutlineItem;
 pub use crate::structure::outline::OutlineKind;
 pub use crate::structure::outline::build_template_outline;

--- a/crates/djls-semantic/src/structure/builder.rs
+++ b/crates/djls-semantic/src/structure/builder.rs
@@ -111,16 +111,68 @@ impl<'db> TemplateTreeBuilder<'db> {
     }
 
     fn active_region(&self) -> RegionId {
-        self.stack
-            .last()
-            .map_or(self.root, |frame| frame.segment_body)
+        self.stack.last().map_or(self.root, |frame| match frame {
+            TreeFrame::Block(frame) => frame.segment_body,
+            TreeFrame::Opaque(frame) => frame.parent_region,
+        })
+    }
+
+    fn in_opaque_content(&self) -> bool {
+        matches!(self.stack.last(), Some(TreeFrame::Opaque(_)))
     }
 
     fn handle_tag(&mut self, name: &str, name_span: Span, bits: &[TagBit], span: Span) {
         let full_span = span.expand_template_tag_marker();
+        if self.close_active_opaque_if_closer(name, bits, span, full_span) {
+            return;
+        }
+        if self.in_opaque_content() {
+            return;
+        }
+
+        let matching_opener = self
+            .index
+            .closer_openers(name)
+            .and_then(|possible_openers| {
+                self.stack.iter().rev().find_map(|frame| {
+                    possible_openers
+                        .iter()
+                        .any(|opener| opener == frame.opener_name())
+                        .then(|| frame.opener_name().to_string())
+                })
+            });
+        if let Some(opener_name) = matching_opener {
+            self.close_block(name, &[opener_name], bits, span);
+            return;
+        }
+
+        if let Some(possible_openers) = self.index.intermediate_openers(name)
+            && self.active_block_accepts_intermediate(possible_openers)
+        {
+            self.add_intermediate(name, possible_openers, name_span, bits, span);
+            return;
+        }
+
         match self.index.classify(name) {
             TagClass::Opener => {
                 let parent = self.active_region();
+
+                if self.index.is_opaque(name) {
+                    self.stack.push(TreeFrame::Opaque(OpaqueFrame {
+                        opener_name: name.to_string(),
+                        closer_name: self
+                            .index
+                            .closer_name(name)
+                            .expect("opaque opener should have closer")
+                            .to_string(),
+                        name_span,
+                        bits: bits.to_vec(),
+                        opener_span: full_span,
+                        parent_region: parent,
+                        body_start: span.end().saturating_add(TagDelimiter::LENGTH_U32),
+                    }));
+                    return;
+                }
 
                 let container = self.alloc_region_id(span, Some(parent));
                 let segment = self.alloc_region_id(
@@ -151,88 +203,52 @@ impl<'db> TemplateTreeBuilder<'db> {
                     },
                 });
 
-                self.stack.push(TreeFrame {
+                self.stack.push(TreeFrame::Block(BlockFrame {
                     opener_name: name.to_string(),
                     opener_bits: bits.to_vec(),
                     opener_span: full_span,
                     container_body: container,
                     parent_region: parent,
                     segment_body: segment,
-                });
+                }));
             }
-            TagClass::Closer { opener_name } => {
-                self.close_block(name, opener_name, bits, span);
+            TagClass::Closer { possible_openers } => {
+                self.close_block(name, possible_openers, bits, span);
             }
             TagClass::Intermediate { possible_openers } => {
                 self.add_intermediate(name, possible_openers, name_span, bits, span);
             }
             TagClass::Unknown => {
-                self.ops.push(TreeOp::AddNode {
-                    target: self.active_region(),
-                    node: TemplateNode::StandaloneTag {
-                        tag: name.to_string(),
-                        name_span,
-                        bits: bits.to_vec(),
-                        full_span,
-                    },
-                });
+                self.add_standalone_tag(name, name_span, bits, full_span);
             }
         }
     }
 
-    fn close_block(
+    fn close_active_opaque_if_closer(
         &mut self,
         closer_name: &str,
-        opener_name: &str,
         closer_bits: &[TagBit],
         span: Span,
-    ) {
-        let full_span = span.expand_template_tag_marker();
-
-        let Some(frame_idx) = self
-            .stack
-            .iter()
-            .rposition(|frame| frame.opener_name == opener_name)
-        else {
-            self.ops.push(TreeOp::AccumulateDiagnostic(
-                ValidationError::OrphanedClosingTag {
-                    tag: closer_name.to_string(),
-                    expected_opener: opener_name.to_string(),
-                    span: full_span,
-                },
-            ));
-            return;
-        };
-
-        while self.stack.len() > frame_idx + 1 {
-            if let Some(unclosed) = self.stack.pop() {
-                self.ops
-                    .push(TreeOp::AccumulateDiagnostic(ValidationError::UnclosedTag {
-                        tag: unclosed.opener_name,
-                        span: unclosed.opener_span,
-                    }));
-            }
+        full_span: Span,
+    ) -> bool {
+        let should_close = matches!(
+            self.stack.last(),
+            Some(TreeFrame::Opaque(frame)) if frame.closer_name == closer_name
+        );
+        if !should_close {
+            return false;
         }
 
-        let frame = self.stack.pop().unwrap();
+        let Some(TreeFrame::Opaque(frame)) = self.stack.pop() else {
+            unreachable!("checked active opaque frame before pop")
+        };
+        let opener_name = frame.opener_name.clone();
         match self
             .index
-            .validate_close(opener_name, &frame.opener_bits, closer_bits)
+            .validate_close(&opener_name, &frame.bits, closer_bits)
         {
             CloseValidation::Valid => {
-                let content_end = span.start().saturating_sub(TagDelimiter::LENGTH_U32);
-                self.ops.push(TreeOp::FinalizeSpanTo {
-                    id: frame.segment_body,
-                    end: content_end,
-                });
-                self.ops.push(TreeOp::ExtendRegionSpan {
-                    id: frame.container_body,
-                    span: full_span,
-                });
-                self.ops.push(TreeOp::ExtendRegionSpan {
-                    id: frame.parent_region,
-                    span: full_span,
-                });
+                self.finalize_frame(TreeFrame::Opaque(frame), span, full_span);
             }
             CloseValidation::ArgumentMismatch { expected, got } => {
                 self.ops.push(TreeOp::AccumulateDiagnostic(
@@ -242,30 +258,153 @@ impl<'db> TemplateTreeBuilder<'db> {
                         span: full_span,
                     },
                 ));
-                let content_end = span.start().saturating_sub(TagDelimiter::LENGTH_U32);
+                self.finalize_frame(TreeFrame::Opaque(frame), span, full_span);
+            }
+            CloseValidation::NotABlock => {
+                self.ops.push(TreeOp::AccumulateDiagnostic(
+                    ValidationError::UnbalancedStructure {
+                        opening_tag: opener_name.clone(),
+                        expected_closing: opener_name,
+                        opening_span: frame.opener_span,
+                        closing_span: Some(full_span),
+                    },
+                ));
+                self.stack.push(TreeFrame::Opaque(frame));
+            }
+        }
+
+        true
+    }
+
+    fn active_block_accepts_intermediate(&self, possible_openers: &[String]) -> bool {
+        matches!(
+            self.stack.last(),
+            Some(TreeFrame::Block(frame)) if possible_openers.contains(&frame.opener_name)
+        )
+    }
+
+    fn add_standalone_tag(
+        &mut self,
+        tag_name: &str,
+        name_span: Span,
+        bits: &[TagBit],
+        full_span: Span,
+    ) {
+        self.ops.push(TreeOp::AddNode {
+            target: self.active_region(),
+            node: TemplateNode::StandaloneTag {
+                tag: tag_name.to_string(),
+                name_span,
+                bits: bits.to_vec(),
+                full_span,
+            },
+        });
+    }
+
+    fn close_block(
+        &mut self,
+        closer_name: &str,
+        possible_openers: &[String],
+        closer_bits: &[TagBit],
+        span: Span,
+    ) {
+        let full_span = span.expand_template_tag_marker();
+
+        let Some(frame_idx) = self.stack.iter().rposition(|frame| {
+            possible_openers
+                .iter()
+                .any(|opener| opener == frame.opener_name())
+        }) else {
+            self.ops.push(TreeOp::AccumulateDiagnostic(
+                ValidationError::OrphanedClosingTag {
+                    tag: closer_name.to_string(),
+                    expected_opener: possible_openers
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "matching opener".to_string()),
+                    span: full_span,
+                },
+            ));
+            return;
+        };
+
+        let opener_name = self.stack[frame_idx].opener_name().to_string();
+
+        while self.stack.len() > frame_idx + 1 {
+            if let Some(unclosed) = self.stack.pop() {
+                self.accumulate_unclosed(unclosed);
+            }
+        }
+
+        let frame = self.stack.pop().unwrap();
+        match self
+            .index
+            .validate_close(&opener_name, frame.opener_bits(), closer_bits)
+        {
+            CloseValidation::Valid => {
+                self.finalize_frame(frame, span, full_span);
+            }
+            CloseValidation::ArgumentMismatch { expected, got } => {
+                self.ops.push(TreeOp::AccumulateDiagnostic(
+                    ValidationError::UnmatchedBlockName {
+                        expected,
+                        got,
+                        span: full_span,
+                    },
+                ));
+                self.finalize_frame(frame, span, full_span);
+            }
+            CloseValidation::NotABlock => {
+                self.ops.push(TreeOp::AccumulateDiagnostic(
+                    ValidationError::UnbalancedStructure {
+                        opening_tag: opener_name.clone(),
+                        expected_closing: opener_name,
+                        opening_span: frame.opener_span(),
+                        closing_span: Some(full_span),
+                    },
+                ));
+                self.stack.push(frame);
+            }
+        }
+    }
+
+    fn finalize_frame(&mut self, frame: TreeFrame, closer_span: Span, closer_full_span: Span) {
+        match frame {
+            TreeFrame::Block(frame) => {
+                let content_end = closer_span.start().saturating_sub(TagDelimiter::LENGTH_U32);
                 self.ops.push(TreeOp::FinalizeSpanTo {
                     id: frame.segment_body,
                     end: content_end,
                 });
                 self.ops.push(TreeOp::ExtendRegionSpan {
                     id: frame.container_body,
-                    span: full_span,
+                    span: closer_full_span,
                 });
                 self.ops.push(TreeOp::ExtendRegionSpan {
                     id: frame.parent_region,
-                    span: full_span,
+                    span: closer_full_span,
                 });
             }
-            CloseValidation::NotABlock => {
-                self.ops.push(TreeOp::AccumulateDiagnostic(
-                    ValidationError::UnbalancedStructure {
-                        opening_tag: opener_name.to_string(),
-                        expected_closing: opener_name.to_string(),
-                        opening_span: frame.opener_span,
-                        closing_span: Some(full_span),
+            TreeFrame::Opaque(frame) => {
+                let body_end = closer_span.start().saturating_sub(TagDelimiter::LENGTH_U32);
+                let body_span = Span::saturating_from_bounds_usize(
+                    frame.body_start as usize,
+                    body_end as usize,
+                );
+                let full_span = Span::saturating_from_bounds_usize(
+                    frame.opener_span.start_usize(),
+                    closer_full_span.end_usize(),
+                );
+                self.ops.push(TreeOp::AddNode {
+                    target: frame.parent_region,
+                    node: TemplateNode::Opaque {
+                        tag: frame.opener_name,
+                        name_span: frame.name_span,
+                        bits: frame.bits,
+                        full_span,
+                        body_span,
                     },
-                ));
-                self.stack.push(frame);
+                });
             }
         }
     }
@@ -280,7 +419,7 @@ impl<'db> TemplateTreeBuilder<'db> {
     ) {
         let full_span = span.expand_template_tag_marker();
 
-        if let Some(frame) = self.stack.last() {
+        if let Some(TreeFrame::Block(frame)) = self.stack.last() {
             if possible_openers.contains(&frame.opener_name) {
                 let content_end = span.start().saturating_sub(TagDelimiter::LENGTH_U32);
                 let segment_to_finalize = frame.segment_body;
@@ -307,7 +446,9 @@ impl<'db> TemplateTreeBuilder<'db> {
                     },
                 });
 
-                self.stack.last_mut().unwrap().segment_body = new_segment_id;
+                if let Some(TreeFrame::Block(frame)) = self.stack.last_mut() {
+                    frame.segment_body = new_segment_id;
+                }
             } else {
                 self.accumulate_orphaned_intermediate(tag_name, possible_openers, full_span);
             }
@@ -332,19 +473,28 @@ impl<'db> TemplateTreeBuilder<'db> {
 
     fn finish(&mut self) {
         while let Some(frame) = self.stack.pop() {
-            if self.index.is_end_required(&frame.opener_name) {
-                self.ops
-                    .push(TreeOp::AccumulateDiagnostic(ValidationError::UnclosedTag {
-                        tag: frame.opener_name,
+            match frame {
+                TreeFrame::Opaque(_) => self.accumulate_unclosed(frame),
+                TreeFrame::Block(frame) if self.index.is_end_required(&frame.opener_name) => {
+                    self.accumulate_unclosed(TreeFrame::Block(frame));
+                }
+                TreeFrame::Block(frame) => {
+                    self.ops.push(TreeOp::ExtendRegionSpan {
+                        id: frame.container_body,
                         span: frame.opener_span,
-                    }));
-            } else {
-                self.ops.push(TreeOp::ExtendRegionSpan {
-                    id: frame.container_body,
-                    span: frame.opener_span,
-                });
+                    });
+                }
             }
         }
+    }
+
+    fn accumulate_unclosed(&mut self, frame: TreeFrame) {
+        let span = frame.opener_span();
+        self.ops
+            .push(TreeOp::AccumulateDiagnostic(ValidationError::UnclosedTag {
+                tag: frame.into_opener_name(),
+                span,
+            }));
     }
 }
 
@@ -378,7 +528,42 @@ fn describe_intermediate_parent(possible_openers: &[String]) -> String {
     }
 }
 
-struct TreeFrame {
+enum TreeFrame {
+    Block(BlockFrame),
+    Opaque(OpaqueFrame),
+}
+
+impl TreeFrame {
+    fn opener_name(&self) -> &str {
+        match self {
+            TreeFrame::Block(frame) => &frame.opener_name,
+            TreeFrame::Opaque(frame) => &frame.opener_name,
+        }
+    }
+
+    fn into_opener_name(self) -> String {
+        match self {
+            TreeFrame::Block(frame) => frame.opener_name,
+            TreeFrame::Opaque(frame) => frame.opener_name,
+        }
+    }
+
+    fn opener_bits(&self) -> &[TagBit] {
+        match self {
+            TreeFrame::Block(frame) => &frame.opener_bits,
+            TreeFrame::Opaque(frame) => &frame.bits,
+        }
+    }
+
+    fn opener_span(&self) -> Span {
+        match self {
+            TreeFrame::Block(frame) => frame.opener_span,
+            TreeFrame::Opaque(frame) => frame.opener_span,
+        }
+    }
+}
+
+struct BlockFrame {
     opener_name: String,
     opener_bits: Vec<TagBit>,
     opener_span: Span,
@@ -387,12 +572,26 @@ struct TreeFrame {
     segment_body: RegionId,
 }
 
+struct OpaqueFrame {
+    opener_name: String,
+    closer_name: String,
+    name_span: Span,
+    bits: Vec<TagBit>,
+    opener_span: Span,
+    parent_region: RegionId,
+    body_start: u32,
+}
+
 impl Visitor for TemplateTreeBuilder<'_> {
     fn visit_tag(&mut self, name: &str, name_span: Span, bits: &[TagBit], span: Span) {
         self.handle_tag(name, name_span, bits, span);
     }
 
     fn visit_comment(&mut self, _content: &str, span: Span) {
+        if self.in_opaque_content() {
+            return;
+        }
+
         self.ops.push(TreeOp::AddNode {
             target: self.active_region(),
             node: TemplateNode::Comment { span },
@@ -400,6 +599,10 @@ impl Visitor for TemplateTreeBuilder<'_> {
     }
 
     fn visit_variable(&mut self, var: &str, var_span: Span, filters: &[Filter], span: Span) {
+        if self.in_opaque_content() {
+            return;
+        }
+
         self.ops.push(TreeOp::AddNode {
             target: self.active_region(),
             node: TemplateNode::Variable {
@@ -412,6 +615,10 @@ impl Visitor for TemplateTreeBuilder<'_> {
     }
 
     fn visit_error(&mut self, span: Span, full_span: Span, _error: &ParseError) {
+        if self.in_opaque_content() {
+            return;
+        }
+
         self.ops.push(TreeOp::AddNode {
             target: self.active_region(),
             node: TemplateNode::Error { span, full_span },
@@ -419,6 +626,10 @@ impl Visitor for TemplateTreeBuilder<'_> {
     }
 
     fn visit_text(&mut self, span: Span) {
+        if self.in_opaque_content() {
+            return;
+        }
+
         self.ops.push(TreeOp::AddNode {
             target: self.active_region(),
             node: TemplateNode::Text { span },

--- a/crates/djls-semantic/src/structure/grammar.rs
+++ b/crates/djls-semantic/src/structure/grammar.rs
@@ -4,14 +4,6 @@ use rustc_hash::FxHashMap;
 use crate::db::Db;
 use crate::tags::TagSpecs;
 
-/// Role a tag plays in Django's block structure.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum TagGrammarRole {
-    Opener(EndMeta),
-    Closer { opener: String },
-    Intermediate { possible_openers: Vec<String> },
-}
-
 /// Compute the tag grammar index from tag specifications.
 #[salsa::tracked(returns(ref))]
 pub fn compute_tag_index(db: &dyn Db) -> TagIndex {
@@ -19,40 +11,66 @@ pub fn compute_tag_index(db: &dyn Db) -> TagIndex {
 }
 
 /// Index for tag grammar lookups.
-///
-/// Uses a single unified map from tag name to [`TagGrammarRole`], so every
-/// lookup (`classify`, `validate_close`, `is_end_required`) is a single
-/// hash probe instead of checking up to three separate maps.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TagIndex {
-    roles: FxHashMap<String, TagGrammarRole>,
+    openers: FxHashMap<String, OpenerMeta>,
+    closers: FxHashMap<String, Vec<String>>,
+    intermediates: FxHashMap<String, Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct EndMeta {
+pub(crate) struct OpenerMeta {
     required: bool,
+    opaque: bool,
+    closer: String,
 }
 
 impl TagIndex {
     #[must_use]
     pub fn classify(&self, tag_name: &str) -> TagClass<'_> {
-        match self.roles.get(tag_name) {
-            Some(TagGrammarRole::Opener(_)) => TagClass::Opener,
-            Some(TagGrammarRole::Closer { opener }) => TagClass::Closer {
-                opener_name: opener.as_str(),
-            },
-            Some(TagGrammarRole::Intermediate { possible_openers }) => TagClass::Intermediate {
+        if self.openers.contains_key(tag_name) {
+            TagClass::Opener
+        } else if let Some(possible_openers) = self.closers.get(tag_name) {
+            TagClass::Closer {
                 possible_openers: possible_openers.as_slice(),
-            },
-            None => TagClass::Unknown,
+            }
+        } else if let Some(possible_openers) = self.intermediates.get(tag_name) {
+            TagClass::Intermediate {
+                possible_openers: possible_openers.as_slice(),
+            }
+        } else {
+            TagClass::Unknown
         }
+    }
+
+    pub fn closer_openers(&self, closer_name: &str) -> Option<&[String]> {
+        self.closers.get(closer_name).map(Vec::as_slice)
+    }
+
+    pub(crate) fn intermediate_openers(&self, intermediate_name: &str) -> Option<&[String]> {
+        self.intermediates.get(intermediate_name).map(Vec::as_slice)
     }
 
     pub(crate) fn is_end_required(&self, opener_name: &str) -> bool {
         matches!(
-            self.roles.get(opener_name),
-            Some(TagGrammarRole::Opener(EndMeta { required: true }))
+            self.openers.get(opener_name),
+            Some(OpenerMeta { required: true, .. })
         )
+    }
+
+    #[must_use]
+    pub fn is_opaque(&self, opener_name: &str) -> bool {
+        matches!(
+            self.openers.get(opener_name),
+            Some(OpenerMeta { opaque: true, .. })
+        )
+    }
+
+    #[must_use]
+    pub fn closer_name(&self, opener_name: &str) -> Option<&str> {
+        self.openers
+            .get(opener_name)
+            .map(|OpenerMeta { closer, .. }| closer.as_str())
     }
 
     pub(crate) fn validate_close(
@@ -61,7 +79,7 @@ impl TagIndex {
         opener_bits: &[TagBit],
         closer_bits: &[TagBit],
     ) -> CloseValidation {
-        if !matches!(self.roles.get(opener_name), Some(TagGrammarRole::Opener(_))) {
+        if !self.openers.contains_key(opener_name) {
             return CloseValidation::NotABlock;
         }
 
@@ -83,38 +101,41 @@ impl TagIndex {
     /// Build a `TagIndex` from an explicit `TagSpecs` value.
     #[must_use]
     fn from_tag_specs(specs: &TagSpecs) -> Self {
-        let mut roles: FxHashMap<String, TagGrammarRole> = FxHashMap::default();
+        let mut openers: FxHashMap<String, OpenerMeta> = FxHashMap::default();
+        let mut closers: FxHashMap<String, Vec<String>> = FxHashMap::default();
+        let mut intermediates: FxHashMap<String, Vec<String>> = FxHashMap::default();
 
         for (name, spec) in specs {
             if let Some(end_tag) = &spec.end_tag {
-                let meta = EndMeta {
+                let closer = end_tag.name.as_ref().to_owned();
+                let meta = OpenerMeta {
                     required: end_tag.required,
+                    opaque: spec.opaque,
+                    closer: closer.clone(),
                 };
 
-                roles.insert(name.clone(), TagGrammarRole::Opener(meta));
-                roles.insert(
-                    end_tag.name.as_ref().to_owned(),
-                    TagGrammarRole::Closer {
-                        opener: name.clone(),
-                    },
-                );
+                openers.insert(name.clone(), meta);
+                closers
+                    .entry(closer)
+                    .and_modify(|possible_openers| possible_openers.push(name.clone()))
+                    .or_insert_with(|| vec![name.clone()]);
 
-                for inter in spec.intermediate_tags.iter() {
-                    roles
-                        .entry(inter.name.as_ref().to_owned())
-                        .and_modify(|role| {
-                            if let TagGrammarRole::Intermediate { possible_openers } = role {
-                                possible_openers.push(name.clone());
-                            }
-                        })
-                        .or_insert_with(|| TagGrammarRole::Intermediate {
-                            possible_openers: vec![name.clone()],
-                        });
+                if !spec.opaque {
+                    for inter in spec.intermediate_tags.iter() {
+                        intermediates
+                            .entry(inter.name.as_ref().to_owned())
+                            .and_modify(|possible_openers| possible_openers.push(name.clone()))
+                            .or_insert_with(|| vec![name.clone()]);
+                    }
                 }
             }
         }
 
-        Self { roles }
+        Self {
+            openers,
+            closers,
+            intermediates,
+        }
     }
 }
 
@@ -126,8 +147,8 @@ impl TagIndex {
 pub enum TagClass<'a> {
     /// This tag opens a block
     Opener,
-    /// This tag closes a block
-    Closer { opener_name: &'a str },
+    /// This tag closes one or more blocks
+    Closer { possible_openers: &'a [String] },
     /// This tag is an intermediate (elif, else, etc.)
     Intermediate { possible_openers: &'a [String] },
     /// Unknown tag - treat as leaf
@@ -210,20 +231,18 @@ mod tests {
         let specs = create_test_specs();
         let index = TagIndex::from_tag_specs(&specs);
 
-        assert_eq!(
-            index.classify("endif"),
-            TagClass::Closer { opener_name: "if" }
-        );
-        assert_eq!(
-            index.classify("endfor"),
-            TagClass::Closer { opener_name: "for" }
-        );
-        assert_eq!(
-            index.classify("endblock"),
-            TagClass::Closer {
-                opener_name: "block"
-            }
-        );
+        match index.classify("endif") {
+            TagClass::Closer { possible_openers } => assert_eq!(possible_openers, ["if"]),
+            tag_class => panic!("expected endif to classify as closer, got {tag_class:?}"),
+        }
+        match index.classify("endfor") {
+            TagClass::Closer { possible_openers } => assert_eq!(possible_openers, ["for"]),
+            tag_class => panic!("expected endfor to classify as closer, got {tag_class:?}"),
+        }
+        match index.classify("endblock") {
+            TagClass::Closer { possible_openers } => assert_eq!(possible_openers, ["block"]),
+            tag_class => panic!("expected endblock to classify as closer, got {tag_class:?}"),
+        }
         assert_eq!(index.classify("endnonexistent"), TagClass::Unknown);
     }
 
@@ -271,5 +290,77 @@ mod tests {
         assert!(index.is_end_required("block"));
         assert!(!index.is_end_required("csrf_token"));
         assert!(!index.is_end_required("nonexistent"));
+    }
+
+    #[test]
+    fn tracks_opaque_openers() {
+        let mut specs = FxHashMap::default();
+        specs.insert(
+            "opaque_if".to_string(),
+            TagSpec::new(
+                "test".into(),
+                Some(EndTag {
+                    name: "endopaque_if".into(),
+                    required: true,
+                }),
+                vec![IntermediateTag {
+                    name: "opaque_else".into(),
+                }]
+                .into(),
+                true,
+            ),
+        );
+
+        let index = TagIndex::from_tag_specs(&TagSpecs::new(specs));
+
+        assert_eq!(index.classify("opaque_if"), TagClass::Opener);
+        assert_eq!(index.classify("opaque_else"), TagClass::Unknown);
+        assert!(index.is_opaque("opaque_if"));
+    }
+
+    #[test]
+    fn opaque_openers_do_not_contribute_shared_intermediates() {
+        let mut specs = FxHashMap::default();
+        specs.insert(
+            "opaque_if".to_string(),
+            TagSpec::new(
+                "test".into(),
+                Some(EndTag {
+                    name: "endopaque_if".into(),
+                    required: true,
+                }),
+                vec![IntermediateTag {
+                    name: "shared_else".into(),
+                }]
+                .into(),
+                true,
+            ),
+        );
+        specs.insert(
+            "plain_if".to_string(),
+            TagSpec::new(
+                "test".into(),
+                Some(EndTag {
+                    name: "endplain_if".into(),
+                    required: true,
+                }),
+                vec![IntermediateTag {
+                    name: "shared_else".into(),
+                }]
+                .into(),
+                false,
+            ),
+        );
+
+        let index = TagIndex::from_tag_specs(&TagSpecs::new(specs));
+
+        match index.classify("shared_else") {
+            TagClass::Intermediate { possible_openers } => {
+                assert_eq!(possible_openers, ["plain_if"]);
+            }
+            tag_class => {
+                panic!("expected shared_else to classify as intermediate, got {tag_class:?}")
+            }
+        }
     }
 }

--- a/crates/djls-semantic/src/structure/opaque.rs
+++ b/crates/djls-semantic/src/structure/opaque.rs
@@ -53,50 +53,69 @@ pub fn compute_opaque_regions(db: &dyn Db, nodelist: NodeList<'_>) -> OpaqueRegi
     let tag_specs = db.tag_specs();
     let index = compute_tag_index(db);
     let mut spans = Vec::new();
-    let mut stack = Vec::new();
+    let mut stack: Vec<OpaqueFrame<'_>> = Vec::new();
 
     for node in nodelist.nodelist(db) {
         let Node::Tag { name, span, .. } = node else {
             continue;
         };
 
-        match index.classify(name) {
-            TagClass::Opener => {
-                let body_start = span.end().saturating_add(TagDelimiter::LENGTH_U32);
-                stack.push(OpaqueFrame {
-                    opener_name: name,
-                    segment_start: body_start,
-                    is_opaque: tag_specs.get(name).is_some_and(|spec| spec.opaque),
-                });
-            }
-            TagClass::Closer { opener_name } => {
-                let Some(frame_idx) = stack
-                    .iter()
-                    .rposition(|frame| frame.opener_name == opener_name)
-                else {
-                    continue;
-                };
-
-                while stack.len() > frame_idx + 1 {
-                    stack.pop();
-                }
-
+        if stack.last().is_some_and(|frame| frame.is_opaque) {
+            if stack
+                .last()
+                .is_some_and(|frame| frame.closer_name == name.as_str())
+            {
                 let Some(frame) = stack.pop() else {
                     continue;
                 };
                 push_opaque_segment(&frame, *span, &mut spans);
             }
-            TagClass::Intermediate { possible_openers } => {
-                if let Some(frame) = stack.last_mut()
-                    && possible_openers
-                        .iter()
-                        .any(|opener| opener == frame.opener_name)
-                {
-                    push_opaque_segment(frame, *span, &mut spans);
-                    frame.segment_start = span.end().saturating_add(TagDelimiter::LENGTH_U32);
-                }
+            continue;
+        }
+
+        if let Some(possible_openers) = index.closer_openers(name)
+            && let Some(frame_idx) = stack.iter().rposition(|frame| {
+                possible_openers
+                    .iter()
+                    .any(|opener| opener == frame.opener_name)
+            })
+        {
+            while stack.len() > frame_idx + 1 {
+                stack.pop();
             }
-            TagClass::Unknown => {}
+
+            let Some(frame) = stack.pop() else {
+                continue;
+            };
+            push_opaque_segment(&frame, *span, &mut spans);
+            continue;
+        }
+
+        if let Some(possible_openers) = index.intermediate_openers(name)
+            && let Some(frame) = stack.last_mut()
+            && possible_openers
+                .iter()
+                .any(|opener| opener == frame.opener_name)
+        {
+            push_opaque_segment(frame, *span, &mut spans);
+            frame.segment_start = span.end().saturating_add(TagDelimiter::LENGTH_U32);
+            continue;
+        }
+
+        match index.classify(name) {
+            TagClass::Opener => {
+                let Some(closer_name) = index.closer_name(name) else {
+                    continue;
+                };
+                let body_start = span.end().saturating_add(TagDelimiter::LENGTH_U32);
+                stack.push(OpaqueFrame {
+                    opener_name: name,
+                    closer_name,
+                    segment_start: body_start,
+                    is_opaque: tag_specs.get(name).is_some_and(|spec| spec.opaque),
+                });
+            }
+            TagClass::Closer { .. } | TagClass::Intermediate { .. } | TagClass::Unknown => {}
         }
     }
 
@@ -117,6 +136,7 @@ fn push_opaque_segment(frame: &OpaqueFrame<'_>, content_span: Span, spans: &mut 
 
 struct OpaqueFrame<'a> {
     opener_name: &'a str,
+    closer_name: &'a str,
     segment_start: u32,
     is_opaque: bool,
 }

--- a/crates/djls-semantic/src/structure/opaque.rs
+++ b/crates/djls-semantic/src/structure/opaque.rs
@@ -1,11 +1,11 @@
 use djls_source::Span;
-use djls_templates::Node;
 use djls_templates::NodeList;
-use djls_templates::TagDelimiter;
 
 use crate::db::Db;
-use crate::structure::grammar::TagClass;
-use crate::structure::grammar::compute_tag_index;
+use crate::structure::build_template_tree;
+use crate::structure::tree::Regions;
+use crate::structure::tree::TemplateNode;
+use crate::structure::tree::TemplateRegion;
 
 /// Sorted, non-overlapping byte-offset spans where validation should be skipped.
 ///
@@ -45,98 +45,26 @@ impl OpaqueRegions {
     }
 }
 
-/// Compute opaque regions for a template by scanning for opaque block tags.
-///
-/// This uses a lightweight source-order scan instead of building a full
-/// `TemplateTree`.
-pub fn compute_opaque_regions(db: &dyn Db, nodelist: NodeList<'_>) -> OpaqueRegions {
-    let tag_specs = db.tag_specs();
-    let index = compute_tag_index(db);
-    let mut spans = Vec::new();
-    let mut stack: Vec<OpaqueFrame<'_>> = Vec::new();
+/// Compute opaque regions for a template by projecting from the template tree.
+pub fn compute_opaque_regions<'db>(db: &'db dyn Db, nodelist: NodeList<'db>) -> OpaqueRegions {
+    let tree = build_template_tree(db, nodelist);
+    opaque_regions_from_tree(tree.regions(db))
+}
 
-    for node in nodelist.nodelist(db) {
-        let Node::Tag { name, span, .. } = node else {
-            continue;
-        };
-
-        if stack.last().is_some_and(|frame| frame.is_opaque) {
-            if stack
-                .last()
-                .is_some_and(|frame| frame.closer_name == name.as_str())
-            {
-                let Some(frame) = stack.pop() else {
-                    continue;
-                };
-                push_opaque_segment(&frame, *span, &mut spans);
-            }
-            continue;
-        }
-
-        if let Some(possible_openers) = index.closer_openers(name)
-            && let Some(frame_idx) = stack.iter().rposition(|frame| {
-                possible_openers
-                    .iter()
-                    .any(|opener| opener == frame.opener_name)
-            })
-        {
-            while stack.len() > frame_idx + 1 {
-                stack.pop();
-            }
-
-            let Some(frame) = stack.pop() else {
-                continue;
-            };
-            push_opaque_segment(&frame, *span, &mut spans);
-            continue;
-        }
-
-        if let Some(possible_openers) = index.intermediate_openers(name)
-            && let Some(frame) = stack.last_mut()
-            && possible_openers
-                .iter()
-                .any(|opener| opener == frame.opener_name)
-        {
-            push_opaque_segment(frame, *span, &mut spans);
-            frame.segment_start = span.end().saturating_add(TagDelimiter::LENGTH_U32);
-            continue;
-        }
-
-        match index.classify(name) {
-            TagClass::Opener => {
-                let Some(closer_name) = index.closer_name(name) else {
-                    continue;
-                };
-                let body_start = span.end().saturating_add(TagDelimiter::LENGTH_U32);
-                stack.push(OpaqueFrame {
-                    opener_name: name,
-                    closer_name,
-                    segment_start: body_start,
-                    is_opaque: tag_specs.get(name).is_some_and(|spec| spec.opaque),
-                });
-            }
-            TagClass::Closer { .. } | TagClass::Intermediate { .. } | TagClass::Unknown => {}
-        }
-    }
+pub(crate) fn opaque_regions_from_tree(regions: &Regions) -> OpaqueRegions {
+    let spans = regions
+        .iter()
+        .flat_map(TemplateRegion::nodes)
+        .filter_map(|node| match node {
+            TemplateNode::Opaque { body_span, .. } => Some(*body_span),
+            TemplateNode::Block { .. }
+            | TemplateNode::StandaloneTag { .. }
+            | TemplateNode::Variable { .. }
+            | TemplateNode::Comment { .. }
+            | TemplateNode::Text { .. }
+            | TemplateNode::Error { .. } => None,
+        })
+        .collect();
 
     OpaqueRegions::new(spans)
-}
-
-fn push_opaque_segment(frame: &OpaqueFrame<'_>, content_span: Span, spans: &mut Vec<Span>) {
-    if frame.is_opaque {
-        let content_end = content_span
-            .start()
-            .saturating_sub(TagDelimiter::LENGTH_U32);
-        spans.push(Span::saturating_from_bounds_usize(
-            frame.segment_start as usize,
-            content_end as usize,
-        ));
-    }
-}
-
-struct OpaqueFrame<'a> {
-    opener_name: &'a str,
-    closer_name: &'a str,
-    segment_start: u32,
-    is_opaque: bool,
 }

--- a/crates/djls-semantic/src/structure/outline.rs
+++ b/crates/djls-semantic/src/structure/outline.rs
@@ -258,8 +258,9 @@ fn outline_items_for_node(
                 })
                 .collect(),
         }],
-        TemplateNode::Comment { .. } | TemplateNode::Text { .. } | TemplateNode::Error { .. } => {
-            Vec::new()
-        }
+        TemplateNode::Opaque { .. }
+        | TemplateNode::Comment { .. }
+        | TemplateNode::Text { .. }
+        | TemplateNode::Error { .. } => Vec::new(),
     }
 }

--- a/crates/djls-semantic/src/structure/tree.rs
+++ b/crates/djls-semantic/src/structure/tree.rs
@@ -166,6 +166,14 @@ pub enum TemplateNode {
         body: RegionId,
         role: BlockRole,
     },
+    /// A paired opaque tag whose body is raw bytes with no internal structure.
+    Opaque {
+        tag: String,
+        name_span: Span,
+        bits: Vec<TagBit>,
+        full_span: Span,
+        body_span: Span,
+    },
     StandaloneTag {
         tag: String,
         name_span: Span,
@@ -194,6 +202,7 @@ impl TemplateNode {
     fn span(&self) -> Span {
         match self {
             TemplateNode::Block { full_span, .. }
+            | TemplateNode::Opaque { full_span, .. }
             | TemplateNode::StandaloneTag { full_span, .. }
             | TemplateNode::Error { full_span, .. } => *full_span,
             TemplateNode::Variable { span, .. }

--- a/crates/djls-semantic/tests/snapshots/validation__snapshot_multiple_error_types.snap
+++ b/crates/djls-semantic/tests/snapshots/validation__snapshot_multiple_error_types.snap
@@ -17,11 +17,6 @@ error[S116]: Filter 'lower' does not accept an argument
   |
 3 | {{ text|lower:"arg" }}
   |         ^^^^^^^^^^^
-error[S100]: Unclosed 'if' tag
- --> test.html:4:14
-  |
-4 | {% comment %}{% if and %}{% endcomment %}
-  |              ^^^^^^^^^^^^
 error[S115]: Filter 'truncatewords' requires an argument
  --> test.html:5:11
   |

--- a/crates/djls-semantic/tests/structure_opaque.rs
+++ b/crates/djls-semantic/tests/structure_opaque.rs
@@ -3,6 +3,9 @@ use djls_semantic::EndTag;
 use djls_semantic::IntermediateTag;
 use djls_semantic::OpaqueRegions;
 use djls_semantic::TagSpec;
+use djls_semantic::ValidationError;
+use djls_semantic::ValidationErrorAccumulator;
+use djls_semantic::build_template_tree;
 use djls_semantic::builtin_tag_specs;
 use djls_semantic::compute_opaque_regions;
 use djls_source::Span;
@@ -18,7 +21,7 @@ fn compute_regions(db: &TestDatabase, source: &str) -> OpaqueRegions {
 }
 
 #[test]
-fn opaque_intermediate_segments_are_opaque() {
+fn opaque_opener_treats_intermediate_as_raw_content() {
     let mut specs = builtin_tag_specs();
     specs.insert(
         "opaque_if".to_string(),
@@ -43,8 +46,13 @@ fn opaque_intermediate_segments_are_opaque() {
     let nodelist = parse_template(&db, file).expect("should parse");
     let regions = compute_opaque_regions(&db, nodelist);
     let first = u32::try_from(source.find("first").unwrap()).unwrap();
+    let opaque_else = u32::try_from(source.find("{% opaque_else %}").unwrap()).unwrap();
+    let opaque_else_last = opaque_else + u32::try_from("{% opaque_else %}".len()).unwrap() - 1;
     let second = u32::try_from(source.find("second").unwrap()).unwrap();
+
     assert!(regions.is_opaque(first));
+    assert!(regions.is_opaque(opaque_else));
+    assert!(regions.is_opaque(opaque_else_last));
     assert!(regions.is_opaque(second));
 }
 
@@ -124,6 +132,25 @@ fn test_non_opaque_block_no_region() {
         regions.is_empty(),
         "if block should NOT produce an opaque region"
     );
+}
+
+#[test]
+fn unclosed_opaque_block_creates_no_region() {
+    let db = TestDatabase::new();
+    let path = "test.html";
+    let source = "{% verbatim %}body";
+    db.add_file(path, source);
+    let file = db.get_or_create_file(Utf8Path::new(path));
+    let nodelist = parse_template(&db, file).expect("should parse");
+    let regions = compute_opaque_regions(&db, nodelist);
+    let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist);
+    let body = u32::try_from(source.find("body").unwrap()).unwrap();
+
+    assert!(!regions.is_opaque(body));
+    assert!(errors.iter().any(|error| matches!(
+        &error.0,
+        ValidationError::UnclosedTag { tag, .. } if tag == "verbatim"
+    )));
 }
 
 #[test]

--- a/crates/djls-semantic/tests/structure_opaque.rs
+++ b/crates/djls-semantic/tests/structure_opaque.rs
@@ -127,6 +127,18 @@ fn test_non_opaque_block_no_region() {
 }
 
 #[test]
+fn outer_closer_inside_opaque_content_does_not_end_outer_block() {
+    let db = TestDatabase::new();
+    let source = "{% if outer %}{% verbatim %}{% endif %}body{% endverbatim %}{% endif %}";
+    let regions = compute_regions(&db, source);
+    let raw_closer = u32::try_from(source.find("{% endif %}").unwrap()).unwrap();
+    let body = u32::try_from(source.find("body").unwrap()).unwrap();
+
+    assert!(regions.is_opaque(raw_closer));
+    assert!(regions.is_opaque(body));
+}
+
+#[test]
 fn test_content_after_verbatim_not_opaque() {
     let db = TestDatabase::new();
     let source = "{% verbatim %}opaque{% endverbatim %}after";

--- a/crates/djls-semantic/tests/structure_tree.rs
+++ b/crates/djls-semantic/tests/structure_tree.rs
@@ -65,6 +65,13 @@ enum NodeSnapshot {
         body: u32,
         role: String,
     },
+    Opaque {
+        tag: String,
+        name_span: djls_source::Span,
+        bits: Vec<djls_templates::TagBit>,
+        full_span: djls_source::Span,
+        body_span: djls_source::Span,
+    },
     StandaloneTag {
         tag: String,
         name_span: djls_source::Span,
@@ -106,6 +113,19 @@ impl From<&TemplateNode> for NodeSnapshot {
                 full_span: *full_span,
                 body: body.id(),
                 role: format!("{role:?}"),
+            },
+            TemplateNode::Opaque {
+                tag,
+                name_span,
+                bits,
+                full_span,
+                body_span,
+            } => Self::Opaque {
+                tag: tag.clone(),
+                name_span: *name_span,
+                bits: bits.clone(),
+                full_span: *full_span,
+                body_span: *body_span,
             },
             TemplateNode::StandaloneTag {
                 tag,
@@ -303,6 +323,258 @@ fn segment_body(region: &TemplateRegion, tag_name: &str) -> RegionId {
             _ => None,
         })
         .expect("expected segment node")
+}
+
+fn opaque_body_span(region: &TemplateRegion, tag_name: &str) -> Span {
+    region
+        .nodes()
+        .iter()
+        .find_map(|node| match node {
+            TemplateNode::Opaque { tag, body_span, .. } if tag == tag_name => Some(*body_span),
+            _ => None,
+        })
+        .expect("expected opaque node")
+}
+
+fn assert_position_inside(span: Span, source: &str, needle: &str) {
+    let position = u32::try_from(source.find(needle).expect("needle should exist")).unwrap();
+    assert!(
+        span.start() <= position && position < span.end(),
+        "expected {needle:?} at {position} inside {span:?}"
+    );
+}
+
+#[test]
+fn opaque_blocks_are_opaque_nodes_without_segments() {
+    let db = TestDatabase::new();
+    let source = "{% verbatim %}raw{% endverbatim %}{% if user %}visible{% endif %}";
+    let tree = tree_for_source(&db, source);
+    let root = root_region(tree, &db);
+
+    let body_span = opaque_body_span(root, "verbatim");
+    assert_position_inside(body_span, source, "raw");
+    assert!(
+        !root
+            .nodes()
+            .iter()
+            .any(|node| matches!(node, TemplateNode::Block { tag, .. } if tag == "verbatim"))
+    );
+    assert!(root
+        .nodes()
+        .iter()
+        .any(|node| matches!(node, TemplateNode::Block { tag, role: BlockRole::Opener, .. } if tag == "if")));
+}
+
+#[test]
+fn shared_intermediate_inside_opaque_block_has_no_structure() {
+    let mut specs = builtin_tag_specs();
+    specs.merge(TagSpecs::new(FxHashMap::from_iter([(
+        "opaque_if".to_string(),
+        TagSpec::new(
+            Cow::Borrowed("test"),
+            Some(EndTag {
+                name: Cow::Borrowed("endopaque_if"),
+                required: true,
+            }),
+            Cow::Owned(vec![djls_semantic::IntermediateTag {
+                name: Cow::Borrowed("else"),
+            }]),
+            true,
+        ),
+    )])));
+    let db = TestDatabase::new().with_specs(specs);
+    let source = "{% opaque_if %}{% if cond %}first{% else %}second{% endif %}{% endopaque_if %}";
+
+    db.add_file("test.html", source);
+    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let nodelist = parse_template(&db, file).expect("should parse");
+    let tree = build_template_tree(&db, nodelist);
+    let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist);
+
+    let validation_errors = errors.iter().map(|error| &error.0).collect::<Vec<_>>();
+    assert!(
+        validation_errors.is_empty(),
+        "shared intermediate should not be orphaned inside opaque content: {validation_errors:?}"
+    );
+
+    let root = root_region(tree, &db);
+    let body_span = opaque_body_span(root, "opaque_if");
+    assert_position_inside(body_span, source, "{% else %}");
+    assert!(
+        !tree
+            .regions(&db)
+            .iter()
+            .flat_map(TemplateRegion::nodes)
+            .any(
+                |node| matches!(node, TemplateNode::StandaloneTag { tag, .. } if tag == "else")
+                    || matches!(node, TemplateNode::Block { tag, .. } if tag == "else")
+            )
+    );
+}
+
+#[test]
+fn opaque_closer_name_can_also_be_structured_opener() {
+    let mut specs = builtin_tag_specs();
+    specs.merge(TagSpecs::new(FxHashMap::from_iter([
+        (
+            "raw".to_string(),
+            TagSpec::new(
+                Cow::Borrowed("test"),
+                Some(EndTag {
+                    name: Cow::Borrowed("panel"),
+                    required: true,
+                }),
+                Cow::Borrowed(&[]),
+                true,
+            ),
+        ),
+        (
+            "panel".to_string(),
+            TagSpec::new(
+                Cow::Borrowed("test"),
+                Some(EndTag {
+                    name: Cow::Borrowed("endpanel"),
+                    required: true,
+                }),
+                Cow::Borrowed(&[]),
+                false,
+            ),
+        ),
+    ])));
+    let db = TestDatabase::new().with_specs(specs);
+    let source = "{% raw %}body{% panel %}";
+
+    db.add_file("test.html", source);
+    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let nodelist = parse_template(&db, file).expect("should parse");
+    let tree = build_template_tree(&db, nodelist);
+    let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
+        .iter()
+        .map(|error| &error.0)
+        .collect::<Vec<_>>();
+
+    assert!(
+        errors.is_empty(),
+        "opaque closer should win over colliding opener role: {errors:?}"
+    );
+    assert_position_inside(
+        opaque_body_span(root_region(tree, &db), "raw"),
+        source,
+        "body",
+    );
+
+    let outside_source = "{% panel %}body{% endpanel %}";
+    db.add_file("outside.html", outside_source);
+    let outside_file = db.get_or_create_file(Utf8Path::new("outside.html"));
+    let outside_nodelist = parse_template(&db, outside_file).expect("should parse");
+    let outside_tree = build_template_tree(&db, outside_nodelist);
+    let outside_errors =
+        build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, outside_nodelist)
+            .iter()
+            .map(|error| &error.0)
+            .collect::<Vec<_>>();
+
+    assert!(
+        outside_errors.is_empty(),
+        "colliding closer should not hide opener role outside opaque content: {outside_errors:?}"
+    );
+    assert!(root_region(outside_tree, &db).nodes().iter().any(
+        |node| matches!(node, TemplateNode::Block { tag, role: BlockRole::Opener, .. } if tag == "panel")
+    ));
+}
+
+#[test]
+fn unclosed_optional_opaque_block_reports_unclosed_without_node() {
+    let mut specs = builtin_tag_specs();
+    specs.merge(TagSpecs::new(FxHashMap::from_iter([(
+        "raw".to_string(),
+        TagSpec::new(
+            Cow::Borrowed("test"),
+            Some(EndTag {
+                name: Cow::Borrowed("endraw"),
+                required: false,
+            }),
+            Cow::Borrowed(&[]),
+            true,
+        ),
+    )])));
+    let db = TestDatabase::new().with_specs(specs);
+    let source = "{% raw %}body";
+
+    db.add_file("test.html", source);
+    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let nodelist = parse_template(&db, file).expect("should parse");
+    let tree = build_template_tree(&db, nodelist);
+    let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
+        .iter()
+        .map(|error| &error.0)
+        .collect::<Vec<_>>();
+
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, ValidationError::UnclosedTag { tag, .. } if tag == "raw"))
+    );
+    assert!(
+        !tree
+            .regions(&db)
+            .iter()
+            .flat_map(TemplateRegion::nodes)
+            .any(|node| matches!(node, TemplateNode::Opaque { tag, .. } if tag == "raw"))
+    );
+}
+
+#[test]
+fn known_opener_and_closer_inside_opaque_block_have_no_structure() {
+    let db = TestDatabase::new();
+    let source = "{% verbatim %}{% if x %}body{% endif %}{% endverbatim %}";
+
+    db.add_file("test.html", source);
+    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let nodelist = parse_template(&db, file).expect("should parse");
+    let tree = build_template_tree(&db, nodelist);
+    let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
+        .iter()
+        .map(|error| &error.0)
+        .collect::<Vec<_>>();
+
+    assert!(
+        errors.is_empty(),
+        "known tags inside opaque content should not affect structure: {errors:?}"
+    );
+
+    let body_span = opaque_body_span(root_region(tree, &db), "verbatim");
+    assert_position_inside(body_span, source, "{% if x %}");
+    assert_position_inside(body_span, source, "{% endif %}");
+    assert!(!tree.regions(&db).iter().flat_map(TemplateRegion::nodes).any(
+        |node| matches!(node, TemplateNode::StandaloneTag { tag, .. } if tag == "if" || tag == "endif")
+            || matches!(node, TemplateNode::Block { tag, .. } if tag == "if")
+    ));
+}
+
+#[test]
+fn outer_closer_inside_opaque_block_has_no_structure() {
+    let db = TestDatabase::new();
+    let source = "{% if outer %}{% verbatim %}{% endif %}{% endverbatim %}{% endif %}";
+
+    db.add_file("test.html", source);
+    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let nodelist = parse_template(&db, file).expect("should parse");
+    let tree = build_template_tree(&db, nodelist);
+    let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
+        .iter()
+        .map(|error| &error.0)
+        .collect::<Vec<_>>();
+
+    assert!(
+        errors.is_empty(),
+        "outer closer inside opaque content should be raw content: {errors:?}"
+    );
+
+    let if_container = first_block_body(root_region(tree, &db), "if");
+    let if_body = segment_body(tree.regions(&db).get(if_container), "if");
+    let body_span = opaque_body_span(tree.regions(&db).get(if_body), "verbatim");
+    assert_position_inside(body_span, source, "{% endif %}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Model opaque template blocks explicitly as `TemplateNode::Opaque` with raw `body_span`.
- Enforce no structural nodes inside opaque content while preserving shared tag grammar outside it.
- Project `OpaqueRegions` from the template tree and reuse that tree during validation.

## Validation
- `cargo test -p djls-semantic --test structure_opaque`
- `cargo test -p djls-semantic --test validation`
- `cargo test -p djls-semantic mdtest`
- `cargo test -p djls-semantic`
- `cargo build -p djls-bench`
- `just clippy --allow-dirty`
- `just fmt --check`
- `codex review "review the uncommitted work as phase 2 of .humanlayer/tasks/unify-opaque-region-computation-with-template-tree/04-structure-outline-opaque-from-tree.md"`