### PR TITLE
Track template name content spans

### DIFF
--- a/.agents/skills/djls-domain-conventions/SKILL.md
+++ b/.agents/skills/djls-domain-conventions/SKILL.md
@@ -12,6 +12,7 @@ Use this for changes to template parsing, semantic validation, environment scann
 - `Node::Tag.bits` excludes the tag name.
 - Example: `{% load i18n %}` becomes `name: "load"`, `bits: ["i18n"]`.
 - Functions processing `bits` work with tag arguments only.
+- Extracted text and its span are computed by the same parse, in the crate that owns the syntax. Do not re-derive quote/content spans in semantic or IDE consumers.
 
 ## Environment scanning
 

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -5,10 +5,6 @@ use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
 
-fn offset_of(source: &str, needle: &str) -> Offset {
-    Offset::new(u32::try_from(source.find(needle).unwrap()).unwrap())
-}
-
 #[test]
 fn find_references_reports_template_name_interior_range() {
     let mut db = TestDatabase::new();
@@ -26,8 +22,12 @@ fn find_references_reports_template_name_interior_range() {
         .install(&mut db);
 
     let file = db.get_or_create_file(Utf8Path::new(child_path));
-    let locations = find_references(&db, file, offset_of(source, "base"))
-        .expect("template reference should resolve to at least one reference");
+    let locations = find_references(
+        &db,
+        file,
+        Offset::new(u32::try_from(source.find("base").unwrap()).unwrap()),
+    )
+    .expect("template reference should resolve to at least one reference");
 
     assert_eq!(locations.len(), 1);
     assert_eq!(

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -1,0 +1,40 @@
+use camino::Utf8Path;
+use djls_ide::find_references;
+use djls_source::Offset;
+use djls_testing::ProjectFixture;
+use djls_testing::TestDatabase;
+use tower_lsp_server::ls_types;
+
+fn offset_of(source: &str, needle: &str) -> Offset {
+    Offset::new(u32::try_from(source.find(needle).unwrap()).unwrap())
+}
+
+#[test]
+fn find_references_reports_template_name_interior_range() {
+    let mut db = TestDatabase::new();
+    let source = r#"{% extends "base.html" %}"#;
+    let child_path = "/test/project/templates/child.html";
+
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .template_file("child.html", child_path, source)
+        .template_file("base.html", "/test/project/templates/base.html", "base")
+        .install(&mut db);
+
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let locations = find_references(&db, file, offset_of(source, "base"))
+        .expect("template reference should resolve to at least one reference");
+
+    assert_eq!(locations.len(), 1);
+    assert_eq!(
+        locations[0].range,
+        ls_types::Range::new(
+            ls_types::Position::new(0, 12),
+            ls_types::Position::new(0, 21)
+        ),
+    );
+}

--- a/crates/djls-semantic/src/offset.rs
+++ b/crates/djls-semantic/src/offset.rs
@@ -121,10 +121,10 @@ impl<'db> SemanticOffsetContext<'db> {
             }
 
             _ => LiteralTemplateReference::from_tag(tag_specs, tag.tag, tag.bits)
-                .filter(|reference| reference.span.contains(offset))
+                .filter(|reference| reference.bit_span.contains(offset))
                 .map_or(Self::None, |reference| Self::TemplateReference {
                     name: TemplateName::new(db, reference.template_name.to_string()),
-                    span: reference.span,
+                    span: reference.value_span,
                 }),
         }
     }

--- a/crates/djls-semantic/src/offset.rs
+++ b/crates/djls-semantic/src/offset.rs
@@ -124,7 +124,7 @@ impl<'db> SemanticOffsetContext<'db> {
                 .filter(|reference| reference.bit_span.contains(offset))
                 .map_or(Self::None, |reference| Self::TemplateReference {
                     name: TemplateName::new(db, reference.template_name.to_string()),
-                    span: reference.value_span,
+                    span: reference.span,
                 }),
         }
     }

--- a/crates/djls-semantic/src/references.rs
+++ b/crates/djls-semantic/src/references.rs
@@ -66,7 +66,7 @@ pub(crate) fn template_references(db: &dyn SemanticDb, project: Project) -> Temp
                 source,
                 target_template_name,
                 reference.kind,
-                reference.value_span,
+                reference.span,
             );
 
             by_template_name
@@ -122,7 +122,7 @@ pub(crate) struct LiteralTemplateReference<'bits> {
     kind: TemplateReferenceKind,
     pub(crate) template_name: &'bits str,
     pub(crate) bit_span: Span,
-    pub(crate) value_span: Span,
+    pub(crate) span: Span,
 }
 
 impl<'bits> LiteralTemplateReference<'bits> {
@@ -139,7 +139,7 @@ impl<'bits> LiteralTemplateReference<'bits> {
         let bit = bits.first()?;
         let TemplateString::Quoted {
             value: template_name,
-            value_span,
+            span,
         } = bit.template_string()
         else {
             return None;
@@ -149,7 +149,7 @@ impl<'bits> LiteralTemplateReference<'bits> {
             kind,
             template_name,
             bit_span: bit.span,
-            value_span,
+            span,
         })
     }
 }

--- a/crates/djls-semantic/src/references.rs
+++ b/crates/djls-semantic/src/references.rs
@@ -5,6 +5,7 @@ use djls_project::template_resolution;
 use djls_source::File;
 use djls_source::Span;
 use djls_templates::TagBit;
+use djls_templates::TemplateString;
 use djls_templates::parse_template;
 use rustc_hash::FxHashMap;
 
@@ -60,8 +61,13 @@ pub(crate) fn template_references(db: &dyn SemanticDb, project: Project) -> Temp
             };
 
             let target_template_name = TemplateName::new(db, reference.template_name.to_string());
-            let reference =
-                TemplateReference::new(db, source, target_template_name, reference.kind, tag.span);
+            let reference = TemplateReference::new(
+                db,
+                source,
+                target_template_name,
+                reference.kind,
+                reference.value_span,
+            );
 
             by_template_name
                 .entry(target_template_name)
@@ -115,7 +121,8 @@ impl<'db> TemplateReference<'db> {
 pub(crate) struct LiteralTemplateReference<'bits> {
     kind: TemplateReferenceKind,
     pub(crate) template_name: &'bits str,
-    pub(crate) span: Span,
+    pub(crate) bit_span: Span,
+    pub(crate) value_span: Span,
 }
 
 impl<'bits> LiteralTemplateReference<'bits> {
@@ -130,12 +137,19 @@ impl<'bits> LiteralTemplateReference<'bits> {
             return None;
         };
         let bit = bits.first()?;
-        let template_name = bit.template_string().quoted_value()?;
+        let TemplateString::Quoted {
+            value: template_name,
+            value_span,
+        } = bit.template_string()
+        else {
+            return None;
+        };
 
         Some(Self {
             kind,
             template_name,
-            span: bit.span,
+            bit_span: bit.span,
+            value_span,
         })
     }
 }

--- a/crates/djls-semantic/src/structure/outline.rs
+++ b/crates/djls-semantic/src/structure/outline.rs
@@ -1,5 +1,6 @@
 use djls_source::Span;
 use djls_templates::TagBit;
+use djls_templates::TemplateString;
 
 use crate::db::Db;
 use crate::scoping::LoadKind;
@@ -76,12 +77,17 @@ fn outline_items_for_tag(
         | TagRole::StaticAssetReference
         | TagRole::RouteReference => {
             let item = if let Some(bit) = bits.first() {
+                let (label, selection_span) = match bit.template_string() {
+                    TemplateString::Quoted { value, value_span } => (value.to_string(), value_span),
+                    TemplateString::Unquoted(value) => (value.to_string(), bit.span),
+                };
+
                 OutlineItem {
-                    label: bit.template_string().value().to_string(),
+                    label,
                     detail: Some(tag.to_string()),
                     kind: role.into(),
                     span,
-                    selection_span: bit.span,
+                    selection_span,
                     children,
                 }
             } else {

--- a/crates/djls-semantic/src/structure/outline.rs
+++ b/crates/djls-semantic/src/structure/outline.rs
@@ -78,7 +78,7 @@ fn outline_items_for_tag(
         | TagRole::RouteReference => {
             let item = if let Some(bit) = bits.first() {
                 let (label, selection_span) = match bit.template_string() {
-                    TemplateString::Quoted { value, value_span } => (value.to_string(), value_span),
+                    TemplateString::Quoted { value, span } => (value.to_string(), span),
                     TemplateString::Unquoted(value) => (value.to_string(), bit.span),
                 };
 

--- a/crates/djls-semantic/tests/offset.rs
+++ b/crates/djls-semantic/tests/offset.rs
@@ -31,7 +31,23 @@ fn identifies_template_reference_context() {
         context,
         SemanticOffsetContext::TemplateReference {
             name: TemplateName::new(&db, "base.html".to_string()),
-            span: Span::saturating_from_parts_usize(11, 11),
+            span: Span::saturating_from_parts_usize(12, 9),
+        }
+    );
+}
+
+#[test]
+fn identifies_template_reference_context_from_opening_quote() {
+    let db = TestDatabase::new();
+    let source = r#"{% extends "base.html" %}"#;
+
+    let context = context_for_source(&db, source, offset_of(source, "\"base"));
+
+    assert_eq!(
+        context,
+        SemanticOffsetContext::TemplateReference {
+            name: TemplateName::new(&db, "base.html".to_string()),
+            span: Span::saturating_from_parts_usize(12, 9),
         }
     );
 }

--- a/crates/djls-semantic/tests/references.rs
+++ b/crates/djls-semantic/tests/references.rs
@@ -61,7 +61,7 @@ fn template_references_record_extends_and_include_kinds() {
     assert_eq!(base_refs[0].kind(&db), TemplateReferenceKind::Extends);
     assert_eq!(
         base_refs[0].span(&db),
-        Span::saturating_from_parts_usize(2, 21)
+        Span::saturating_from_parts_usize(12, 9)
     );
     assert_eq!(partial_refs.len(), 1);
     assert_eq!(partial_refs[0].kind(&db), TemplateReferenceKind::Include);

--- a/crates/djls-semantic/tests/structure_outline.rs
+++ b/crates/djls-semantic/tests/structure_outline.rs
@@ -27,10 +27,6 @@ fn labels(items: &[OutlineItem]) -> Vec<&str> {
     items.iter().map(|item| item.label.as_str()).collect()
 }
 
-fn span_of(source: &str, needle: &str) -> Span {
-    Span::saturating_from_parts_usize(source.find(needle).unwrap(), needle.len())
-}
-
 #[test]
 fn header_tags_produce_outline_items() {
     let db = TestDatabase::new();
@@ -59,10 +55,16 @@ fn header_tags_produce_outline_items() {
             .collect::<Vec<_>>(),
         vec![Some("extends"), Some("load"), Some("load"), Some("include")]
     );
-    assert_eq!(outline[0].selection_span, span_of(source, "base.html"));
+    assert_eq!(
+        outline[0].selection_span,
+        Span::saturating_from_parts_usize(source.find("base.html").unwrap(), "base.html".len())
+    );
     assert_eq!(
         outline[3].selection_span,
-        span_of(source, "partials/nav.html")
+        Span::saturating_from_parts_usize(
+            source.find("partials/nav.html").unwrap(),
+            "partials/nav.html".len()
+        )
     );
 }
 

--- a/crates/djls-semantic/tests/structure_outline.rs
+++ b/crates/djls-semantic/tests/structure_outline.rs
@@ -10,6 +10,7 @@ use djls_semantic::TagSpecs;
 use djls_semantic::build_template_outline;
 use djls_semantic::build_template_tree;
 use djls_semantic::builtin_tag_specs;
+use djls_source::Span;
 use djls_templates::parse_template;
 use djls_testing::TestDatabase;
 use rustc_hash::FxHashMap;
@@ -26,15 +27,17 @@ fn labels(items: &[OutlineItem]) -> Vec<&str> {
     items.iter().map(|item| item.label.as_str()).collect()
 }
 
+fn span_of(source: &str, needle: &str) -> Span {
+    Span::saturating_from_parts_usize(source.find(needle).unwrap(), needle.len())
+}
+
 #[test]
 fn header_tags_produce_outline_items() {
     let db = TestDatabase::new();
-    let outline = outline_for_source(
-        &db,
-        r#"{% extends "base.html" %}
+    let source = r#"{% extends "base.html" %}
 {% load static i18n %}
-{% include "partials/nav.html" %}"#,
-    );
+{% include "partials/nav.html" %}"#;
+    let outline = outline_for_source(&db, source);
 
     assert_eq!(
         labels(outline),
@@ -55,6 +58,11 @@ fn header_tags_produce_outline_items() {
             .map(|item| item.detail.as_deref())
             .collect::<Vec<_>>(),
         vec![Some("extends"), Some("load"), Some("load"), Some("include")]
+    );
+    assert_eq!(outline[0].selection_span, span_of(source, "base.html"));
+    assert_eq!(
+        outline[3].selection_span,
+        span_of(source, "partials/nav.html")
     );
 }
 

--- a/crates/djls-templates/src/bits.rs
+++ b/crates/djls-templates/src/bits.rs
@@ -22,7 +22,7 @@ impl TagBit {
 
     #[must_use]
     pub fn template_string(&self) -> TemplateString<'_> {
-        TemplateString::parse(&self.text)
+        TemplateString::parse(&self.text, self.span)
     }
 }
 

--- a/crates/djls-templates/src/quotes.rs
+++ b/crates/djls-templates/src/quotes.rs
@@ -1,12 +1,15 @@
+use djls_source::Span;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TemplateString<'a> {
-    Quoted(&'a str),
+    Quoted { value: &'a str, value_span: Span },
     Unquoted(&'a str),
 }
 
 impl<'a> TemplateString<'a> {
     #[must_use]
-    pub(crate) fn parse(raw: &'a str) -> Self {
+    pub(crate) fn parse(raw: &'a str, raw_span: Span) -> Self {
+        let trim_start_len = raw.len() - raw.trim_start().len();
         let raw = raw.trim();
         let Some(first) = raw.chars().next() else {
             return Self::Unquoted(raw);
@@ -19,22 +22,14 @@ impl<'a> TemplateString<'a> {
             return Self::Unquoted(raw);
         }
 
-        Self::Quoted(&raw[1..raw.len() - 1])
-    }
+        let value = &raw[1..raw.len() - 1];
+        let value_start = raw_span
+            .start_usize()
+            .saturating_add(trim_start_len)
+            .saturating_add(first.len_utf8());
+        let value_span = Span::saturating_from_parts_usize(value_start, value.len());
 
-    #[must_use]
-    pub fn value(self) -> &'a str {
-        match self {
-            Self::Quoted(value) | Self::Unquoted(value) => value,
-        }
-    }
-
-    #[must_use]
-    pub fn quoted_value(self) -> Option<&'a str> {
-        match self {
-            Self::Quoted(value) => Some(value),
-            Self::Unquoted(_) => None,
-        }
+        Self::Quoted { value, value_span }
     }
 }
 
@@ -179,29 +174,86 @@ mod tests {
 
     #[test]
     fn template_string_recognizes_single_quoted_values() {
-        let value = TemplateString::parse("'images/logo.png'");
+        let value = TemplateString::parse(
+            "'images/logo.png'",
+            Span::saturating_from_parts_usize(0, 17),
+        );
 
-        assert_eq!(value, TemplateString::Quoted("images/logo.png"));
-        assert_eq!(value.value(), "images/logo.png");
-        assert_eq!(value.quoted_value(), Some("images/logo.png"));
+        assert_eq!(
+            value,
+            TemplateString::Quoted {
+                value: "images/logo.png",
+                value_span: Span::saturating_from_parts_usize(1, 15),
+            }
+        );
     }
 
     #[test]
     fn template_string_recognizes_double_quoted_values() {
-        let value = TemplateString::parse(r#""base.html""#);
+        let value =
+            TemplateString::parse(r#""base.html""#, Span::saturating_from_parts_usize(0, 11));
 
-        assert_eq!(value, TemplateString::Quoted("base.html"));
-        assert_eq!(value.value(), "base.html");
-        assert_eq!(value.quoted_value(), Some("base.html"));
+        assert_eq!(
+            value,
+            TemplateString::Quoted {
+                value: "base.html",
+                value_span: Span::saturating_from_parts_usize(1, 9),
+            }
+        );
+    }
+
+    #[test]
+    fn template_string_records_empty_value_span() {
+        let value = TemplateString::parse(r#""""#, Span::saturating_from_parts_usize(10, 2));
+
+        assert_eq!(
+            value,
+            TemplateString::Quoted {
+                value: "",
+                value_span: Span::saturating_from_parts_usize(11, 0),
+            }
+        );
+    }
+
+    #[test]
+    fn template_string_accounts_for_trimmed_leading_bytes() {
+        let value =
+            TemplateString::parse("  'base.html' ", Span::saturating_from_parts_usize(40, 14));
+
+        assert_eq!(
+            value,
+            TemplateString::Quoted {
+                value: "base.html",
+                value_span: Span::saturating_from_parts_usize(43, 9),
+            }
+        );
+    }
+
+    #[test]
+    fn template_string_records_non_ascii_byte_length() {
+        let value = TemplateString::parse(r#""é.html""#, Span::saturating_from_parts_usize(0, 9));
+
+        assert_eq!(
+            value,
+            TemplateString::Quoted {
+                value: "é.html",
+                value_span: Span::saturating_from_parts_usize(1, 7),
+            }
+        );
+    }
+
+    #[test]
+    fn template_string_leaves_unterminated_quotes_unquoted() {
+        let value = TemplateString::parse("'base.html", Span::saturating_from_parts_usize(0, 10));
+
+        assert_eq!(value, TemplateString::Unquoted("'base.html"));
     }
 
     #[test]
     fn template_string_leaves_bare_values_unquoted() {
-        let value = TemplateString::parse("user.name");
+        let value = TemplateString::parse("user.name", Span::saturating_from_parts_usize(0, 9));
 
         assert_eq!(value, TemplateString::Unquoted("user.name"));
-        assert_eq!(value.value(), "user.name");
-        assert_eq!(value.quoted_value(), None);
     }
 
     fn split_on_unquoted_whitespace_text(input: &str) -> Vec<String> {

--- a/crates/djls-templates/src/quotes.rs
+++ b/crates/djls-templates/src/quotes.rs
@@ -2,7 +2,7 @@ use djls_source::Span;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TemplateString<'a> {
-    Quoted { value: &'a str, value_span: Span },
+    Quoted { value: &'a str, span: Span },
     Unquoted(&'a str),
 }
 
@@ -27,9 +27,9 @@ impl<'a> TemplateString<'a> {
             .start_usize()
             .saturating_add(trim_start_len)
             .saturating_add(first.len_utf8());
-        let value_span = Span::saturating_from_parts_usize(value_start, value.len());
+        let span = Span::saturating_from_parts_usize(value_start, value.len());
 
-        Self::Quoted { value, value_span }
+        Self::Quoted { value, span }
     }
 }
 
@@ -183,7 +183,7 @@ mod tests {
             value,
             TemplateString::Quoted {
                 value: "images/logo.png",
-                value_span: Span::saturating_from_parts_usize(1, 15),
+                span: Span::saturating_from_parts_usize(1, 15),
             }
         );
     }
@@ -197,20 +197,20 @@ mod tests {
             value,
             TemplateString::Quoted {
                 value: "base.html",
-                value_span: Span::saturating_from_parts_usize(1, 9),
+                span: Span::saturating_from_parts_usize(1, 9),
             }
         );
     }
 
     #[test]
-    fn template_string_records_empty_value_span() {
+    fn template_string_records_empty_span() {
         let value = TemplateString::parse(r#""""#, Span::saturating_from_parts_usize(10, 2));
 
         assert_eq!(
             value,
             TemplateString::Quoted {
                 value: "",
-                value_span: Span::saturating_from_parts_usize(11, 0),
+                span: Span::saturating_from_parts_usize(11, 0),
             }
         );
     }
@@ -224,7 +224,7 @@ mod tests {
             value,
             TemplateString::Quoted {
                 value: "base.html",
-                value_span: Span::saturating_from_parts_usize(43, 9),
+                span: Span::saturating_from_parts_usize(43, 9),
             }
         );
     }
@@ -237,7 +237,7 @@ mod tests {
             value,
             TemplateString::Quoted {
                 value: "é.html",
-                value_span: Span::saturating_from_parts_usize(1, 7),
+                span: Span::saturating_from_parts_usize(1, 7),
             }
         );
     }

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -110,9 +110,9 @@ async def test_find_references_for_template_reference(client: LanguageClient):
         )
         for location in result
     } == {
-        (HOME_TEMPLATE.as_uri(), 0, 2, 0, 32),
-        (EXTENDS_TAG_TEMPLATE.as_uri(), 2, 2, 2, 32),
-        (EXTENDS_TAG_TEMPLATE.as_uri(), 10, 2, 10, 32),
+        (HOME_TEMPLATE.as_uri(), 0, 12, 0, 30),
+        (EXTENDS_TAG_TEMPLATE.as_uri(), 2, 12, 2, 30),
+        (EXTENDS_TAG_TEMPLATE.as_uri(), 10, 12, 10, 30),
     }
 
 


### PR DESCRIPTION
## Summary
- compute quote-interior value spans in djls-templates
- thread template-reference value spans through semantic offset/reference consumers
- tighten outline selection spans and add IDE range regression coverage

## Validation
- cargo test -q
- just clippy
- just fmt
- just lint
- just hawk