### PR TITLE
Name Django settings source set

### DIFF
--- a/crates/djls-project/src/settings.rs
+++ b/crates/djls-project/src/settings.rs
@@ -5,7 +5,8 @@ mod types;
 
 use djls_source::File;
 pub(crate) use extraction::extract_settings;
-pub(crate) use sources::settings_source_files;
+pub(crate) use sources::DjangoSettingsSources;
+pub(crate) use sources::settings_sources;
 pub(crate) use types::DjangoSettings;
 pub(crate) use types::SettingsSource;
 pub(crate) use types::SettingsSourceResolver;

--- a/crates/djls-project/src/settings/sources.rs
+++ b/crates/djls-project/src/settings/sources.rs
@@ -17,63 +17,70 @@ pub(super) fn django_settings_from_file(
     project: Project,
     file: File,
 ) -> DjangoSettings {
-    let source = file.source(db);
-    let path = file.path(db);
-    let mut resolver = SalsaSettingsResolver { db, project };
-    extract_settings(source.as_str(), path, &mut resolver)
+    let mut reader = TrackedSettingsSourceReader { db };
+    let Some(source) = reader.read_source(file) else {
+        return DjangoSettings::default();
+    };
+    let mut resolver = ReaderResolver::new(db, project, reader);
+    extract_settings(source.source.as_str(), &source.path, &mut resolver)
 }
 
-pub(crate) fn settings_source_files(db: &dyn ProjectDb, project: Project) -> Vec<File> {
-    let Some(file) = crate::settings::settings_module_file(db, project) else {
-        return Vec::new();
-    };
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct DjangoSettingsSources(Vec<File>);
 
-    let path = file.path(db).to_path_buf();
-    let Ok(source) = db.read_file(&path) else {
-        return vec![file];
+impl DjangoSettingsSources {
+    fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    fn from_files(db: &dyn ProjectDb, files: impl IntoIterator<Item = File>) -> Self {
+        let mut seen = BTreeSet::new();
+        let mut deduped = Vec::new();
+        for file in files {
+            if seen.insert(file.path(db).to_path_buf()) {
+                deduped.push(file);
+            }
+        }
+
+        Self(deduped)
+    }
+
+    pub(crate) fn files(&self) -> &[File] {
+        &self.0
+    }
+
+    pub(crate) fn root(&self) -> Option<File> {
+        self.0.first().copied()
+    }
+}
+
+pub(crate) fn settings_sources(db: &dyn ProjectDb, project: Project) -> DjangoSettingsSources {
+    let Some(file) = crate::settings::settings_module_file(db, project) else {
+        return DjangoSettingsSources::empty();
     };
 
     // The refresh bump set must cover the same settings source graph the
     // extractor would read against current disk content.
-    let mut resolver = DiskSettingsResolver {
-        db,
-        project,
-        touched: Vec::new(),
+    let mut reader = RefreshSettingsSourceReader { db };
+    let Some(source) = reader.read_source(file) else {
+        return DjangoSettingsSources::from_files(db, [file]);
     };
-    let _ = extract_settings(&source, &path, &mut resolver);
+    let mut resolver = ReaderResolver::new(db, project, reader);
+    let _ = extract_settings(source.source.as_str(), &source.path, &mut resolver);
 
-    let mut seen = BTreeSet::new();
-    let mut files = Vec::new();
-    if seen.insert(path) {
-        files.push(file);
-    }
-    for file in resolver.touched {
-        let path = file.path(db).to_path_buf();
-        if seen.insert(path) {
-            files.push(file);
-        }
-    }
-    files
+    DjangoSettingsSources::from_files(db, std::iter::once(file).chain(resolver.into_resolved()))
 }
 
-struct SalsaSettingsResolver<'db> {
+trait SettingsSourceReader {
+    fn read_source(&mut self, file: File) -> Option<SettingsSource>;
+}
+
+struct TrackedSettingsSourceReader<'db> {
     db: &'db dyn ProjectDb,
-    project: Project,
 }
 
-impl SettingsSourceResolver for SalsaSettingsResolver<'_> {
-    fn resolve_star_import(
-        &mut self,
-        import: &SettingsStarImport,
-        importer: &Utf8Path,
-    ) -> Option<SettingsSource> {
-        let parts = ImportParts {
-            level: import.level,
-            module: import.module.as_deref(),
-            importer,
-        };
-        let module_path = crate::resolve::resolve_import(self.db, self.project, parts)?;
-        let file = crate::resolve::module_file(self.db, self.project, &module_path)?;
+impl SettingsSourceReader for TrackedSettingsSourceReader<'_> {
+    fn read_source(&mut self, file: File) -> Option<SettingsSource> {
         Some(SettingsSource {
             source: file.source(self.db).as_str().to_string(),
             path: file.path(self.db).to_path_buf(),
@@ -81,13 +88,41 @@ impl SettingsSourceResolver for SalsaSettingsResolver<'_> {
     }
 }
 
-struct DiskSettingsResolver<'db> {
+struct RefreshSettingsSourceReader<'db> {
     db: &'db dyn ProjectDb,
-    project: Project,
-    touched: Vec<File>,
 }
 
-impl SettingsSourceResolver for DiskSettingsResolver<'_> {
+impl SettingsSourceReader for RefreshSettingsSourceReader<'_> {
+    fn read_source(&mut self, file: File) -> Option<SettingsSource> {
+        let path = file.path(self.db).to_path_buf();
+        let source = self.db.read_file(&path).ok()?;
+        Some(SettingsSource { source, path })
+    }
+}
+
+struct ReaderResolver<'db, R> {
+    db: &'db dyn ProjectDb,
+    project: Project,
+    reader: R,
+    resolved: Vec<File>,
+}
+
+impl<'db, R> ReaderResolver<'db, R> {
+    fn new(db: &'db dyn ProjectDb, project: Project, reader: R) -> Self {
+        Self {
+            db,
+            project,
+            reader,
+            resolved: Vec::new(),
+        }
+    }
+
+    fn into_resolved(self) -> Vec<File> {
+        self.resolved
+    }
+}
+
+impl<R: SettingsSourceReader> SettingsSourceResolver for ReaderResolver<'_, R> {
     fn resolve_star_import(
         &mut self,
         import: &SettingsStarImport,
@@ -100,10 +135,7 @@ impl SettingsSourceResolver for DiskSettingsResolver<'_> {
         };
         let module_path = crate::resolve::resolve_import(self.db, self.project, parts)?;
         let file = crate::resolve::module_file(self.db, self.project, &module_path)?;
-        let path = file.path(self.db).to_path_buf();
-        self.touched.push(file);
-        let source = self.db.read_file(&path).ok()?;
-
-        Some(SettingsSource { source, path })
+        self.resolved.push(file);
+        self.reader.read_source(file)
     }
 }

--- a/crates/djls-project/src/sync.rs
+++ b/crates/djls-project/src/sync.rs
@@ -12,7 +12,8 @@ use crate::project::Project;
 use crate::resolve::SearchPaths;
 use crate::resolve::model_modules;
 use crate::resolve::templatetag_modules;
-use crate::settings::settings_source_files;
+use crate::settings::DjangoSettingsSources;
+use crate::settings::settings_sources;
 use crate::templates::templatetag_candidate_paths;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -75,12 +76,17 @@ impl RefreshQuery {
                 project.interpreter(db),
                 project.pythonpath(db),
             )),
-            Self::SettingsSources => RefreshDataPart::FilePaths(
-                settings_source_files(db, project)
-                    .into_iter()
-                    .map(|file| file.path(db).to_path_buf())
-                    .collect(),
-            ),
+            Self::SettingsSources => {
+                let sources: DjangoSettingsSources = settings_sources(db, project);
+                RefreshDataPart::FilePaths(
+                    sources
+                        .root()
+                        .into_iter()
+                        .chain(sources.files().iter().copied().skip(1))
+                        .map(|file| file.path(db).to_path_buf())
+                        .collect(),
+                )
+            }
             Self::ModelModules => RefreshDataPart::FilePaths(
                 model_modules(db, project)
                     .iter()

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -8,8 +9,11 @@ use djls_project::Db as ProjectDb;
 use djls_project::*;
 use djls_source::Db as _;
 use djls_source::FileSystem;
+use djls_source::InMemoryFileSystem;
 use djls_source::OsFileSystem;
 use djls_source::SourceFiles;
+use djls_source::WalkEntry;
+use djls_source::WalkOptions;
 use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use serde::Deserialize;
@@ -40,16 +44,20 @@ struct GoldenTemplateSymbol {
 #[derive(Clone)]
 struct OsTestDatabase {
     storage: salsa::Storage<Self>,
-    fs: Arc<OsFileSystem>,
+    fs: Arc<dyn FileSystem>,
     files: SourceFiles,
     project: Option<Project>,
 }
 
 impl OsTestDatabase {
     fn new() -> Self {
+        Self::with_file_system(Arc::new(OsFileSystem))
+    }
+
+    fn with_file_system(fs: Arc<dyn FileSystem>) -> Self {
         Self {
             storage: salsa::Storage::default(),
-            fs: Arc::new(OsFileSystem),
+            fs,
             files: SourceFiles::default(),
             project: None,
         }
@@ -77,6 +85,40 @@ impl ProjectDb for OsTestDatabase {
     }
 }
 
+struct FailingReadFileSystem {
+    inner: InMemoryFileSystem,
+    unreadable: Utf8PathBuf,
+}
+
+impl FileSystem for FailingReadFileSystem {
+    fn read_to_string(&self, path: &Utf8Path) -> io::Result<String> {
+        if path == self.unreadable.as_path() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "test file is unreadable",
+            ));
+        }
+
+        self.inner.read_to_string(path)
+    }
+
+    fn exists(&self, path: &Utf8Path) -> bool {
+        self.inner.exists(path)
+    }
+
+    fn is_file(&self, path: &Utf8Path) -> bool {
+        self.inner.is_file(path)
+    }
+
+    fn is_dir(&self, path: &Utf8Path) -> bool {
+        self.inner.is_dir(path)
+    }
+
+    fn walk_entries(&self, root: &Utf8Path, options: &WalkOptions) -> io::Result<Vec<WalkEntry>> {
+        self.inner.walk_entries(root, options)
+    }
+}
+
 fn project_with_settings(
     db: &mut TestDatabase,
     settings_module: &str,
@@ -99,6 +141,104 @@ fn apply_project_refresh(db: &mut TestDatabase) {
     );
 
     apply_refresh(db, refresh);
+}
+
+#[test]
+fn project_refresh_enumerates_settings_star_import_chain() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            (
+                "/proj/myproject/settings.py",
+                "from .base import *\nfrom .feature import *\n",
+            ),
+            (
+                "/proj/myproject/base.py",
+                "from .common import *\nINSTALLED_APPS = []\n",
+            ),
+            ("/proj/myproject/feature.py", "from .common import *\n"),
+            (
+                "/proj/myproject/common.py",
+                "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False}]\n",
+            ),
+        ],
+    );
+
+    let refresh = RefreshData::from_query_results(
+        RefreshQuery::ALL
+            .iter()
+            .copied()
+            .map(|query| query.compute(&db, project)),
+    );
+
+    let expected = [
+        Utf8PathBuf::from("/proj/myproject/base.py"),
+        Utf8PathBuf::from("/proj/myproject/common.py"),
+        Utf8PathBuf::from("/proj/myproject/feature.py"),
+        Utf8PathBuf::from("/proj/myproject/settings.py"),
+    ];
+    assert_eq!(refresh.file_paths(), expected.as_slice());
+}
+
+#[test]
+fn project_refresh_includes_deduped_unreadable_settings_source() {
+    let unreadable = Utf8PathBuf::from("/proj/myproject/unreadable.py");
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file(
+        Utf8PathBuf::from("/proj/myproject/settings.py"),
+        "from .base import *\nfrom .unreadable import *\nfrom .base import *\n".to_string(),
+    );
+    fs.add_file(
+        Utf8PathBuf::from("/proj/myproject/base.py"),
+        "INSTALLED_APPS = []\n".to_string(),
+    );
+    fs.add_file(unreadable.clone(), "TEMPLATES = []\n".to_string());
+
+    let mut db = OsTestDatabase::with_file_system(Arc::new(FailingReadFileSystem {
+        inner: fs,
+        unreadable: unreadable.clone(),
+    }));
+    let root = Utf8PathBuf::from("/proj");
+    let interpreter = Interpreter::Auto;
+    let pythonpath = Vec::new();
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        root.as_path(),
+        &interpreter,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let tag_specs = djls_conf::Settings::default().tagspecs().clone();
+    let project = Project::new(
+        &db,
+        root,
+        search_paths,
+        interpreter,
+        Some("myproject.settings".to_string()),
+        pythonpath,
+        Vec::new(),
+        tag_specs,
+    );
+    db.project = Some(project);
+
+    let settings_sources = RefreshQuery::SettingsSources.compute(&db, project);
+    assert_eq!(settings_sources.item_count(), 3);
+
+    let refresh = RefreshData::from_query_results(
+        RefreshQuery::ALL
+            .iter()
+            .copied()
+            .map(|query| query.compute(&db, project)),
+    );
+
+    let expected = [
+        Utf8PathBuf::from("/proj/myproject/base.py"),
+        Utf8PathBuf::from("/proj/myproject/settings.py"),
+        unreadable,
+    ];
+    assert_eq!(refresh.file_paths(), expected.as_slice());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- unify settings star-import source reading behind a shared reader resolver
- introduce DjangoSettingsSources for refresh source enumeration
- update refresh integration and cover deduped unreadable settings sources

## Validation
- cargo test -p djls-project
- cargo test -p djls-db
- cargo build -q
- just fmt
- just clippy
- just hawk