### PR TITLE
Stop synthesizing required end tags from ambiguous block-spec extraction

### DIFF
--- a/crates/djls-project/src/templates/tags.rs
+++ b/crates/djls-project/src/templates/tags.rs
@@ -24,6 +24,7 @@ use crate::templates::tags::analysis::CallContext;
 use crate::templates::tags::analysis::Env;
 use crate::templates::tags::analysis::extract_return_value;
 use crate::templates::tags::analysis::process_statements;
+use crate::templates::tags::blocks::EndTagEvidence;
 pub use crate::templates::tags::types::ArgumentCountConstraint;
 pub use crate::templates::tags::types::AsVar;
 pub use crate::templates::tags::types::BlockSpec;
@@ -173,7 +174,19 @@ pub fn extract_block_specs(
 
         for_each_registration(body, &registration_module, |reg, func, key| {
             if let Some(block_spec) = reg.kind.extract_block_spec(func) {
-                block_specs.insert(key, block_spec);
+                let end_tag = match block_spec.end_tag {
+                    EndTagEvidence::Literal(end_tag) => Some(end_tag),
+                    EndTagEvidence::SelfNamed => Some(format!("end{}", key.name)),
+                    EndTagEvidence::Unknown => None,
+                };
+                block_specs.insert(
+                    key,
+                    BlockSpec {
+                        end_tag,
+                        intermediates: block_spec.intermediates,
+                        opaque: block_spec.opaque,
+                    },
+                );
             }
         });
 

--- a/crates/djls-project/src/templates/tags.rs
+++ b/crates/djls-project/src/templates/tags.rs
@@ -172,9 +172,7 @@ pub fn extract_block_specs(
         let mut block_specs = BlockSpecs::default();
 
         for_each_registration(body, &registration_module, |reg, func, key| {
-            if let Some(block_spec) =
-                normalize_block_spec(reg.kind.extract_block_spec(func), &key.name)
-            {
+            if let Some(block_spec) = reg.kind.extract_block_spec(func) {
                 block_specs.insert(key, block_spec);
             }
         });
@@ -193,15 +191,6 @@ fn with_parsed_body<M: Default>(
     };
 
     f(parsed.body(db))
-}
-
-fn normalize_block_spec(block_spec: Option<BlockSpec>, tag_name: &str) -> Option<BlockSpec> {
-    block_spec.map(|mut block_spec| {
-        if block_spec.end_tag.is_none() {
-            block_spec.end_tag = Some(format!("end{tag_name}"));
-        }
-        block_spec
-    })
 }
 
 #[cfg(test)]

--- a/crates/djls-project/src/templates/tags/analysis/match_arms.rs
+++ b/crates/djls-project/src/templates/tags/analysis/match_arms.rs
@@ -13,6 +13,7 @@ use ruff_python_ast::StmtMatch;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
 use crate::templates::tags::analysis::constraints::ExtractedTagConstraints;
+use crate::templates::tags::analysis::exceptions::direct_raise_exception;
 use crate::templates::tags::analysis::expressions::eval_expr;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
@@ -39,8 +40,10 @@ pub(super) fn extract_match_constraints(
     let mut min_variable_length: Option<usize> = None;
 
     for case in &match_stmt.cases {
-        if any_path_raises_exception(&case.body) {
-            continue;
+        match classify_case_body(&case.body) {
+            CaseBody::UnconditionalRaise => continue,
+            CaseBody::MixedRaise => return None,
+            CaseBody::NeverRaises => {}
         }
 
         match analyze_case_pattern(&case.pattern) {
@@ -165,7 +168,7 @@ fn extract_keywords_from_valid_cases(cases: &[MatchCase]) -> Vec<RequiredKeyword
         std::collections::HashMap::new();
 
     for case in cases {
-        if any_path_raises_exception(&case.body) {
+        if !matches!(classify_case_body(&case.body), CaseBody::NeverRaises) {
             continue;
         }
         if let Pattern::MatchSequence(PatternMatchSequence { patterns, .. }) = &case.pattern {
@@ -222,11 +225,29 @@ fn pattern_literal(pattern: &Pattern) -> Option<String> {
     }
 }
 
+enum CaseBody {
+    UnconditionalRaise,
+    MixedRaise,
+    NeverRaises,
+}
+
+fn classify_case_body(body: &[Stmt]) -> CaseBody {
+    if direct_raise_exception(body).is_some() {
+        return CaseBody::UnconditionalRaise;
+    }
+
+    if any_path_raises_exception(body) {
+        CaseBody::MixedRaise
+    } else {
+        CaseBody::NeverRaises
+    }
+}
+
 /// Check if any code path in a body contains a `raise` with an exception.
 ///
 /// Unlike `exceptions::direct_raise_exception` (which only checks direct raises),
 /// this recurses into control flow branches. Used for match case classification
-/// where any raise in any branch means the case can error. Any exception type
+/// where a nested raise means only some paths can error. Any exception type
 /// counts — `TemplateSyntaxError`, `ValueError`, etc.
 fn any_path_raises_exception(body: &[Stmt]) -> bool {
     let mut found = false;
@@ -246,4 +267,77 @@ fn any_path_raises_exception(body: &[Stmt]) -> bool {
         ControlFlow::Continue(())
     });
     found
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_parser::parse_module;
+
+    use super::*;
+
+    fn parse_match(source: &str) -> StmtMatch {
+        let parsed = parse_module(source).expect("valid Python");
+        let module = parsed.into_syntax();
+        for stmt in module.body {
+            if let Stmt::FunctionDef(func) = stmt {
+                for stmt in func.body {
+                    if let Stmt::Match(match_stmt) = stmt {
+                        return match_stmt;
+                    }
+                }
+            }
+        }
+        panic!("no match statement found in source");
+    }
+
+    #[test]
+    fn unconditional_raise_arms_are_skipped() {
+        let match_stmt = parse_match(
+            r#"
+def do_tag(parser, token):
+    match token.split_contents():
+        case "tag":
+            raise TemplateSyntaxError("bad")
+        case "tag", name:
+            pass
+        case _:
+            raise TemplateSyntaxError("bad")
+"#,
+        );
+        let constraints = extract_match_constraints(
+            &match_stmt,
+            &mut Env::for_compile_function("parser", "token"),
+        )
+        .expect("valid arm should produce constraints");
+
+        assert_eq!(
+            constraints.arg_constraints,
+            vec![ArgumentCountConstraint::Exact(2)]
+        );
+    }
+
+    #[test]
+    fn mixed_raise_arm_bails_out_of_match_extraction() {
+        let match_stmt = parse_match(
+            r#"
+def do_tag(parser, token):
+    match token.split_contents():
+        case "tag", name:
+            if name == "bad":
+                raise TemplateSyntaxError("bad")
+        case "tag", name, value:
+            pass
+        case _:
+            raise TemplateSyntaxError("bad")
+"#,
+        );
+
+        assert!(
+            extract_match_constraints(
+                &match_stmt,
+                &mut Env::for_compile_function("parser", "token")
+            )
+            .is_none()
+        );
+    }
 }

--- a/crates/djls-project/src/templates/tags/blocks.rs
+++ b/crates/djls-project/src/templates/tags/blocks.rs
@@ -260,10 +260,9 @@ def do_block(self, token):
         assert_eq!(spec.end_tag.as_deref(), Some("endblock"));
     }
 
-    // Fabricated: tests convention tie-breaker when a single parse() call has
-    // both "end*" and non-"end*" tokens with no control flow. Real Django
-    // functions always have multiple parse calls or control flow that the
-    // classifier uses — this tests the fallback convention path.
+    // Fabricated: a single parse() call with both "end*" and non-"end*"
+    // tokens has no control-flow evidence. Convention alone is not evidence,
+    // so ambiguous single-call multi-token shapes are conservatively skipped.
     #[test]
     fn convention_tiebreaker_single_call_multi_token() {
         let source = r#"
@@ -272,9 +271,7 @@ def do_if(parser, token):
     return IfNode(nodelist)
 "#;
         let func = parse_function(source);
-        let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endif"));
-        assert_eq!(spec.intermediates, vec!["else".to_string()]);
+        assert!(extract_block_spec(&func).is_none());
     }
 
     // Corpus: do_block in loader_tags.py — parse(("endblock",)) with next_token

--- a/crates/djls-project/src/templates/tags/blocks.rs
+++ b/crates/djls-project/src/templates/tags/blocks.rs
@@ -9,7 +9,41 @@ use ruff_python_ast::ExprCall;
 use ruff_python_ast::StmtFunctionDef;
 
 use crate::ast::ExprExt;
-use crate::templates::tags::types::BlockSpec;
+use crate::templates::tags::analysis::AbstractValue;
+use crate::templates::tags::types::SplitPosition;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EndTagEvidence {
+    Literal(String),
+    SelfNamed,
+    Unknown,
+}
+
+impl EndTagEvidence {
+    #[cfg(test)]
+    fn as_literal(&self) -> Option<&str> {
+        match self {
+            Self::Literal(end_tag) => Some(end_tag.as_str()),
+            Self::SelfNamed | Self::Unknown => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExtractedBlockSpec {
+    pub(crate) end_tag: EndTagEvidence,
+    pub(crate) intermediates: Vec<String>,
+    pub(crate) opaque: bool,
+}
+
+pub(super) fn is_tag_name_value(value: &AbstractValue) -> bool {
+    matches!(
+        value,
+        AbstractValue::SplitElement {
+            index: SplitPosition::Forward(0)
+        }
+    )
+}
 
 /// Extract a block spec from a tag's compile function.
 ///
@@ -22,7 +56,7 @@ use crate::templates::tags::types::BlockSpec;
 ///
 /// Returns `None` when no block structure is detected or inference is ambiguous.
 #[must_use]
-pub(crate) fn extract_block_spec(func: &StmtFunctionDef) -> Option<BlockSpec> {
+pub(crate) fn extract_block_spec(func: &StmtFunctionDef) -> Option<ExtractedBlockSpec> {
     let parser_var = func
         .parameters
         .args
@@ -46,7 +80,7 @@ pub(crate) fn extract_block_spec(func: &StmtFunctionDef) -> Option<BlockSpec> {
     }
 
     // Try dynamic end-tag patterns: parser.parse((f"end{tag_name}",))
-    if let Some(spec) = dynamic_end::detect(&func.body, &parser_var) {
+    if let Some(spec) = dynamic_end::detect(&func.body, &parser_var, &token_var) {
         return Some(spec);
     }
 
@@ -149,7 +183,7 @@ mod tests {
     fn simple_end_tag_single_parse() {
         let func = django_function("django/template/defaulttags.py", "verbatim").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endverbatim"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endverbatim"));
         assert!(spec.intermediates.is_empty());
         assert!(!spec.opaque);
     }
@@ -159,7 +193,7 @@ mod tests {
     fn if_else_intermediates() {
         let func = django_function("django/template/defaulttags.py", "do_if").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endif"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endif"));
         assert!(spec.intermediates.contains(&"elif".to_string()));
         assert!(spec.intermediates.contains(&"else".to_string()));
         assert!(!spec.opaque);
@@ -170,7 +204,7 @@ mod tests {
     fn opaque_block_skip_past() {
         let func = django_function("django/template/defaulttags.py", "comment").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endcomment"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endcomment"));
         assert!(spec.intermediates.is_empty());
         assert!(spec.opaque);
     }
@@ -187,7 +221,7 @@ def do_repeat(parser, token):
 "#;
         let func = parse_function(source);
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("done"));
+        assert_eq!(spec.end_tag.as_literal(), Some("done"));
         assert!(spec.intermediates.is_empty());
     }
 
@@ -221,7 +255,7 @@ def do_block(parser, token):
 "#;
         let func = parse_function(source);
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert!(spec.end_tag.is_none());
+        assert_eq!(spec.end_tag, EndTagEvidence::SelfNamed);
         assert!(spec.intermediates.is_empty());
         assert!(!spec.opaque);
     }
@@ -232,7 +266,7 @@ def do_block(parser, token):
     fn multiple_parse_calls_classify_correctly() {
         let func = django_function("django/template/defaulttags.py", "do_for").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endfor"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endfor"));
         assert_eq!(spec.intermediates, vec!["empty".to_string()]);
         assert!(!spec.opaque);
     }
@@ -257,7 +291,7 @@ def do_block(self, token):
 "#;
         let func = parse_function(source);
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endblock"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endblock"));
     }
 
     // Fabricated: a single parse() call with both "end*" and non-"end*"
@@ -280,7 +314,7 @@ def do_if(parser, token):
     fn simple_block_with_endblock_validation() {
         let func = django_function("django/template/loader_tags.py", "do_block").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endblock"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endblock"));
         assert!(spec.intermediates.is_empty());
         assert!(!spec.opaque);
     }
@@ -291,7 +325,7 @@ def do_if(parser, token):
     fn sequential_parse_then_check() {
         let func = django_function("django/template/defaulttags.py", "spaceless").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endspaceless"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endspaceless"));
         assert!(spec.intermediates.is_empty());
     }
 
@@ -301,7 +335,7 @@ def do_if(parser, token):
     fn next_token_loop_blocktrans_pattern() {
         let func = django_function("django/templatetags/i18n.py", "do_block_translate").unwrap();
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert!(spec.end_tag.is_none());
+        assert_eq!(spec.end_tag, EndTagEvidence::SelfNamed);
         assert_eq!(spec.intermediates, vec!["plural".to_string()]);
         assert!(!spec.opaque);
     }
@@ -326,7 +360,7 @@ def do_custom_block(parser, token):
 "#;
         let func = parse_function(source);
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endcustom"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endcustom"));
         assert!(spec.intermediates.is_empty());
         assert!(!spec.opaque);
     }
@@ -359,7 +393,7 @@ def do_custom(parser, token):
 "#;
         let func = parse_function(source);
         let spec = extract_block_spec(&func).expect("should extract block spec");
-        assert_eq!(spec.end_tag.as_deref(), Some("endcustom"));
+        assert_eq!(spec.end_tag.as_literal(), Some("endcustom"));
         assert_eq!(spec.intermediates, vec!["middle".to_string()]);
     }
 

--- a/crates/djls-project/src/templates/tags/blocks/dynamic_end.rs
+++ b/crates/djls-project/src/templates/tags/blocks/dynamic_end.rs
@@ -15,37 +15,81 @@ use ruff_python_ast::StmtReturn;
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
+use crate::templates::tags::analysis::CallContext;
+use crate::templates::tags::analysis::Env;
+use crate::templates::tags::analysis::expressions::eval_expr;
+use crate::templates::tags::analysis::process_statements;
+use crate::templates::tags::blocks::EndTagEvidence;
+use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::is_parser_receiver;
-use crate::templates::tags::types::BlockSpec;
+use crate::templates::tags::blocks::is_tag_name_value;
 
 /// Detect dynamic end-tag patterns: `parser.parse((f"end{tag_name}",))`.
 ///
-/// Returns a `BlockSpec` with `end_tag: None` (dynamic, not statically known)
-/// when the function uses f-string or format-string patterns for the end tag.
-pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<BlockSpec> {
-    if !has_dynamic_end_in_body(body, parser_var) {
-        return None;
-    }
-    Some(BlockSpec {
-        end_tag: None,
+/// Returns `SelfNamed` only when the dynamic expression is evidenced as the
+/// compile function's own tag name. Other dynamic end-tag expressions remain
+/// `Unknown` so callers don't synthesize a closer from convention alone.
+pub(super) fn detect(
+    body: &[Stmt],
+    parser_var: &str,
+    token_var: &str,
+) -> Option<ExtractedBlockSpec> {
+    let env = analyze_env(body, parser_var, token_var);
+    let assignments = collect_simple_assignments(body);
+    let end_tag = find_dynamic_end_parse_call(body, parser_var, &assignments, &env)?;
+    Some(ExtractedBlockSpec {
+        end_tag,
         intermediates: Vec::new(),
         opaque: false,
     })
 }
 
-fn has_dynamic_end_in_body(body: &[Stmt], parser_var: &str) -> bool {
-    let mut found = false;
+fn analyze_env(body: &[Stmt], parser_var: &str, token_var: &str) -> Env {
+    let mut env = Env::for_compile_function(parser_var, token_var);
+    let mut ctx = CallContext {
+        db: None,
+        file: None,
+    };
+    let _result = process_statements(body, &mut env, &mut ctx);
+    env
+}
+
+fn collect_simple_assignments(body: &[Stmt]) -> Vec<(String, &Expr)> {
+    let mut assignments = Vec::new();
     walk_stmts(body, Recurse::ControlFlow, |stmt| {
-        let has_dynamic_end = match stmt {
-            Stmt::Expr(expr_stmt) => is_dynamic_end_parse_call(&expr_stmt.value, parser_var),
-            Stmt::Assign(StmtAssign { value, .. }) => is_dynamic_end_parse_call(value, parser_var),
+        if let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt
+            && targets.len() == 1
+            && let Some(name) = targets[0].name_target()
+        {
+            assignments.push((name.to_string(), value.as_ref()));
+        }
+        ControlFlow::Continue(())
+    });
+    assignments
+}
+
+fn find_dynamic_end_parse_call(
+    body: &[Stmt],
+    parser_var: &str,
+    assignments: &[(String, &Expr)],
+    env: &Env,
+) -> Option<EndTagEvidence> {
+    let mut found = None;
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        let evidence = match stmt {
+            Stmt::Expr(expr_stmt) => {
+                dynamic_end_parse_call_evidence(&expr_stmt.value, parser_var, assignments, env)
+            }
+            Stmt::Assign(StmtAssign { value, .. }) => {
+                dynamic_end_parse_call_evidence(value, parser_var, assignments, env)
+            }
             Stmt::Return(StmtReturn {
                 value: Some(val), ..
-            }) => is_dynamic_end_parse_call(val, parser_var),
-            _ => false,
+            }) => dynamic_end_parse_call_evidence(val, parser_var, assignments, env),
+            _ => None,
         };
-        if has_dynamic_end {
-            found = true;
+        if let Some(evidence) = evidence {
+            found = Some(evidence);
             ControlFlow::Break(())
         } else {
             ControlFlow::Continue(())
@@ -54,97 +98,88 @@ fn has_dynamic_end_in_body(body: &[Stmt], parser_var: &str) -> bool {
     found
 }
 
-/// Check if an expression is `parser.parse((f"end{...}",))`.
-fn is_dynamic_end_parse_call(expr: &Expr, parser_var: &str) -> bool {
+/// Check if an expression is `parser.parse((f"end{...}",))` or uses one
+/// intermediate variable assigned from that dynamic expression.
+fn dynamic_end_parse_call_evidence(
+    expr: &Expr,
+    parser_var: &str,
+    assignments: &[(String, &Expr)],
+    env: &Env,
+) -> Option<EndTagEvidence> {
     let Expr::Call(ExprCall {
         func, arguments, ..
     }) = expr
     else {
-        return false;
+        return None;
     };
     let Expr::Attribute(ExprAttribute {
         attr, value: obj, ..
     }) = func.as_ref()
     else {
-        return false;
+        return None;
     };
     if attr.as_str() != "parse" {
-        return false;
+        return None;
     }
     if !is_parser_receiver(obj, parser_var) {
-        return false;
+        return None;
     }
     if arguments.args.is_empty() {
-        return false;
+        return None;
     }
 
-    // Check if the argument is a tuple/list containing an f-string with "end" prefix
     let seq = &arguments.args[0];
     let elements = match seq {
         Expr::Tuple(t) => &t.elts,
         Expr::List(l) => &l.elts,
-        _ => return false,
+        _ => return None,
     };
 
     for elt in elements {
-        if is_end_fstring(elt) {
-            return true;
+        if let Some(evidence) = dynamic_end_expr_evidence(elt, assignments, env) {
+            return Some(evidence);
         }
     }
-    false
+    None
 }
 
-/// Check if an expression is an f-string starting with "end".
-fn is_end_fstring(expr: &Expr) -> bool {
-    let Expr::FString(ExprFString { value, .. }) = expr else {
-        return false;
-    };
-
-    for part in value {
-        match part {
-            FStringPart::FString(fstr) => {
-                let Some(first) = fstr.elements.first() else {
-                    continue;
-                };
-
-                let has_end_prefix = matches!(
-                    first,
-                    InterpolatedStringElement::Literal(lit) if lit.value.starts_with("end")
-                );
-                if !has_end_prefix {
-                    continue;
-                }
-
-                let has_interpolation = fstr
-                    .elements
-                    .iter()
-                    .any(|e| matches!(e, InterpolatedStringElement::Interpolation(_)));
-
-                if has_interpolation {
-                    return true;
-                }
-            }
-            FStringPart::Literal(_) => {}
+fn dynamic_end_expr_evidence(
+    expr: &Expr,
+    assignments: &[(String, &Expr)],
+    env: &Env,
+) -> Option<EndTagEvidence> {
+    direct_dynamic_end_expr_evidence(expr, env).or_else(|| {
+        let name = expr.name_target()?;
+        let (_, value) = assignments
+            .iter()
+            .rev()
+            .find(|(assigned, _)| assigned == name)?;
+        match direct_dynamic_end_expr_evidence(value, env) {
+            Some(EndTagEvidence::SelfNamed) => Some(EndTagEvidence::SelfNamed),
+            Some(EndTagEvidence::Literal(_) | EndTagEvidence::Unknown) | None => None,
         }
-    }
-
-    false
+    })
 }
 
-/// Check for dynamic end-tag format strings: `"end%s" % bits[0]` or `f"end{bits[0]}"`.
-pub(super) fn has_dynamic_end_tag_format(body: &[Stmt]) -> bool {
-    let mut found = false;
+/// Check for dynamic end-tag format strings in a `next_token()` function body.
+pub(super) fn dynamic_end_tag_format_evidence(
+    body: &[Stmt],
+    parser_var: &str,
+    token_var: &str,
+) -> Option<EndTagEvidence> {
+    let env = analyze_env(body, parser_var, token_var);
+    let mut found = None;
     walk_stmts(body, Recurse::ControlFlow, |stmt| {
-        let has_dynamic_end = match stmt {
-            Stmt::Expr(expr_stmt) => is_end_format_expr(&expr_stmt.value),
-            Stmt::Assign(StmtAssign { value, .. }) => is_end_format_expr(value),
+        let evidence = match stmt {
+            Stmt::Expr(expr_stmt) => direct_dynamic_end_expr_evidence(&expr_stmt.value, &env),
+            Stmt::Assign(StmtAssign { value, .. }) => direct_dynamic_end_expr_evidence(value, &env),
             Stmt::Return(StmtReturn {
                 value: Some(val), ..
-            }) => is_end_format_expr(val),
-            _ => false,
+            }) => direct_dynamic_end_expr_evidence(val, &env),
+            _ => None,
         };
-        if has_dynamic_end {
-            found = true;
+        if let Some(evidence) = evidence {
+            found = Some(evidence);
             ControlFlow::Break(())
         } else {
             ControlFlow::Continue(())
@@ -153,23 +188,78 @@ pub(super) fn has_dynamic_end_tag_format(body: &[Stmt]) -> bool {
     found
 }
 
-/// Check if an expression is `"end%s" % something` or similar end-tag format.
-fn is_end_format_expr(expr: &Expr) -> bool {
-    // `"end%s" % bits[0]`
-    if let Expr::BinOp(ExprBinOp {
+fn direct_dynamic_end_expr_evidence(expr: &Expr, env: &Env) -> Option<EndTagEvidence> {
+    percent_format_evidence(expr, env).or_else(|| fstring_evidence(expr, env))
+}
+
+fn percent_format_evidence(expr: &Expr, env: &Env) -> Option<EndTagEvidence> {
+    let Expr::BinOp(ExprBinOp {
         left,
         op: Operator::Mod,
+        right,
         ..
     }) = expr
-        && let Some(s) = left.string_literal()
-        && s.starts_with("end")
-        && s.contains('%')
+    else {
+        return None;
+    };
+    let format = left.string_literal()?;
+    if !format.starts_with("end") || !format.contains('%') {
+        return None;
+    }
+    if format == "end%s" && expr_resolves_to_tag_name(right, env) {
+        Some(EndTagEvidence::SelfNamed)
+    } else {
+        Some(EndTagEvidence::Unknown)
+    }
+}
+
+fn fstring_evidence(expr: &Expr, env: &Env) -> Option<EndTagEvidence> {
+    let Expr::FString(ExprFString { value, .. }) = expr else {
+        return None;
+    };
+
+    if let Some(interpolation) = exact_end_fstring_interpolation(expr)
+        && expr_resolves_to_tag_name(interpolation, env)
     {
-        return true;
+        return Some(EndTagEvidence::SelfNamed);
     }
-    // f"end{...}" patterns
-    if is_end_fstring(expr) {
-        return true;
-    }
-    false
+
+    let has_dynamic_end_prefix = value.iter().any(|part| {
+        let FStringPart::FString(fstr) = part else {
+            return false;
+        };
+        let starts_with_end = matches!(
+            fstr.elements.first(),
+            Some(InterpolatedStringElement::Literal(lit)) if lit.value.starts_with("end")
+        );
+        starts_with_end
+            && fstr
+                .elements
+                .iter()
+                .any(|element| matches!(element, InterpolatedStringElement::Interpolation(_)))
+    });
+
+    has_dynamic_end_prefix.then_some(EndTagEvidence::Unknown)
+}
+
+fn exact_end_fstring_interpolation(expr: &Expr) -> Option<&Expr> {
+    let Expr::FString(ExprFString { value, .. }) = expr else {
+        return None;
+    };
+    let [FStringPart::FString(fstr)] = value.as_slice() else {
+        return None;
+    };
+    let [
+        InterpolatedStringElement::Literal(prefix),
+        InterpolatedStringElement::Interpolation(interpolation),
+    ] = &*fstr.elements
+    else {
+        return None;
+    };
+    (prefix.value.as_ref() == "end").then_some(interpolation.expression.as_ref())
+}
+
+fn expr_resolves_to_tag_name(expr: &Expr, env: &Env) -> bool {
+    let mut env = env.clone();
+    is_tag_name_value(&eval_expr(expr, &mut env))
 }

--- a/crates/djls-project/src/templates/tags/blocks/next_token.rs
+++ b/crates/djls-project/src/templates/tags/blocks/next_token.rs
@@ -9,9 +9,10 @@ use ruff_python_ast::StmtAssign;
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
+use crate::templates::tags::blocks::EndTagEvidence;
+use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::dynamic_end;
 use crate::templates::tags::blocks::is_token_contents_expr;
-use crate::templates::tags::types::BlockSpec;
 
 /// Detect block structure from `parser.next_token()` loop patterns.
 ///
@@ -31,36 +32,41 @@ use crate::templates::tags::types::BlockSpec;
 /// if token.contents.strip() != end_tag_name:
 ///     raise TemplateSyntaxError(...)
 /// ```
-pub(super) fn detect(body: &[Stmt], parser_var: &str, token_var: &str) -> Option<BlockSpec> {
+pub(super) fn detect(
+    body: &[Stmt],
+    parser_var: &str,
+    token_var: &str,
+) -> Option<ExtractedBlockSpec> {
     if !has_next_token_loop(body, parser_var) {
         return None;
     }
 
     let token_comparisons = collect_token_content_comparisons(body, token_var);
-    let has_dynamic_end = dynamic_end::has_dynamic_end_tag_format(body);
+    let dynamic_end_tag = dynamic_end::dynamic_end_tag_format_evidence(body, parser_var, token_var);
+    let has_dynamic_end = dynamic_end_tag.is_some();
 
     if token_comparisons.is_empty() && !has_dynamic_end {
         return None;
     }
 
     let mut intermediates = Vec::new();
-    let mut end_tag = None;
+    let mut end_tag = dynamic_end_tag.unwrap_or(EndTagEvidence::Unknown);
 
     for token in &token_comparisons {
         if token.starts_with("end") {
-            end_tag = Some(token.clone());
+            end_tag = EndTagEvidence::Literal(token.clone());
         } else {
             intermediates.push(token.clone());
         }
     }
 
-    if end_tag.is_none() && !has_dynamic_end && intermediates.is_empty() {
+    if matches!(end_tag, EndTagEvidence::Unknown) && !has_dynamic_end && intermediates.is_empty() {
         return None;
     }
 
     intermediates.sort();
 
-    Some(BlockSpec {
+    Some(ExtractedBlockSpec {
         end_tag,
         intermediates,
         opaque: false,

--- a/crates/djls-project/src/templates/tags/blocks/opaque.rs
+++ b/crates/djls-project/src/templates/tags/blocks/opaque.rs
@@ -9,21 +9,22 @@ use ruff_python_ast::StmtAssign;
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
+use crate::templates::tags::blocks::EndTagEvidence;
+use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::is_parser_receiver;
-use crate::templates::tags::types::BlockSpec;
 
 /// Detect opaque block patterns: `parser.skip_past("endtag")`.
-pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<BlockSpec> {
+pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<ExtractedBlockSpec> {
     let skip_past_tokens = collect_skip_past_tokens(body, parser_var);
     if skip_past_tokens.is_empty() {
         return None;
     }
     let end_tag = if skip_past_tokens.len() == 1 {
-        Some(skip_past_tokens[0].clone())
+        EndTagEvidence::Literal(skip_past_tokens[0].clone())
     } else {
-        None
+        EndTagEvidence::Unknown
     };
-    Some(BlockSpec {
+    Some(ExtractedBlockSpec {
         end_tag,
         intermediates: Vec::new(),
         opaque: true,

--- a/crates/djls-project/src/templates/tags/blocks/parse_calls.rs
+++ b/crates/djls-project/src/templates/tags/blocks/parse_calls.rs
@@ -152,16 +152,7 @@ fn classify_stop_tokens(
             if tokens.len() == 1 {
                 end_tags.push(tokens[0].clone());
             } else {
-                for token in tokens {
-                    if token.starts_with("end") {
-                        end_tags.push(token.clone());
-                    } else {
-                        intermediates.push(token.clone());
-                    }
-                }
-                if end_tags.is_empty() {
-                    return None;
-                }
+                return None;
             }
         }
     }

--- a/crates/djls-project/src/templates/tags/blocks/parse_calls.rs
+++ b/crates/djls-project/src/templates/tags/blocks/parse_calls.rs
@@ -10,17 +10,22 @@ use ruff_python_ast::StmtIf;
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
+use crate::templates::tags::blocks::EndTagEvidence;
+use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::extract_string_sequence;
 use crate::templates::tags::blocks::is_parser_receiver;
 use crate::templates::tags::blocks::is_token_contents_expr;
-use crate::templates::tags::types::BlockSpec;
 
 /// Detect block structure from `parser.parse((...))` calls with control flow analysis.
 ///
 /// Collects all stop-tokens from parse calls, then classifies them as intermediates
 /// or end-tags based on whether they lead to further parse calls (intermediate) or
 /// return/construction (end-tag).
-pub(super) fn detect(body: &[Stmt], parser_var: &str, token_var: &str) -> Option<BlockSpec> {
+pub(super) fn detect(
+    body: &[Stmt],
+    parser_var: &str,
+    token_var: &str,
+) -> Option<ExtractedBlockSpec> {
     let parse_calls = collect_parser_parse_calls(body, parser_var);
 
     if parse_calls.is_empty() {
@@ -102,7 +107,7 @@ fn classify_stop_tokens(
     parser_var: &str,
     token_var: &str,
     parse_calls: &[ParseCallInfo],
-) -> Option<BlockSpec> {
+) -> Option<ExtractedBlockSpec> {
     let mut all_tokens: Vec<String> = Vec::new();
     for call in parse_calls {
         for token in &call.stop_tokens {
@@ -164,13 +169,13 @@ fn classify_stop_tokens(
     }
 
     let end_tag = match end_tags.len() {
-        1 => Some(end_tags[0].clone()),
-        _ => None,
+        1 => EndTagEvidence::Literal(end_tags[0].clone()),
+        _ => EndTagEvidence::Unknown,
     };
 
     intermediates.sort();
 
-    Some(BlockSpec {
+    Some(ExtractedBlockSpec {
         end_tag,
         intermediates,
         opaque: false,

--- a/crates/djls-project/src/templates/tags/registry.rs
+++ b/crates/djls-project/src/templates/tags/registry.rs
@@ -8,7 +8,6 @@ use crate::templates::tags::analysis;
 use crate::templates::tags::blocks;
 use crate::templates::tags::signature;
 use crate::templates::tags::types::AsVar;
-use crate::templates::tags::types::BlockSpec;
 use crate::templates::tags::types::TagRule;
 
 impl RegistrationKind {
@@ -52,7 +51,10 @@ impl RegistrationKind {
         }
     }
 
-    pub(crate) fn extract_block_spec(self, func: &StmtFunctionDef) -> Option<BlockSpec> {
+    pub(crate) fn extract_block_spec(
+        self,
+        func: &StmtFunctionDef,
+    ) -> Option<blocks::ExtractedBlockSpec> {
         match self {
             Self::Filter => None,
             Self::Tag | Self::SimpleTag | Self::InclusionTag | Self::SimpleBlockTag => {

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -7,6 +7,7 @@ use djls_testing::TestDatabase;
 use djls_testing::extract_bundle;
 use djls_testing::sorted_snapshot;
 
+const ALLAUTH_TAGS_SOURCE: &str = include_str!("../src/templates/tags/testdata/allauth_tags.py");
 const CUSTOM_SOURCE: &str = include_str!("../src/templates/tags/testdata/django_custom.py");
 const DEFAULTFILTERS_SOURCE: &str =
     include_str!("../src/templates/tags/testdata/django_defaultfilters.py");
@@ -17,6 +18,10 @@ const INCLUSION_SOURCE: &str = include_str!("../src/templates/tags/testdata/djan
 const LOADER_TAGS_SOURCE: &str =
     include_str!("../src/templates/tags/testdata/django_loader_tags.py");
 const TESTTAGS_SOURCE: &str = include_str!("../src/templates/tags/testdata/django_testtags.py");
+const TZ_SOURCE: &str = include_str!("../src/templates/tags/testdata/django_tz.py");
+const ADMIN_URLS_SOURCE: &str = include_str!("../src/templates/tags/testdata/django_admin_urls.py");
+const WAGTAILADMIN_TAGS_SOURCE: &str =
+    include_str!("../src/templates/tags/testdata/wagtailadmin_tags.py");
 
 fn extract_source(source: &str, module_name: &str) -> ExtractionBundle {
     let db = TestDatabase::new();
@@ -208,6 +213,45 @@ fn golden_testtags() {
     let result = extract_source(
         TESTTAGS_SOURCE,
         "tests.template_tests.templatetags.testtags",
+    );
+    insta::assert_yaml_snapshot!(sorted_snapshot(&result));
+}
+
+// Corpus: django-allauth/allauth/templatetags/allauth.py — custom block tag.
+// Exercises helper-based argument parsing and explicit end tag extraction.
+#[test]
+fn golden_allauth_tags() {
+    let result = extract_source(ALLAUTH_TAGS_SOURCE, "allauth.templatetags.allauth");
+    insta::assert_yaml_snapshot!(sorted_snapshot(&result));
+}
+
+// Corpus: wagtail/admin/templatetags/wagtailadmin_tags.py — call-style
+// registrations. Exercises register.tag("name", Class.handle) and
+// register.filter("name", func) without local function definitions.
+#[test]
+fn golden_wagtailadmin_tags() {
+    let result = extract_source(
+        WAGTAILADMIN_TAGS_SOURCE,
+        "wagtail.admin.templatetags.wagtailadmin_tags",
+    );
+    insta::assert_yaml_snapshot!(sorted_snapshot(&result));
+}
+
+// Corpus: django/templatetags/tz.py — timezone tags.
+// Exercises simple tags and block tags with conventional end tags.
+#[test]
+fn golden_django_tz() {
+    let result = extract_source(TZ_SOURCE, "django.templatetags.tz");
+    insta::assert_yaml_snapshot!(sorted_snapshot(&result));
+}
+
+// Corpus: django/contrib/admin/templatetags/admin_urls.py — admin URL helpers.
+// Exercises simple_tag with takes_context and optional function parameters.
+#[test]
+fn golden_django_admin_urls() {
+    let result = extract_source(
+        ADMIN_URLS_SOURCE,
+        "django.contrib.admin.templatetags.admin_urls",
     );
     insta::assert_yaml_snapshot!(sorted_snapshot(&result));
 }
@@ -487,17 +531,37 @@ fn corpus_non_opaque_no_split_contents() {
     assert_eq!(spec.end_tag.as_deref(), Some("endverbatim"));
 }
 
-// Corpus: `spaceless` in defaulttags.py — uses `token.split_contents()[0]`
-// in f-string for dynamic end tag name.
+// Corpus: `spaceless` in defaulttags.py — uses parser.parse(("endspaceless",))
+// with a literal end tag.
 #[test]
-fn corpus_dynamic_end_tag() {
+fn corpus_literal_end_tag() {
     let result = extract_source(DEFAULTTAGS_SOURCE, "django.template.defaulttags");
     let key = SymbolKey::tag("django.template.defaulttags", "spaceless");
     assert!(result.block_specs.as_map().contains_key(&key));
     let spec = &result.block_specs.as_map()[&key];
-    // Dynamic end-tag detected as None (computed at runtime), but
-    // extract_block_specs() fills it with "end{name}" as fallback
-    assert!(spec.end_tag.is_some());
+    assert_eq!(spec.end_tag.as_deref(), Some("endspaceless"));
+}
+
+// Edge case — dynamic f-string end tag through the full extraction path.
+// Ensures ambiguous closers remain unknown instead of being re-synthesized from
+// the registered tag name.
+#[test]
+fn ambiguous_closer_stays_unknown_after_extraction() {
+    let source = r#"
+from django import template
+register = template.Library()
+
+@register.tag("mystery")
+def do_block(parser, token):
+    tag_name, *rest = token.split_contents()
+    nodelist = parser.parse((f"end{tag_name}",))
+    parser.delete_first_token()
+    return BlockNode(tag_name, nodelist)
+"#;
+    let result = extract_source(source, "app.templatetags.custom");
+    let key = SymbolKey::tag("app.templatetags.custom", "mystery");
+    let spec = &result.block_specs.as_map()[&key];
+    assert!(spec.end_tag.is_none());
 }
 
 // Corpus: `do_block` in loader_tags.py — simple block tag with endblock.

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -542,11 +542,30 @@ fn corpus_literal_end_tag() {
     assert_eq!(spec.end_tag.as_deref(), Some("endspaceless"));
 }
 
-// Edge case — dynamic f-string end tag through the full extraction path.
-// Ensures ambiguous closers remain unknown instead of being re-synthesized from
-// the registered tag name.
+// Edge case — genuinely unknowable dynamic f-string end tag through the full
+// extraction path. Ensures ambiguous closers remain unknown instead of being
+// re-synthesized from the registered tag name.
 #[test]
 fn ambiguous_closer_stays_unknown_after_extraction() {
+    let source = r#"
+from django import template
+register = template.Library()
+
+@register.tag("mystery")
+def do_block(parser, token):
+    options = {"name": "mystery"}
+    nodelist = parser.parse((f"end{options['name']}",))
+    parser.delete_first_token()
+    return BlockNode(nodelist)
+"#;
+    let result = extract_source(source, "app.templatetags.custom");
+    let key = SymbolKey::tag("app.templatetags.custom", "mystery");
+    let spec = &result.block_specs.as_map()[&key];
+    assert!(spec.end_tag.is_none());
+}
+
+#[test]
+fn self_named_dynamic_closer_concretizes_per_registration_name() {
     let source = r#"
 from django import template
 register = template.Library()
@@ -561,7 +580,7 @@ def do_block(parser, token):
     let result = extract_source(source, "app.templatetags.custom");
     let key = SymbolKey::tag("app.templatetags.custom", "mystery");
     let spec = &result.block_specs.as_map()[&key];
-    assert!(spec.end_tag.is_none());
+    assert_eq!(spec.end_tag.as_deref(), Some("endmystery"));
 }
 
 // Corpus: `do_block` in loader_tags.py — simple block tag with endblock.

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -250,12 +250,12 @@ filter_arities:
     arg_optional: false
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
-    end_tag: ~
+    end_tag: endblocktrans
     intermediates:
       - plural
     opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
-    end_tag: ~
+    end_tag: endblocktranslate
     intermediates:
       - plural
     opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: sorted_snapshot(&bundle)
 ---
 tag_rules:
   "django.templatetags.i18n::tag::blocktrans":
@@ -250,12 +250,12 @@ filter_arities:
     arg_optional: false
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
-    end_tag: endblocktrans
+    end_tag: ~
     intermediates:
       - plural
     opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
-    end_tag: endblocktranslate
+    end_tag: ~
     intermediates:
       - plural
     opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -250,12 +250,12 @@ filter_arities:
     arg_optional: false
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
-    end_tag: ~
+    end_tag: endblocktrans
     intermediates:
       - plural
     opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
-    end_tag: ~
+    end_tag: endblocktranslate
     intermediates:
       - plural
     opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: sorted_snapshot(&bundle)
 ---
 tag_rules:
   "django.templatetags.i18n::tag::blocktrans":
@@ -250,12 +250,12 @@ filter_arities:
     arg_optional: false
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
-    end_tag: endblocktrans
+    end_tag: ~
     intermediates:
       - plural
     opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
-    end_tag: endblocktranslate
+    end_tag: ~
     intermediates:
       - plural
     opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_allauth_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_allauth_tags.snap
@@ -1,0 +1,11 @@
+---
+source: crates/djls-project/tests/extraction.rs
+expression: sorted_snapshot(&result)
+---
+tag_rules: {}
+filter_arities: {}
+block_specs:
+  "allauth.templatetags.allauth::tag::element":
+    end_tag: endelement
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_django_admin_urls.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_django_admin_urls.snap
@@ -1,0 +1,28 @@
+---
+source: crates/djls-project/tests/extraction.rs
+expression: sorted_snapshot(&result)
+---
+tag_rules:
+  "django.contrib.admin.templatetags.admin_urls::tag::add_preserved_filters":
+    arg_constraints:
+      - Min: 2
+      - Max: 4
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: url
+        required: true
+        kind: Variable
+        position: 0
+      - name: popup
+        required: false
+        kind: Variable
+        position: 1
+      - name: to_field
+        required: false
+        kind: Variable
+        position: 2
+    as_var: strip
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_django_tz.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_django_tz.snap
@@ -1,0 +1,97 @@
+---
+source: crates/djls-project/tests/extraction.rs
+expression: sorted_snapshot(&result)
+---
+tag_rules:
+  "django.templatetags.tz::tag::get_current_timezone":
+    arg_constraints:
+      - Exact: 3
+    required_keywords:
+      - position:
+          Forward: 1
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "django.templatetags.tz::tag::localtime":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - "on"
+          - "off"
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Max: 2
+        message:
+          PercentFormat:
+            template: "%r argument should be 'on' or 'off'"
+            args:
+              - SplitElement:
+                  Forward: 0
+      - constraint:
+          ChoiceAt:
+            position:
+              Forward: 1
+            values:
+              - "on"
+              - "off"
+        message:
+          PercentFormat:
+            template: "%r argument should be 'on' or 'off'"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.templatetags.tz::tag::timezone":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes one argument (timezone)"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+filter_arities: {}
+block_specs:
+  "django.templatetags.tz::tag::localtime":
+    end_tag: endlocaltime
+    intermediates: []
+    opaque: false
+  "django.templatetags.tz::tag::timezone":
+    end_tag: endtimezone
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
@@ -92,12 +92,12 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
-    end_tag: ~
+    end_tag: endblocktrans
     intermediates:
       - plural
     opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
-    end_tag: ~
+    end_tag: endblocktranslate
     intermediates:
       - plural
     opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
@@ -92,12 +92,12 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
-    end_tag: endblocktrans
+    end_tag: ~
     intermediates:
       - plural
     opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
-    end_tag: endblocktranslate
+    end_tag: ~
     intermediates:
       - plural
     opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_wagtailadmin_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_wagtailadmin_tags.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/extraction.rs
+expression: sorted_snapshot(&result)
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-semantic/src/tags/specs.rs
+++ b/crates/djls-semantic/src/tags/specs.rs
@@ -45,13 +45,16 @@ impl TagSpecs {
                 continue;
             }
             if let Some(spec) = self.0.get_mut(&key.name) {
-                // Override end_tag from extraction
-                if let Some(end_tag_name) = &block_spec.end_tag {
-                    spec.end_tag = Some(EndTag {
-                        name: end_tag_name.clone().into(),
-                        required: true,
-                    });
-                }
+                // An unknown closer is insufficient evidence to modify an
+                // existing spec.
+                let Some(end_tag_name) = &block_spec.end_tag else {
+                    continue;
+                };
+
+                spec.end_tag = Some(EndTag {
+                    name: end_tag_name.clone().into(),
+                    required: true,
+                });
                 // Override intermediates from extraction
                 spec.intermediate_tags = if block_spec.intermediates.is_empty() {
                     std::borrow::Cow::Borrowed(&[])
@@ -821,6 +824,65 @@ mod tests {
                 .iter()
                 .any(|t| t.name.as_ref() == "elseif")
         );
+    }
+
+    #[test]
+    fn test_merge_block_specs_unknown_end_tag_preserves_existing_spec() {
+        let mut spec_map = FxHashMap::default();
+        spec_map.insert(
+            "guarded".to_string(),
+            TagSpec {
+                module: "django.template.defaulttags".into(),
+                end_tag: Some(EndTag {
+                    name: "endguarded".into(),
+                    required: true,
+                }),
+                intermediate_tags: Cow::Owned(vec![IntermediateTag {
+                    name: "middle".into(),
+                }]),
+                opaque: true,
+                role: None,
+                extracted_rules: None,
+            },
+        );
+        let mut specs = TagSpecs::new(spec_map);
+        let original = specs.get("guarded").unwrap().clone();
+
+        let mut block_specs = BlockSpecs::default();
+        block_specs.insert(
+            djls_project::SymbolKey::tag("django.template.defaulttags", "guarded"),
+            BlockSpec {
+                end_tag: None,
+                intermediates: vec![],
+                opaque: false,
+            },
+        );
+
+        specs.merge_block_specs(&block_specs);
+
+        assert_eq!(specs.get("guarded").unwrap(), &original);
+    }
+
+    #[test]
+    fn test_merge_block_specs_unknown_end_tag_inserts_new_spec_without_end_tag() {
+        let mut specs = create_test_specs();
+        let original_count = specs.len();
+
+        let mut block_specs = BlockSpecs::default();
+        block_specs.insert(
+            djls_project::SymbolKey::tag("myapp.templatetags.custom", "unknownblock"),
+            BlockSpec {
+                end_tag: None,
+                intermediates: vec![],
+                opaque: false,
+            },
+        );
+
+        specs.merge_block_specs(&block_specs);
+
+        assert_eq!(specs.len(), original_count + 1);
+        let unknownblock = specs.get("unknownblock").unwrap();
+        assert_eq!(unknownblock.end_tag, None);
     }
 
     #[test]

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -229,19 +229,7 @@ fn collect_all_errors(db: &TestDatabase, source: &str) -> Vec<ValidationError> {
     collect_errors(db, "test.html", source)
 }
 
-fn extracted_unknown_block_db() -> TestDatabase {
-    let source = r#"
-from django import template
-
-register = template.Library()
-
-@register.tag("mystery")
-def do_mystery(parser, token):
-    tag_name = token.split_contents()[0]
-    nodelist = parser.parse((f"end{tag_name}",))
-    return MysteryNode(nodelist)
-"#;
-
+fn extracted_block_db(source: &str) -> TestDatabase {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
         .django_settings_module("myproject.settings")
@@ -257,6 +245,38 @@ def do_mystery(parser, token):
     db = db.with_template_libraries(libraries);
     let specs = compute_tag_specs(&db, project).clone();
     db.with_specs(specs)
+}
+
+fn extracted_unknown_block_db() -> TestDatabase {
+    let source = r#"
+from django import template
+
+register = template.Library()
+
+@register.tag("mystery")
+def do_mystery(parser, token):
+    options = {"name": "mystery"}
+    nodelist = parser.parse((f"end{options['name']}",))
+    return MysteryNode(nodelist)
+"#;
+
+    extracted_block_db(source)
+}
+
+fn extracted_self_named_block_db() -> TestDatabase {
+    let source = r#"
+from django import template
+
+register = template.Library()
+
+@register.tag("mystery")
+def do_mystery(parser, token):
+    tag_name, *rest = token.split_contents()
+    nodelist = parser.parse((f"end{tag_name}",))
+    return MysteryNode(nodelist)
+"#;
+
+    extracted_block_db(source)
 }
 
 #[test]
@@ -282,6 +302,28 @@ fn extracted_unknown_block_does_not_require_synthesized_end_tag() {
             ValidationError::UnbalancedStructure { opening_tag, .. } if opening_tag == "mystery"
         )),
         "extracted dynamic block tags should not require a synthesized closer: {errors:?}"
+    );
+}
+
+#[test]
+fn extracted_self_named_block_requires_concretized_end_tag() {
+    let db = extracted_self_named_block_db();
+    assert_eq!(
+        db.tag_specs()
+            .get("mystery")
+            .and_then(|spec| spec.end_tag.as_ref())
+            .map(|end_tag| end_tag.name.as_ref()),
+        Some("endmystery")
+    );
+
+    let errors = collect_all_errors(&db, "{% load ambiguous %}\n{% mystery %}\n");
+
+    assert!(
+        errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnclosedTag { tag, .. } if tag == "mystery" && error.code() == "S100"
+        )),
+        "self-named extracted block tags should require their evidenced closer: {errors:?}"
     );
 }
 

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -7,8 +7,12 @@ use djls_project::FilterArity;
 use djls_project::SymbolKey;
 use djls_project::TemplateInventoryStatus;
 use djls_project::TemplateLibraries;
+use djls_project::template_libraries;
+use djls_semantic::Db as SemanticDb;
 use djls_semantic::FilterAritySpecs;
 use djls_semantic::ValidationError;
+use djls_semantic::compute_tag_specs;
+use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use djls_testing::available_library_filter;
 use djls_testing::available_library_tag;
@@ -223,6 +227,62 @@ fn crispy_available_filters() -> Vec<serde_json::Value> {
 
 fn collect_all_errors(db: &TestDatabase, source: &str) -> Vec<ValidationError> {
     collect_errors(db, "test.html", source)
+}
+
+fn extracted_unknown_block_db() -> TestDatabase {
+    let source = r#"
+from django import template
+
+register = template.Library()
+
+@register.tag("mystery")
+def do_mystery(parser, token):
+    tag_name = token.split_contents()[0]
+    nodelist = parser.parse((f"end{tag_name}",))
+    return MysteryNode(nodelist)
+"#;
+
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/blog/templatetags/__init__.py", "")
+        .file("/proj/blog/templatetags/ambiguous.py", source)
+        .file(
+            "/proj/myproject/settings.py",
+            "INSTALLED_APPS = ['blog']\nTEMPLATES = []\n",
+        )
+        .install(&mut db);
+
+    let libraries = template_libraries(&db, project).clone();
+    db = db.with_template_libraries(libraries);
+    let specs = compute_tag_specs(&db, project).clone();
+    db.with_specs(specs)
+}
+
+#[test]
+fn extracted_unknown_block_does_not_require_synthesized_end_tag() {
+    let db = extracted_unknown_block_db();
+    assert_eq!(
+        db.tag_specs()
+            .get("mystery")
+            .and_then(|spec| spec.end_tag.as_ref())
+            .map(|end_tag| end_tag.name.as_ref()),
+        None::<&str>,
+        "ambiguous extracted closer must stay unknown, not be synthesized"
+    );
+
+    let errors = collect_all_errors(&db, "{% load ambiguous %}\n{% mystery %}\n");
+
+    assert!(
+        !errors.iter().any(|error| matches!(
+            error,
+            ValidationError::UnclosedTag { tag, .. } if tag == "mystery"
+        ) || matches!(
+            error,
+            ValidationError::UnbalancedStructure { opening_tag, .. } if opening_tag == "mystery"
+        )),
+        "extracted dynamic block tags should not require a synthesized closer: {errors:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`djls-project` tag extraction converted "we don't know the closer" into "the closer is `end{tag}` and it's required": `normalize_block_spec` rewrote every extracted `BlockSpec { end_tag: None }` (documented as *ambiguous*) into `Some("end{tag}")`, and `merge_block_specs` promoted that guess to `EndTag { required: true }`. Valid templates using third-party block tags with dynamic or undetectable closers got spurious unclosed-tag diagnostics — a direct violation of the zero-false-positive-on-corpus invariant.

This PR does two things, in two commits:

1. **Remove the guessing end to end** (audit findings TAGS-04/05/09; plan `.agents/plans/python-foundation/001-block-spec-false-positives.md`).
2. **Recognize self-named dynamic closers as evidence** (plan 007 Step 2b, pulled forward per review): `"end%s" % bits[0]` and `f"end{tag_name}"` where the interpolated value is provably the tag's own name are *knowable*, not ambiguous — `bits[0]` at parse time is the registration name. Removing the guess without this would have regressed `blocktrans`/`blocktranslate` extraction coverage.

### Commit 1 — remove synthesis

- `normalize_block_spec` deleted; `end_tag: None` flows through extraction unchanged.
- The `starts_with("end")` convention tiebreaker for single-parse-call multi-token shapes now bails out (`None`) instead of partitioning stop tokens by prefix. Closers derived from literal `parser.parse(("endfoo",))` evidence are kept.
- `merge_block_specs`: an unknown-closer spec never modifies an existing handcoded spec (previously it still overrode `intermediate_tags`/`opaque`), and extracted-only tags with unknown closers are inserted without an `EndTag`, so the structure grammar never indexes them as openers. Net effect: a real unclosed third-party block becomes a silent false negative, by policy (false negatives over false positives).
- Match-arm argument-count extraction classifies case bodies three ways (unconditional raise / never raises / mixed); a mixed-raise case aborts extraction for the whole function instead of narrowing inferred counts.

### Commit 2 — self-named closers are evidence

- Block extraction now returns an internal `ExtractedBlockSpec` with `EndTagEvidence::{Literal, SelfNamed, Unknown}`; the public `BlockSpec` shape is unchanged.
- `SelfNamed` is produced only when the closer expression is `"end%s" % <x>` or `f"end{<x>}"` (directly in `parser.parse((...))`, in a `next_token()` loop body, or through one intermediate variable assignment) **and** `<x>` abstractly evaluates to `split_contents()[0]` — reusing the existing tag-rule interpreter (`AbstractValue::SplitElement { Forward(0) }`), not a new walker. Closers built from anything else (config lookups, attributes, other split positions) stay `Unknown`.
- Concretization happens at the registration loop in `extract_block_specs`, the one place the registration name is known — so `do_block_translate` registered as both `blocktrans` and `blocktranslate` yields `endblocktrans` and `endblocktranslate` respectively.
- Variable indirection can only *upgrade* an already-detected dynamic closer to `SelfNamed`; it never widens what counts as a dynamic parse call.

## Tests

- End-to-end regression `extracted_unknown_block_does_not_require_synthesized_end_tag`: an extracted tag with a genuinely unknowable dynamic closer (`f"end{options['name']}"` — a subscript the interpreter does not follow), used in a template without any closer, emits no unclosed-tag diagnostic. (The fixture originally used `f"end{tag_name}"`; commit 2 makes that shape correctly evidenced, so the unknowable fixture was swapped in to keep pinning the conservative path.)
- End-to-end companion `extracted_self_named_block_requires_concretized_end_tag`: the self-named shape produces spec `end_tag == Some("endmystery")` and an unclosed `{% mystery %}` yields the S100 unclosed diagnostic — the extraction-only closer is enforced, with provenance.
- Extraction-level `ambiguous_closer_stays_unknown_after_extraction` (unknowable shape) and `self_named_dynamic_closer_concretizes_per_registration_name` through the full bundle path.
- Merge-policy unit tests (`test_merge_block_specs_unknown_end_tag_preserves_existing_spec`, `test_merge_block_specs_unknown_end_tag_inserts_new_spec_without_end_tag`).
- Match-arm unit tests for the unconditional-raise skip and mixed-raise bail-out.
- Characterization-first: golden extraction snapshots for the four previously uncovered pinned fixtures (`allauth_tags.py`, `wagtailadmin_tags.py`, `django_tz.py`, `django_admin_urls.py`) were added before any behavior change. None of them contained synthesized closers (allauth/tz closers are literal-evidenced), so their snapshots did not churn.

## Snapshot diffs

Net versus main: **none on corpus snapshots**. Commit 1 dropped the synthesized `endblocktrans`/`endblocktranslate` from the django-5.2/6.0 i18n corpus snapshots; commit 2 restores the same strings as *evidence-backed* closers (self-named pattern, concretized per registration). The new `extraction__golden_i18n` snapshot (added in this PR as characterization) records them with that provenance.

Zero new diagnostics on corpus templates at both commits (full workspace suite including corpus tests).

## Fabricated-test disposition (plan Step 2)

Inventory of the fabricated no-corpus-shape tests in `crates/djls-project/src/templates/tags/blocks.rs`. Nothing was silently deleted.

| Test | Fabricated shape | Evidence | Decision | Reason |
|---|---|---|---|---|
| `non_conventional_closer_found_via_control_flow` | `parse(("done",))` single-token, non-`end*` closer | literal stop-token = direct evidence | preserve | protects the literal-evidence path this change keeps; documents evidence-beats-convention |
| `ambiguous_returns_none_for_end_tag` | multi-token parse, no control flow, no `end*` token | extractor returns `None` | preserve | pins ambiguity→conservatism, the invariant this PR enforces |
| `dynamic_fstring_end_tag` | f-string in `parse()` | self-named pattern | expectation flipped (commit 2) | now asserts `EndTagEvidence::SelfNamed` — the shape became evidenced under Step 2b |
| `self_parser_pattern` | `self.parser.parse(("endblock",))` | literal token evidence; classytags/wagtail style | preserve | intended third-party support, evidenced closer |
| `convention_tiebreaker_single_call_multi_token` | `parse(("else", "endif"))`, single call, no flow | `starts_with("end")` heuristic — the guess removed here | expectations replaced | now asserts `None`: convention alone is not evidence; keeps the shape as the negative case |
| `next_token_loop_static_end_tag` | `next_token` loop + literal `!= "endcustom"` raise | literal comparison = evidence | preserve | evidenced closer via comparison, not prefix guessing |
| `next_token_loop_with_intermediate_and_static_end` | above + `"middle"` intermediate | literal comparisons | preserve | same |
| `no_next_token_loop_no_parse_returns_none`, `no_parameters_returns_none` | negative guards | n/a | preserve | cheap edge guards |

## Verification

- `cargo test -p djls-project`, `cargo test -q` (full workspace incl. corpus) — green; no pending `.snap.new` artifacts.
- `just clippy`, `just fmt --check`, `just lint` — green.
- `rg 'format!\("end'` — one remaining hit: `djls-semantic/src/tags/specs.rs` `from_tagspec_def`, which defaults the closer for block tags *explicitly declared in user config*. Different trust domain (user assertion, not extraction guessing); out of scope per the plan.
