### PR TITLE
Refactor template semantics through Template Tree

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - run: true
 
   pre-commit:
-    needs: [should-run]
+    needs: should-run
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -71,28 +71,8 @@ jobs:
           SKIP=no-commit-to-branch,cargo-fmt,cargo-clippy \
           uv run --no-project --with "nox[uv]" nox --session lint
 
-  rust-changes:
-    needs: [should-run]
-    runs-on: ubuntu-latest
-    outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          filters: |
-            rust:
-              - '.github/workflows/lint.yml'
-              - 'crates/**'
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-
   ast-grep-tests:
-    needs: [should-run]
+    needs: should-run
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -115,6 +95,26 @@ jobs:
 
       - name: Run ast-grep rule tests
         run: sg test --config tools/ast-grep/sgconfig.yml --skip-snapshot-tests --color=never
+
+  rust-changes:
+    needs: should-run
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '.github/workflows/lint.yml'
+              - 'crates/**'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
 
   rustfmt:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
 
 env:
+  AST_GREP_VERSION: "0.44.0"
   CARGO_TERM_COLOR: always
   FORCE_COLOR: "1"
   PYTHONUNBUFFERED: "1"
@@ -51,6 +52,20 @@ jobs:
           path: ~/.cache/pre-commit/
           key: pre-commit-1|${{ hashFiles('.pre-commit-config.yaml') }}
 
+      - name: Cache ast-grep binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/sg
+            ~/.cargo/bin/ast-grep
+          key: ${{ runner.os }}-${{ runner.arch }}-ast-grep-${{ env.AST_GREP_VERSION }}
+
+      - name: Install ast-grep
+        run: |
+          if ! command -v sg >/dev/null 2>&1 || [ "$(sg --version)" != "ast-grep ${AST_GREP_VERSION}" ]; then
+            cargo install ast-grep --version "${AST_GREP_VERSION}" --locked --force
+          fi
+
       - name: Run pre-commit
         run: |
           SKIP=no-commit-to-branch,cargo-fmt,cargo-clippy \
@@ -75,6 +90,31 @@ jobs:
               - 'crates/**'
               - 'Cargo.lock'
               - 'Cargo.toml'
+
+  ast-grep-tests:
+    needs: [should-run]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Cache Cargo binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/sg
+            ~/.cargo/bin/ast-grep
+          key: ${{ runner.os }}-${{ runner.arch }}-ast-grep-${{ env.AST_GREP_VERSION }}
+
+      - name: Install ast-grep
+        run: |
+          if ! command -v sg >/dev/null 2>&1 || [ "$(sg --version)" != "ast-grep ${AST_GREP_VERSION}" ]; then
+            cargo install ast-grep --version "${AST_GREP_VERSION}" --locked --force
+          fi
+
+      - name: Run ast-grep rule tests
+        run: sg test --config tools/ast-grep/sgconfig.yml --skip-snapshot-tests --color=never
 
   rustfmt:
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,9 @@ repos:
       - id: ast-grep
         name: ast-grep
         entry: sg scan --config tools/ast-grep/sgconfig.yml --report-style=short --color=never
-        language: system
+        language: node
+        additional_dependencies:
+          - "@ast-grep/cli@0.44.0"
         types: [rust]
         pass_filenames: false
       - id: cargo-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
         args: ["--branch", "main"]
   - repo: local
     hooks:
+      - id: ast-grep
+        name: ast-grep
+        entry: sg scan --config tools/ast-grep/sgconfig.yml --report-style=short --color=never
+        language: system
+        types: [rust]
+        pass_filenames: false
       - id: cargo-fmt
         name: cargo fmt
         entry: cargo +nightly fmt --check

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -235,7 +235,7 @@ A range of template source whose contents the language server treats as a black 
 _Avoid_: ignored content, raw text, hidden block
 
 **Template Tree**:
-The language server's tree-shaped structural view of a **Template**, made of **Template Branches** and **Template Leaves**.
+The language server's tree-shaped structural view of a **Template**, made of **Template Branches** and **Template Leaves**. It is the canonical structure for semantically active **Template Tags** and **Template Variables**; callers that need structured template meaning should use **Template Tree**-derived queries rather than re-walking the raw **Template Node List**.
 _Avoid_: AST, syntax tree, parse tree
 
 **Template Branch**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,18 @@ So far it's all been built by [a simple country CRUD web developer](https://yout
 
 ### Linting
 
+#### Structural Lints
+
+[ast-grep](https://ast-grep.github.io/) enforces repository-specific structural conventions that Clippy cannot express. The configuration lives in [`tools/ast-grep/`](./tools/ast-grep/).
+
+Install the native `sg` CLI, then run the ast-grep scan and native rule tests through `just`:
+
+```bash
+just ast-grep
+```
+
+When changing ast-grep rules, update the matching tests in [`tools/ast-grep/tests/`](./tools/ast-grep/tests/).
+
 #### Visibility Audits
 
 [Hawk](https://github.com/astral-sh/hawk) is an experimental Cargo lint from Astral that checks unnecessary public Rust visibility across a closed-world workspace. It is useful here because most crates are internal architecture layers behind the shipped `djls` binary.
@@ -305,6 +317,7 @@ $ just
 $ # just --list --list-submodules
 
 Available recipes:
+    ast-grep       # run ast-grep scan and rule tests
     bumpver *ARGS
     check *ARGS
     clean

--- a/Justfile
+++ b/Justfile
@@ -17,6 +17,11 @@ cog:
 nox SESSION *ARGS:
     uv run --no-project --with "nox[uv]" nox --session "{{ SESSION }}" -- "{{ ARGS }}"
 
+# run ast-grep scan and rule tests
+ast-grep:
+    sg scan --config tools/ast-grep/sgconfig.yml --report-style=short --color=never
+    sg test --config tools/ast-grep/sgconfig.yml --skip-snapshot-tests --color=never
+
 bumpver *ARGS:
     uv run --with bumpver bumpver {{ ARGS }}
 

--- a/crates/djls-ide/src/folding.rs
+++ b/crates/djls-ide/src/folding.rs
@@ -1,5 +1,5 @@
-use djls_semantic::TagClass;
-use djls_semantic::TagIndex;
+use djls_semantic::TemplateFold;
+use djls_semantic::TemplateFoldKind;
 use djls_source::File;
 use djls_source::Span;
 use djls_templates::Node;
@@ -17,8 +17,10 @@ pub fn collect_folding_ranges(
     };
 
     let source = file.source(db);
-    let tag_index = djls_semantic::compute_tag_index(db);
-    let folds = FoldSpans::collect(nodelist.nodelist(db), source.as_str(), tag_index).into_vec();
+    let template_tree = djls_semantic::build_template_tree(db, nodelist);
+    let semantic_folds = djls_semantic::build_template_folds(db, template_tree);
+    let folds =
+        FoldSpans::collect(semantic_folds, nodelist.nodelist(db), source.as_str()).into_vec();
 
     let line_index = file.line_index(db);
     folds
@@ -30,108 +32,46 @@ pub fn collect_folding_ranges(
 #[derive(Default)]
 struct FoldSpans(Vec<FoldSpan>);
 
-struct FoldFrame {
-    opener_name: String,
-    opener_span: Span,
-    closer_name: Option<String>,
-    opaque: bool,
-}
-
 impl FoldSpans {
-    fn collect(nodes: &[Node], source: &str, tag_index: &TagIndex) -> Self {
+    fn collect(semantic_folds: &[TemplateFold], nodes: &[Node], source: &str) -> Self {
         let mut folds = Self::default();
-        folds.collect_semantic(nodes, tag_index);
-        folds.collect_header(nodes, source);
+        for fold in semantic_folds {
+            folds.push((*fold).into());
+        }
+
+        let mut import_header = ImportHeaderFold::None;
+        for node in nodes {
+            match node {
+                Node::Comment { .. } => {
+                    folds.push_imports(import_header.finish());
+                    folds.push(FoldSpan::comment(node.full_span()));
+                }
+                Node::Tag { name, .. } if name == "extends" => {
+                    folds.push_imports(import_header.finish());
+                    import_header.start_at_extends(node.full_span());
+                }
+                Node::Tag { name, .. } if name == "load" => {
+                    import_header.include_load(node.full_span());
+                }
+                Node::Text { span }
+                    if source
+                        .get(span.start_usize()..span.end_usize())
+                        .is_some_and(|text| text.trim().is_empty()) => {}
+                Node::Tag { .. }
+                | Node::Text { .. }
+                | Node::Variable { .. }
+                | Node::Error { .. } => {
+                    folds.push_imports(import_header.finish());
+                }
+            }
+        }
+        folds.push_imports(import_header.finish());
+
         folds
-    }
-
-    fn collect_semantic(&mut self, nodes: &[Node], tag_index: &TagIndex) {
-        let mut stack: Vec<FoldFrame> = Vec::new();
-
-        for node in nodes {
-            let Node::Tag { name, .. } = node else {
-                continue;
-            };
-
-            if let Some(frame) = stack
-                .pop_if(|frame| frame.opaque && frame.closer_name.as_deref() == Some(name.as_str()))
-            {
-                self.push_bounds(
-                    frame.opener_span.start(),
-                    node.full_span().end(),
-                    FoldKind::from_semantic_tag_name(&frame.opener_name),
-                );
-                continue;
-            }
-            if stack.last().is_some_and(|frame| frame.opaque) {
-                continue;
-            }
-
-            if let Some(possible_openers) = tag_index.closer_openers(name)
-                && let Some(open_idx) = stack.iter().rposition(|frame| {
-                    possible_openers
-                        .iter()
-                        .any(|opener| opener == &frame.opener_name)
-                })
-            {
-                while stack.len() > open_idx + 1 {
-                    stack.pop();
-                }
-                let frame = stack.pop().expect("matched opener should remain on stack");
-                self.push_bounds(
-                    frame.opener_span.start(),
-                    node.full_span().end(),
-                    FoldKind::from_semantic_tag_name(&frame.opener_name),
-                );
-                continue;
-            }
-
-            match tag_index.classify(name) {
-                TagClass::Opener => {
-                    stack.push(FoldFrame {
-                        opener_name: name.clone(),
-                        opener_span: node.full_span(),
-                        closer_name: tag_index.closer_name(name).map(str::to_string),
-                        opaque: tag_index.is_opaque(name),
-                    });
-                }
-                TagClass::Closer { .. } | TagClass::Intermediate { .. } | TagClass::Unknown => {}
-            }
-        }
-    }
-
-    fn collect_header(&mut self, nodes: &[Node], source: &str) {
-        let mut imports = ImportHeaderCandidate::None;
-
-        for node in nodes {
-            match HeaderItem::from_node(node, source) {
-                HeaderItem::Comment(span) => {
-                    self.push_imports(imports.finish());
-                    self.push(FoldSpan::comment(span));
-                }
-                HeaderItem::Extends(span) => {
-                    self.push_imports(imports.finish());
-                    imports.begin_with_extends(span);
-                }
-                HeaderItem::Load(span) => {
-                    imports.include_load(span);
-                }
-                HeaderItem::Whitespace => {}
-                HeaderItem::Boundary => self.push_imports(imports.finish()),
-            }
-        }
-
-        self.push_imports(imports.finish());
     }
 
     fn push(&mut self, fold: FoldSpan) {
         self.0.push(fold);
-    }
-
-    fn push_bounds(&mut self, start: u32, end: u32, kind: FoldKind) {
-        if let Some(fold) = FoldSpan::from_bounds(start, end, kind) {
-            self.push(fold);
-        }
     }
 
     fn push_imports(&mut self, fold: Option<FoldSpan>) {
@@ -151,6 +91,15 @@ impl FoldSpans {
 pub(crate) struct FoldSpan {
     pub(crate) span: Span,
     pub(crate) kind: FoldKind,
+}
+
+impl From<TemplateFold> for FoldSpan {
+    fn from(fold: TemplateFold) -> Self {
+        Self {
+            span: fold.span,
+            kind: fold.kind.into(),
+        }
+    }
 }
 
 impl FoldSpan {
@@ -188,14 +137,16 @@ pub(crate) enum FoldKind {
     Imports,
 }
 
-impl FoldKind {
-    fn from_semantic_tag_name(name: &str) -> Self {
-        match name {
-            "comment" => Self::Comment,
-            _ => Self::Region,
+impl From<TemplateFoldKind> for FoldKind {
+    fn from(kind: TemplateFoldKind) -> Self {
+        match kind {
+            TemplateFoldKind::Region => Self::Region,
+            TemplateFoldKind::Comment => Self::Comment,
         }
     }
+}
 
+impl FoldKind {
     fn sort_key(self) -> u8 {
         match self {
             Self::Region => 0,
@@ -206,78 +157,43 @@ impl FoldKind {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum HeaderItem {
-    Comment(Span),
-    Extends(Span),
-    Load(Span),
-    Whitespace,
-    Boundary,
-}
-
-impl HeaderItem {
-    fn from_node(node: &Node, source: &str) -> Self {
-        match node {
-            Node::Comment { .. } => Self::Comment(node.full_span()),
-            Node::Tag { name, .. } if name == "extends" => Self::Extends(node.full_span()),
-            Node::Tag { name, .. } if name == "load" => Self::Load(node.full_span()),
-            Node::Text { span }
-                if source
-                    .get(span.start_usize()..span.end() as usize)
-                    .is_some_and(|text| text.trim().is_empty()) =>
-            {
-                Self::Whitespace
-            }
-            Node::Tag { .. } | Node::Text { .. } | Node::Variable { .. } | Node::Error { .. } => {
-                Self::Boundary
-            }
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ImportHeaderCandidate {
+enum ImportHeaderFold {
     None,
-    Started {
-        start: u32,
-        last_load_end: Option<u32>,
-    },
+    ExtendsOnly { start: u32 },
+    Imports { start: u32, end: u32 },
 }
 
-impl ImportHeaderCandidate {
-    fn begin_with_extends(&mut self, span: Span) {
-        *self = Self::Started {
+impl ImportHeaderFold {
+    fn start_at_extends(&mut self, span: Span) {
+        *self = Self::ExtendsOnly {
             start: span.start(),
-            last_load_end: None,
         };
     }
 
     fn include_load(&mut self, span: Span) {
         match self {
             Self::None => {
-                *self = Self::Started {
+                *self = Self::Imports {
                     start: span.start(),
-                    last_load_end: Some(span.end()),
+                    end: span.end(),
                 };
             }
-            Self::Started { last_load_end, .. } => {
-                *last_load_end = Some(span.end());
+            Self::ExtendsOnly { start } => {
+                *self = Self::Imports {
+                    start: *start,
+                    end: span.end(),
+                };
+            }
+            Self::Imports { end, .. } => {
+                *end = span.end();
             }
         }
     }
 
     fn finish(&mut self) -> Option<FoldSpan> {
-        let finished = std::mem::replace(self, Self::None);
-
-        match finished {
-            Self::Started {
-                start,
-                last_load_end: Some(end),
-            } => FoldSpan::imports(start, end),
-            Self::None
-            | Self::Started {
-                last_load_end: None,
-                ..
-            } => None,
+        match std::mem::replace(self, Self::None) {
+            Self::Imports { start, end } => FoldSpan::imports(start, end),
+            Self::None | Self::ExtendsOnly { .. } => None,
         }
     }
 }

--- a/crates/djls-ide/tests/folding.rs
+++ b/crates/djls-ide/tests/folding.rs
@@ -53,3 +53,34 @@ fn folding_ranges_include_top_level_and_nested_template_blocks() {
             && range.kind == Some(ls_types::FoldingRangeKind::Region)
     }));
 }
+
+#[test]
+fn folding_ranges_ignore_closer_looking_tags_inside_opaque_content() {
+    let source = r"{% if outer %}
+{% verbatim %}
+{% endif %}
+body
+{% endverbatim %}
+{% endif %}
+";
+    let db = TestDatabase::new();
+    db.add_file("template.html", source);
+    let file = db.get_or_create_file(Utf8Path::new("template.html"));
+    let ranges = collect_folding_ranges(&db, file);
+
+    assert!(ranges.iter().any(|range| {
+        range.start_line == 0
+            && range.end_line == 5
+            && range.kind == Some(ls_types::FoldingRangeKind::Region)
+    }));
+    assert!(ranges.iter().any(|range| {
+        range.start_line == 1
+            && range.end_line == 4
+            && range.kind == Some(ls_types::FoldingRangeKind::Region)
+    }));
+    assert!(!ranges.iter().any(|range| {
+        range.start_line == 0
+            && range.end_line == 2
+            && range.kind == Some(ls_types::FoldingRangeKind::Region)
+    }));
+}

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -25,15 +25,15 @@ pub use structure::OpaqueRegions;
 pub use structure::OutlineItem;
 pub use structure::OutlineKind;
 pub use structure::RegionId;
-pub use structure::TagClass;
-pub use structure::TagIndex;
+pub use structure::TemplateFold;
+pub use structure::TemplateFoldKind;
 pub use structure::TemplateNode;
 pub use structure::TemplateRegion;
 pub use structure::TemplateTree;
+pub use structure::build_template_folds;
 pub use structure::build_template_outline;
 pub use structure::build_template_tree;
 pub use structure::compute_opaque_regions;
-pub use structure::compute_tag_index;
 pub use tags::EndTag;
 pub use tags::IntermediateTag;
 pub use tags::TagRole;
@@ -42,7 +42,7 @@ pub use tags::TagSpecs;
 pub use tags::builtin_tag_specs;
 pub use tags::compute_tag_specs;
 
-use crate::structure::opaque_regions_from_tree;
+use crate::structure::active_template_nodes;
 use crate::validation::TemplateValidator;
 
 /// Validate a Django template file.
@@ -70,16 +70,11 @@ pub fn validate_template_file(db: &dyn Db, file: djls_source::File) {
 /// - Unmatched block names
 #[salsa::tracked]
 pub fn validate_nodelist(db: &dyn Db, nodelist: djls_templates::NodeList<'_>) {
-    let nodes = nodelist.nodelist(db);
-    if nodes.is_empty() {
-        return;
-    }
-
     // 1. Structural analysis accumulates block-structure diagnostics.
     let template_tree = build_template_tree(db, nodelist);
 
-    // 2. Perform all other validations in a single walk.
-    let opaque_regions = opaque_regions_from_tree(template_tree.regions(db));
-    let validator = TemplateValidator::new(db, nodelist, &opaque_regions);
-    validator.validate(nodes);
+    // 2. Perform all other validations from the tree-derived active semantic view.
+    let active_nodes = active_template_nodes(template_tree.regions(db), template_tree.root(db));
+    let validator = TemplateValidator::new(db, nodelist);
+    validator.validate(&active_nodes);
 }

--- a/crates/djls-semantic/src/offset.rs
+++ b/crates/djls-semantic/src/offset.rs
@@ -2,13 +2,16 @@ use djls_project::TemplateName;
 use djls_source::File;
 use djls_source::Offset;
 use djls_source::Span;
-use djls_templates::Node;
-use djls_templates::TagBit;
 use djls_templates::parse_template;
 
 use crate::db::Db as SemanticDb;
 use crate::references::LiteralTemplateReference;
 use crate::scoping::LoadKind;
+use crate::structure::ActiveTemplateNode;
+use crate::structure::ActiveTemplateTag;
+use crate::structure::ActiveTemplateVariable;
+use crate::structure::active_template_nodes;
+use crate::structure::build_template_tree;
 use crate::tags::TagSpecs;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -28,66 +31,65 @@ impl<'db> SemanticOffsetContext<'db> {
             return Self::None;
         };
 
-        let Some(node) = nodelist.node_at(db, offset) else {
-            return Self::None;
-        };
-
+        let tree = build_template_tree(db, nodelist);
         let tag_specs = db.tag_specs();
 
-        match node {
-            Node::Tag {
-                name,
-                name_span,
-                bits,
-                ..
-            } => Self::from_tag(db, tag_specs, name, *name_span, bits, offset),
-            Node::Variable {
-                var,
-                var_span,
-                filters,
-                ..
-            } => {
-                for filter in filters {
-                    let span = filter.span.with_length_usize_saturating(filter.name.len());
-                    if span.contains(offset) {
-                        return Self::Filter {
-                            name: filter.name.clone(),
-                            span,
-                        };
-                    }
+        for node in active_template_nodes(tree.regions(db), tree.root(db)) {
+            let context = match node {
+                ActiveTemplateNode::Tag(tag) if tag.full_span.contains(offset) => {
+                    Self::from_tag(db, tag_specs, tag, offset)
                 }
-
-                if var_span.contains(offset) {
-                    return Self::Variable {
-                        name: var.clone(),
-                        span: *var_span,
-                    };
+                ActiveTemplateNode::Variable(variable) if variable.span.contains(offset) => {
+                    Self::from_variable(variable, offset)
                 }
+                ActiveTemplateNode::Tag(_) | ActiveTemplateNode::Variable(_) => Self::None,
+            };
 
-                Self::None
+            if context != Self::None {
+                return context;
             }
-            Node::Comment { .. } | Node::Text { .. } | Node::Error { .. } => Self::None,
         }
+
+        Self::None
+    }
+
+    fn from_variable(variable: ActiveTemplateVariable<'_>, offset: Offset) -> Self {
+        for filter in variable.filters {
+            let span = filter.span.with_length_usize_saturating(filter.name.len());
+            if span.contains(offset) {
+                return Self::Filter {
+                    name: filter.name.clone(),
+                    span,
+                };
+            }
+        }
+
+        if variable.var_span.contains(offset) {
+            return Self::Variable {
+                name: variable.var.to_string(),
+                span: variable.var_span,
+            };
+        }
+
+        Self::None
     }
 
     fn from_tag(
         db: &'db dyn SemanticDb,
         tag_specs: &TagSpecs,
-        name: &str,
-        name_span: Span,
-        bits: &[TagBit],
+        tag: ActiveTemplateTag<'_>,
         offset: Offset,
     ) -> Self {
-        if name_span.contains(offset) {
+        if tag.name_span.contains(offset) {
             return Self::Tag {
-                name: name.to_string(),
-                span: name_span,
+                name: tag.tag.to_string(),
+                span: tag.name_span,
             };
         }
 
-        match name {
+        match tag.tag {
             "load" => {
-                let Some(load_kind) = LoadKind::from_tag(name, bits) else {
+                let Some(load_kind) = LoadKind::from_tag(tag.tag, tag.bits) else {
                     return Self::None;
                 };
 
@@ -118,7 +120,7 @@ impl<'db> SemanticOffsetContext<'db> {
                 }
             }
 
-            _ => LiteralTemplateReference::from_tag(tag_specs, name, bits)
+            _ => LiteralTemplateReference::from_tag(tag_specs, tag.tag, tag.bits)
                 .filter(|reference| reference.span.contains(offset))
                 .map_or(Self::None, |reference| Self::TemplateReference {
                     name: TemplateName::new(db, reference.template_name.to_string()),

--- a/crates/djls-semantic/src/references.rs
+++ b/crates/djls-semantic/src/references.rs
@@ -4,12 +4,13 @@ use djls_project::TemplateOrigin;
 use djls_project::template_resolution;
 use djls_source::File;
 use djls_source::Span;
-use djls_templates::Node;
 use djls_templates::TagBit;
 use djls_templates::parse_template;
 use rustc_hash::FxHashMap;
 
 use crate::db::Db as SemanticDb;
+use crate::structure::active_template_tags;
+use crate::structure::build_template_tree;
 use crate::tags::TagRole;
 use crate::tags::TagSpecs;
 use crate::tags::compute_tag_specs;
@@ -18,54 +19,6 @@ use crate::tags::compute_tag_specs;
 pub enum TemplateReferenceKind {
     Extends,
     Include,
-}
-
-#[salsa::tracked(returns(ref))]
-fn template_origin_tags(db: &dyn SemanticDb, origin: TemplateOrigin<'_>) -> Vec<Tag> {
-    let file = origin.file(db);
-    let Some(nodelist) = parse_template(db, file) else {
-        return Vec::new();
-    };
-
-    nodelist
-        .nodelist(db)
-        .iter()
-        .filter_map(|node| match node {
-            Node::Tag {
-                name, bits, span, ..
-            } => Some(Tag::new(name.clone(), bits.clone(), *span)),
-            _ => None,
-        })
-        .collect()
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Tag {
-    name: String,
-    bits: Vec<TagBit>,
-    span: Span,
-}
-
-impl Tag {
-    #[must_use]
-    fn new(name: String, bits: Vec<TagBit>, span: Span) -> Self {
-        Self { name, bits, span }
-    }
-
-    #[must_use]
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    #[must_use]
-    fn bits(&self) -> &[TagBit] {
-        &self.bits
-    }
-
-    #[must_use]
-    fn span(&self) -> Span {
-        self.span
-    }
 }
 
 #[salsa::tracked]
@@ -94,21 +47,21 @@ pub(crate) fn template_references(db: &dyn SemanticDb, project: Project) -> Temp
     let tag_specs = compute_tag_specs(db, project);
 
     for source in resolution.origins(db) {
-        for tag in template_origin_tags(db, source) {
-            let Some(reference) =
-                LiteralTemplateReference::from_tag(tag_specs, tag.name(), tag.bits())
+        let file = source.file(db);
+        let Some(nodelist) = parse_template(db, file) else {
+            continue;
+        };
+        let tree = build_template_tree(db, nodelist);
+
+        for tag in active_template_tags(tree.regions(db), tree.root(db)) {
+            let Some(reference) = LiteralTemplateReference::from_tag(tag_specs, tag.tag, tag.bits)
             else {
                 continue;
             };
 
             let target_template_name = TemplateName::new(db, reference.template_name.to_string());
-            let reference = TemplateReference::new(
-                db,
-                source,
-                target_template_name,
-                reference.kind,
-                tag.span(),
-            );
+            let reference =
+                TemplateReference::new(db, source, target_template_name, reference.kind, tag.span);
 
             by_template_name
                 .entry(target_template_name)

--- a/crates/djls-semantic/src/scoping.rs
+++ b/crates/djls-semantic/src/scoping.rs
@@ -1,7 +1,6 @@
 pub(crate) mod loads;
 pub(crate) mod symbols;
 
-use djls_templates::Node;
 use djls_templates::NodeList;
 
 use crate::db::Db;
@@ -11,19 +10,16 @@ pub(crate) use crate::scoping::loads::LoadStatement;
 pub(crate) use crate::scoping::loads::LoadedLibraries;
 pub use crate::scoping::symbols::AvailableSymbols;
 pub(crate) use crate::scoping::symbols::SymbolIndex;
+use crate::structure::active_template_tags;
+use crate::structure::build_template_tree;
 
 /// Compute the [`LoadedLibraries`] for a parsed template's node list.
 #[salsa::tracked(returns(ref))]
 pub(crate) fn compute_loaded_libraries(db: &dyn Db, nodelist: NodeList<'_>) -> LoadedLibraries {
-    let statements: Vec<LoadStatement> = nodelist
-        .nodelist(db)
-        .iter()
-        .filter_map(|node| match node {
-            Node::Tag {
-                name, bits, span, ..
-            } => LoadStatement::from_tag(name, bits, *span),
-            _ => None,
-        })
+    let tree = build_template_tree(db, nodelist);
+    let statements = active_template_tags(tree.regions(db), tree.root(db))
+        .into_iter()
+        .filter_map(|tag| LoadStatement::from_tag(tag.tag, tag.bits, tag.span))
         .collect();
 
     LoadedLibraries::new(statements)

--- a/crates/djls-semantic/src/structure.rs
+++ b/crates/djls-semantic/src/structure.rs
@@ -9,26 +9,33 @@
 //! not affect structure, such as exact parse errors, remain available from the
 //! original `NodeList`.
 
+pub(crate) mod active;
 pub(crate) mod builder;
+pub(crate) mod folding;
 pub(crate) mod grammar;
 pub(crate) mod opaque;
 pub(crate) mod outline;
 pub(crate) mod tree;
 
 use crate::db::Db;
+pub(crate) use crate::structure::active::ActiveTemplateNode;
+pub(crate) use crate::structure::active::ActiveTemplateTag;
+pub(crate) use crate::structure::active::ActiveTemplateVariable;
+pub(crate) use crate::structure::active::active_template_nodes;
+pub(crate) use crate::structure::active::active_template_tags;
 pub(crate) use crate::structure::builder::TemplateTreeBuilder;
-pub use crate::structure::grammar::TagClass;
-pub use crate::structure::grammar::TagIndex;
-pub use crate::structure::grammar::compute_tag_index;
+pub use crate::structure::folding::TemplateFold;
+pub use crate::structure::folding::TemplateFoldKind;
+pub use crate::structure::folding::build_template_folds;
+pub(crate) use crate::structure::grammar::compute_tag_index;
 pub use crate::structure::opaque::OpaqueRegions;
 pub use crate::structure::opaque::compute_opaque_regions;
-pub(crate) use crate::structure::opaque::opaque_regions_from_tree;
 pub use crate::structure::outline::OutlineItem;
 pub use crate::structure::outline::OutlineKind;
 pub use crate::structure::outline::build_template_outline;
 pub use crate::structure::tree::BlockRole;
 pub use crate::structure::tree::RegionId;
-pub use crate::structure::tree::Regions;
+pub(crate) use crate::structure::tree::Regions;
 pub use crate::structure::tree::TemplateNode;
 pub use crate::structure::tree::TemplateRegion;
 pub use crate::structure::tree::TemplateTree;

--- a/crates/djls-semantic/src/structure/active.rs
+++ b/crates/djls-semantic/src/structure/active.rs
@@ -1,0 +1,301 @@
+use djls_source::Span;
+use djls_templates::Filter;
+use djls_templates::TagBit;
+use djls_templates::TagDelimiter;
+
+use crate::structure::BlockRole;
+use crate::structure::RegionId;
+use crate::structure::Regions;
+use crate::structure::TemplateNode;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ActiveTemplateTag<'a> {
+    pub tag: &'a str,
+    pub name_span: Span,
+    pub bits: &'a [TagBit],
+    pub span: Span,
+    pub full_span: Span,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ActiveTemplateVariable<'a> {
+    pub var: &'a str,
+    pub var_span: Span,
+    pub filters: &'a [Filter],
+    pub span: Span,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ActiveTemplateNode<'a> {
+    Tag(ActiveTemplateTag<'a>),
+    Variable(ActiveTemplateVariable<'a>),
+}
+
+impl<'a> ActiveTemplateNode<'a> {
+    fn tag(tag: &'a str, name_span: Span, bits: &'a [TagBit], full_span: Span) -> Self {
+        Self::Tag(ActiveTemplateTag {
+            tag,
+            name_span,
+            bits,
+            span: Span::saturating_from_bounds_usize(
+                full_span
+                    .start_usize()
+                    .saturating_add(TagDelimiter::LENGTH_U32 as usize),
+                full_span
+                    .end_usize()
+                    .saturating_sub(TagDelimiter::LENGTH_U32 as usize),
+            ),
+            full_span,
+        })
+    }
+
+    fn variable(var: &'a str, var_span: Span, filters: &'a [Filter], span: Span) -> Self {
+        Self::Variable(ActiveTemplateVariable {
+            var,
+            var_span,
+            filters,
+            span,
+        })
+    }
+}
+
+#[must_use]
+pub(crate) fn active_template_nodes(
+    regions: &Regions,
+    root: RegionId,
+) -> Vec<ActiveTemplateNode<'_>> {
+    let mut nodes = Vec::new();
+    collect_active_nodes_for_region(regions, root, &mut nodes);
+    nodes
+}
+
+#[must_use]
+pub(crate) fn active_template_tags(
+    regions: &Regions,
+    root: RegionId,
+) -> Vec<ActiveTemplateTag<'_>> {
+    active_template_nodes(regions, root)
+        .into_iter()
+        .filter_map(|node| match node {
+            ActiveTemplateNode::Tag(tag) => Some(tag),
+            ActiveTemplateNode::Variable(_) => None,
+        })
+        .collect()
+}
+
+fn collect_active_nodes_for_region<'a>(
+    regions: &'a Regions,
+    region: RegionId,
+    nodes: &mut Vec<ActiveTemplateNode<'a>>,
+) {
+    for node in regions.get(region).nodes() {
+        collect_active_nodes_for_node(regions, node, nodes);
+    }
+}
+
+fn collect_active_nodes_for_node<'a>(
+    regions: &'a Regions,
+    node: &'a TemplateNode,
+    nodes: &mut Vec<ActiveTemplateNode<'a>>,
+) {
+    match node {
+        TemplateNode::Block {
+            tag,
+            name_span,
+            bits,
+            full_span,
+            body,
+            role: BlockRole::Opener,
+        } => {
+            nodes.push(ActiveTemplateNode::tag(tag, *name_span, bits, *full_span));
+            collect_active_nodes_for_block_body(regions, *body, *full_span, nodes);
+        }
+        TemplateNode::Block {
+            tag,
+            name_span,
+            bits,
+            full_span,
+            body,
+            role: BlockRole::Segment,
+        } => {
+            nodes.push(ActiveTemplateNode::tag(tag, *name_span, bits, *full_span));
+            collect_active_nodes_for_region(regions, *body, nodes);
+        }
+        TemplateNode::StandaloneTag {
+            tag,
+            name_span,
+            bits,
+            full_span,
+        } => nodes.push(ActiveTemplateNode::tag(tag, *name_span, bits, *full_span)),
+        TemplateNode::Variable {
+            var,
+            var_span,
+            filters,
+            span,
+        } => nodes.push(ActiveTemplateNode::variable(var, *var_span, filters, *span)),
+        TemplateNode::Opaque {
+            tag,
+            name_span,
+            bits,
+            full_span,
+            body_span,
+            ..
+        } => {
+            let opener_full_span = Span::saturating_from_bounds_usize(
+                full_span.start_usize(),
+                body_span.start_usize(),
+            );
+            nodes.push(ActiveTemplateNode::tag(
+                tag,
+                *name_span,
+                bits,
+                opener_full_span,
+            ));
+        }
+        TemplateNode::Comment { .. } | TemplateNode::Text { .. } | TemplateNode::Error { .. } => {}
+    }
+}
+
+fn collect_active_nodes_for_block_body<'a>(
+    regions: &'a Regions,
+    body: RegionId,
+    opener_span: Span,
+    nodes: &mut Vec<ActiveTemplateNode<'a>>,
+) {
+    for node in regions.get(body).nodes() {
+        match node {
+            TemplateNode::Block {
+                body: segment_body,
+                full_span,
+                role: BlockRole::Segment,
+                ..
+            } if *full_span == opener_span => {
+                collect_active_nodes_for_region(regions, *segment_body, nodes);
+            }
+            _ => collect_active_nodes_for_node(regions, node, nodes),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_bits() -> Vec<TagBit> {
+        Vec::new()
+    }
+
+    #[test]
+    fn active_template_nodes_preserve_source_order() {
+        let mut regions = Regions::default();
+        let root = regions.alloc(Span::new(0, 0), None);
+        let if_container = regions.alloc(Span::new(20, 0), Some(root));
+        let if_segment = regions.alloc(Span::new(30, 0), Some(if_container));
+        let bits = empty_bits();
+
+        regions.push_node(
+            root,
+            TemplateNode::StandaloneTag {
+                tag: "load".to_string(),
+                name_span: Span::new(3, 4),
+                bits: bits.clone(),
+                full_span: Span::new(0, 15),
+            },
+        );
+        regions.push_node(
+            root,
+            TemplateNode::Block {
+                tag: "if".to_string(),
+                name_span: Span::new(18, 2),
+                bits: bits.clone(),
+                full_span: Span::new(15, 12),
+                body: if_container,
+                role: BlockRole::Opener,
+            },
+        );
+        regions.push_node(
+            if_container,
+            TemplateNode::Block {
+                tag: "if".to_string(),
+                name_span: Span::new(18, 2),
+                bits: bits.clone(),
+                full_span: Span::new(15, 12),
+                body: if_segment,
+                role: BlockRole::Segment,
+            },
+        );
+        regions.push_node(
+            if_segment,
+            TemplateNode::Variable {
+                var: "value".to_string(),
+                var_span: Span::new(30, 5),
+                filters: Vec::new(),
+                span: Span::new(27, 11),
+            },
+        );
+        regions.push_node(
+            root,
+            TemplateNode::StandaloneTag {
+                tag: "include".to_string(),
+                name_span: Span::new(53, 7),
+                bits,
+                full_span: Span::new(50, 25),
+            },
+        );
+
+        let labels = active_template_nodes(&regions, root)
+            .into_iter()
+            .map(|node| match node {
+                ActiveTemplateNode::Tag(tag) => format!("tag:{}", tag.tag),
+                ActiveTemplateNode::Variable(variable) => format!("var:{}", variable.var),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            labels,
+            vec!["tag:load", "tag:if", "var:value", "tag:include"]
+        );
+    }
+
+    #[test]
+    fn active_template_queries_skip_opaque_body_content() {
+        let mut regions = Regions::default();
+        let root = regions.alloc(Span::new(0, 0), None);
+        let bits = empty_bits();
+
+        regions.push_node(
+            root,
+            TemplateNode::Opaque {
+                tag: "verbatim".to_string(),
+                name_span: Span::new(3, 8),
+                bits,
+                full_span: Span::new(0, 54),
+                body_span: Span::new(14, 24),
+            },
+        );
+        regions.push_node(
+            root,
+            TemplateNode::Variable {
+                var: "active".to_string(),
+                var_span: Span::new(59, 6),
+                filters: Vec::new(),
+                span: Span::new(56, 12),
+            },
+        );
+
+        let tags = active_template_tags(&regions, root)
+            .into_iter()
+            .map(|tag| tag.tag.to_string())
+            .collect::<Vec<_>>();
+        let variables = active_template_nodes(&regions, root)
+            .into_iter()
+            .filter_map(|node| match node {
+                ActiveTemplateNode::Tag(_) => None,
+                ActiveTemplateNode::Variable(variable) => Some(variable.var.to_string()),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(tags, vec!["verbatim"]);
+        assert_eq!(variables, vec!["active"]);
+    }
+}

--- a/crates/djls-semantic/src/structure/folding.rs
+++ b/crates/djls-semantic/src/structure/folding.rs
@@ -1,0 +1,81 @@
+use djls_source::Span;
+
+use crate::db::Db;
+use crate::structure::BlockRole;
+use crate::structure::RegionId;
+use crate::structure::Regions;
+use crate::structure::TemplateNode;
+use crate::structure::TemplateTree;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TemplateFold {
+    pub span: Span,
+    pub kind: TemplateFoldKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TemplateFoldKind {
+    Region,
+    Comment,
+}
+
+#[salsa::tracked(returns(ref))]
+pub fn build_template_folds(db: &dyn Db, tree: TemplateTree<'_>) -> Vec<TemplateFold> {
+    let mut folds = Vec::new();
+    collect_folds_for_region(tree.regions(db), tree.root(db), &mut folds);
+    folds
+}
+
+fn collect_folds_for_region(regions: &Regions, region: RegionId, folds: &mut Vec<TemplateFold>) {
+    for node in regions.get(region).nodes() {
+        collect_folds_for_node(regions, node, folds);
+    }
+}
+
+fn collect_folds_for_node(regions: &Regions, node: &TemplateNode, folds: &mut Vec<TemplateFold>) {
+    match node {
+        TemplateNode::Block {
+            tag,
+            full_span,
+            body,
+            role: BlockRole::Opener,
+            ..
+        } => {
+            let end = regions.get(*body).span().end();
+            if end > full_span.end() {
+                folds.push(TemplateFold {
+                    span: Span::saturating_from_bounds_usize(full_span.start_usize(), end as usize),
+                    kind: TemplateFoldKind::from_tag_name(tag),
+                });
+            }
+            collect_folds_for_region(regions, *body, folds);
+        }
+        TemplateNode::Block {
+            body,
+            role: BlockRole::Segment,
+            ..
+        } => {
+            collect_folds_for_region(regions, *body, folds);
+        }
+        TemplateNode::Opaque { tag, full_span, .. } => {
+            folds.push(TemplateFold {
+                span: *full_span,
+                kind: TemplateFoldKind::from_tag_name(tag),
+            });
+        }
+        TemplateNode::StandaloneTag { .. }
+        | TemplateNode::Variable { .. }
+        | TemplateNode::Comment { .. }
+        | TemplateNode::Text { .. }
+        | TemplateNode::Error { .. } => {}
+    }
+}
+
+impl TemplateFoldKind {
+    fn from_tag_name(name: &str) -> Self {
+        match name {
+            "comment" => Self::Comment,
+            _ => Self::Region,
+        }
+    }
+}

--- a/crates/djls-semantic/src/structure/folding.rs
+++ b/crates/djls-semantic/src/structure/folding.rs
@@ -28,46 +28,45 @@ pub fn build_template_folds(db: &dyn Db, tree: TemplateTree<'_>) -> Vec<Template
 
 fn collect_folds_for_region(regions: &Regions, region: RegionId, folds: &mut Vec<TemplateFold>) {
     for node in regions.get(region).nodes() {
-        collect_folds_for_node(regions, node, folds);
-    }
-}
-
-fn collect_folds_for_node(regions: &Regions, node: &TemplateNode, folds: &mut Vec<TemplateFold>) {
-    match node {
-        TemplateNode::Block {
-            tag,
-            full_span,
-            body,
-            role: BlockRole::Opener,
-            ..
-        } => {
-            let end = regions.get(*body).span().end();
-            if end > full_span.end() {
+        match node {
+            TemplateNode::Block {
+                tag,
+                full_span,
+                body,
+                role: BlockRole::Opener,
+                ..
+            } => {
+                let end = regions.get(*body).span().end();
+                if end > full_span.end() {
+                    folds.push(TemplateFold {
+                        span: Span::saturating_from_bounds_usize(
+                            full_span.start_usize(),
+                            end as usize,
+                        ),
+                        kind: TemplateFoldKind::from_tag_name(tag),
+                    });
+                }
+                collect_folds_for_region(regions, *body, folds);
+            }
+            TemplateNode::Block {
+                body,
+                role: BlockRole::Segment,
+                ..
+            } => {
+                collect_folds_for_region(regions, *body, folds);
+            }
+            TemplateNode::Opaque { tag, full_span, .. } => {
                 folds.push(TemplateFold {
-                    span: Span::saturating_from_bounds_usize(full_span.start_usize(), end as usize),
+                    span: *full_span,
                     kind: TemplateFoldKind::from_tag_name(tag),
                 });
             }
-            collect_folds_for_region(regions, *body, folds);
+            TemplateNode::StandaloneTag { .. }
+            | TemplateNode::Variable { .. }
+            | TemplateNode::Comment { .. }
+            | TemplateNode::Text { .. }
+            | TemplateNode::Error { .. } => {}
         }
-        TemplateNode::Block {
-            body,
-            role: BlockRole::Segment,
-            ..
-        } => {
-            collect_folds_for_region(regions, *body, folds);
-        }
-        TemplateNode::Opaque { tag, full_span, .. } => {
-            folds.push(TemplateFold {
-                span: *full_span,
-                kind: TemplateFoldKind::from_tag_name(tag),
-            });
-        }
-        TemplateNode::StandaloneTag { .. }
-        | TemplateNode::Variable { .. }
-        | TemplateNode::Comment { .. }
-        | TemplateNode::Text { .. }
-        | TemplateNode::Error { .. } => {}
     }
 }
 

--- a/crates/djls-semantic/src/structure/opaque.rs
+++ b/crates/djls-semantic/src/structure/opaque.rs
@@ -51,7 +51,7 @@ pub fn compute_opaque_regions<'db>(db: &'db dyn Db, nodelist: NodeList<'db>) -> 
     opaque_regions_from_tree(tree.regions(db))
 }
 
-pub(crate) fn opaque_regions_from_tree(regions: &Regions) -> OpaqueRegions {
+fn opaque_regions_from_tree(regions: &Regions) -> OpaqueRegions {
     let spans = regions
         .iter()
         .flat_map(TemplateRegion::nodes)

--- a/crates/djls-semantic/src/validation.rs
+++ b/crates/djls-semantic/src/validation.rs
@@ -4,17 +4,14 @@ mod if_expressions;
 mod scoping;
 
 use djls_project::TemplateLibraries;
-use djls_source::Span;
-use djls_templates::Filter;
-use djls_templates::Node;
-use djls_templates::Visitor;
-use djls_templates::walk_nodelist;
 
 use crate::db::Db;
 use crate::filters::FilterAritySpecs;
 use crate::scoping::LoadedLibraries;
 use crate::scoping::SymbolIndex;
-use crate::structure::OpaqueRegions;
+use crate::structure::ActiveTemplateNode;
+use crate::structure::ActiveTemplateTag;
+use crate::structure::ActiveTemplateVariable;
 use crate::structure::compute_tag_index;
 use crate::structure::grammar::TagClass;
 use crate::structure::grammar::TagIndex;
@@ -42,10 +39,10 @@ impl ExtendsPosition {
     }
 }
 
-/// Combined validator that performs a single-pass validation of a template AST.
+/// Combined validator for active template semantic facts.
 ///
-/// This visitor consolidates multiple validation rules (scoping, arity, bits,
-/// structure) into a single walk of the `NodeList`, reducing redundant traversals.
+/// The validator consumes the `TemplateTree`-derived active view rather than the
+/// raw parser `NodeList`, so opaque body content cannot affect semantic rules.
 pub(crate) struct TemplateValidator<'a> {
     db: &'a dyn Db,
     tag_specs: &'a TagSpecs,
@@ -53,7 +50,6 @@ pub(crate) struct TemplateValidator<'a> {
     symbol_index: &'a SymbolIndex,
     loaded_libraries: &'a LoadedLibraries,
     template_libraries: &'a TemplateLibraries,
-    opaque_regions: &'a OpaqueRegions,
     filter_arity_specs: &'a FilterAritySpecs,
 
     // Tracking state for positional checks (e.g. {% extends %})
@@ -62,11 +58,7 @@ pub(crate) struct TemplateValidator<'a> {
 
 impl<'a> TemplateValidator<'a> {
     #[must_use]
-    pub(crate) fn new(
-        db: &'a dyn Db,
-        nodelist: djls_templates::NodeList<'_>,
-        opaque_regions: &'a OpaqueRegions,
-    ) -> Self {
+    pub(crate) fn new(db: &'a dyn Db, nodelist: djls_templates::NodeList<'_>) -> Self {
         let template_libraries = db.template_libraries();
         let tag_specs = db.tag_specs();
         let tag_index = compute_tag_index(db);
@@ -81,48 +73,43 @@ impl<'a> TemplateValidator<'a> {
             symbol_index,
             loaded_libraries,
             template_libraries,
-            opaque_regions,
             filter_arity_specs,
             extends_position: ExtendsPosition::default(),
         }
     }
 
-    pub(crate) fn validate(mut self, nodes: &[Node]) {
-        walk_nodelist(&mut self, nodes);
+    pub(crate) fn validate(mut self, nodes: &[ActiveTemplateNode<'_>]) {
+        for node in nodes {
+            match node {
+                ActiveTemplateNode::Tag(tag) => self.validate_tag(*tag),
+                ActiveTemplateNode::Variable(variable) => self.validate_variable(*variable),
+            }
+        }
     }
-}
 
-impl Visitor for TemplateValidator<'_> {
-    fn visit_tag(
-        &mut self,
-        name: &str,
-        _name_span: Span,
-        bits: &[djls_templates::TagBit],
-        span: Span,
-    ) {
-        let is_opaque = self.opaque_regions.is_opaque(span.start());
+    fn validate_tag(&mut self, tag: ActiveTemplateTag<'_>) {
+        let name = tag.tag;
+        let bits = tag.bits;
+        let span = tag.span;
 
-        // 1. Extends validation (cares about order/opacity)
+        // 1. Extends validation
         if name == "extends" {
-            use djls_templates::TagDelimiter;
             use salsa::Accumulator;
 
             use crate::ValidationError;
             use crate::ValidationErrorAccumulator;
 
-            let full_span = span.expand(TagDelimiter::LENGTH_U32, TagDelimiter::LENGTH_U32);
-
             match self.extends_position {
                 ExtendsPosition::Start => {}
                 ExtendsPosition::AfterContent => {
                     ValidationErrorAccumulator(ValidationError::ExtendsMustBeFirst {
-                        span: full_span,
+                        span: tag.full_span,
                     })
                     .accumulate(self.db);
                 }
                 ExtendsPosition::AfterExtends => {
                     ValidationErrorAccumulator(ValidationError::MultipleExtends {
-                        span: full_span,
+                        span: tag.full_span,
                     })
                     .accumulate(self.db);
                 }
@@ -131,48 +118,40 @@ impl Visitor for TemplateValidator<'_> {
             self.extends_position = ExtendsPosition::AfterExtends;
         }
 
-        if !is_opaque {
-            // 2. Scoping validation (skip structural tags and "load")
-            if name != "load"
-                && !matches!(
-                    self.tag_index.classify(name),
-                    TagClass::Closer { .. } | TagClass::Intermediate { .. }
-                )
-            {
-                let symbols = self.symbol_index.symbols_at(span.start());
-                scoping::check_tag_scoping_rule(
-                    self.db,
-                    name,
-                    span,
-                    symbols,
-                    self.template_libraries,
-                );
-            }
+        // 2. Scoping validation (skip structural tags and "load")
+        if name != "load"
+            && !matches!(
+                self.tag_index.classify(name),
+                TagClass::Closer { .. } | TagClass::Intermediate { .. }
+            )
+        {
+            let symbols = self.symbol_index.symbols_at(span.start());
+            scoping::check_tag_scoping_rule(self.db, name, span, symbols, self.template_libraries);
+        }
 
-            // 3. Argument validation
-            if let Some(spec) = self.tag_specs.get(name)
-                && let Some(rules) = spec.extracted_rules()
-            {
-                arguments::check_tag_arguments_rule(self.db, name, bits, span, rules);
-            }
+        // 3. Argument validation
+        if let Some(spec) = self.tag_specs.get(name)
+            && let Some(rules) = spec.extracted_rules()
+        {
+            arguments::check_tag_arguments_rule(self.db, name, bits, span, rules);
+        }
 
-            // 4. Load library validation
-            scoping::check_load_libraries_rule(self.db, name, bits, self.template_libraries);
+        // 4. Load library validation
+        scoping::check_load_libraries_rule(self.db, name, bits, self.template_libraries);
 
-            // 5. If expression validation
-            if name == "if" || name == "elif" {
-                if_expressions::check_if_expression_rule(self.db, name, bits, span);
-            }
+        // 5. If expression validation
+        if name == "if" || name == "elif" {
+            if_expressions::check_if_expression_rule(self.db, name, bits, span);
         }
 
         self.extends_position = self.extends_position.record_non_text();
     }
 
-    fn visit_variable(&mut self, _var: &str, _var_span: Span, filters: &[Filter], span: Span) {
-        if !filters.is_empty() && !self.opaque_regions.is_opaque(span.start()) {
-            let symbols = self.symbol_index.symbols_at(span.start());
+    fn validate_variable(&mut self, variable: ActiveTemplateVariable<'_>) {
+        if !variable.filters.is_empty() {
+            let symbols = self.symbol_index.symbols_at(variable.span.start());
 
-            for filter in filters {
+            for filter in variable.filters {
                 // 1. Filter Scoping
                 scoping::check_filter_scoping_rule(
                     self.db,
@@ -187,7 +166,7 @@ impl Visitor for TemplateValidator<'_> {
                         && self
                             .loaded_libraries
                             .has_unknown_load_that_can_shadow_symbol_before(
-                                span.start(),
+                                variable.span.start(),
                                 &filter.name,
                                 self.template_libraries,
                             );
@@ -203,17 +182,5 @@ impl Visitor for TemplateValidator<'_> {
         }
 
         self.extends_position = self.extends_position.record_non_text();
-    }
-
-    fn visit_comment(&mut self, _content: &str, _span: Span) {
-        // Comments don't count as non-text for {% extends %} check
-    }
-
-    fn visit_text(&mut self, _span: Span) {
-        // Text doesn't count as non-text for {% extends %} check
-    }
-
-    fn visit_error(&mut self, _span: Span, _full_span: Span, _error: &djls_templates::ParseError) {
-        // Errors don't count as non-text for {% extends %} check
     }
 }

--- a/crates/djls-semantic/tests/offset.rs
+++ b/crates/djls-semantic/tests/offset.rs
@@ -111,11 +111,47 @@ fn identifies_tag_name_context() {
 }
 
 #[test]
+fn identifies_opaque_opener_tag_context() {
+    let db = TestDatabase::new();
+    let source = r#"{% verbatim %}{% include "partial.html" %}{% endverbatim %}"#;
+
+    let context = context_for_source(&db, source, offset_of(source, "verbatim"));
+
+    assert_eq!(
+        context,
+        SemanticOffsetContext::Tag {
+            name: "verbatim".to_string(),
+            span: Span::new(3, 8),
+        }
+    );
+}
+
+#[test]
 fn ignores_unrecognized_tag_arguments() {
     let db = TestDatabase::new();
     let source = "{% if user %}";
 
     let context = context_for_source(&db, source, offset_of(source, "user"));
+
+    assert_eq!(context, SemanticOffsetContext::None);
+}
+
+#[test]
+fn ignores_template_reference_inside_verbatim() {
+    let db = TestDatabase::new();
+    let source = r#"{% verbatim %}{% include "partial.html" %}{% endverbatim %}"#;
+
+    let context = context_for_source(&db, source, offset_of(source, "partial.html"));
+
+    assert_eq!(context, SemanticOffsetContext::None);
+}
+
+#[test]
+fn ignores_load_library_inside_comment() {
+    let db = TestDatabase::new();
+    let source = "{% comment %}{% load static %}{% endcomment %}";
+
+    let context = context_for_source(&db, source, offset_of(source, "static"));
 
     assert_eq!(context, SemanticOffsetContext::None);
 }

--- a/crates/djls-semantic/tests/references.rs
+++ b/crates/djls-semantic/tests/references.rs
@@ -95,6 +95,84 @@ fn template_references_ignore_dynamic_template_names() {
 }
 
 #[test]
+fn template_references_ignore_include_inside_verbatim() {
+    let mut db = TestDatabase::new();
+    let project = project_with_templates(
+        &mut db,
+        vec!["/test/project/templates"],
+        vec![
+            (
+                "child.html",
+                "/test/project/templates/child.html",
+                "{% verbatim %}{% include \"partial.html\" %}{% endverbatim %}",
+            ),
+            (
+                "partial.html",
+                "/test/project/templates/partial.html",
+                "partial",
+            ),
+        ],
+    );
+
+    let partial = TemplateName::new(&db, "partial.html".to_string());
+    let references = references_to_template_name(&db, project, partial);
+
+    assert!(references.is_empty());
+}
+
+#[test]
+fn template_references_ignore_extends_inside_comment() {
+    let mut db = TestDatabase::new();
+    let project = project_with_templates(
+        &mut db,
+        vec!["/test/project/templates"],
+        vec![
+            (
+                "child.html",
+                "/test/project/templates/child.html",
+                "{% comment %}{% extends \"base.html\" %}{% endcomment %}",
+            ),
+            ("base.html", "/test/project/templates/base.html", "base"),
+        ],
+    );
+
+    let base = TemplateName::new(&db, "base.html".to_string());
+    let references = references_to_template_name(&db, project, base);
+
+    assert!(references.is_empty());
+}
+
+#[test]
+fn template_references_include_only_active_references() {
+    let mut db = TestDatabase::new();
+    let project = project_with_templates(
+        &mut db,
+        vec!["/test/project/templates"],
+        vec![
+            (
+                "child.html",
+                "/test/project/templates/child.html",
+                concat!(
+                    "{% verbatim %}{% include \"partial.html\" %}{% endverbatim %}\n",
+                    "{% include \"partial.html\" %}",
+                ),
+            ),
+            (
+                "partial.html",
+                "/test/project/templates/partial.html",
+                "partial",
+            ),
+        ],
+    );
+
+    let partial = TemplateName::new(&db, "partial.html".to_string());
+    let references = references_to_template_name(&db, project, partial);
+
+    assert_eq!(references.len(), 1);
+    assert_eq!(references[0].kind(&db), TemplateReferenceKind::Include);
+}
+
+#[test]
 fn template_references_to_template_name_include_all_sources() {
     let mut db = TestDatabase::new();
     let project = project_with_templates(

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -666,6 +666,44 @@ fn comment_block_also_opaque() {
 }
 
 #[test]
+fn load_inside_verbatim_does_not_affect_later_tag_availability() {
+    let db = standard_db();
+    let source = concat!(
+        "{% verbatim %}{% load i18n %}{% endverbatim %}\n",
+        "{% trans \"hello\" %}\n",
+    );
+    let errors = collect_all_errors(&db, source);
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnloadedTag { tag, library, .. }
+                if tag == "trans" && library == "i18n"
+        )),
+        "opaque load should not make trans available: {errors:?}"
+    );
+}
+
+#[test]
+fn load_inside_comment_does_not_affect_later_tag_availability() {
+    let db = standard_db();
+    let source = concat!(
+        "{% comment %}{% load i18n %}{% endcomment %}\n",
+        "{% trans \"hello\" %}\n",
+    );
+    let errors = collect_all_errors(&db, source);
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnloadedTag { tag, library, .. }
+                if tag == "trans" && library == "i18n"
+        )),
+        "opaque load should not make trans available: {errors:?}"
+    );
+}
+
+#[test]
 fn unloaded_tag_and_filter_with_expression_error() {
     let db = standard_db();
     // trans requires {% load i18n %}, but it's not loaded
@@ -989,6 +1027,55 @@ fn tag_before_extends_and_multiple_extends_s122_and_s123() {
         .collect();
     assert_eq!(s122.len(), 1, "Expected S122, got: {s122:?}");
     assert_eq!(s123.len(), 1, "Expected S123, got: {s123:?}");
+}
+
+#[test]
+fn extends_inside_verbatim_after_content_does_not_need_to_be_first() {
+    let db = standard_db();
+    let source = r#"<p>body</p>{% verbatim %}{% extends "base.html" %}{% endverbatim %}"#;
+    let errors = collect_all_errors(&db, source);
+    let s122: Vec<_> = errors
+        .iter()
+        .filter(|e| matches!(e, ValidationError::ExtendsMustBeFirst { .. }))
+        .collect();
+
+    assert!(
+        s122.is_empty(),
+        "Extends inside verbatim should not affect extends ordering, got: {s122:?}"
+    );
+}
+
+#[test]
+fn multiple_extends_inside_comment_do_not_count_as_multiple_extends() {
+    let db = standard_db();
+    let source = r#"{% comment %}{% extends "a.html" %}{% extends "b.html" %}{% endcomment %}"#;
+    let errors = collect_all_errors(&db, source);
+    let s123: Vec<_> = errors
+        .iter()
+        .filter(|e| matches!(e, ValidationError::MultipleExtends { .. }))
+        .collect();
+
+    assert!(
+        s123.is_empty(),
+        "Extends inside comment should not count as active extends tags, got: {s123:?}"
+    );
+}
+
+#[test]
+fn opaque_extends_after_active_extends_does_not_count_as_second_extends() {
+    let db = standard_db();
+    let source =
+        r#"{% extends "base.html" %}{% verbatim %}{% extends "ignored.html" %}{% endverbatim %}"#;
+    let errors = collect_all_errors(&db, source);
+    let s123: Vec<_> = errors
+        .iter()
+        .filter(|e| matches!(e, ValidationError::MultipleExtends { .. }))
+        .collect();
+
+    assert!(
+        s123.is_empty(),
+        "Extends inside verbatim should not count as a second active extends tag, got: {s123:?}"
+    );
 }
 
 // Corpus / template validation tests

--- a/crates/djls-templates/src/lib.rs
+++ b/crates/djls-templates/src/lib.rs
@@ -62,7 +62,6 @@ use salsa::Accumulator;
 pub use tokens::TagDelimiter;
 pub use tokens::Token;
 pub use visitor::Visitor;
-pub use visitor::walk_nodelist;
 
 /// Lex a Django template file.
 #[salsa::tracked(returns(ref))]

--- a/crates/djls-templates/src/nodelist.rs
+++ b/crates/djls-templates/src/nodelist.rs
@@ -1,5 +1,3 @@
-use djls_source::Db;
-use djls_source::Offset;
 use djls_source::Span;
 
 use crate::bits::TagBit;
@@ -12,15 +10,6 @@ pub struct NodeList<'db> {
     #[tracked]
     #[returns(ref)]
     pub nodelist: Vec<Node>,
-}
-
-impl<'db> NodeList<'db> {
-    #[must_use]
-    pub fn node_at(self, db: &'db dyn Db, offset: Offset) -> Option<&'db Node> {
-        self.nodelist(db)
-            .iter()
-            .find(|node| node.full_span().contains(offset))
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/djls-templates/src/visitor.rs
+++ b/crates/djls-templates/src/visitor.rs
@@ -42,10 +42,3 @@ fn walk_node<V: Visitor + ?Sized>(visitor: &mut V, node: &Node) {
         } => visitor.visit_error(*span, *full_span, error),
     }
 }
-
-/// Walk a list of nodes, visiting each one in sequence.
-pub fn walk_nodelist<V: Visitor + ?Sized>(visitor: &mut V, nodes: &[Node]) {
-    for node in nodes {
-        visitor.visit_node(node);
-    }
-}

--- a/tools/ast-grep/rules/no-trivial-whitespace-helper.yml
+++ b/tools/ast-grep/rules/no-trivial-whitespace-helper.yml
@@ -1,0 +1,27 @@
+id: no-trivial-whitespace-helper
+language: Rust
+severity: error
+message: "Do not wrap std whitespace predicates in a local helper; inline trim().is_empty() or name the domain concept."
+note: "Parser/grammar whitespace helpers are okay when they encode grammar policy. This rule targets trivial wrappers around standard whitespace checks."
+rule:
+  any:
+    - pattern: |
+        fn $NAME($TEXT: &str) -> bool {
+          $TEXT.trim().is_empty()
+        }
+    - pattern: |
+        fn $NAME($TEXT: &str) -> bool {
+          $TEXT.trim_ascii().is_empty()
+        }
+    - pattern: |
+        fn $NAME($TEXT: &str) -> bool {
+          $TEXT.chars().all(char::is_whitespace)
+        }
+    - pattern: |
+        fn $NAME($SOURCE: &str, $SPAN: Span) -> bool {
+          $SOURCE.get($RANGE).is_some_and(|$TEXT| $TEXT.trim().is_empty())
+        }
+    - pattern: |
+        fn $NAME($SOURCE: &str, $SPAN: Span) -> bool {
+          $SOURCE.get($RANGE).is_some_and(|$TEXT| $TEXT.trim_ascii().is_empty())
+        }

--- a/tools/ast-grep/sgconfig.yml
+++ b/tools/ast-grep/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - rules
+testConfigs:
+  - testDir: tests

--- a/tools/ast-grep/tests/no-trivial-whitespace-helper-test.yml
+++ b/tools/ast-grep/tests/no-trivial-whitespace-helper-test.yml
@@ -1,0 +1,49 @@
+id: no-trivial-whitespace-helper
+valid:
+  - |
+    fn collect(nodes: &[Node], source: &str) {
+        for node in nodes {
+            match node {
+                Node::Text { span }
+                    if source
+                        .get(span.start_usize()..span.end_usize())
+                        .is_some_and(|text| text.trim().is_empty()) => {}
+                _ => {}
+            }
+        }
+    }
+  - |
+    fn contains_whitespace(text: &str) -> bool {
+        text.chars().any(char::is_whitespace)
+    }
+  - |
+    fn lex_whitespace(&mut self, first: char) {
+        if first.is_whitespace() {
+            self.advance();
+        }
+    }
+invalid:
+  - |
+    fn is_blank(text: &str) -> bool {
+        text.trim().is_empty()
+    }
+  - |
+    fn is_blank_ascii(text: &str) -> bool {
+        text.trim_ascii().is_empty()
+    }
+  - |
+    fn is_whitespace(text: &str) -> bool {
+        text.chars().all(char::is_whitespace)
+    }
+  - |
+    fn is_whitespace(source: &str, span: Span) -> bool {
+        source
+            .get(span.start_usize()..span.end_usize())
+            .is_some_and(|text| text.trim().is_empty())
+    }
+  - |
+    fn is_whitespace_ascii(source: &str, span: Span) -> bool {
+        source
+            .get(span.start_usize()..span.end_usize())
+            .is_some_and(|text| text.trim_ascii().is_empty())
+    }


### PR DESCRIPTION
## Summary
- route template scoping, references, offset context, validation, and structural folding through TemplateTree-derived semantic views
- add active template node and semantic folding projections inside djls-semantic
- add opaque-region regressions for load availability, template references, offset context, validation, and folding
- tighten public API/visibility after the seam refactor, including Hawk cleanups

## Validation
- cargo test -q -p djls-semantic
- cargo test -q -p djls-ide
- cargo test -q
- just fmt --check
- just clippy
- just lint
- just hawk

## Notes
- Remaining raw NodeList walk in folding is limited to header/import presentation folding. Structural template folding now comes from the semantic fold projection.
