### PR TITLE
Add LocationLink goto for template references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
+- Changed template goto definition to return origin ranges for clients that support definition links.
 - Changed template tag library discovery to derive libraries from project source and Django settings instead of the runtime inspector.
 - Changed static Django discovery to preserve inactive-app evidence for `S118`, `S119`, and `S121` diagnostics without runtime introspection.
 - Changed Django discovery to run after LSP initialization, refresh in the background, and warm IDE caches without blocking read requests.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A language server for the Django web framework.
   ![Diagnostics](docs/assets/diagnostics.png)
 - [ ] **Go to definition** - Jump to template, block, or variable definitions
     - [x] Template navigation for `{% extends %}` and `{% include %}`
+    - [x] Exact template-name highlighting in editors that support definition links
     - [ ] Block and variable definitions
 - [ ] **Find references** - See where templates, blocks, and variables are used
     - [x] Template references for `{% extends %}` and `{% include %}`
@@ -76,7 +77,7 @@ Once configured, open any Django template file in your project to get:
 - Template tag and filter completions with snippets
 - Real-time syntax validation and diagnostics
 - Hover documentation for template tags, filters, libraries, and template references
-- Navigation to template definitions and references
+- Navigation to template definitions and references, including exact template-name highlighting for goto in supported editors
 - Clickable links for `{% extends %}`, `{% include %}`, and `{% load %}` names
 - Folding for Django template regions
 - Outline symbols for template structure

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ The project is currently a template-first Django language server. The near-term 
 
 ## Strategy
 
-Finish high-value template IDE features first: links, precise navigation, template-name completion, block navigation, and quick fixes. Broader Django intelligence should build from static project facts through settings, URLs/static assets, model facts, view context, and finally template variable types.
+Finish high-value template IDE features first: template-name completion, block navigation, block references, and quick fixes. Broader Django intelligence should build from static project facts through settings, URLs/static assets, model facts, view context, and finally template variable types.
 
 Prefer conservative diagnostics over false positives when project facts are partial or dynamic. Defer rename, code lens, and type-driven features until references and symbol identity are strong enough to make them safe.
 
@@ -28,7 +28,7 @@ Prefer conservative diagnostics over false positives when project facts are part
 
 **Status:** 🚧 Partially supported
 
-`{% extends %}` and `{% include %}` references should feel complete across completion, navigation, and editor links. Document links are supported for resolved `{% extends %}`, `{% include %}`, and `{% load %}` template-library names. Remaining first-pass polish should add precise goto targets and template-name completion from discovered templates.
+`{% extends %}` and `{% include %}` references should feel complete across completion, navigation, and editor links. Document links are supported for resolved `{% extends %}`, `{% include %}`, and `{% load %}` template-library names. Go to definition resolves literal `{% extends %}` and `{% include %}` names and sends exact origin ranges to clients that support definition links. Remaining first-pass polish should add template-name completion from discovered templates.
 
 #### Inheritance block intelligence
 
@@ -102,7 +102,7 @@ Hover is supported for template tags, filters, libraries, selectively loaded sym
 
 **Status:** 🚧 Partially supported
 
-Go to definition works for template references in `{% extends %}` and `{% include %}`. The next improvements are precise template-reference targets and parent block navigation across inheritance.
+Go to definition works for literal template references in `{% extends %}` and `{% include %}`. Clients that support definition links receive exact origin ranges for the referenced template name; older clients still receive plain locations. The next improvement is parent block navigation across inheritance.
 
 #### Find references
 
@@ -216,15 +216,14 @@ Execute commands may be useful for hierarchy views, project-status inspection, o
 
 ## Priority Order
 
-1. Precise template-reference goto targets.
-2. Template-name completion for `{% extends %}` and `{% include %}`.
-3. Block navigation across inheritance.
-4. Block references and block-name completion.
-5. Code actions for existing diagnostics.
-6. URL/static completions and diagnostics.
-7. Settings hover and typo diagnostics.
-8. Model facts surfaced through navigation and hover.
-9. Template context and variable intelligence.
+1. Template-name completion for `{% extends %}` and `{% include %}`.
+2. Block navigation across inheritance.
+3. Block references and block-name completion.
+4. Code actions for existing diagnostics.
+5. URL/static completions and diagnostics.
+6. Settings hover and typo diagnostics.
+7. Model facts surfaced through navigation and hover.
+8. Template context and variable intelligence.
 
 ## Deferred or Not Planned
 

--- a/crates/djls-ide/src/navigation.rs
+++ b/crates/djls-ide/src/navigation.rs
@@ -13,11 +13,12 @@ pub fn goto_definition(
     db: &dyn djls_semantic::Db,
     file: File,
     offset: Offset,
+    supports_location_links: bool,
 ) -> Option<ls_types::GotoDefinitionResponse> {
     match SemanticOffsetContext::from_offset(db, file, offset) {
         SemanticOffsetContext::TemplateReference {
             name: template_name,
-            ..
+            span,
         } => {
             tracing::debug!("Found template reference: '{}'", template_name.name(db));
 
@@ -28,12 +29,27 @@ pub fn goto_definition(
                     let path = origin.path_buf(db);
                     tracing::debug!("Resolved template to: {}", path);
 
-                    Some(ls_types::GotoDefinitionResponse::Scalar(
-                        ls_types::Location {
-                            uri: path.to_lsp_uri()?,
-                            range: ls_types::Range::default(),
-                        },
-                    ))
+                    let target_uri = path.to_lsp_uri()?;
+                    let target_range = ls_types::Range::default();
+                    if supports_location_links {
+                        Some(ls_types::GotoDefinitionResponse::Link(vec![
+                            ls_types::LocationLink {
+                                origin_selection_range: Some(
+                                    span.to_lsp_range(file.line_index(db)),
+                                ),
+                                target_uri,
+                                target_range,
+                                target_selection_range: target_range,
+                            },
+                        ]))
+                    } else {
+                        Some(ls_types::GotoDefinitionResponse::Scalar(
+                            ls_types::Location {
+                                uri: target_uri,
+                                range: target_range,
+                            },
+                        ))
+                    }
                 }
                 FindTemplateResult::DoesNotExist(error) => {
                     tracing::warn!(

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -1,9 +1,87 @@
 use camino::Utf8Path;
 use djls_ide::find_references;
+use djls_ide::goto_definition;
 use djls_source::Offset;
 use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
+
+#[test]
+fn goto_definition_reports_location_link_with_origin_range() {
+    let mut db = TestDatabase::new();
+    let source = r#"{% extends "base.html" %}"#;
+    let child_path = "/test/project/templates/child.html";
+
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .template_file("child.html", child_path, source)
+        .template_file("base.html", "/test/project/templates/base.html", "base")
+        .install(&mut db);
+
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let response = goto_definition(
+        &db,
+        file,
+        Offset::new(u32::try_from(source.find("base").unwrap()).unwrap()),
+        true,
+    )
+    .expect("template reference should resolve to the target template");
+
+    assert_eq!(
+        response,
+        ls_types::GotoDefinitionResponse::Link(vec![ls_types::LocationLink {
+            origin_selection_range: Some(ls_types::Range::new(
+                ls_types::Position::new(0, 12),
+                ls_types::Position::new(0, 21),
+            )),
+            target_uri: "file:///test/project/templates/base.html"
+                .parse()
+                .expect("test URI should parse"),
+            target_range: ls_types::Range::default(),
+            target_selection_range: ls_types::Range::default(),
+        }])
+    );
+}
+
+#[test]
+fn goto_definition_falls_back_to_location_without_link_support() {
+    let mut db = TestDatabase::new();
+    let source = r#"{% extends "base.html" %}"#;
+    let child_path = "/test/project/templates/child.html";
+
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .template_file("child.html", child_path, source)
+        .template_file("base.html", "/test/project/templates/base.html", "base")
+        .install(&mut db);
+
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let response = goto_definition(
+        &db,
+        file,
+        Offset::new(u32::try_from(source.find("base").unwrap()).unwrap()),
+        false,
+    )
+    .expect("template reference should resolve to the target template");
+
+    assert_eq!(
+        response,
+        ls_types::GotoDefinitionResponse::Scalar(ls_types::Location {
+            uri: "file:///test/project/templates/base.html"
+                .parse()
+                .expect("test URI should parse"),
+            range: ls_types::Range::default(),
+        })
+    );
+}
 
 #[test]
 fn find_references_reports_template_name_interior_range() {

--- a/crates/djls-server/src/client.rs
+++ b/crates/djls-server/src/client.rs
@@ -86,7 +86,7 @@ impl ClientInfo {
 
     #[must_use]
     pub(crate) fn supports_location_links(&self) -> bool {
-        self.capabilities.definition.supports_location_links()
+        self.capabilities.location_links
     }
 }
 
@@ -103,10 +103,14 @@ pub(crate) enum Client {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "LSP client capabilities are independent protocol feature flags"
+)]
 pub(crate) struct ClientCapabilities {
     pull_diagnostics: bool,
     snippets: bool,
-    definition: DefinitionCapabilities,
+    location_links: bool,
     work_done_progress: bool,
 }
 
@@ -127,7 +131,12 @@ impl ClientCapabilities {
             .and_then(|completion_item| completion_item.snippet_support)
             .unwrap_or(false);
 
-        let definition = DefinitionCapabilities::new(capabilities);
+        let location_links = capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.definition.as_ref())
+            .and_then(|definition| definition.link_support)
+            .unwrap_or(false);
 
         let work_done_progress = capabilities
             .window
@@ -138,33 +147,9 @@ impl ClientCapabilities {
         Self {
             pull_diagnostics,
             snippets,
-            definition,
+            location_links,
             work_done_progress,
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct DefinitionCapabilities {
-    location_links: bool,
-}
-
-impl DefinitionCapabilities {
-    #[must_use]
-    fn new(capabilities: &ls_types::ClientCapabilities) -> Self {
-        let location_links = capabilities
-            .text_document
-            .as_ref()
-            .and_then(|text_document| text_document.definition.as_ref())
-            .and_then(|definition| definition.link_support)
-            .unwrap_or(false);
-
-        Self { location_links }
-    }
-
-    #[must_use]
-    fn supports_location_links(self) -> bool {
-        self.location_links
     }
 }
 

--- a/crates/djls-server/src/client.rs
+++ b/crates/djls-server/src/client.rs
@@ -83,6 +83,11 @@ impl ClientInfo {
     pub(crate) fn supports_snippets(&self) -> bool {
         self.capabilities.snippets
     }
+
+    #[must_use]
+    pub(crate) fn supports_location_links(&self) -> bool {
+        self.capabilities.definition.supports_location_links()
+    }
 }
 
 /// LSP client identification for client-specific behavioral overrides.
@@ -101,6 +106,7 @@ pub(crate) enum Client {
 pub(crate) struct ClientCapabilities {
     pull_diagnostics: bool,
     snippets: bool,
+    definition: DefinitionCapabilities,
     work_done_progress: bool,
 }
 
@@ -121,6 +127,8 @@ impl ClientCapabilities {
             .and_then(|completion_item| completion_item.snippet_support)
             .unwrap_or(false);
 
+        let definition = DefinitionCapabilities::new(capabilities);
+
         let work_done_progress = capabilities
             .window
             .as_ref()
@@ -130,8 +138,33 @@ impl ClientCapabilities {
         Self {
             pull_diagnostics,
             snippets,
+            definition,
             work_done_progress,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DefinitionCapabilities {
+    location_links: bool,
+}
+
+impl DefinitionCapabilities {
+    #[must_use]
+    fn new(capabilities: &ls_types::ClientCapabilities) -> Self {
+        let location_links = capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.definition.as_ref())
+            .and_then(|definition| definition.link_support)
+            .unwrap_or(false);
+
+        Self { location_links }
+    }
+
+    #[must_use]
+    fn supports_location_links(self) -> bool {
+        self.location_links
     }
 }
 
@@ -207,6 +240,33 @@ mod tests {
         let capabilities = ls_types::ClientCapabilities::default();
         let client_info = ClientInfo::new(&capabilities, None, ClientOptions::default());
         assert_eq!(client_info.position_encoding(), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn test_supports_location_links_when_definition_link_support_is_declared() {
+        let capabilities = ls_types::ClientCapabilities {
+            text_document: Some(ls_types::TextDocumentClientCapabilities {
+                definition: Some(ls_types::GotoCapability {
+                    link_support: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let client_info = ClientInfo::new(&capabilities, None, ClientOptions::default());
+
+        assert!(client_info.supports_location_links());
+    }
+
+    #[test]
+    fn test_does_not_support_location_links_when_definition_link_support_is_absent() {
+        let capabilities = ls_types::ClientCapabilities::default();
+
+        let client_info = ClientInfo::new(&capabilities, None, ClientOptions::default());
+
+        assert!(!client_info.supports_location_links());
     }
 
     #[test]

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -425,7 +425,12 @@ impl LanguageServer for DjangoLanguageServer {
                     return None;
                 }
 
-                djls_ide::goto_definition(db, file, offset)
+                djls_ide::goto_definition(
+                    db,
+                    file,
+                    offset,
+                    snapshot.client_info().supports_location_links(),
+                )
             })
             .await;
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -32,7 +32,7 @@ env_file = ".env.local"
 
 Your Django settings module name (e.g., `"myproject.settings"`).
 
-The server uses this to statically introspect your Django project for template tag completions, diagnostics, navigation, hover, and template-library document links. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
+The server uses this to statically introspect your Django project for template tag completions, diagnostics, template navigation, hover, and document links for templates and template libraries. If not explicitly configured, the server reads the `DJANGO_SETTINGS_MODULE` environment variable.
 
 **When to configure:**
 
@@ -56,7 +56,7 @@ The server needs access to your virtual environment to discover installed Django
 
 **Default:** `[]` (empty list)
 
-Additional directories to add to the Python import search paths used for static project introspection. These paths are searched alongside the project root when the server resolves settings modules, installed apps, template tag libraries, and Python sources for diagnostics, hover, completions, and `{% load %}` document links.
+Additional directories to add to the Python import search paths used for static project introspection. These paths are searched alongside the project root when the server resolves settings modules, installed apps, template tag libraries, and Python sources for diagnostics, hover, completions, template navigation, and `{% load %}` document links.
 
 **When to configure:**
 

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -49,6 +49,8 @@ Each layer has a different failure mode and a different fix:
 
 The same inventory powers editor links: resolved `{% load %}` library names become document links to their `templatetags/*.py` source files. Unresolved libraries are skipped.
 
+Template directory discovery also powers goto definition for literal `{% extends %}` and `{% include %}` names. Editors that support definition links receive the exact template-name range as the origin.
+
 This gives you diagnostics based on the same template tag inventory Django would use at runtime, while distinguishing "not installed or misspelled" from "installed but not activated".
 
 ## What djls Validates
@@ -121,7 +123,7 @@ Django templates are deeply dynamic — many things can only be checked at runti
 
 - **Variable resolution** — Whether a variable exists in the template context
 - **Type coercion** — Whether filter arguments have the correct type at runtime
-- **Template existence and inheritance semantics** — Whether every `{% extends %}` / `{% include %}` target exists or whether inherited blocks match intended runtime behavior
+- **Template existence diagnostics and inheritance semantics** — djls resolves static `{% extends %}` / `{% include %}` targets for navigation, but it does not report missing targets as validation errors or verify inherited block behavior
 - **Dynamic tag behavior** — Tags whose validation depends on runtime state
 - **Format strings** — Whether date/time format strings are valid
 

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -43,8 +43,18 @@ async def test_goto_definition_for_extends_template_reference(client: LanguageCl
     )
 
     assert result is not None
-    assert result.uri == BASE_TEMPLATE.as_uri()
-    assert result.range == Range(
+    assert len(result) == 1
+    link = result[0]
+    assert link.origin_selection_range == Range(
+        start=Position(line=0, character=12),
+        end=Position(line=0, character=30),
+    )
+    assert link.target_uri == BASE_TEMPLATE.as_uri()
+    assert link.target_range == Range(
+        start=Position(line=0, character=0),
+        end=Position(line=0, character=0),
+    )
+    assert link.target_selection_range == Range(
         start=Position(line=0, character=0),
         end=Position(line=0, character=0),
     )
@@ -71,8 +81,18 @@ async def test_goto_definition_for_include_template_reference(client: LanguageCl
     )
 
     assert result is not None
-    assert result.uri == HEADER_TEMPLATE.as_uri()
-    assert result.range == Range(
+    assert len(result) == 1
+    link = result[0]
+    assert link.origin_selection_range == Range(
+        start=Position(line=11, character=16),
+        end=Position(line=11, character=36),
+    )
+    assert link.target_uri == HEADER_TEMPLATE.as_uri()
+    assert link.target_range == Range(
+        start=Position(line=0, character=0),
+        end=Position(line=0, character=0),
+    )
+    assert link.target_selection_range == Range(
         start=Position(line=0, character=0),
         end=Position(line=0, character=0),
     )


### PR DESCRIPTION
## Summary
- return `LocationLink` goto responses with exact origin ranges for clients that support definition links
- preserve the plain `Location` fallback for clients without definition-link support
- update README, roadmap, and docs for the new template goto behavior

## Tests
- `cargo test -p djls-server`
- `cargo test -p djls-ide`
- `cargo test -q`
- `just e2e`
- `just fmt`
- `just clippy`
- `just lint`
- `just hawk`