### PR TITLE
Unify template tag library discovery

### DIFF
--- a/crates/djls-project/src/sync.rs
+++ b/crates/djls-project/src/sync.rs
@@ -14,7 +14,7 @@ use crate::resolve::model_modules;
 use crate::resolve::templatetag_modules;
 use crate::settings::DjangoSettingsSources;
 use crate::settings::settings_sources;
-use crate::templates::templatetag_candidate_paths;
+use crate::templates::refresh_templatetag_candidate_paths;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RefreshData {
@@ -100,7 +100,7 @@ impl RefreshQuery {
                     .collect(),
             ),
             Self::TemplateTagCandidates => {
-                RefreshDataPart::FilePaths(templatetag_candidate_paths(db, project))
+                RefreshDataPart::FilePaths(refresh_templatetag_candidate_paths(db, project))
             }
         };
 

--- a/crates/djls-project/src/templates.rs
+++ b/crates/djls-project/src/templates.rs
@@ -1,3 +1,4 @@
+mod candidates;
 mod dirs;
 pub(crate) mod filters;
 mod inactive;
@@ -8,6 +9,10 @@ mod registrations;
 mod symbols;
 mod tags;
 
+pub(crate) use candidates::TemplateTagCandidate;
+pub(crate) use candidates::refresh_templatetag_candidate_paths;
+pub(crate) use candidates::templatetag_candidates;
+pub(crate) use candidates::templatetag_package_candidates;
 pub use dirs::template_dirs;
 pub use filters::FilterArity;
 pub use filters::FilterArityMap;
@@ -15,7 +20,6 @@ pub use filters::extract_filter_arities;
 pub use inactive::InactiveLibraries;
 pub use inactive::InactiveLibrary;
 pub use inactive::inactive_template_libraries;
-pub(crate) use inactive::templatetag_candidate_paths;
 pub use libraries::InstalledSymbolCandidate;
 pub use libraries::InstalledSymbolOrigin;
 pub use libraries::TemplateLibraries;

--- a/crates/djls-project/src/templates/candidates.rs
+++ b/crates/djls-project/src/templates/candidates.rs
@@ -1,0 +1,446 @@
+use std::cmp::Ordering;
+
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use djls_source::File;
+use djls_source::FileRootKind;
+use djls_source::FileSystem;
+use djls_source::WalkEntryKind;
+use djls_source::WalkOptions;
+use rustc_hash::FxHashMap;
+
+use crate::db::Db as ProjectDb;
+use crate::project::Project;
+use crate::python::PythonModulePath;
+use crate::resolve::package_dir;
+use crate::settings::StaticKnowledge;
+use crate::templates::LibraryName;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TemplateTagDiscoveryMode {
+    ActivePackage,
+    InactiveCandidate,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct TemplateTagCandidate {
+    pub(crate) app: PythonModulePath,
+    pub(crate) name: LibraryName,
+    pub(crate) module: PythonModulePath,
+    path: Utf8PathBuf,
+    pub(crate) file: File,
+}
+
+impl TemplateTagCandidate {
+    fn from_source(db: &dyn ProjectDb, source: TemplateTagCandidateSource) -> Self {
+        let file = db.get_or_create_file(&source.path);
+        Self {
+            app: source.app,
+            name: source.name,
+            module: source.module,
+            path: source.path,
+            file,
+        }
+    }
+
+    fn into_path(self) -> Utf8PathBuf {
+        self.path
+    }
+
+    fn cmp_by_app_name_path(&self, other: &Self) -> Ordering {
+        self.app
+            .cmp(&other.app)
+            .then_with(|| self.name.cmp(&other.name))
+            .then_with(|| self.path.cmp(&other.path))
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct TemplateTagCandidateSource {
+    app: PythonModulePath,
+    name: LibraryName,
+    module: PythonModulePath,
+    path: Utf8PathBuf,
+}
+
+impl TemplateTagCandidateSource {
+    fn new(app: PythonModulePath, name: LibraryName, path: Utf8PathBuf) -> Option<Self> {
+        let module = templatetag_module(&app, &name)?;
+        Some(Self {
+            app,
+            name,
+            module,
+            path,
+        })
+    }
+}
+
+pub(crate) struct TemplateTagPackageScan {
+    candidates: Vec<TemplateTagCandidate>,
+    knowledge: StaticKnowledge,
+}
+
+impl TemplateTagPackageScan {
+    fn known() -> Self {
+        Self {
+            candidates: Vec::new(),
+            knowledge: StaticKnowledge::Known,
+        }
+    }
+
+    fn demote_to_partial(&mut self) {
+        self.knowledge = self.knowledge.demoted_to_partial();
+    }
+
+    pub(crate) fn into_parts(self) -> (StaticKnowledge, Vec<TemplateTagCandidate>) {
+        (self.knowledge, self.candidates)
+    }
+}
+
+#[salsa::tracked(returns(ref))]
+pub(crate) fn templatetag_candidates(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> Vec<TemplateTagCandidate> {
+    project.touch_search_path_roots(db);
+    walk_candidates(db, project, TemplateTagDiscoveryMode::InactiveCandidate)
+}
+
+pub(crate) fn refresh_templatetag_candidate_paths(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> Vec<Utf8PathBuf> {
+    walk_candidates(db, project, TemplateTagDiscoveryMode::InactiveCandidate)
+        .into_iter()
+        .map(TemplateTagCandidate::into_path)
+        .collect()
+}
+
+pub(crate) fn templatetag_package_candidates(
+    db: &dyn ProjectDb,
+    project: Project,
+    package_module: &str,
+) -> TemplateTagPackageScan {
+    let mut scan = TemplateTagPackageScan::known();
+
+    if package_module.is_empty() {
+        scan.demote_to_partial();
+        return scan;
+    }
+
+    let Ok(package_module) = PythonModulePath::parse(package_module) else {
+        scan.demote_to_partial();
+        return scan;
+    };
+
+    let Some(package_dir) = package_dir(db, project, package_module.as_str()) else {
+        scan.demote_to_partial();
+        return scan;
+    };
+
+    let templatetags_dir = package_dir.join("templatetags");
+    if !db.path_is_file(&templatetags_dir.join("__init__.py")) {
+        return scan;
+    }
+
+    let entries = match db.walk_entries(&templatetags_dir, &WalkOptions::shallow()) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
+            scan.demote_to_partial();
+            return scan;
+        }
+    };
+
+    for entry in entries {
+        if entry.kind != WalkEntryKind::File {
+            continue;
+        }
+
+        match recognize_candidate_source(
+            db.file_system(),
+            &package_dir,
+            entry.path,
+            &[],
+            TemplateTagDiscoveryMode::ActivePackage,
+            Some(&package_module),
+        ) {
+            CandidateSourceRecognition::Candidate(source) => {
+                scan.candidates
+                    .push(TemplateTagCandidate::from_source(db, source));
+            }
+            CandidateSourceRecognition::InvalidIdentifier => scan.demote_to_partial(),
+            CandidateSourceRecognition::NotCandidate => {}
+        }
+    }
+
+    scan.candidates
+        .sort_by(TemplateTagCandidate::cmp_by_app_name_path);
+    scan
+}
+
+fn walk_candidates(
+    db: &dyn ProjectDb,
+    project: Project,
+    mode: TemplateTagDiscoveryMode,
+) -> Vec<TemplateTagCandidate> {
+    let search_paths = project.search_paths(db);
+    let mut candidates_by_path: Vec<(usize, TemplateTagCandidate)> = Vec::new();
+    let mut path_indexes: FxHashMap<Utf8PathBuf, usize> = FxHashMap::default();
+
+    for search_path in search_paths.iter() {
+        let excluded_paths = if search_path.is_first_party() {
+            search_paths
+                .iter()
+                .filter(|other| {
+                    !other.is_first_party() && other.path().starts_with(search_path.path())
+                })
+                .map(|other| other.path().to_path_buf())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let search_path_len = search_path.path().as_str().len();
+
+        for candidate in discover_templatetag_candidates(
+            db,
+            search_path.path(),
+            search_path.root_kind(),
+            &excluded_paths,
+            mode,
+        ) {
+            let path = candidate.path.clone();
+            if let Some(index) = path_indexes.get(&path).copied() {
+                let (existing_search_path_len, existing) = &mut candidates_by_path[index];
+                if search_path_len > *existing_search_path_len {
+                    *existing_search_path_len = search_path_len;
+                    *existing = candidate;
+                }
+            } else {
+                path_indexes.insert(path, candidates_by_path.len());
+                candidates_by_path.push((search_path_len, candidate));
+            }
+        }
+    }
+
+    candidates_by_path
+        .into_iter()
+        .map(|(_search_path_len, candidate)| candidate)
+        .collect()
+}
+
+fn discover_templatetag_candidates(
+    db: &dyn ProjectDb,
+    base_dir: &Utf8Path,
+    root_kind: FileRootKind,
+    excluded_roots: &[Utf8PathBuf],
+    mode: TemplateTagDiscoveryMode,
+) -> Vec<TemplateTagCandidate> {
+    let mut results: Vec<_> = discover_templatetag_candidate_sources(
+        db.file_system(),
+        base_dir,
+        root_kind,
+        excluded_roots,
+        mode,
+    )
+    .into_iter()
+    .map(|source| TemplateTagCandidate::from_source(db, source))
+    .collect();
+
+    results.sort_by(TemplateTagCandidate::cmp_by_app_name_path);
+    results
+}
+
+fn discover_templatetag_candidate_sources(
+    fs: &dyn FileSystem,
+    base_dir: &Utf8Path,
+    root_kind: FileRootKind,
+    excluded_roots: &[Utf8PathBuf],
+    mode: TemplateTagDiscoveryMode,
+) -> Vec<TemplateTagCandidateSource> {
+    let options = match root_kind {
+        FileRootKind::Project => WalkOptions::project(),
+        FileRootKind::SearchPath => WalkOptions::library_search_path(),
+    };
+
+    let mut results = Vec::new();
+
+    let entries = match fs.walk_entries(base_dir, &options) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!("Failed to walk Python source root {}: {}", base_dir, err);
+            return results;
+        }
+    };
+
+    for entry in entries {
+        if entry.kind != WalkEntryKind::File {
+            continue;
+        }
+        let path = entry.path;
+        match recognize_candidate_source(fs, base_dir, path, excluded_roots, mode, None) {
+            CandidateSourceRecognition::Candidate(candidate) => results.push(candidate),
+            CandidateSourceRecognition::InvalidIdentifier
+            | CandidateSourceRecognition::NotCandidate => {}
+        }
+    }
+
+    results
+}
+
+enum CandidateSourceRecognition {
+    Candidate(TemplateTagCandidateSource),
+    InvalidIdentifier,
+    NotCandidate,
+}
+
+fn recognize_candidate_source(
+    fs: &dyn FileSystem,
+    base_dir: &Utf8Path,
+    path: Utf8PathBuf,
+    excluded_roots: &[Utf8PathBuf],
+    mode: TemplateTagDiscoveryMode,
+    active_package: Option<&PythonModulePath>,
+) -> CandidateSourceRecognition {
+    if path.extension() != Some("py") {
+        return CandidateSourceRecognition::NotCandidate;
+    }
+    let Some(stem) = path.file_stem() else {
+        return CandidateSourceRecognition::NotCandidate;
+    };
+    if stem.starts_with('_') {
+        return CandidateSourceRecognition::NotCandidate;
+    }
+
+    if excluded_roots
+        .iter()
+        .any(|excluded| path.starts_with(excluded))
+    {
+        return CandidateSourceRecognition::NotCandidate;
+    }
+
+    let Some(templatetags_dir) = path.parent() else {
+        return CandidateSourceRecognition::NotCandidate;
+    };
+    if templatetags_dir.file_name() != Some("templatetags") {
+        return CandidateSourceRecognition::NotCandidate;
+    }
+    if !fs.exists(&templatetags_dir.join("__init__.py")) {
+        return CandidateSourceRecognition::NotCandidate;
+    }
+
+    let app = match mode {
+        TemplateTagDiscoveryMode::ActivePackage => {
+            let Some(package_module) = active_package else {
+                return CandidateSourceRecognition::NotCandidate;
+            };
+            package_module.clone()
+        }
+        TemplateTagDiscoveryMode::InactiveCandidate => {
+            let Some(app_dir) = templatetags_dir.parent() else {
+                return CandidateSourceRecognition::NotCandidate;
+            };
+            if app_dir == base_dir || !fs.exists(&app_dir.join("__init__.py")) {
+                return CandidateSourceRecognition::NotCandidate;
+            }
+            let Ok(app_rel) = app_dir.strip_prefix(base_dir) else {
+                return CandidateSourceRecognition::NotCandidate;
+            };
+            let Ok(app) = PythonModulePath::from_relative_package(app_rel) else {
+                return CandidateSourceRecognition::NotCandidate;
+            };
+            app
+        }
+    };
+
+    let Ok(name) = LibraryName::parse(stem) else {
+        return CandidateSourceRecognition::InvalidIdentifier;
+    };
+    let Some(candidate) = TemplateTagCandidateSource::new(app, name, path) else {
+        return CandidateSourceRecognition::InvalidIdentifier;
+    };
+    CandidateSourceRecognition::Candidate(candidate)
+}
+
+fn templatetag_module(app: &PythonModulePath, name: &LibraryName) -> Option<PythonModulePath> {
+    PythonModulePath::parse(&format!("{}.templatetags.{}", app.as_str(), name.as_str())).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use djls_source::InMemoryFileSystem;
+
+    use super::*;
+
+    #[test]
+    fn discover_templatetag_candidates_requires_django_package_shape() {
+        let mut fs = InMemoryFileSystem::new();
+        fs.add_file("/root/pkg_a/__init__.py".into(), String::new());
+        fs.add_file("/root/pkg_a/templatetags/__init__.py".into(), String::new());
+        fs.add_file("/root/pkg_a/templatetags/foo.py".into(), String::new());
+        fs.add_file("/root/pkg_a/templatetags/_private.py".into(), String::new());
+        fs.add_file("/root/pkg_b/__init__.py".into(), String::new());
+        fs.add_file("/root/pkg_b/templatetags/bar.py".into(), String::new());
+        fs.add_file("/root/loose/templatetags/__init__.py".into(), String::new());
+        fs.add_file("/root/loose/templatetags/baz.py".into(), String::new());
+
+        let discovered = discover_templatetag_candidate_sources(
+            &fs,
+            Utf8Path::new("/root"),
+            FileRootKind::Project,
+            &[],
+            TemplateTagDiscoveryMode::InactiveCandidate,
+        );
+
+        assert_eq!(discovered.len(), 1);
+        let candidate = &discovered[0];
+        assert_eq!(candidate.app.as_str(), "pkg_a");
+        assert_eq!(candidate.name.as_str(), "foo");
+        assert_eq!(candidate.module.as_str(), "pkg_a.templatetags.foo");
+        assert_eq!(candidate.path.as_str(), "/root/pkg_a/templatetags/foo.py");
+    }
+
+    #[test]
+    fn recognizer_modes_keep_active_and_inactive_package_shape_distinct() {
+        let mut fs = InMemoryFileSystem::new();
+        fs.add_file(
+            "/root/namespace_app/templatetags/__init__.py".into(),
+            String::new(),
+        );
+        fs.add_file(
+            "/root/namespace_app/templatetags/tools.py".into(),
+            String::new(),
+        );
+
+        let path = Utf8PathBuf::from("/root/namespace_app/templatetags/tools.py");
+        let package = PythonModulePath::parse("namespace_app").unwrap();
+        let active = recognize_candidate_source(
+            &fs,
+            Utf8Path::new("/root/namespace_app"),
+            path.clone(),
+            &[],
+            TemplateTagDiscoveryMode::ActivePackage,
+            Some(&package),
+        );
+        let inactive = recognize_candidate_source(
+            &fs,
+            Utf8Path::new("/root"),
+            path,
+            &[],
+            TemplateTagDiscoveryMode::InactiveCandidate,
+            None,
+        );
+
+        let CandidateSourceRecognition::Candidate(candidate) = active else {
+            panic!("active package scan should accept namespace package templatetags");
+        };
+        assert_eq!(candidate.app.as_str(), "namespace_app");
+        assert_eq!(candidate.name.as_str(), "tools");
+        assert_eq!(
+            candidate.module.as_str(),
+            "namespace_app.templatetags.tools"
+        );
+        assert!(matches!(inactive, CandidateSourceRecognition::NotCandidate));
+    }
+}

--- a/crates/djls-project/src/templates/inactive.rs
+++ b/crates/djls-project/src/templates/inactive.rs
@@ -3,21 +3,15 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
-use camino::Utf8Path;
-use camino::Utf8PathBuf;
-use djls_source::FileRootKind;
-use djls_source::FileSystem;
-use djls_source::WalkEntryKind;
-use djls_source::WalkOptions;
-use rustc_hash::FxHashMap;
-
 use super::names::LibraryName;
 use crate::db::Db as ProjectDb;
 use crate::project::Project;
 use crate::python::PythonModulePath;
 use crate::templates::TemplateLibraryAnalysis;
 use crate::templates::TemplateSymbolKind;
+use crate::templates::TemplateTagCandidate;
 use crate::templates::template_libraries;
+use crate::templates::templatetag_candidates;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InactiveLibrary {
@@ -38,8 +32,7 @@ impl InactiveLibrary {
             return None;
         }
 
-        let file = db.get_or_create_file(&candidate.path);
-        let analysis = TemplateLibraryAnalysis::from_file(db, file);
+        let analysis = TemplateLibraryAnalysis::from_file(db, candidate.file);
         if !analysis.defines_library && analysis.symbols.is_empty() {
             return None;
         }
@@ -130,40 +123,6 @@ impl InactiveLibraries {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct TemplateTagCandidate {
-    app: PythonModulePath,
-    name: LibraryName,
-    module: PythonModulePath,
-    path: Utf8PathBuf,
-}
-
-impl TemplateTagCandidate {
-    fn new(app: PythonModulePath, name: LibraryName, path: Utf8PathBuf) -> Option<Self> {
-        let module =
-            PythonModulePath::parse(&format!("{}.templatetags.{}", app.as_str(), name.as_str()))
-                .ok()?;
-
-        Some(Self {
-            app,
-            name,
-            module,
-            path,
-        })
-    }
-
-    fn into_path(self) -> Utf8PathBuf {
-        self.path
-    }
-
-    fn cmp_by_app_name_path(&self, other: &Self) -> Ordering {
-        self.app
-            .cmp(&other.app)
-            .then_with(|| self.name.cmp(&other.name))
-            .then_with(|| self.path.cmp(&other.path))
-    }
-}
-
 #[salsa::tracked(returns(ref))]
 pub fn inactive_template_libraries(db: &dyn ProjectDb, project: Project) -> InactiveLibraries {
     project.touch_search_path_roots(db);
@@ -177,7 +136,7 @@ pub fn inactive_template_libraries(db: &dyn ProjectDb, project: Project) -> Inac
         .collect();
 
     let mut inactive = InactiveLibraries::default();
-    for candidate in discover_project_templatetag_candidates(db, project) {
+    for candidate in templatetag_candidates(db, project).iter().cloned() {
         if let Some(library) = InactiveLibrary::from_candidate(db, candidate, &active_modules) {
             inactive.push(library);
         }
@@ -185,178 +144,4 @@ pub fn inactive_template_libraries(db: &dyn ProjectDb, project: Project) -> Inac
 
     inactive.sort_and_dedup();
     inactive
-}
-
-pub(crate) fn templatetag_candidate_paths(
-    db: &dyn ProjectDb,
-    project: Project,
-) -> Vec<Utf8PathBuf> {
-    discover_project_templatetag_candidates(db, project)
-        .into_iter()
-        .map(TemplateTagCandidate::into_path)
-        .collect()
-}
-
-fn discover_project_templatetag_candidates(
-    db: &dyn ProjectDb,
-    project: Project,
-) -> Vec<TemplateTagCandidate> {
-    let search_paths = project.search_paths(db);
-    let mut candidates_by_path: Vec<(usize, TemplateTagCandidate)> = Vec::new();
-    let mut path_indexes: FxHashMap<Utf8PathBuf, usize> = FxHashMap::default();
-
-    for search_path in search_paths.iter() {
-        let excluded_paths = if search_path.is_first_party() {
-            search_paths
-                .iter()
-                .filter(|other| {
-                    !other.is_first_party() && other.path().starts_with(search_path.path())
-                })
-                .map(|other| other.path().to_path_buf())
-                .collect()
-        } else {
-            Vec::new()
-        };
-        let search_path_len = search_path.path().as_str().len();
-
-        for candidate in discover_templatetag_candidates(
-            db.file_system(),
-            search_path.path(),
-            search_path.root_kind(),
-            &excluded_paths,
-        ) {
-            let path = candidate.path.clone();
-            if let Some(index) = path_indexes.get(&path).copied() {
-                let (existing_search_path_len, existing) = &mut candidates_by_path[index];
-                if search_path_len > *existing_search_path_len {
-                    *existing_search_path_len = search_path_len;
-                    *existing = candidate;
-                }
-            } else {
-                path_indexes.insert(path, candidates_by_path.len());
-                candidates_by_path.push((search_path_len, candidate));
-            }
-        }
-    }
-
-    candidates_by_path
-        .into_iter()
-        .map(|(_search_path_len, candidate)| candidate)
-        .collect()
-}
-
-fn discover_templatetag_candidates(
-    fs: &dyn FileSystem,
-    base_dir: &Utf8Path,
-    root_kind: FileRootKind,
-    excluded_roots: &[Utf8PathBuf],
-) -> Vec<TemplateTagCandidate> {
-    let options = match root_kind {
-        FileRootKind::Project => WalkOptions::project(),
-        FileRootKind::SearchPath => WalkOptions::library_search_path(),
-    };
-
-    let mut results = Vec::new();
-
-    let entries = match fs.walk_entries(base_dir, &options) {
-        Ok(entries) => entries,
-        Err(err) => {
-            tracing::warn!("Failed to walk Python source root {}: {}", base_dir, err);
-            return results;
-        }
-    };
-
-    for entry in entries {
-        if entry.kind != WalkEntryKind::File {
-            continue;
-        }
-        let path = entry.path;
-
-        if path.extension() != Some("py") {
-            continue;
-        }
-        let Some(stem) = path.file_stem() else {
-            continue;
-        };
-        if stem.starts_with('_') {
-            continue;
-        }
-
-        if excluded_roots
-            .iter()
-            .any(|excluded| path.starts_with(excluded))
-        {
-            continue;
-        }
-
-        let Some(templatetags_dir) = path.parent() else {
-            continue;
-        };
-        if templatetags_dir.file_name() != Some("templatetags") {
-            continue;
-        }
-        if !fs.exists(&templatetags_dir.join("__init__.py")) {
-            continue;
-        }
-
-        let Some(app_dir) = templatetags_dir.parent() else {
-            continue;
-        };
-        if app_dir == base_dir || !fs.exists(&app_dir.join("__init__.py")) {
-            continue;
-        }
-
-        let Some(app_rel) = app_dir.strip_prefix(base_dir).ok() else {
-            continue;
-        };
-        let Ok(app) = PythonModulePath::from_relative_package(app_rel) else {
-            continue;
-        };
-        let Ok(name) = LibraryName::parse(stem) else {
-            continue;
-        };
-        let Some(candidate) = TemplateTagCandidate::new(app, name, path) else {
-            continue;
-        };
-
-        results.push(candidate);
-    }
-
-    results.sort_by(TemplateTagCandidate::cmp_by_app_name_path);
-    results
-}
-
-#[cfg(test)]
-mod tests {
-    use camino::Utf8Path;
-    use djls_source::InMemoryFileSystem;
-
-    use super::*;
-
-    #[test]
-    fn discover_templatetag_candidates_requires_django_package_shape() {
-        let mut fs = InMemoryFileSystem::new();
-        fs.add_file("/root/pkg_a/__init__.py".into(), String::new());
-        fs.add_file("/root/pkg_a/templatetags/__init__.py".into(), String::new());
-        fs.add_file("/root/pkg_a/templatetags/foo.py".into(), String::new());
-        fs.add_file("/root/pkg_a/templatetags/_private.py".into(), String::new());
-        fs.add_file("/root/pkg_b/__init__.py".into(), String::new());
-        fs.add_file("/root/pkg_b/templatetags/bar.py".into(), String::new());
-        fs.add_file("/root/loose/templatetags/__init__.py".into(), String::new());
-        fs.add_file("/root/loose/templatetags/baz.py".into(), String::new());
-
-        let discovered = discover_templatetag_candidates(
-            &fs,
-            Utf8Path::new("/root"),
-            FileRootKind::Project,
-            &[],
-        );
-
-        assert_eq!(discovered.len(), 1);
-        let candidate = &discovered[0];
-        assert_eq!(candidate.app.as_str(), "pkg_a");
-        assert_eq!(candidate.name.as_str(), "foo");
-        assert_eq!(candidate.module.as_str(), "pkg_a.templatetags.foo");
-        assert_eq!(candidate.path.as_str(), "/root/pkg_a/templatetags/foo.py");
-    }
 }

--- a/crates/djls-project/src/templates/libraries.rs
+++ b/crates/djls-project/src/templates/libraries.rs
@@ -1,8 +1,5 @@
 use std::collections::BTreeMap;
 
-use djls_source::WalkEntryKind;
-use djls_source::WalkOptions;
-
 use super::names::LibraryName;
 use super::registrations::TemplateLibraryAnalysis;
 use super::symbols::TemplateSymbol;
@@ -10,12 +7,12 @@ use crate::db::Db as ProjectDb;
 use crate::project::Project;
 use crate::python::PythonModulePath;
 use crate::resolve::module_file;
-use crate::resolve::package_dir;
 use crate::settings::StaticKnowledge;
 use crate::settings::django_settings;
 use crate::settings::settings_module_file;
 use crate::templates::TemplateSymbolKind;
 use crate::templates::guess_package_module_from_installed_app_entry;
+use crate::templates::templatetag_package_candidates;
 
 const DEFAULT_TEMPLATE_BUILTINS: &[&str] = &[
     "django.template.defaulttags",
@@ -107,65 +104,19 @@ fn templatetag_package_libraries(
     project: Project,
     package_module: &str,
 ) -> (StaticKnowledge, Vec<(LibraryName, TemplateLibrary)>) {
-    let mut knowledge = StaticKnowledge::Known;
+    let (knowledge, candidates) =
+        templatetag_package_candidates(db, project, package_module).into_parts();
     let mut libraries = Vec::new();
 
-    if package_module.is_empty() {
-        return (knowledge.demoted_to_partial(), libraries);
-    }
-
-    if PythonModulePath::parse(package_module).is_err() {
-        return (knowledge.demoted_to_partial(), libraries);
-    }
-
-    let Some(package_dir) = package_dir(db, project, package_module) else {
-        return (knowledge.demoted_to_partial(), libraries);
-    };
-
-    let templatetags_dir = package_dir.join("templatetags");
-    if !db.path_is_file(&templatetags_dir.join("__init__.py")) {
-        return (knowledge, libraries);
-    }
-
-    let entries = match db.walk_entries(&templatetags_dir, &WalkOptions::shallow()) {
-        Ok(entries) => entries,
-        Err(err) => {
-            tracing::warn!("Failed to walk template tag package {templatetags_dir}: {err}");
-            return (knowledge.demoted_to_partial(), libraries);
-        }
-    };
-
-    for entry in entries {
-        if entry.kind != WalkEntryKind::File || entry.path.extension() != Some("py") {
-            continue;
-        }
-
-        let Some(stem) = entry.path.file_stem() else {
-            continue;
-        };
-        if stem.starts_with('_') {
-            continue;
-        }
-
-        let Ok(load_name) = LibraryName::parse(stem) else {
-            knowledge = knowledge.demoted_to_partial();
-            continue;
-        };
-        let module_path = format!("{package_module}.templatetags.{stem}");
-        let Ok(module) = PythonModulePath::parse(&module_path) else {
-            knowledge = knowledge.demoted_to_partial();
-            continue;
-        };
-
-        let file = db.get_or_create_file(&entry.path);
-        let analysis = TemplateLibraryAnalysis::from_file(db, file);
+    for candidate in candidates {
+        let analysis = TemplateLibraryAnalysis::from_file(db, candidate.file);
         if !analysis.defines_library && analysis.symbols.is_empty() {
             continue;
         }
 
-        let mut library = TemplateLibrary::new(module);
+        let mut library = TemplateLibrary::new(candidate.module);
         library.merge_symbols(analysis.symbols);
-        libraries.push((load_name, library));
+        libraries.push((candidate.name, library));
     }
 
     (knowledge, libraries)

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -738,6 +738,38 @@ fn compute_and_apply_refresh_discovers_site_packages_created_after_bootstrap() {
 }
 
 #[test]
+fn project_refresh_enumerates_new_empty_templatetag_candidate_before_root_bump() {
+    let mut db = TestDatabase::new();
+    db.add_file("/project/blog/__init__.py", "");
+    db.add_file("/project/blog/templatetags/__init__.py", "");
+
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &[],
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    assert_eq!(
+        RefreshQuery::TemplateTagCandidates
+            .compute(&db, project)
+            .item_count(),
+        0
+    );
+
+    db.add_file("/project/blog/templatetags/future.py", "");
+
+    assert_eq!(
+        RefreshQuery::TemplateTagCandidates
+            .compute(&db, project)
+            .item_count(),
+        1
+    );
+}
+
+#[test]
 fn model_modules_finds_models_py_without_inspecting_contents() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -515,6 +515,34 @@ fn template_libraries_discover_app_templatetags_and_builtins() {
 }
 
 #[test]
+fn template_libraries_discover_namespace_package_templatetags() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            ("/proj/nsapp/templatetags/__init__.py", ""),
+            (
+                "/proj/nsapp/templatetags/custom.py",
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef hello():\n    pass\n",
+            ),
+            (
+                "/proj/myproject/settings.py",
+                "INSTALLED_APPS = ['nsapp']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
+            ),
+        ],
+    );
+
+    let libraries = template_libraries(&db, project);
+
+    let custom = libraries
+        .loadable_library_str("custom")
+        .expect("namespace package templatetag should be discovered");
+    assert_eq!(custom.module().as_str(), "nsapp.templatetags.custom");
+    assert!(custom.symbols.iter().any(|symbol| symbol.name() == "hello"));
+}
+
+#[test]
 fn template_libraries_include_empty_registered_modules() {
     let mut db = TestDatabase::new();
     let project = project_with_settings(


### PR DESCRIPTION
## Summary
- move template tag candidates into a shared discovery seam
- use shared bottom-up refresh/inactive candidate discovery and top-down active package scans
- add regression coverage for refresh-before-bump and namespace-package active libraries

## Validation
- cargo build -q -p djls-project
- cargo test -p djls-project
- cargo test -p djls-project candidates
- cargo test -p djls-project -- --ignored django_facts_golden_template_libraries_match
- just hawk
- just clippy && just fmt --check
- cargo test -q