### PR TITLE
Reduce Ruff StatementVisitor boilerplate

### DIFF
--- a/crates/djls-project/src/ast.rs
+++ b/crates/djls-project/src/ast.rs
@@ -1,9 +1,104 @@
+use std::marker::PhantomData;
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprNumberLiteral;
 use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::ExprUnaryOp;
 use ruff_python_ast::Number;
+use ruff_python_ast::Stmt;
 use ruff_python_ast::UnaryOp;
+use ruff_python_ast::statement_visitor::StatementVisitor;
+use ruff_python_ast::statement_visitor::walk_body;
+use ruff_python_ast::statement_visitor::walk_stmt;
+
+#[expect(
+    dead_code,
+    reason = "later migration phases construct the remaining policies"
+)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Recurse {
+    /// Control-flow bodies only: If/For/While/Try/With/Match. Stops at nested fn/class scopes.
+    ControlFlow,
+    /// Everything except nested fn/class scopes.
+    WithinScope,
+    /// Only `ClassDef` bodies.
+    IntoClasses,
+    /// No recursion; scan the given body's direct statements only.
+    Flat,
+}
+
+/// Run `matcher` on every statement in `body` pre-order, recursing per `policy`.
+///
+/// `matcher` returns `ControlFlow::Break(())` to stop the entire walk.
+pub(crate) fn walk_stmts<'a>(
+    body: &'a [Stmt],
+    policy: Recurse,
+    matcher: impl FnMut(&'a Stmt) -> ControlFlow<()>,
+) {
+    let mut walker = Walker {
+        matcher,
+        policy,
+        stopped: false,
+        _pd: PhantomData,
+    };
+    walker.visit_body(body);
+}
+
+struct Walker<'a, F> {
+    matcher: F,
+    policy: Recurse,
+    stopped: bool,
+    _pd: PhantomData<&'a ()>,
+}
+
+impl<'a, F> StatementVisitor<'a> for Walker<'a, F>
+where
+    F: FnMut(&'a Stmt) -> ControlFlow<()>,
+{
+    fn visit_body(&mut self, body: &'a [Stmt]) {
+        if self.stopped {
+            return;
+        }
+        walk_body(self, body);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if self.stopped {
+            return;
+        }
+
+        match (self.matcher)(stmt) {
+            ControlFlow::Continue(()) => {}
+            ControlFlow::Break(()) => {
+                self.stopped = true;
+                return;
+            }
+        }
+
+        match self.policy {
+            Recurse::ControlFlow => match stmt {
+                Stmt::If(_)
+                | Stmt::For(_)
+                | Stmt::While(_)
+                | Stmt::Try(_)
+                | Stmt::With(_)
+                | Stmt::Match(_) => walk_stmt(self, stmt),
+                _ => {}
+            },
+            Recurse::WithinScope => match stmt {
+                Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
+                _ => walk_stmt(self, stmt),
+            },
+            Recurse::IntoClasses => {
+                if let Stmt::ClassDef(_) = stmt {
+                    walk_stmt(self, stmt);
+                }
+            }
+            Recurse::Flat => {}
+        }
+    }
+}
 
 pub trait ExprExt {
     /// Extract the full string value from a string literal expression.

--- a/crates/djls-project/src/ast.rs
+++ b/crates/djls-project/src/ast.rs
@@ -12,10 +12,6 @@ use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::statement_visitor::walk_body;
 use ruff_python_ast::statement_visitor::walk_stmt;
 
-#[expect(
-    dead_code,
-    reason = "later migration phases construct the remaining policies"
-)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Recurse {
     /// Control-flow bodies only: If/For/While/Try/With/Match. Stops at nested fn/class scopes.

--- a/crates/djls-project/src/extraction/registry.rs
+++ b/crates/djls-project/src/extraction/registry.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
@@ -5,10 +7,10 @@ use ruff_python_ast::Keyword;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtExpr;
 use ruff_python_ast::StmtFunctionDef;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 
 /// Decorator helper names on `django.template.Library` that register filters.
 const FILTER_DECORATORS: &[&str] = &["filter"];
@@ -36,33 +38,22 @@ pub enum RegistrationKind {
 /// This avoids re-parsing the source when the caller already has the AST.
 #[must_use]
 pub fn collect_registrations_from_body(body: &[Stmt]) -> Vec<RegistrationInfo> {
-    let mut visitor = RegistrationCollector::default();
-    visitor.visit_body(body);
-    visitor.registrations
-}
-
-#[derive(Default)]
-struct RegistrationCollector {
-    registrations: Vec<RegistrationInfo>,
-}
-
-impl StatementVisitor<'_> for RegistrationCollector {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
+    let mut registrations = Vec::new();
+    walk_stmts(body, Recurse::IntoClasses, |stmt| {
         match stmt {
             Stmt::FunctionDef(func_def) => {
-                collect_from_decorated_function(func_def, &mut self.registrations);
+                collect_from_decorated_function(func_def, &mut registrations);
             }
             Stmt::Expr(StmtExpr { value, .. }) => {
                 if let Expr::Call(call) = value.as_ref() {
-                    collect_from_call_statement(call, &mut self.registrations);
+                    collect_from_call_statement(call, &mut registrations);
                 }
-            }
-            Stmt::ClassDef(_) => {
-                walk_stmt(self, stmt);
             }
             _ => {}
         }
-    }
+        ControlFlow::Continue(())
+    });
+    registrations
 }
 
 /// Extract registrations from a decorated function definition.

--- a/crates/djls-project/src/specs.rs
+++ b/crates/djls-project/src/specs.rs
@@ -9,12 +9,14 @@ mod types;
 #[cfg(test)]
 pub(crate) mod testing;
 
+use std::ops::ControlFlow;
+
 use djls_source::File;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtFunctionDef;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::extraction::registry::RegistrationInfo;
 use crate::extraction::registry::collect_registrations_from_body;
 use crate::names::ModulePath;
@@ -267,28 +269,14 @@ fn normalize_block_spec(block_spec: Option<BlockSpec>, tag_name: &str) -> Option
 
 /// Recursively collect all function definitions from a module body.
 fn collect_func_defs(body: &[Stmt]) -> Vec<&StmtFunctionDef> {
-    let mut visitor = FunctionDefCollector::default();
-    visitor.visit_body(body);
-    visitor.defs
-}
-
-#[derive(Default)]
-struct FunctionDefCollector<'a> {
-    defs: Vec<&'a StmtFunctionDef>,
-}
-
-impl<'a> StatementVisitor<'a> for FunctionDefCollector<'a> {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt {
-            Stmt::FunctionDef(func) => {
-                self.defs.push(func);
-            }
-            Stmt::ClassDef(_) => {
-                walk_stmt(self, stmt);
-            }
-            _ => {}
+    let mut defs = Vec::new();
+    walk_stmts(body, Recurse::IntoClasses, |stmt| {
+        if let Stmt::FunctionDef(func) = stmt {
+            defs.push(func);
         }
-    }
+        ControlFlow::Continue(())
+    });
+    defs
 }
 
 #[cfg(test)]

--- a/crates/djls-project/src/specs.rs
+++ b/crates/djls-project/src/specs.rs
@@ -128,18 +128,18 @@ fn analyze_helper_cycle_recover(
 }
 
 fn find_function_def<'a>(body: &'a [Stmt], name: &str) -> Option<&'a StmtFunctionDef> {
-    for stmt in body {
-        match stmt {
-            Stmt::FunctionDef(func) if func.name.as_str() == name => return Some(func),
-            Stmt::ClassDef(class) => {
-                if let Some(found) = find_function_def(&class.body, name) {
-                    return Some(found);
-                }
-            }
-            _ => {}
+    let mut found = None;
+    walk_stmts(body, Recurse::IntoClasses, |stmt| {
+        if let Stmt::FunctionDef(func) = stmt
+            && func.name.as_str() == name
+        {
+            found = Some(func);
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
         }
-    }
-    None
+    });
+    found
 }
 
 /// Extract tag validation rules from a Python file, cached by Salsa.

--- a/crates/djls-project/src/specs/analysis/calls.rs
+++ b/crates/djls-project/src/specs/analysis/calls.rs
@@ -1,9 +1,11 @@
 //! Intra-module function call resolution via Salsa tracked functions.
 
-use ruff_python_ast::Stmt;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
+use std::ops::ControlFlow;
 
+use ruff_python_ast::Stmt;
+
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::HelperCall;
 use crate::specs::analysis::CallContext;
 use crate::specs::analysis::state::AbstractValue;
@@ -93,22 +95,29 @@ pub(crate) fn resolve_call(
 /// Scans for `return expr` statements. If exactly one return path yields
 /// a non-Unknown value, returns that. If multiple yields differ, returns Unknown.
 pub(crate) fn extract_return_value(body: &[Stmt], env: &mut Env) -> AbstractValue {
-    let mut visitor = ReturnVisitor::new(env);
-    visitor.visit_body(body);
+    let mut returns = Vec::new();
+    walk_stmts(body, Recurse::WithinScope, |stmt| {
+        if let Stmt::Return(ret) = stmt {
+            let value = ret.value.as_deref().map_or(AbstractValue::Unknown, |expr| {
+                crate::specs::analysis::expressions::eval_expr(expr, env)
+            });
+            returns.push(value);
+        }
+        ControlFlow::Continue(())
+    });
 
-    if visitor.returns.is_empty() {
+    if returns.is_empty() {
         return AbstractValue::Unknown;
     }
 
     // If all returns are the same, use that value
-    let first = &visitor.returns[0];
-    if visitor.returns.iter().all(|r| r == first) {
+    let first = &returns[0];
+    if returns.iter().all(|r| r == first) {
         return first.clone();
     }
 
     // Filter out Unknown values — if a single non-Unknown value remains, use it
-    let non_unknown: Vec<_> = visitor
-        .returns
+    let non_unknown: Vec<_> = returns
         .iter()
         .filter(|r| !matches!(r, AbstractValue::Unknown))
         .collect();
@@ -121,36 +130,6 @@ pub(crate) fn extract_return_value(body: &[Stmt], env: &mut Env) -> AbstractValu
     }
 
     AbstractValue::Unknown
-}
-
-struct ReturnVisitor<'a> {
-    env: &'a mut Env,
-    returns: Vec<AbstractValue>,
-}
-
-impl<'a> ReturnVisitor<'a> {
-    fn new(env: &'a mut Env) -> Self {
-        Self {
-            env,
-            returns: Vec::new(),
-        }
-    }
-}
-
-impl StatementVisitor<'_> for ReturnVisitor<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        match stmt {
-            Stmt::Return(ret) => {
-                let value = ret.value.as_deref().map_or(AbstractValue::Unknown, |expr| {
-                    crate::specs::analysis::expressions::eval_expr(expr, self.env)
-                });
-                self.returns.push(value);
-            }
-            // Only collect returns from the current function scope.
-            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
-            _ => walk_stmt(self, stmt),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/djls-project/src/specs/analysis/match_arms.rs
+++ b/crates/djls-project/src/specs/analysis/match_arms.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::MatchCase;
@@ -7,9 +9,9 @@ use ruff_python_ast::PatternMatchSequence;
 use ruff_python_ast::PatternMatchValue;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtMatch;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::analysis::constraints::ExtractedTagConstraints;
 use crate::specs::analysis::expressions::eval_expr;
 use crate::specs::analysis::state::AbstractValue;
@@ -227,40 +229,21 @@ fn pattern_literal(pattern: &Pattern) -> Option<String> {
 /// where any raise in any branch means the case can error. Any exception type
 /// counts — `TemplateSyntaxError`, `ValueError`, etc.
 fn any_path_raises_exception(body: &[Stmt]) -> bool {
-    let mut visitor = RaiseFinder::default();
-    visitor.visit_body(body);
-    visitor.found
-}
-
-#[derive(Default)]
-struct RaiseFinder {
-    found: bool,
-}
-
-impl StatementVisitor<'_> for RaiseFinder {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
+    let mut found = false;
+    // Recurse into control flow to check all possible execution paths.
+    // NOTE: Recursing into Stmt::Try means a raise caught by an except
+    // handler is still treated as "this case can error." This is a known
+    // false positive — no corpus projects exhibit this pattern, but it's
+    // possible in the wild.
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        if matches!(
+            stmt,
+            Stmt::Raise(ruff_python_ast::StmtRaise { exc: Some(_), .. })
+        ) {
+            found = true;
+            return ControlFlow::Break(());
         }
-
-        match stmt {
-            Stmt::Raise(ruff_python_ast::StmtRaise { exc: Some(_), .. }) => {
-                self.found = true;
-            }
-            // Recurse into control flow to check all possible execution paths.
-            // NOTE: Recursing into Stmt::Try means a raise caught by an except
-            // handler is still treated as "this case can error." This is a known
-            // false positive — no corpus projects exhibit this pattern, but it's
-            // possible in the wild.
-            Stmt::If(_)
-            | Stmt::For(_)
-            | Stmt::While(_)
-            | Stmt::Try(_)
-            | Stmt::With(_)
-            | Stmt::Match(_) => {
-                walk_stmt(self, stmt);
-            }
-            _ => {}
-        }
-    }
+        ControlFlow::Continue(())
+    });
+    found
 }

--- a/crates/djls-project/src/specs/analysis/mutations.rs
+++ b/crates/djls-project/src/specs/analysis/mutations.rs
@@ -8,7 +8,6 @@ use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtIf;
 use ruff_python_ast::StmtWhile;
-use ruff_python_ast::statement_visitor::StatementVisitor;
 
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
@@ -149,7 +148,7 @@ fn extract_option_checks(
 ) {
     let mut visitor =
         OptionCheckVisitor::new(option_var, values, rejects_unknown, allow_duplicates);
-    visitor.visit_stmt(&Stmt::If(if_stmt.clone()));
+    visitor.visit_if(if_stmt);
 }
 
 struct OptionCheckVisitor<'a> {
@@ -173,33 +172,29 @@ impl<'a> OptionCheckVisitor<'a> {
             allow_duplicates,
         }
     }
-}
 
-impl StatementVisitor<'_> for OptionCheckVisitor<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if let Stmt::If(if_stmt) = stmt {
-            if is_duplicate_check(&if_stmt.test, self.option_var) {
-                *self.allow_duplicates = false;
-            } else if let Some(opt_name) = extract_option_equality(&if_stmt.test, self.option_var)
-                && !self.values.contains(&opt_name)
-            {
-                self.values.push(opt_name);
-            }
+    fn visit_if(&mut self, if_stmt: &StmtIf) {
+        if is_duplicate_check(&if_stmt.test, self.option_var) {
+            *self.allow_duplicates = false;
+        } else if let Some(opt_name) = extract_option_equality(&if_stmt.test, self.option_var)
+            && !self.values.contains(&opt_name)
+        {
+            self.values.push(opt_name);
+        }
 
-            for clause in &if_stmt.elif_else_clauses {
-                if let Some(test) = &clause.test {
-                    if is_duplicate_check(test, self.option_var) {
-                        *self.allow_duplicates = false;
-                    } else if let Some(opt_name) = extract_option_equality(test, self.option_var)
-                        && !self.values.contains(&opt_name)
-                    {
-                        self.values.push(opt_name);
-                    }
-                } else {
-                    // else branch — if it raises, unknown options are rejected
-                    if direct_raise_exception(&clause.body).is_some() {
-                        *self.rejects_unknown = true;
-                    }
+        for clause in &if_stmt.elif_else_clauses {
+            if let Some(test) = &clause.test {
+                if is_duplicate_check(test, self.option_var) {
+                    *self.allow_duplicates = false;
+                } else if let Some(opt_name) = extract_option_equality(test, self.option_var)
+                    && !self.values.contains(&opt_name)
+                {
+                    self.values.push(opt_name);
+                }
+            } else {
+                // else branch — if it raises, unknown options are rejected
+                if direct_raise_exception(&clause.body).is_some() {
+                    *self.rejects_unknown = true;
                 }
             }
         }

--- a/crates/djls-project/src/specs/analysis/mutations.rs
+++ b/crates/djls-project/src/specs/analysis/mutations.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::CmpOp;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
@@ -9,6 +11,8 @@ use ruff_python_ast::StmtWhile;
 use ruff_python_ast::statement_visitor::StatementVisitor;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::analysis::exceptions::direct_raise_exception;
 use crate::specs::analysis::state::AbstractValue;
 use crate::specs::analysis::state::Env;
@@ -117,43 +121,22 @@ pub(super) fn try_extract_option_loop(while_stmt: &StmtWhile, env: &Env) -> Opti
 
 /// Find the variable assigned from `loop_var.pop(0)` in a while-loop body.
 fn find_option_pop_var(body: &[Stmt], loop_var: &str) -> Option<String> {
-    let mut visitor = OptionPopFinder::new(loop_var);
-    visitor.visit_body(body);
-    visitor.option_var
-}
-
-struct OptionPopFinder<'a> {
-    loop_var: &'a str,
-    option_var: Option<String>,
-}
-
-impl<'a> OptionPopFinder<'a> {
-    fn new(loop_var: &'a str) -> Self {
-        Self {
-            loop_var,
-            option_var: None,
-        }
-    }
-}
-
-impl StatementVisitor<'_> for OptionPopFinder<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.option_var.is_some() {
-            return;
-        }
-
+    let mut option_var = None;
+    walk_stmts(body, Recurse::Flat, |stmt| {
         if let Stmt::Assign(assign) = stmt
             && assign.targets.len() == 1
             && let Some(name) = assign.targets[0].name_target()
         {
             let is_pop_zero = try_extract_pop_call(&assign.value)
-                .is_some_and(|info| info.var_name == self.loop_var && info.from_front);
+                .is_some_and(|info| info.var_name == loop_var && info.from_front);
             if is_pop_zero {
-                self.option_var = Some(name.to_string());
+                option_var = Some(name.to_string());
+                return ControlFlow::Break(());
             }
         }
-        // Do not recurse into nested statements.
-    }
+        ControlFlow::Continue(())
+    });
+    option_var
 }
 
 /// Extract option names from if/elif/else chains checking the option variable.

--- a/crates/djls-project/src/specs/blocks/dynamic_end.rs
+++ b/crates/djls-project/src/specs/blocks/dynamic_end.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprBinOp;
@@ -9,10 +11,10 @@ use ruff_python_ast::Operator;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
 use ruff_python_ast::StmtReturn;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::blocks::is_parser_receiver;
 use crate::specs::types::BlockSpec;
 
@@ -32,55 +34,24 @@ pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<BlockSpec> {
 }
 
 fn has_dynamic_end_in_body(body: &[Stmt], parser_var: &str) -> bool {
-    let mut visitor = DynamicEndFinder::new(parser_var);
-    visitor.visit_body(body);
-    visitor.found
-}
-
-struct DynamicEndFinder<'a> {
-    parser_var: &'a str,
-    found: bool,
-}
-
-impl<'a> DynamicEndFinder<'a> {
-    fn new(parser_var: &'a str) -> Self {
-        Self {
-            parser_var,
-            found: false,
-        }
-    }
-}
-
-impl StatementVisitor<'_> for DynamicEndFinder<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
-        }
-
-        match stmt {
-            Stmt::Expr(expr_stmt) => {
-                self.found = is_dynamic_end_parse_call(&expr_stmt.value, self.parser_var);
-            }
-            Stmt::Assign(StmtAssign { value, .. }) => {
-                self.found = is_dynamic_end_parse_call(value, self.parser_var);
-            }
+    let mut found = false;
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        let has_dynamic_end = match stmt {
+            Stmt::Expr(expr_stmt) => is_dynamic_end_parse_call(&expr_stmt.value, parser_var),
+            Stmt::Assign(StmtAssign { value, .. }) => is_dynamic_end_parse_call(value, parser_var),
             Stmt::Return(StmtReturn {
                 value: Some(val), ..
-            }) => {
-                self.found = is_dynamic_end_parse_call(val, self.parser_var);
-            }
-            // Recurse into control flow to find all possible parse calls.
-            Stmt::If(_)
-            | Stmt::For(_)
-            | Stmt::While(_)
-            | Stmt::Try(_)
-            | Stmt::With(_)
-            | Stmt::Match(_) => {
-                walk_stmt(self, stmt);
-            }
-            _ => {}
+            }) => is_dynamic_end_parse_call(val, parser_var),
+            _ => false,
+        };
+        if has_dynamic_end {
+            found = true;
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
         }
-    }
+    });
+    found
 }
 
 /// Check if an expression is `parser.parse((f"end{...}",))`.
@@ -162,46 +133,24 @@ pub(super) fn is_end_fstring(expr: &Expr) -> bool {
 
 /// Check for dynamic end-tag format strings: `"end%s" % bits[0]` or `f"end{bits[0]}"`.
 pub(super) fn has_dynamic_end_tag_format(body: &[Stmt]) -> bool {
-    let mut visitor = DynamicEndFormatFinder::default();
-    visitor.visit_body(body);
-    visitor.found
-}
-
-#[derive(Default)]
-struct DynamicEndFormatFinder {
-    found: bool,
-}
-
-impl StatementVisitor<'_> for DynamicEndFormatFinder {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
-        }
-
-        match stmt {
-            Stmt::Expr(expr_stmt) => {
-                self.found = is_end_format_expr(&expr_stmt.value);
-            }
-            Stmt::Assign(StmtAssign { value, .. }) => {
-                self.found = is_end_format_expr(value);
-            }
+    let mut found = false;
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        let has_dynamic_end = match stmt {
+            Stmt::Expr(expr_stmt) => is_end_format_expr(&expr_stmt.value),
+            Stmt::Assign(StmtAssign { value, .. }) => is_end_format_expr(value),
             Stmt::Return(StmtReturn {
                 value: Some(val), ..
-            }) => {
-                self.found = is_end_format_expr(val);
-            }
-            // Recurse into control flow to find all possible parse calls.
-            Stmt::If(_)
-            | Stmt::For(_)
-            | Stmt::While(_)
-            | Stmt::Try(_)
-            | Stmt::With(_)
-            | Stmt::Match(_) => {
-                walk_stmt(self, stmt);
-            }
-            _ => {}
+            }) => is_end_format_expr(val),
+            _ => false,
+        };
+        if has_dynamic_end {
+            found = true;
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
         }
-    }
+    });
+    found
 }
 
 /// Check if an expression is `"end%s" % something` or similar end-tag format.

--- a/crates/djls-project/src/specs/blocks/next_token.rs
+++ b/crates/djls-project/src/specs/blocks/next_token.rs
@@ -1,12 +1,14 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::blocks::dynamic_end;
 use crate::specs::blocks::is_token_contents_expr;
 use crate::specs::types::BlockSpec;
@@ -67,46 +69,19 @@ pub(super) fn detect(body: &[Stmt], parser_var: &str, token_var: &str) -> Option
 
 /// Check if a body contains `while parser.tokens:` with `parser.next_token()`.
 fn has_next_token_loop(body: &[Stmt], parser_var: &str) -> bool {
-    let mut visitor = NextTokenLoopFinder::new(parser_var);
-    visitor.visit_body(body);
-    visitor.found
-}
-
-struct NextTokenLoopFinder<'a> {
-    parser_var: &'a str,
-    found: bool,
-}
-
-impl<'a> NextTokenLoopFinder<'a> {
-    fn new(parser_var: &'a str) -> Self {
-        Self {
-            parser_var,
-            found: false,
+    let mut found = false;
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        if let Stmt::While(while_stmt) = stmt
+            && is_parser_tokens_check(&while_stmt.test, parser_var)
+            && body_has_next_token_call(&while_stmt.body, parser_var)
+        {
+            found = true;
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
         }
-    }
-}
-
-impl StatementVisitor<'_> for NextTokenLoopFinder<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
-        }
-
-        match stmt {
-            Stmt::While(while_stmt) => {
-                if is_parser_tokens_check(&while_stmt.test, self.parser_var)
-                    && body_has_next_token_call(&while_stmt.body, self.parser_var)
-                {
-                    self.found = true;
-                    return;
-                }
-                walk_stmt(self, stmt);
-            }
-            // Recurse into control flow to find all possible loop patterns.
-            Stmt::If(_) | Stmt::For(_) | Stmt::Try(_) => walk_stmt(self, stmt),
-            _ => {}
-        }
-    }
+    });
+    found
 }
 
 /// Check if an expression is `parser.tokens` (the token list attribute).
@@ -121,41 +96,21 @@ fn is_parser_tokens_check(expr: &Expr, parser_var: &str) -> bool {
 
 /// Check if a body contains a `parser.next_token()` call.
 fn body_has_next_token_call(body: &[Stmt], parser_var: &str) -> bool {
-    let mut visitor = NextTokenCallFinder::new(parser_var);
-    visitor.visit_body(body);
-    visitor.found
-}
-
-struct NextTokenCallFinder<'a> {
-    parser_var: &'a str,
-    found: bool,
-}
-
-impl<'a> NextTokenCallFinder<'a> {
-    fn new(parser_var: &'a str) -> Self {
-        Self {
-            parser_var,
-            found: false,
+    let mut found = false;
+    walk_stmts(body, Recurse::Flat, |stmt| {
+        let has_next_token_call = match stmt {
+            Stmt::Assign(StmtAssign { value, .. }) => is_next_token_call(value, parser_var),
+            Stmt::Expr(expr_stmt) => is_next_token_call(&expr_stmt.value, parser_var),
+            _ => false,
+        };
+        if has_next_token_call {
+            found = true;
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
         }
-    }
-}
-
-impl StatementVisitor<'_> for NextTokenCallFinder<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
-        }
-
-        match stmt {
-            Stmt::Assign(StmtAssign { value, .. }) => {
-                self.found = is_next_token_call(value, self.parser_var);
-            }
-            Stmt::Expr(expr_stmt) => {
-                self.found = is_next_token_call(&expr_stmt.value, self.parser_var);
-            }
-            _ => {}
-        }
-    }
+    });
+    found
 }
 
 /// Check if an expression is `parser.next_token()`.
@@ -185,57 +140,37 @@ fn is_next_token_call(expr: &Expr, parser_var: &str) -> bool {
 /// - `token.contents == "endblocktrans"`
 /// - `token.contents.strip() != end_tag_name` (skipped — dynamic)
 fn collect_token_content_comparisons(body: &[Stmt], token_var: &str) -> Vec<String> {
-    let mut visitor = TokenComparisonVisitor::new(token_var);
-    visitor.visit_body(body);
-    visitor.comparisons
-}
-
-struct TokenComparisonVisitor<'a> {
-    token_var: &'a str,
-    comparisons: Vec<String>,
-}
-
-impl<'a> TokenComparisonVisitor<'a> {
-    fn new(token_var: &'a str) -> Self {
-        Self {
-            token_var,
-            comparisons: Vec::new(),
-        }
-    }
-
-    fn add_all(&mut self, values: Vec<String>) {
-        for value in values {
-            if !self.comparisons.contains(&value) {
-                self.comparisons.push(value);
-            }
-        }
-    }
-}
-
-impl StatementVisitor<'_> for TokenComparisonVisitor<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
+    let mut comparisons = Vec::new();
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
         match stmt {
             Stmt::If(if_stmt) => {
-                self.add_all(extract_comparisons_from_expr(&if_stmt.test, self.token_var));
-                for clause in &if_stmt.elif_else_clauses {
-                    if let Some(test) = &clause.test {
-                        self.add_all(extract_comparisons_from_expr(test, self.token_var));
+                for value in extract_comparisons_from_expr(&if_stmt.test, token_var) {
+                    if !comparisons.contains(&value) {
+                        comparisons.push(value);
                     }
                 }
-                walk_stmt(self, stmt);
+                for clause in &if_stmt.elif_else_clauses {
+                    if let Some(test) = &clause.test {
+                        for value in extract_comparisons_from_expr(test, token_var) {
+                            if !comparisons.contains(&value) {
+                                comparisons.push(value);
+                            }
+                        }
+                    }
+                }
             }
             Stmt::While(while_stmt) => {
-                self.add_all(extract_comparisons_from_expr(
-                    &while_stmt.test,
-                    self.token_var,
-                ));
-                walk_stmt(self, stmt);
+                for value in extract_comparisons_from_expr(&while_stmt.test, token_var) {
+                    if !comparisons.contains(&value) {
+                        comparisons.push(value);
+                    }
+                }
             }
-            // Recurse into control flow to find all possible loop patterns.
-            Stmt::For(_) | Stmt::Try(_) => walk_stmt(self, stmt),
             _ => {}
         }
-    }
+        ControlFlow::Continue(())
+    });
+    comparisons
 }
 
 /// Extract string comparisons against token.contents from a comparison expression.

--- a/crates/djls-project/src/specs/blocks/opaque.rs
+++ b/crates/djls-project/src/specs/blocks/opaque.rs
@@ -1,12 +1,14 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::blocks::is_parser_receiver;
 use crate::specs::types::BlockSpec;
 
@@ -33,49 +35,21 @@ pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<BlockSpec> {
 /// Uses Ruff's statement visitor to avoid hand-written recursion across
 /// statement variants.
 fn collect_skip_past_tokens(body: &[Stmt], parser_var: &str) -> Vec<String> {
-    let mut visitor = SkipPastVisitor::new(parser_var);
-    visitor.visit_body(body);
-    visitor.tokens
-}
-
-struct SkipPastVisitor<'a> {
-    parser_var: &'a str,
-    tokens: Vec<String>,
-}
-
-impl<'a> SkipPastVisitor<'a> {
-    fn new(parser_var: &'a str) -> Self {
-        Self {
-            parser_var,
-            tokens: Vec::new(),
+    let mut tokens = Vec::new();
+    walk_stmts(body, Recurse::WithinScope, |stmt| {
+        let token = match stmt {
+            Stmt::Expr(expr_stmt) => extract_skip_past_token(&expr_stmt.value, parser_var),
+            Stmt::Assign(StmtAssign { value, .. }) => extract_skip_past_token(value, parser_var),
+            _ => None,
+        };
+        if let Some(token) = token
+            && !tokens.contains(&token)
+        {
+            tokens.push(token);
         }
-    }
-
-    fn insert_token(&mut self, token: String) {
-        if !self.tokens.contains(&token) {
-            self.tokens.push(token);
-        }
-    }
-}
-
-impl StatementVisitor<'_> for SkipPastVisitor<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        match stmt {
-            Stmt::Expr(expr_stmt) => {
-                if let Some(token) = extract_skip_past_token(&expr_stmt.value, self.parser_var) {
-                    self.insert_token(token);
-                }
-            }
-            Stmt::Assign(StmtAssign { value, .. }) => {
-                if let Some(token) = extract_skip_past_token(value, self.parser_var) {
-                    self.insert_token(token);
-                }
-            }
-            // Stay within the current function scope.
-            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
-            _ => walk_stmt(self, stmt),
-        }
-    }
+        ControlFlow::Continue(())
+    });
+    tokens
 }
 
 /// Check if an expression is `parser.skip_past("token")` and extract the token.

--- a/crates/djls-project/src/specs/blocks/parse_calls.rs
+++ b/crates/djls-project/src/specs/blocks/parse_calls.rs
@@ -1,14 +1,15 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
 use ruff_python_ast::StmtIf;
-use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::statement_visitor::walk_body;
-use ruff_python_ast::statement_visitor::walk_stmt;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::blocks::extract_string_sequence;
 use crate::specs::blocks::is_parser_receiver;
 use crate::specs::blocks::is_token_contents_expr;
@@ -36,49 +37,25 @@ struct ParseCallInfo {
 }
 
 /// Collect all `parser.parse((...))` calls in a statement body.
-///
-/// Uses Ruff's statement visitor to avoid hand-written recursion across
-/// statement variants.
 fn collect_parser_parse_calls(body: &[Stmt], parser_var: &str) -> Vec<ParseCallInfo> {
-    let mut visitor = ParseCallCollector::new(parser_var);
-    visitor.visit_body(body);
-    visitor.calls
-}
-
-struct ParseCallCollector<'a> {
-    parser_var: &'a str,
-    calls: Vec<ParseCallInfo>,
-}
-
-impl<'a> ParseCallCollector<'a> {
-    fn new(parser_var: &'a str) -> Self {
-        Self {
-            parser_var,
-            calls: Vec::new(),
-        }
-    }
-}
-
-impl StatementVisitor<'_> for ParseCallCollector<'_> {
-    fn visit_stmt(&mut self, stmt: &Stmt) {
+    let mut calls = Vec::new();
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
         match stmt {
             Stmt::Expr(expr_stmt) => {
-                if let Some(info) = extract_parse_call_info(&expr_stmt.value, self.parser_var) {
-                    self.calls.push(info);
+                if let Some(info) = extract_parse_call_info(&expr_stmt.value, parser_var) {
+                    calls.push(info);
                 }
             }
             Stmt::Assign(StmtAssign { value, .. }) => {
-                if let Some(info) = extract_parse_call_info(value, self.parser_var) {
-                    self.calls.push(info);
+                if let Some(info) = extract_parse_call_info(value, parser_var) {
+                    calls.push(info);
                 }
-            }
-            // Recurse into control flow to find all possible parse calls.
-            Stmt::If(_) | Stmt::For(_) | Stmt::While(_) | Stmt::Try(_) | Stmt::With(_) => {
-                walk_stmt(self, stmt);
             }
             _ => {}
         }
-    }
+        ControlFlow::Continue(())
+    });
+    calls
 }
 
 /// Check if an expression is a `parser.parse((...))` call and extract stop-tokens.
@@ -460,50 +437,23 @@ fn extract_startswith_check(
 
 /// Check if a statement body contains a `parser.parse(...)` call.
 fn body_has_parse_call(body: &[Stmt], parser_var: &str) -> bool {
-    let mut visitor = ParseCallFinder::new(parser_var);
-    visitor.visit_body(body);
-    visitor.found
-}
-
-struct ParseCallFinder<'a> {
-    parser_var: &'a str,
-    found: bool,
-}
-
-impl<'a> ParseCallFinder<'a> {
-    fn new(parser_var: &'a str) -> Self {
-        Self {
-            parser_var,
-            found: false,
-        }
-    }
-}
-
-impl StatementVisitor<'_> for ParseCallFinder<'_> {
-    fn visit_body(&mut self, body: &[Stmt]) {
-        if self.found {
-            return;
-        }
-        walk_body(self, body);
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if self.found {
-            return;
-        }
-
-        match stmt {
+    let mut found = false;
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        let has_parse_call = match stmt {
             Stmt::Expr(expr_stmt) => {
-                self.found = extract_parse_call_info(&expr_stmt.value, self.parser_var).is_some();
+                extract_parse_call_info(&expr_stmt.value, parser_var).is_some()
             }
             Stmt::Assign(StmtAssign { value, .. }) => {
-                self.found = extract_parse_call_info(value, self.parser_var).is_some();
+                extract_parse_call_info(value, parser_var).is_some()
             }
-            // Recurse into control flow to find all possible parse calls.
-            Stmt::If(_) | Stmt::For(_) | Stmt::While(_) | Stmt::Try(_) | Stmt::With(_) => {
-                walk_stmt(self, stmt);
-            }
-            _ => {}
+            _ => false,
+        };
+        if has_parse_call {
+            found = true;
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
         }
-    }
+    });
+    found
 }

--- a/crates/djls-project/src/specs/models/extract.rs
+++ b/crates/djls-project/src/specs/models/extract.rs
@@ -1,10 +1,13 @@
+use std::ops::ControlFlow;
+
 use ruff_python_ast::Expr;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtClassDef;
-use ruff_python_ast::statement_visitor::StatementVisitor;
 use rustc_hash::FxHashSet;
 
 use crate::ast::ExprExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::specs::models::graph::FieldName;
 use crate::specs::models::graph::ModelDef;
 use crate::specs::models::graph::ModelGraph;
@@ -38,7 +41,10 @@ pub(crate) fn extract_model_graph_from_body(
     module_path: &str,
 ) -> ModelGraph {
     let mut collector = ModelCollector::new(module_path, source);
-    collector.visit_body(body);
+    walk_stmts(body, Recurse::Flat, |stmt| {
+        collector.scan_stmt(stmt);
+        ControlFlow::Continue(())
+    });
     collector.finish()
 }
 
@@ -70,10 +76,8 @@ impl<'a> ModelCollector<'a> {
         );
         self.graph
     }
-}
 
-impl<'a> StatementVisitor<'a> for ModelCollector<'a> {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+    fn scan_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::ImportFrom(import) => {
                 let Some(module) = import


### PR DESCRIPTION
## Summary
- add a shared walk_stmts/Recurse primitive for djls-project AST statement walks
- migrate block, analysis, specs, registry, and flat model scans to the shared primitive
- leave bespoke non-fit extraction logic explicit while reducing Ruff StatementVisitor impls to the internal walker

## Validation
- cargo build -q -p djls-project
- cargo test -q -p djls-project
- cargo test -q -p djls-project --test corpus
- cargo test -q
- just clippy --allow-dirty
- just fmt --check

## Review
- codex review reported no actionable issues for Phase 4