### PR TITLE
Add template name completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
+- Added completion for resolvable template names inside quoted `{% extends %}` and `{% include %}` arguments.
 - Added document links for resolvable Django template and template-library references.
 - Added opt-in whole-document Django template formatting through `djangofmt`.
 - Added startup progress reporting for Django project discovery and IDE cache warm-up.

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -9,8 +9,10 @@
 use djls_project::TemplateLibraries;
 use djls_project::TemplateSymbolAvailability;
 use djls_project::TemplateSymbolKind;
+use djls_project::template_resolution;
 use djls_semantic::AvailableSymbols;
 use djls_semantic::TagArgumentKind;
+use djls_semantic::TagRole;
 use djls_semantic::TagSpecs;
 use djls_source::File;
 use djls_source::FileKind;
@@ -36,6 +38,7 @@ pub(crate) enum CompletionCandidateKind {
     TagArgumentChoice,
     TagArgumentPlaceholder,
     TagArgumentSnippet,
+    TemplateName,
     LibraryName,
     LoadSymbol,
     Filter,
@@ -48,6 +51,7 @@ impl CompletionCandidateKind {
             Self::TagName
             | Self::TagArgumentLiteral
             | Self::TagArgumentChoice
+            | Self::TemplateName
             | Self::LibraryName
             | Self::LoadSymbol
             | Self::Filter => 1,
@@ -156,6 +160,35 @@ impl CompletionEdit {
 
         Self::plain(
             Self::span_with_source_suffix(prefix, suffix, close.partial_replacement_suffix_len()),
+            insert_text,
+        )
+    }
+
+    fn template_name(
+        name: &str,
+        quote: char,
+        prefix: &OffsetPrefix<'_>,
+        suffix: &OffsetSuffix<'_>,
+        closed: bool,
+        close: TagClose,
+    ) -> Self {
+        let mut insert_text = name.to_string();
+        let close_suffix_len = match (closed, close) {
+            (true, TagClose::Full { .. }) => 0,
+            (true, close) => {
+                insert_text.push(quote);
+                Self::append_tag_close(&mut insert_text, close);
+                quote.len_utf8() + close.partial_replacement_suffix_len()
+            }
+            (false, close) => {
+                insert_text.push(quote);
+                Self::append_tag_close(&mut insert_text, close);
+                close.partial_replacement_suffix_len()
+            }
+        };
+
+        Self::plain(
+            Self::span_with_source_suffix(prefix, suffix, close_suffix_len),
             insert_text,
         )
     }
@@ -350,6 +383,23 @@ impl CompletionCandidate {
         }
     }
 
+    fn template_name(
+        name: &str,
+        quote: char,
+        prefix: &OffsetPrefix<'_>,
+        suffix: &OffsetSuffix<'_>,
+        closed: bool,
+        close: TagClose,
+    ) -> Self {
+        Self {
+            label: name.to_string(),
+            kind: CompletionCandidateKind::TemplateName,
+            edit: CompletionEdit::template_name(name, quote, prefix, suffix, closed, close),
+            detail: Some("Django template".to_string()),
+            documentation: None,
+        }
+    }
+
     fn library_name(
         name: &str,
         prefix: &OffsetPrefix<'_>,
@@ -434,25 +484,8 @@ pub fn completion(
     let tokens = djls_templates::lex_template(db, file);
     let context = CompletionOffsetContext::new(*source.kind(), source.as_str(), tokens, offset);
     let template_libraries = db.template_libraries();
-
-    let available_symbols = if template_libraries.has_symbol_inventory() {
-        match &context {
-            CompletionOffsetContext::Template(
-                TemplateCompletionContext::TagName { .. }
-                | TemplateCompletionContext::Filter { .. },
-            ) => djls_templates::parse_template(db, file)
-                .map(|nodelist| djls_semantic::available_symbols_at(db, nodelist, offset.get())),
-            CompletionOffsetContext::Template(
-                TemplateCompletionContext::Text
-                | TemplateCompletionContext::TagArgument { .. }
-                | TemplateCompletionContext::LibraryName { .. }
-                | TemplateCompletionContext::LoadSymbol { .. },
-            )
-            | CompletionOffsetContext::None => None,
-        }
-    } else {
-        None
-    };
+    let available_symbols =
+        available_symbols_for_completion(db, file, offset, &context, template_libraries);
 
     let mut candidates = match &context {
         CompletionOffsetContext::Template(TemplateCompletionContext::TagName {
@@ -481,6 +514,27 @@ pub fn completion(
             *close,
             db.tag_specs(),
             supports_snippets,
+        ),
+        CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+            tag,
+            position,
+            quote,
+            prefix,
+            suffix,
+            closed,
+            close,
+        }) => generate_template_name_candidates(
+            db,
+            TemplateNameCandidateInput {
+                tag,
+                position: *position,
+                quote: *quote,
+                prefix,
+                suffix,
+                closed: *closed,
+                close: *close,
+            },
+            db.tag_specs(),
         ),
         CompletionOffsetContext::Template(TemplateCompletionContext::LibraryName {
             prefix,
@@ -517,6 +571,33 @@ pub fn completion(
         .collect::<Vec<_>>();
 
     Some(ls_types::CompletionResponse::Array(items))
+}
+
+fn available_symbols_for_completion(
+    db: &dyn djls_semantic::Db,
+    file: File,
+    offset: Offset,
+    context: &CompletionOffsetContext<'_>,
+    template_libraries: &TemplateLibraries,
+) -> Option<AvailableSymbols> {
+    if !template_libraries.has_symbol_inventory() {
+        return None;
+    }
+
+    match context {
+        CompletionOffsetContext::Template(
+            TemplateCompletionContext::TagName { .. } | TemplateCompletionContext::Filter { .. },
+        ) => djls_templates::parse_template(db, file)
+            .map(|nodelist| djls_semantic::available_symbols_at(db, nodelist, offset.get())),
+        CompletionOffsetContext::Template(
+            TemplateCompletionContext::Text
+            | TemplateCompletionContext::TagArgument { .. }
+            | TemplateCompletionContext::QuotedArgument { .. }
+            | TemplateCompletionContext::LibraryName { .. }
+            | TemplateCompletionContext::LoadSymbol { .. },
+        )
+        | CompletionOffsetContext::None => None,
+    }
 }
 
 fn generate_tag_name_candidates(
@@ -652,6 +733,51 @@ fn generate_tag_argument_candidates(
     }
 
     candidates
+}
+
+#[derive(Clone, Copy)]
+struct TemplateNameCandidateInput<'context, 'source> {
+    tag: &'source str,
+    position: usize,
+    quote: char,
+    prefix: &'context OffsetPrefix<'source>,
+    suffix: &'context OffsetSuffix<'source>,
+    closed: bool,
+    close: TagClose,
+}
+
+fn generate_template_name_candidates(
+    db: &dyn djls_semantic::Db,
+    input: TemplateNameCandidateInput<'_, '_>,
+    tag_specs: &TagSpecs,
+) -> Vec<CompletionCandidate> {
+    let Some(spec) = tag_specs.get(input.tag) else {
+        return Vec::new();
+    };
+    if !matches!(spec.role(), Some(TagRole::TemplateReference(_))) || input.position != 0 {
+        return Vec::new();
+    }
+
+    let Some(project) = db.project() else {
+        return Vec::new();
+    };
+
+    template_resolution(db, project)
+        .template_names(db)
+        .filter_map(|name| {
+            let name = name.name(db);
+            name.starts_with(input.prefix.text).then(|| {
+                CompletionCandidate::template_name(
+                    name,
+                    input.quote,
+                    input.prefix,
+                    input.suffix,
+                    input.closed,
+                    input.close,
+                )
+            })
+        })
+        .collect()
 }
 
 fn generate_library_name_candidates(
@@ -1010,6 +1136,112 @@ mod tests {
         assert_eq!(
             snippet.detail.as_deref(),
             Some("Complete remaining arguments")
+        );
+    }
+
+    #[test]
+    fn template_name_candidate_closes_open_quote_and_tag() {
+        let candidate = CompletionCandidate::template_name(
+            "base.html",
+            '"',
+            &prefix("ba"),
+            &suffix("", 2),
+            false,
+            TagClose::None,
+        );
+
+        assert_eq!(candidate.kind, CompletionCandidateKind::TemplateName);
+        assert_eq!(candidate.edit.replacement_span, Span::new(0, 2));
+        assert_eq!(candidate.edit.insert_text, "base.html\" %}");
+        assert_eq!(candidate.detail.as_deref(), Some("Django template"));
+    }
+
+    #[test]
+    fn template_name_candidate_preserves_existing_full_close_after_open_quote() {
+        let candidate = CompletionCandidate::template_name(
+            "base.html",
+            '"',
+            &prefix("ba"),
+            &suffix("", 2),
+            false,
+            full_close(),
+        );
+
+        assert_eq!(candidate.edit.replacement_span, Span::new(0, 2));
+        assert_eq!(candidate.edit.insert_text, "base.html\"");
+    }
+
+    #[test]
+    fn template_name_candidate_replaces_autopaired_quote_and_partial_close() {
+        let candidate = CompletionCandidate::template_name(
+            "base.html",
+            '"',
+            &prefix("ba"),
+            &suffix("", 2),
+            true,
+            TagClose::Partial {
+                replacement_suffix_len: 1,
+            },
+        );
+
+        assert_eq!(candidate.edit.replacement_span, Span::new(0, 4));
+        assert_eq!(candidate.edit.insert_text, "base.html\" %}");
+    }
+
+    #[test]
+    fn template_name_candidate_replaces_closed_quote_interior() {
+        let candidate = CompletionCandidate::template_name(
+            "base.html",
+            '"',
+            &prefix("ba"),
+            &suffix("se.html", 2),
+            true,
+            full_close(),
+        );
+
+        assert_eq!(candidate.edit.replacement_span, Span::new(0, 9));
+        assert_eq!(candidate.edit.insert_text, "base.html");
+    }
+
+    #[test]
+    fn template_name_candidates_are_role_and_position_gated() {
+        let db = djls_testing::TestDatabase::new();
+        let tag_specs = djls_semantic::builtin_tag_specs();
+
+        let prefix = prefix("");
+        let suffix = suffix("", 0);
+
+        assert!(
+            generate_template_name_candidates(
+                &db,
+                TemplateNameCandidateInput {
+                    tag: "cache",
+                    position: 0,
+                    quote: '"',
+                    prefix: &prefix,
+                    suffix: &suffix,
+                    closed: false,
+                    close: TagClose::None,
+                },
+                &tag_specs,
+            )
+            .is_empty()
+        );
+        assert!(
+            generate_template_name_candidates(
+                &db,
+                TemplateNameCandidateInput {
+                    tag: "extends",
+                    position: 1,
+                    quote: '"',
+                    prefix: &prefix,
+                    suffix: &suffix,
+                    closed: false,
+                    close: TagClose::None,
+                },
+                &tag_specs,
+            )
+            .is_empty()
         );
     }
 

--- a/crates/djls-ide/src/context.rs
+++ b/crates/djls-ide/src/context.rs
@@ -40,6 +40,15 @@ pub(crate) enum TemplateCompletionContext<'source> {
         prefix: OffsetPrefix<'source>,
         close: TagClose,
     },
+    QuotedArgument {
+        tag: &'source str,
+        position: usize,
+        quote: char,
+        prefix: OffsetPrefix<'source>,
+        suffix: OffsetSuffix<'source>,
+        closed: bool,
+        close: TagClose,
+    },
     LibraryName {
         prefix: OffsetPrefix<'source>,
         suffix: OffsetSuffix<'source>,
@@ -123,6 +132,20 @@ impl<'source> TemplateCompletionContext<'source> {
         } else {
             (0, "")
         };
+
+        if let Some((quote, quoted_prefix)) = unclosed_quote_prefix(prefix) {
+            let (suffix, closed, close) =
+                OffsetSuffix::quoted_at_offset(source, offset, content_span, quote);
+            return Self::QuotedArgument {
+                tag,
+                position,
+                quote,
+                prefix: OffsetPrefix::new(quoted_prefix, offset),
+                suffix,
+                closed,
+                close,
+            };
+        }
 
         Self::TagArgument {
             tag,
@@ -318,6 +341,46 @@ impl<'source> OffsetSuffix<'source> {
 
         Self::new(&text[..suffix_len], offset)
     }
+
+    fn quoted_at_offset(
+        source: &'source str,
+        offset: Offset,
+        content_span: Span,
+        quote: char,
+    ) -> (Self, bool, TagClose) {
+        let start = (offset.get() as usize).min(source.len());
+        let content_end = content_span.end_usize().min(source.len());
+        if start >= content_end {
+            return (
+                Self::new("", offset),
+                false,
+                TagClose::after_offset(source, offset, content_span),
+            );
+        }
+
+        let text = &source[start..content_end];
+        if let Some((closing_index, _)) = text.char_indices().find(|(index, character)| {
+            *character == quote && !is_escaped(source.as_bytes(), start + index)
+        }) {
+            let after_quote = Offset::try_from(start + closing_index + quote.len_utf8())
+                .expect("closing quote offset is bounded by the token content span");
+            return (
+                Self::new(&text[..closing_index], offset),
+                true,
+                TagClose::after_offset(source, after_quote, content_span),
+            );
+        }
+
+        let close = TagClose::after_offset(source, offset, content_span);
+        let suffix =
+            if matches!(close, TagClose::Full { .. }) && text.chars().all(char::is_whitespace) {
+                ""
+            } else {
+                text
+            };
+
+        (Self::new(suffix, offset), false, close)
+    }
 }
 
 fn token_at_offset(tokens: &[Token], offset: Offset) -> Option<&Token> {
@@ -411,6 +474,30 @@ fn split_tag_words(text: &str) -> Vec<&str> {
     }
 
     words
+}
+
+fn unclosed_quote_prefix(text: &str) -> Option<(char, &str)> {
+    let mut quote = None;
+    let mut quote_start = 0;
+    let bytes = text.as_bytes();
+
+    for (index, character) in text.char_indices() {
+        match character {
+            '\'' | '"'
+                if (quote.is_none() || quote == Some(character)) && !is_escaped(bytes, index) =>
+            {
+                if quote == Some(character) {
+                    quote = None;
+                } else {
+                    quote = Some(character);
+                    quote_start = index;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    quote.map(|quote| (quote, &text[quote_start + quote.len_utf8()..]))
 }
 
 fn is_escaped(bytes: &[u8], index: usize) -> bool {
@@ -563,15 +650,240 @@ mod tests {
     }
 
     #[test]
-    fn tag_argument_syntax_context_keeps_trailing_whitespace_inside_open_quote() {
+    fn quoted_argument_syntax_context_keeps_trailing_whitespace_inside_open_quote() {
         with_syntax_context("{% include \"base layout ▮", |source, context| {
-            let prefix = "\"base layout ";
+            let prefix = "base layout ";
+            let prefix_start = source.find(prefix).unwrap();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "include",
+                    position: 0,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: prefix,
+                        span: Span::new(
+                            u32::try_from(prefix_start).unwrap(),
+                            u32::try_from(prefix.len()).unwrap(),
+                        ),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start + prefix.len()).unwrap(), 0,),
+                    },
+                    closed: false,
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_tracks_prefix() {
+        with_syntax_context("{% extends \"ba▮", |source, context| {
+            let prefix_start = source.find("ba").unwrap();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "extends",
+                    position: 0,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: "ba",
+                        span: Span::new(u32::try_from(prefix_start).unwrap(), 2),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start + 2).unwrap(), 0),
+                    },
+                    closed: false,
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_tracks_slash_prefix() {
+        with_syntax_context("{% include \"partials/na▮", |source, context| {
+            let prefix = "partials/na";
+            let prefix_start = source.find(prefix).unwrap();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "include",
+                    position: 0,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: prefix,
+                        span: Span::new(
+                            u32::try_from(prefix_start).unwrap(),
+                            u32::try_from(prefix.len()).unwrap(),
+                        ),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start + prefix.len()).unwrap(), 0),
+                    },
+                    closed: false,
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_preserves_existing_full_close() {
+        with_syntax_context("{% extends \"ba▮ %}", |source, context| {
+            let prefix_start = source.find("ba").unwrap();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "extends",
+                    position: 0,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: "ba",
+                        span: Span::new(u32::try_from(prefix_start).unwrap(), 2),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start + 2).unwrap(), 0),
+                    },
+                    closed: false,
+                    close: TagClose::Full {
+                        replacement_suffix_len: 3,
+                    },
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_tracks_closed_suffix() {
+        with_syntax_context("{% extends \"ba▮se.html\" %}", |source, context| {
+            let prefix_start = source.find("ba").unwrap();
+            let suffix_start = prefix_start + 2;
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "extends",
+                    position: 0,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: "ba",
+                        span: Span::new(u32::try_from(prefix_start).unwrap(), 2),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "se.html",
+                        span: Span::new(u32::try_from(suffix_start).unwrap(), 7),
+                    },
+                    closed: true,
+                    close: TagClose::Full {
+                        replacement_suffix_len: 3,
+                    },
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_supports_single_quotes() {
+        with_syntax_context("{% extends 'ba▮", |source, context| {
+            let prefix_start = source.find("ba").unwrap();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "extends",
+                    position: 0,
+                    quote: '\'',
+                    prefix: OffsetPrefix {
+                        text: "ba",
+                        span: Span::new(u32::try_from(prefix_start).unwrap(), 2),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start + 2).unwrap(), 0),
+                    },
+                    closed: false,
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_tracks_later_quoted_argument_positions() {
+        with_syntax_context("{% include \"a.html\" with x=\"▮", |source, context| {
+            let prefix_start = source.find("x=\"").unwrap() + "x=\"".len();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "include",
+                    position: 2,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start).unwrap(), 0),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start).unwrap(), 0),
+                    },
+                    closed: false,
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn quoted_argument_syntax_context_ignores_escaped_quotes() {
+        with_syntax_context(r#"{% extends "ba\"se▮"#, |source, context| {
+            let prefix = r#"ba\"se"#;
+            let prefix_start = source.find(prefix).unwrap();
+
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::QuotedArgument {
+                    tag: "extends",
+                    position: 0,
+                    quote: '"',
+                    prefix: OffsetPrefix {
+                        text: prefix,
+                        span: Span::new(
+                            u32::try_from(prefix_start).unwrap(),
+                            u32::try_from(prefix.len()).unwrap(),
+                        ),
+                    },
+                    suffix: OffsetSuffix {
+                        text: "",
+                        span: Span::new(u32::try_from(prefix_start + prefix.len()).unwrap(), 0,),
+                    },
+                    closed: false,
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn closed_quoted_argument_stays_tag_argument_after_quote() {
+        with_syntax_context("{% extends \"base.html\"▮", |source, context| {
+            let prefix = "\"base.html\"";
             let prefix_start = source.find(prefix).unwrap();
 
             assert_eq!(
                 context,
                 CompletionOffsetContext::Template(TemplateCompletionContext::TagArgument {
-                    tag: "include",
+                    tag: "extends",
                     position: 0,
                     prefix: OffsetPrefix {
                         text: prefix,
@@ -579,6 +891,24 @@ mod tests {
                             u32::try_from(prefix_start).unwrap(),
                             u32::try_from(prefix.len()).unwrap(),
                         ),
+                    },
+                    close: TagClose::None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn cursor_before_quote_stays_tag_argument() {
+        with_syntax_context("{% extends ▮\"base.html\"", |_, context| {
+            assert_eq!(
+                context,
+                CompletionOffsetContext::Template(TemplateCompletionContext::TagArgument {
+                    tag: "extends",
+                    position: 0,
+                    prefix: OffsetPrefix {
+                        text: "",
+                        span: Span::new(11, 0),
                     },
                     close: TagClose::None,
                 })

--- a/crates/djls-ide/src/ext.rs
+++ b/crates/djls-ide/src/ext.rs
@@ -172,6 +172,7 @@ impl CompletionCandidateKindExt for CompletionCandidateKind {
                 ls_types::CompletionItemKind::VARIABLE
             }
             CompletionCandidateKind::TagArgumentSnippet => ls_types::CompletionItemKind::SNIPPET,
+            CompletionCandidateKind::TemplateName => ls_types::CompletionItemKind::FILE,
             CompletionCandidateKind::LibraryName => ls_types::CompletionItemKind::MODULE,
             CompletionCandidateKind::LoadSymbol | CompletionCandidateKind::Filter => {
                 ls_types::CompletionItemKind::FUNCTION

--- a/crates/djls-ide/tests/completions.rs
+++ b/crates/djls-ide/tests/completions.rs
@@ -9,6 +9,7 @@ use djls_semantic::TagSpec;
 use djls_semantic::TagSpecs;
 use djls_source::Offset;
 use djls_source::PositionEncoding;
+use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use djls_testing::builtin_tag;
 use djls_testing::library_filter;
@@ -72,11 +73,11 @@ fn source_and_offset(marked_source: &str) -> (String, Offset) {
     (source, Offset::new(u32::try_from(offset).unwrap()))
 }
 
-fn completion_labels(
+fn completion_items(
     marked_source: &str,
     template_libraries: impl FnOnce(&TestDatabase) -> TemplateLibraries,
     tag_specs: TagSpecs,
-) -> Vec<String> {
+) -> Vec<ls_types::CompletionItem> {
     let (source, offset) = source_and_offset(marked_source);
     let db = TestDatabase::new().with_specs(tag_specs);
     let template_libraries = template_libraries(&db);
@@ -88,11 +89,36 @@ fn completion_labels(
         return Vec::new();
     };
 
-    let items = match response {
+    match response {
         ls_types::CompletionResponse::Array(items) => items,
         ls_types::CompletionResponse::List(list) => list.items,
-    };
-    items.into_iter().map(|item| item.label).collect()
+    }
+}
+
+fn completion_labels(
+    marked_source: &str,
+    template_libraries: impl FnOnce(&TestDatabase) -> TemplateLibraries,
+    tag_specs: TagSpecs,
+) -> Vec<String> {
+    completion_items(marked_source, template_libraries, tag_specs)
+        .into_iter()
+        .map(|item| item.label)
+        .collect()
+}
+
+fn install_template_completion_project(db: &mut TestDatabase, child_path: &str, source: &str) {
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/app/templates'], 'APP_DIRS': False}]\n",
+        )
+        .template_file("child.html", child_path, source)
+        .template_file("base.html", "/test/project/templates/base.html", "base")
+        .template_file("shared.html", "/test/project/templates/shared.html", "primary")
+        .template_file("account/detail.html", "/test/project/app/templates/account/detail.html", "detail")
+        .template_file("shared.html", "/test/project/app/templates/shared.html", "shadow")
+        .install(db);
 }
 
 #[test]
@@ -139,4 +165,141 @@ fn filter_completions_respect_load_position() {
 
     assert!(before_load.is_empty());
     assert_eq!(after_load, vec!["trans"]);
+}
+
+#[test]
+fn template_name_completions_use_resolvable_project_names() {
+    let mut db = TestDatabase::new();
+    let (source, offset) = source_and_offset(r#"{% extends "§" %}"#);
+    let child_path = "/test/project/templates/child.html";
+    install_template_completion_project(&mut db, child_path, &source);
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+
+    let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
+        .expect("template names should complete inside quoted references");
+    let items = match response {
+        ls_types::CompletionResponse::Array(items) => items,
+        ls_types::CompletionResponse::List(list) => list.items,
+    };
+    let labels = items
+        .iter()
+        .map(|item| item.label.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        labels,
+        vec![
+            "account/detail.html",
+            "base.html",
+            "child.html",
+            "shared.html",
+        ]
+    );
+    assert_eq!(items[0].kind, Some(ls_types::CompletionItemKind::FILE));
+    assert_eq!(items[0].detail.as_deref(), Some("Django template"));
+}
+
+#[test]
+fn template_name_completion_replaces_quoted_argument_interior() {
+    let mut db = TestDatabase::new();
+    let (source, offset) = source_and_offset(r#"{% extends "acc§ount/detail.html" %}"#);
+    let child_path = "/test/project/templates/child.html";
+    install_template_completion_project(&mut db, child_path, &source);
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+
+    let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
+        .expect("template names should complete inside quoted references");
+    let items = match response {
+        ls_types::CompletionResponse::Array(items) => items,
+        ls_types::CompletionResponse::List(list) => list.items,
+    };
+    let item = items
+        .iter()
+        .find(|item| item.label == "account/detail.html")
+        .expect("expected account/detail.html completion");
+    let text_edit = item
+        .text_edit
+        .as_ref()
+        .expect("template-name completion should carry a text edit");
+
+    assert_eq!(
+        text_edit,
+        &ls_types::CompletionTextEdit::Edit(ls_types::TextEdit::new(
+            ls_types::Range::new(
+                ls_types::Position::new(0, 12),
+                ls_types::Position::new(0, 31),
+            ),
+            "account/detail.html".to_string(),
+        ))
+    );
+}
+
+#[test]
+fn template_name_completion_preserves_existing_full_close_after_open_quote() {
+    let mut db = TestDatabase::new();
+    let (source, offset) = source_and_offset(r#"{% extends "ba§ %}"#);
+    let child_path = "/test/project/templates/child.html";
+    install_template_completion_project(&mut db, child_path, &source);
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+
+    let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
+        .expect("template names should complete inside quoted references");
+    let items = match response {
+        ls_types::CompletionResponse::Array(items) => items,
+        ls_types::CompletionResponse::List(list) => list.items,
+    };
+    let item = items
+        .iter()
+        .find(|item| item.label == "base.html")
+        .expect("expected base.html completion");
+    let text_edit = item
+        .text_edit
+        .as_ref()
+        .expect("template-name completion should carry a text edit");
+
+    assert_eq!(
+        text_edit,
+        &ls_types::CompletionTextEdit::Edit(ls_types::TextEdit::new(
+            ls_types::Range::new(
+                ls_types::Position::new(0, 12),
+                ls_types::Position::new(0, 14),
+            ),
+            "base.html\"".to_string(),
+        ))
+    );
+}
+
+#[test]
+fn template_name_completion_repairs_autopaired_quote_before_lone_brace() {
+    let mut db = TestDatabase::new();
+    let (source, offset) = source_and_offset(r#"{% include "ba§"}"#);
+    let child_path = "/test/project/templates/child.html";
+    install_template_completion_project(&mut db, child_path, &source);
+    let file = db.get_or_create_file(Utf8Path::new(child_path));
+
+    let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
+        .expect("template names should complete inside quoted references");
+    let items = match response {
+        ls_types::CompletionResponse::Array(items) => items,
+        ls_types::CompletionResponse::List(list) => list.items,
+    };
+    let item = items
+        .iter()
+        .find(|item| item.label == "base.html")
+        .expect("expected base.html completion");
+    let text_edit = item
+        .text_edit
+        .as_ref()
+        .expect("template-name completion should carry a text edit");
+
+    assert_eq!(
+        text_edit,
+        &ls_types::CompletionTextEdit::Edit(ls_types::TextEdit::new(
+            ls_types::Range::new(
+                ls_types::Position::new(0, 12),
+                ls_types::Position::new(0, 16),
+            ),
+            "base.html\" %}".to_string(),
+        ))
+    );
 }

--- a/crates/djls-project/src/templates/resolution.rs
+++ b/crates/djls-project/src/templates/resolution.rs
@@ -136,6 +136,16 @@ impl<'db> TemplateResolution<'db> {
             .copied()
     }
 
+    pub fn template_names(
+        self,
+        db: &'db dyn ProjectDb,
+    ) -> impl Iterator<Item = TemplateName<'db>> + 'db {
+        template_resolution_index(db, self)
+            .first_by_template_name(db)
+            .keys()
+            .copied()
+    }
+
     #[must_use]
     pub fn known_template_dirs(self, db: &'db dyn ProjectDb) -> Option<Vec<Utf8PathBuf>> {
         matches!(self.status(db), TemplateDirStatus::Complete)

--- a/crates/djls-project/tests/templates.rs
+++ b/crates/djls-project/tests/templates.rs
@@ -94,6 +94,40 @@ fn derived_template_origins_keep_shadowed_names_in_template_dir_order() {
 }
 
 #[test]
+fn template_names_returns_unique_resolvable_names() {
+    let mut db = TestDatabase::new();
+    let project = project_with_templates(
+        &mut db,
+        vec!["/test/project/templates", "/test/project/app/templates"],
+        vec![
+            (
+                "base.html",
+                "/test/project/templates/base.html",
+                "project base",
+            ),
+            (
+                "base.html",
+                "/test/project/app/templates/base.html",
+                "app base",
+            ),
+            (
+                "account/detail.html",
+                "/test/project/app/templates/account/detail.html",
+                "detail",
+            ),
+        ],
+    );
+
+    let mut names: Vec<_> = template_resolution(&db, project)
+        .template_names(&db)
+        .map(|name| name.name(&db).clone())
+        .collect();
+    names.sort();
+
+    assert_eq!(names, ["account/detail.html", "base.html"]);
+}
+
+#[test]
 fn find_template_returns_first_origin_for_duplicate_template_names() {
     let mut db = TestDatabase::new();
     let project = project_with_templates(

--- a/crates/djls-semantic/src/tags/specs.rs
+++ b/crates/djls-semantic/src/tags/specs.rs
@@ -367,7 +367,7 @@ impl TagSpec {
     }
 
     #[must_use]
-    pub(crate) fn role(&self) -> Option<TagRole> {
+    pub fn role(&self) -> Option<TagRole> {
         self.role
     }
 

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -153,6 +153,8 @@ impl LanguageServer for DjangoLanguageServer {
                         "{".to_string(),
                         "%".to_string(),
                         " ".to_string(),
+                        "\"".to_string(),
+                        "'".to_string(),
                     ]),
                     ..Default::default()
                 }),

--- a/tests/e2e/test_completions.py
+++ b/tests/e2e/test_completions.py
@@ -13,6 +13,7 @@ from .conftest import TEST_WORKSPACE
 from .utils import position_after
 
 BASE_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "base.html"
+HOME_TEMPLATE = TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "home.html"
 LOAD_TEMPLATE = (
     TEST_WORKSPACE / "djls_app" / "templates" / "djls_app" / "tags" / "load.html"
 )
@@ -50,6 +51,35 @@ async def test_completes_available_template_tags(client: LanguageClient):
     static = next(item for item in result if item.label == "static")
     assert static.detail == "{% load static %}"
     assert static.filter_text == "static"
+
+
+@pytest.mark.asyncio
+async def test_completes_template_names_inside_quoted_references(client: LanguageClient):
+    client.text_document_did_open(
+        DidOpenTextDocumentParams(
+            text_document=TextDocumentItem(
+                uri=HOME_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=HOME_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    result = await client.text_document_completion_async(
+        CompletionParams(
+            text_document=TextDocumentIdentifier(uri=HOME_TEMPLATE.as_uri()),
+            position=position_after(HOME_TEMPLATE, '{% extends "'),
+        )
+    )
+
+    assert result is not None
+    base = next(item for item in result if item.label == "djls_app/base.html")
+    assert base.kind == CompletionItemKind.File
+    assert base.insert_text_format == InsertTextFormat.PlainText
+    assert base.detail == "Django template"
+    assert base.text_edit is not None
+    assert base.text_edit.new_text == "djls_app/base.html"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add quoted-argument completion context for Django template tags
- complete resolvable template names for template-reference tag arguments
- handle auto-paired quotes and partial tag closes so accepting a completion repairs the closing `%}` when needed

## Validation
- `just fmt`
- `just clippy`
- `cargo test -p djls-ide template_name`
- `cargo test -p djls-ide`
- `cargo test -q`
- `just e2e`
- `just lint`

Manual: tested in Neovim with auto-closing quotes.