### PR TITLE
Narrow djls-project test-support API

### DIFF
--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -8,6 +8,7 @@ use djls_bench::model_fixtures;
 use djls_project::ModelGraph;
 use djls_project::ModelId;
 use djls_project::PythonModulePath;
+use djls_project::testing::extract_model_graph;
 
 fn main() {
     divan::main();
@@ -24,7 +25,7 @@ fn model_graph_from_source(
     module_path: PythonModulePath,
 ) -> ModelGraph {
     let file = db.file_with_contents(path, source);
-    djls_project::extract_model_graph(db, file, module_path).clone()
+    extract_model_graph(db, file, module_path).clone()
 }
 
 // Batch extraction: all fixtures in one iteration

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -1106,7 +1106,7 @@ def my_filter(value, arg):
 
     fn apply_project_refresh(db: &mut DjangoDatabase) {
         let project = db.project().expect("project refresh data");
-        let refresh = djls_project::compute_refresh(db, project);
+        let refresh = djls_project::testing::compute_refresh(db, project);
         djls_project::apply_refresh(db, refresh);
     }
 
@@ -1145,7 +1145,7 @@ def my_filter(value, arg):
         let project = Project::bootstrap(&db, root.as_path(), &settings);
         db.project = Some(project);
 
-        let refresh = djls_project::compute_refresh(&db, project);
+        let refresh = djls_project::testing::compute_refresh(&db, project);
         let file_paths: Vec<_> = refresh.file_paths().to_vec();
         assert!(!file_paths.is_empty());
         djls_project::apply_refresh(&mut db, refresh);
@@ -1168,7 +1168,7 @@ def my_filter(value, arg):
             .collect();
         assert!(!root_revisions.is_empty());
 
-        let refresh = djls_project::compute_refresh(&db, project);
+        let refresh = djls_project::testing::compute_refresh(&db, project);
         djls_project::apply_refresh(&mut db, refresh);
 
         let unchanged_file_revisions: Vec<_> = file_paths

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -13,7 +13,6 @@ pub use db::Db;
 pub use models::ModelGraph;
 pub use models::ModelId;
 pub use models::compute_model_graph;
-pub use models::extract_model_graph;
 pub use project::Project;
 pub use python::Interpreter;
 pub use python::InvalidModulePath;
@@ -26,11 +25,9 @@ pub use refresh::RefreshTask;
 pub use refresh::RefreshTaskDescriptor;
 pub use refresh::RefreshTaskGroup;
 pub use refresh::apply_refresh;
-pub use refresh::compute_refresh;
 pub use refresh::refresh_tasks;
 pub use resolve::SearchPath;
 pub use resolve::SearchPaths;
-pub use resolve::model_modules;
 pub use resolve::templatetag_modules;
 pub use settings::StaticKnowledge;
 pub use templates::ArgumentCountConstraint;
@@ -76,3 +73,11 @@ pub use templates::extract_tag_rules;
 pub use templates::inactive_template_libraries;
 pub use templates::template_libraries;
 pub use templates::template_resolution;
+
+// Test and benchmark support only; not part of the stable Project Facts façade.
+#[doc(hidden)]
+pub mod testing {
+    pub use crate::models::extract_model_graph;
+    pub use crate::refresh::compute_refresh;
+    pub use crate::resolve::model_modules;
+}

--- a/crates/djls-project/tests/corpus_models.rs
+++ b/crates/djls-project/tests/corpus_models.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use djls_project::PythonModulePath;
-use djls_project::extract_model_graph;
+use djls_project::testing::extract_model_graph;
 use djls_testing::Corpus;
 use djls_testing::TestDatabase;
 use djls_testing::module_path_from_file;

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8Path;
+use djls_project::testing::compute_refresh;
+use djls_project::testing::model_modules;
 use djls_project::*;
 use djls_source::Db as _;
 use djls_source::FileRootKind;

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_project::Db as ProjectDb;
+use djls_project::testing::compute_refresh;
 use djls_project::*;
 use djls_source::Db as _;
 use djls_source::FileSystem;


### PR DESCRIPTION
## Summary
- move djls-project test/bench-only helpers behind a hidden testing facade
- update project tests, db invalidation tests, and model benchmarks to import through djls_project::testing

## Validation
- cargo build -q
- cargo test -q
- just hawk
- just clippy
- just fmt --check
- just lint
