### PR TITLE
Make model extraction a file-backed Salsa query

### DIFF
--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -2,6 +2,7 @@ use std::sync::OnceLock;
 
 use camino::Utf8PathBuf;
 use divan::Bencher;
+use djls_bench::Db;
 use djls_bench::REPEATED_INNER_ITERS;
 use djls_bench::model_fixtures;
 use djls_project::ModelGraph;
@@ -15,14 +16,27 @@ fn module_path(path: &str) -> PythonModulePath {
     PythonModulePath::parse(path).unwrap()
 }
 
+fn model_graph_from_source(
+    db: &mut Db,
+    path: impl Into<Utf8PathBuf>,
+    source: &str,
+    module_path: PythonModulePath,
+) -> ModelGraph {
+    let file = db.file_with_contents(path, source);
+    djls_project::extract_model_graph(db, file, module_path).clone()
+}
+
 // Batch extraction: all fixtures in one iteration
 
 #[divan::bench]
 fn extract(bencher: Bencher) {
     let fixtures = model_fixtures();
     bencher.bench_local(move || {
-        for fixture in fixtures {
-            divan::black_box(djls_project::extract_model_graph(
+        let mut db = Db::new();
+        for (index, fixture) in fixtures.iter().enumerate() {
+            divan::black_box(model_graph_from_source(
+                &mut db,
+                format!("/bench/models/extract/{index}.py"),
                 &fixture.source,
                 module_path("bench.models"),
             ));
@@ -35,9 +49,18 @@ fn extract(bencher: Bencher) {
 #[divan::bench]
 fn merge(bencher: Bencher) {
     let fixtures = model_fixtures();
+    let mut db = Db::new();
     let graphs: Vec<ModelGraph> = fixtures
         .iter()
-        .map(|f| djls_project::extract_model_graph(&f.source, module_path("bench.models")))
+        .enumerate()
+        .map(|(index, fixture)| {
+            model_graph_from_source(
+                &mut db,
+                format!("/bench/models/merge/{index}.py"),
+                &fixture.source,
+                module_path("bench.models"),
+            )
+        })
         .collect();
 
     bencher.bench_local(move || {
@@ -63,7 +86,13 @@ fn auth_graph() -> &'static ModelGraph {
             .iter()
             .find(|f| f.label == "medium_auth.py")
             .expect("medium_auth fixture missing");
-        djls_project::extract_model_graph(&auth.source, module_path("django.contrib.auth.models"))
+        let mut db = Db::new();
+        model_graph_from_source(
+            &mut db,
+            "/bench/models/auth.py",
+            &auth.source,
+            module_path("django.contrib.auth.models"),
+        )
     })
 }
 
@@ -169,9 +198,15 @@ fn bench_corpus(bencher: Bencher, corpus: Option<&'static CorpusModels>) {
     bencher
         .counter(divan::counter::ItemsCount::new(file_count))
         .bench_local(move || {
+            let mut db = Db::new();
             let mut merged = ModelGraph::new();
-            for (source, module_path) in &corpus.files {
-                let graph = djls_project::extract_model_graph(source, module_path.clone());
+            for (index, (source, module_path)) in corpus.files.iter().enumerate() {
+                let graph = model_graph_from_source(
+                    &mut db,
+                    format!("/bench/models/corpus/{index}.py"),
+                    source,
+                    module_path.clone(),
+                );
                 merged.merge(graph);
             }
             divan::black_box(merged);

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -1301,4 +1301,92 @@ def my_filter(value, arg):
             "compute_model_graph should NOT re-execute on second call (cached)"
         );
     }
+
+    #[test]
+    fn model_graph_reuses_unchanged_file_graphs_after_one_model_changes() {
+        let event_log = EventLog::default();
+        let settings = Settings::default();
+        let root = Utf8PathBuf::from("/test/project");
+        let first_model_path = root.join("app1/models.py");
+        let second_model_path = root.join("app2/models.py");
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(
+                first_model_path.clone(),
+                "from django.db import models\nclass First(models.Model):\n    pass\n".to_string(),
+            );
+            fs.add_file(
+                second_model_path,
+                "from django.db import models\nclass Second(models.Model):\n    pass\n".to_string(),
+            );
+        }
+
+        let mut db = DjangoDatabase {
+            fs: fs.clone(),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            storage: salsa::Storage::new(Some(Box::new({
+                let log = event_log.clone();
+                move |event| {
+                    log.events.lock().unwrap().push(event);
+                }
+            }))),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, &root, &settings);
+        db.project = Some(project);
+
+        let graph = db.model_graph();
+        assert!(graph.get("First").is_some());
+        assert!(graph.get("Second").is_some());
+        let events = event_log.take();
+        let extracted_graph_count = events
+            .iter()
+            .filter(|event| match &event.kind {
+                salsa::EventKind::WillExecute { database_key } => {
+                    let name = db.ingredient_debug_name(database_key.ingredient_index());
+                    name.contains("extract_model_graph")
+                }
+                _ => false,
+            })
+            .count();
+        assert_eq!(
+            extracted_graph_count, 2,
+            "both model files should be extracted on first model graph computation"
+        );
+
+        let first_model = db.get_or_create_file(&first_model_path);
+        fs.lock().unwrap().add_file(
+            first_model_path,
+            "from django.db import models\nclass FirstRenamed(models.Model):\n    pass\n"
+                .to_string(),
+        );
+        db.bump_file_revision(first_model);
+
+        let graph = db.model_graph();
+        assert!(graph.get("First").is_none());
+        assert!(graph.get("FirstRenamed").is_some());
+        assert!(graph.get("Second").is_some());
+        let events = event_log.take();
+        assert!(
+            was_executed(&db, &events, "compute_model_graph"),
+            "the aggregate model graph should re-run after one model file changes"
+        );
+        let extracted_graph_count = events
+            .iter()
+            .filter(|event| match &event.kind {
+                salsa::EventKind::WillExecute { database_key } => {
+                    let name = db.ingredient_debug_name(database_key.ingredient_index());
+                    name.contains("extract_model_graph")
+                }
+                _ => false,
+            })
+            .count();
+        assert_eq!(
+            extracted_graph_count, 1,
+            "only the changed model file should re-run extraction"
+        );
+    }
 }

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -25,7 +25,6 @@ pub use python::PythonModule;
 pub use python::PythonModulePath;
 pub use resolve::SearchPath;
 pub use resolve::SearchPaths;
-pub use resolve::discover_model_files;
 pub use resolve::model_modules;
 pub use resolve::templatetag_modules;
 pub use settings::DjangoSettings;

--- a/crates/djls-project/src/models.rs
+++ b/crates/djls-project/src/models.rs
@@ -1,13 +1,16 @@
 mod extract;
 mod graph;
 
+use std::ops::ControlFlow;
+
 use djls_source::File;
-pub use extract::extract_model_graph;
+use djls_source::FileKind;
 pub use graph::ModelGraph;
 
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
 use crate::db::Db;
-use crate::models::extract::extract_model_graph_from_body;
-use crate::parse::parse_python_module;
+use crate::models::extract::ModelCollector;
 use crate::project::Project;
 use crate::python::PythonModulePath;
 use crate::resolve::model_modules;
@@ -20,8 +23,7 @@ pub fn compute_model_graph(db: &dyn Db, project: Project) -> ModelGraph {
     // `ModelGraph::merge` is last-wins. Iterate search paths in reverse so
     // earlier Python search paths keep normal import precedence.
     for module in model_modules(db, project).iter().rev() {
-        let model_graph =
-            extract_model_graph_from_file(db, module.file(), module.module_path().clone());
+        let model_graph = extract_model_graph(db, module.file(), module.module_path().clone());
         if !model_graph.is_empty() {
             graph.merge(model_graph.clone());
         }
@@ -30,16 +32,34 @@ pub fn compute_model_graph(db: &dyn Db, project: Project) -> ModelGraph {
     graph
 }
 
+/// Extract a model graph from one Python file, cached by Salsa.
+///
+/// This is a separate query from `compute_model_graph` so project-wide graph
+/// recomputation can reuse unchanged per-file graphs.
 #[salsa::tracked(returns(ref))]
-fn extract_model_graph_from_file(
-    db: &dyn Db,
+pub fn extract_model_graph(
+    db: &dyn djls_source::Db,
     file: File,
     module_path: PythonModulePath,
 ) -> ModelGraph {
     let source = file.source(db);
-    let Some(parsed) = parse_python_module(db, file) else {
+    if *source.kind() != FileKind::Python {
+        return ModelGraph::default();
+    }
+
+    extract_model_graph_impl(source.as_ref(), module_path)
+}
+
+fn extract_model_graph_impl(source: &str, module_path: PythonModulePath) -> ModelGraph {
+    let Ok(parsed) = ruff_python_parser::parse_module(source) else {
         return ModelGraph::default();
     };
 
-    extract_model_graph_from_body(parsed.body(db), source.as_ref(), module_path)
+    let module = parsed.into_syntax();
+    let mut collector = ModelCollector::new(module_path, source);
+    walk_stmts(&module.body, Recurse::Flat, |stmt| {
+        collector.scan_stmt(stmt);
+        ControlFlow::Continue(())
+    });
+    collector.finish()
 }

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -1,13 +1,9 @@
-use std::ops::ControlFlow;
-
 use ruff_python_ast::Expr;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtClassDef;
 use rustc_hash::FxHashSet;
 
 use crate::ast::ExprExt;
-use crate::ast::Recurse;
-use crate::ast::walk_stmts;
 use crate::models::graph::FieldName;
 use crate::models::graph::ModelDef;
 use crate::models::graph::ModelGraph;
@@ -17,39 +13,7 @@ use crate::models::graph::Relation;
 use crate::models::graph::RelationType;
 use crate::python::PythonModulePath;
 
-/// Extract a model graph from Python source text.
-///
-/// Parses the source with Ruff's Python parser, walks the AST to find
-/// `class Foo(models.Model):` definitions, extracts field declarations
-/// and relation metadata, and builds a graph of models and their
-/// relationships.
-///
-/// The `module_path` parameter is the dotted Python module path (e.g.,
-/// `"myapp.models"`) recorded on each extracted `ModelDef`.
-#[must_use]
-pub fn extract_model_graph(source: &str, module_path: PythonModulePath) -> ModelGraph {
-    let Ok(parsed) = ruff_python_parser::parse_module(source) else {
-        return ModelGraph::default();
-    };
-    let module = parsed.into_syntax();
-    extract_model_graph_from_body(&module.body, source, module_path)
-}
-
-/// Extract a model graph from an already-parsed Python module body.
-pub(crate) fn extract_model_graph_from_body(
-    body: &[Stmt],
-    source: &str,
-    module_path: PythonModulePath,
-) -> ModelGraph {
-    let mut collector = ModelCollector::new(module_path, source);
-    walk_stmts(body, Recurse::Flat, |stmt| {
-        collector.scan_stmt(stmt);
-        ControlFlow::Continue(())
-    });
-    collector.finish()
-}
-
-struct ModelCollector<'a> {
+pub(super) struct ModelCollector<'a> {
     module_path: PythonModulePath,
     source: &'a str,
     aliases: ImportAliases,
@@ -58,7 +22,7 @@ struct ModelCollector<'a> {
 }
 
 impl<'a> ModelCollector<'a> {
-    fn new(module_path: PythonModulePath, source: &'a str) -> Self {
+    pub(super) fn new(module_path: PythonModulePath, source: &'a str) -> Self {
         Self {
             module_path,
             source,
@@ -68,7 +32,7 @@ impl<'a> ModelCollector<'a> {
         }
     }
 
-    fn finish(mut self) -> ModelGraph {
+    pub(super) fn finish(mut self) -> ModelGraph {
         resolve_children(
             &mut self.graph,
             &self.children,
@@ -78,7 +42,7 @@ impl<'a> ModelCollector<'a> {
         self.graph
     }
 
-    fn scan_stmt(&mut self, stmt: &'a Stmt) {
+    pub(super) fn scan_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::ImportFrom(import) => {
                 let Some(module) = import
@@ -466,7 +430,10 @@ mod tests {
     use super::*;
 
     fn extract_model_graph(source: &str, module_path: &str) -> ModelGraph {
-        super::extract_model_graph(source, PythonModulePath::parse(module_path).unwrap())
+        super::super::extract_model_graph_impl(
+            source,
+            PythonModulePath::parse(module_path).unwrap(),
+        )
     }
 
     #[test]

--- a/crates/djls-project/src/resolve.rs
+++ b/crates/djls-project/src/resolve.rs
@@ -182,7 +182,7 @@ pub fn model_modules(db: &dyn ProjectDb, project: Project) -> Vec<PythonModule> 
         };
 
         let search_path_len = search_path.path().as_str().len();
-        for (module_path, file_path) in discover_model_files_excluding(
+        for (module_path, file_path) in discover_model_files_in_root(
             db.file_system(),
             search_path.path(),
             search_path.root_kind(),
@@ -283,20 +283,11 @@ pub fn templatetag_modules(db: &dyn ProjectDb, project: Project) -> Vec<PythonMo
     modules.into_iter().map(|(_index, module)| module).collect()
 }
 
-/// Discover Django model source files and return their resolved module paths.
+/// Discover Django model source files under one Python search root.
 ///
 /// Finds `models.py` files and `.py` files inside `models/` packages
 /// (directories with `__init__.py`) without reading file contents.
-#[must_use]
-pub fn discover_model_files(
-    fs: &dyn FileSystem,
-    base_dir: &Utf8Path,
-    root_kind: FileRootKind,
-) -> Vec<(PythonModulePath, Utf8PathBuf)> {
-    discover_model_files_excluding(fs, base_dir, root_kind, &[])
-}
-
-fn discover_model_files_excluding(
+fn discover_model_files_in_root(
     fs: &dyn FileSystem,
     base_dir: &Utf8Path,
     root_kind: FileRootKind,

--- a/crates/djls-project/tests/corpus_models.rs
+++ b/crates/djls-project/tests/corpus_models.rs
@@ -1,7 +1,7 @@
 //! Corpus model extraction snapshot tests.
 //!
-//! Runs `extract_model_graph` against every `models.py` in the corpus
-//! and snapshots the result. Each file gets its own snapshot.
+//! Runs the model graph extraction query against every `models.py` in the
+//! corpus and snapshots the result. Each file gets its own snapshot.
 //!
 //! # Running
 //!
@@ -21,6 +21,7 @@
 use djls_project::PythonModulePath;
 use djls_project::extract_model_graph;
 use djls_testing::Corpus;
+use djls_testing::TestDatabase;
 use djls_testing::module_path_from_file;
 
 fn snapshot_dir() -> insta::internals::SettingsBindDropGuard {
@@ -39,14 +40,17 @@ fn model_extraction_snapshots() {
     assert!(!targets.is_empty(), "No model files in corpus.");
 
     let _guard = snapshot_dir();
+    let db = TestDatabase::new();
 
     for path in targets {
         let source = std::fs::read_to_string(path.as_std_path()).unwrap();
+        db.add_file(path.as_str(), &source);
+        let file = db.get_or_create_file(&path);
         let module_path = module_path_from_file(&path);
         let Ok(module_path) = PythonModulePath::parse(&module_path) else {
             continue;
         };
-        let graph = extract_model_graph(&source, module_path);
+        let graph = extract_model_graph(&db, file, module_path);
 
         // Skip files that produce no models — they're likely just
         // re-exports or empty __init__-style modules

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8Path;
-use camino::Utf8PathBuf;
 use djls_project::*;
 use djls_source::Db as _;
 use djls_source::FileRootKind;
@@ -739,145 +738,69 @@ fn compute_and_apply_refresh_discovers_site_packages_created_after_bootstrap() {
 }
 
 #[test]
-fn discover_external_model_files_finds_models() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+fn model_modules_finds_models_py_without_inspecting_contents() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/emptyapp/models.py", "# no models here\n")
+        .build(&db);
 
-    let app_dir = root.join("myapp");
-    std::fs::create_dir_all(&app_dir).unwrap();
-    std::fs::write(
-        app_dir.join("models.py"),
-        r"
-from django.db import models
-
-class Article(models.Model):
-title = models.CharField(max_length=200)
-author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
-",
-    )
-    .unwrap();
-
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::SearchPath);
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].0.as_str(), "myapp.models");
-    assert!(results[0].1.ends_with("models.py"));
+    let modules = model_modules(&db, project);
+    assert_eq!(modules.len(), 1);
+    assert_eq!(modules[0].module_path().as_str(), "emptyapp.models");
+    assert!(modules[0].path().ends_with("models.py"));
 }
 
 #[test]
-fn discover_external_model_files_finds_files_without_inspecting_contents() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
-
-    let app_dir = root.join("emptyapp");
-    std::fs::create_dir_all(&app_dir).unwrap();
-    std::fs::write(app_dir.join("models.py"), "# no models here\n").unwrap();
-
-    // Discovery finds the file (it doesn't inspect contents)
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::SearchPath);
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].0.as_str(), "emptyapp.models");
-}
-
-#[test]
-fn discover_external_model_files_nested_apps() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
-
-    for app in &["blog", "accounts"] {
-        let app_dir = root.join(app);
-        std::fs::create_dir_all(&app_dir).unwrap();
-        std::fs::write(
-            app_dir.join("models.py"),
-            format!(
-                "from django.db import models\nclass {name}Model(models.Model):\n    pass\n",
-                name = app.chars().next().unwrap().to_uppercase().to_string() + &app[1..]
-            ),
+fn model_modules_finds_nested_apps() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nclass BlogModel(models.Model):\n    pass\n",
         )
-        .unwrap();
-    }
+        .file(
+            "/project/accounts/models.py",
+            "from django.db import models\nclass AccountsModel(models.Model):\n    pass\n",
+        )
+        .build(&db);
 
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::SearchPath);
-    assert_eq!(results.len(), 2);
-    let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
+    let modules = model_modules(&db, project);
+    assert_eq!(modules.len(), 2);
+    let module_paths: Vec<&str> = modules
+        .iter()
+        .map(|module| module.module_path().as_str())
+        .collect();
     assert!(module_paths.contains(&"blog.models"));
     assert!(module_paths.contains(&"accounts.models"));
 }
 
 #[test]
-fn discover_model_files_workspace_finds_models() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+fn model_modules_finds_models_package_files() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/myapp/models/__init__.py",
+            "from .user import User\nfrom .order import Order\n",
+        )
+        .file(
+            "/project/myapp/models/user.py",
+            "from django.db import models\nclass User(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/myapp/models/order.py",
+            "from django.db import models\nclass Order(models.Model):\n    user = models.ForeignKey(User, on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
 
-    let app_dir = root.join("myapp");
-    std::fs::create_dir_all(&app_dir).unwrap();
-    std::fs::write(
-        app_dir.join("models.py"),
-        "from django.db import models\nclass Foo(models.Model): pass\n",
-    )
-    .unwrap();
-
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::Project);
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].0.as_str(), "myapp.models");
-    assert!(results[0].1.ends_with("models.py"));
-}
-
-#[test]
-fn discover_external_model_files_package() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
-
-    let models_dir = root.join("myapp/models");
-    std::fs::create_dir_all(&models_dir).unwrap();
-    std::fs::write(
-        models_dir.join("__init__.py"),
-        "from .user import User\nfrom .order import Order\n",
-    )
-    .unwrap();
-    std::fs::write(
-        models_dir.join("user.py"),
-        "from django.db import models\nclass User(models.Model):\n    pass\n",
-    )
-    .unwrap();
-    std::fs::write(
-        models_dir.join("order.py"),
-        "from django.db import models\nclass Order(models.Model):\n    user = models.ForeignKey(User, on_delete=models.CASCADE)\n",
-    )
-    .unwrap();
-
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::SearchPath);
-    // Discovers all three files (including __init__.py)
-    assert_eq!(results.len(), 3);
-    let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
+    let modules = model_modules(&db, project);
+    assert_eq!(modules.len(), 3);
+    let module_paths: Vec<&str> = modules
+        .iter()
+        .map(|module| module.module_path().as_str())
+        .collect();
     assert!(module_paths.contains(&"myapp.models"));
     assert!(module_paths.contains(&"myapp.models.user"));
     assert!(module_paths.contains(&"myapp.models.order"));
-}
-
-#[test]
-fn discover_workspace_models_package() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
-
-    let models_dir = root.join("myapp/models");
-    std::fs::create_dir_all(&models_dir).unwrap();
-    std::fs::write(models_dir.join("__init__.py"), "").unwrap();
-    std::fs::write(
-        models_dir.join("user.py"),
-        "from django.db import models\nclass User(models.Model): pass\n",
-    )
-    .unwrap();
-
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::Project);
-    let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
-    assert!(
-        module_paths.contains(&"myapp.models"),
-        "should discover __init__.py as myapp.models"
-    );
-    assert!(
-        module_paths.contains(&"myapp.models.user"),
-        "should discover user.py as myapp.models.user"
-    );
 }
 
 #[test]
@@ -895,45 +818,22 @@ fn module_path_from_submodule() {
 }
 
 #[test]
-fn discover_workspace_models_nested_package() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+fn model_modules_finds_nested_models_package_files() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/myapp/models/__init__.py", "")
+        .file("/project/myapp/models/base/__init__.py", "")
+        .file(
+            "/project/myapp/models/base/abstract.py",
+            "from django.db import models\nclass BaseModel(models.Model):\n    class Meta:\n        abstract = True\n",
+        )
+        .build(&db);
 
-    let base_dir = root.join("myapp/models/base");
-    std::fs::create_dir_all(&base_dir).unwrap();
-    std::fs::write(root.join("myapp/models/__init__.py"), "").unwrap();
-    std::fs::write(base_dir.join("__init__.py"), "").unwrap();
-    std::fs::write(
-        base_dir.join("abstract.py"),
-        "from django.db import models\nclass BaseModel(models.Model):\n    class Meta:\n        abstract = True\n",
-    )
-    .unwrap();
-
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::Project);
-    let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
-    assert!(
-        module_paths.contains(&"myapp.models.base.abstract"),
-        "should discover nested model files: got {module_paths:?}"
-    );
-}
-
-#[test]
-fn discover_external_model_files_nested_package() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
-
-    let base_dir = root.join("myapp/models/base");
-    std::fs::create_dir_all(&base_dir).unwrap();
-    std::fs::write(root.join("myapp/models/__init__.py"), "").unwrap();
-    std::fs::write(base_dir.join("__init__.py"), "").unwrap();
-    std::fs::write(
-        base_dir.join("abstract.py"),
-        "from django.db import models\nclass BaseModel(models.Model):\n    class Meta:\n        abstract = True\n",
-    )
-    .unwrap();
-
-    let results = discover_model_files(&djls_source::OsFileSystem, &root, FileRootKind::SearchPath);
-    let module_paths: Vec<&str> = results.iter().map(|(m, _)| m.as_str()).collect();
+    let modules = model_modules(&db, project);
+    let module_paths: Vec<&str> = modules
+        .iter()
+        .map(|module| module.module_path().as_str())
+        .collect();
     assert!(
         module_paths.contains(&"myapp.models.base.abstract"),
         "should discover nested model files: got {module_paths:?}"


### PR DESCRIPTION
## Summary
- replace the public raw-source model graph extractor with a file-backed Salsa query
- keep project-wide `compute_model_graph` as the aggregate query and parsed-body extraction crate-private
- update corpus tests and model benchmarks to materialize files before extraction
- add an incremental regression test proving only the changed model file re-extracts while the aggregate graph recomputes

## Validation
- `cargo build -q`
- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`

## Review
- Hickey reviewer: no must-fix findings
- Lamport reviewer: no must-fix findings; added the suggested incremental regression test