### PR TITLE
Type interpreter and pythonpath as UTF-8 paths

### DIFF
--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -72,12 +72,12 @@ pub enum ConfigError {
 pub struct Settings {
     #[serde(default)]
     debug: bool,
-    venv_path: Option<String>,
+    venv_path: Option<Utf8PathBuf>,
     django_settings_module: Option<String>,
     #[serde(default)]
     django_environments: Vec<DjangoEnvironmentConfig>,
     #[serde(default)]
-    pythonpath: Vec<String>,
+    pythonpath: Vec<Utf8PathBuf>,
     env_file: Option<String>,
     #[serde(default)]
     tagspecs: TagSpecDef,
@@ -168,7 +168,7 @@ impl Settings {
     }
 
     #[must_use]
-    pub fn venv_path(&self) -> Option<&str> {
+    pub fn venv_path(&self) -> Option<&Utf8Path> {
         self.venv_path.as_deref()
     }
 
@@ -184,7 +184,7 @@ impl Settings {
     }
 
     #[must_use]
-    pub fn pythonpath(&self) -> &[String] {
+    pub fn pythonpath(&self) -> &[Utf8PathBuf] {
         &self.pythonpath
     }
 
@@ -266,7 +266,7 @@ mod tests {
             assert_eq!(
                 settings,
                 Settings {
-                    venv_path: Some("/path/to/venv".to_string()),
+                    venv_path: Some(Utf8PathBuf::from("/path/to/venv")),
                     ..Default::default()
                 }
             );
@@ -284,7 +284,10 @@ mod tests {
             assert_eq!(
                 settings,
                 Settings {
-                    pythonpath: vec!["/path/to/lib".to_string(), "/another/path".to_string()],
+                    pythonpath: vec![
+                        Utf8PathBuf::from("/path/to/lib"),
+                        Utf8PathBuf::from("/another/path"),
+                    ],
                     ..Default::default()
                 }
             );

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -826,7 +826,7 @@ env_file = ".env.local"
                 .map(djls_project::PythonModuleName::as_str),
             Some("config.settings")
         );
-        assert_eq!(project.pythonpath(&db), &vec![extra_path.to_string()]);
+        assert_eq!(project.pythonpath(&db), &vec![extra_path.clone()]);
         assert_eq!(
             project.env_vars(&db),
             &vec![("FROM_ENV".to_string(), "loaded".to_string())]

--- a/crates/djls-project/src/project.rs
+++ b/crates/djls-project/src/project.rs
@@ -36,7 +36,7 @@ pub struct Project {
     pub django_settings_module: Option<PythonModuleName>,
     /// Additional Python import paths (PYTHONPATH entries)
     #[returns(ref)]
-    pub pythonpath: Vec<String>,
+    pub pythonpath: Vec<Utf8PathBuf>,
     /// Extra environment variables for project introspection, loaded from an
     /// env file (e.g. `.env`). Each entry is a `(key, value)` pair.
     #[returns(ref)]
@@ -63,7 +63,7 @@ impl Project {
     pub fn initial(db: &dyn ProjectDb, root: &Utf8Path, settings: &Settings) -> Project {
         let search_paths = SearchPaths::root_only(root);
         let interpreter = settings.venv_path().map_or(Interpreter::Auto, |path| {
-            Interpreter::VenvPath(path.to_string())
+            Interpreter::VenvPath(path.to_path_buf())
         });
         let django_settings_module = settings
             .django_settings_module()

--- a/crates/djls-project/src/python/interpreter.rs
+++ b/crates/djls-project/src/python/interpreter.rs
@@ -13,23 +13,23 @@ pub enum Interpreter {
     /// Automatically discover interpreter (`VIRTUAL_ENV`, project venv dirs)
     Auto,
     /// Use specific virtual environment path
-    VenvPath(String),
+    VenvPath(Utf8PathBuf),
     /// Use specific interpreter executable path
-    InterpreterPath(String),
+    InterpreterPath(Utf8PathBuf),
 }
 
 impl Interpreter {
     /// Discover interpreter based on explicit path, `VIRTUAL_ENV`, or auto
     #[must_use]
-    pub fn discover(venv_path: Option<&str>) -> Self {
-        let virtual_env = std::env::var("VIRTUAL_ENV").ok();
+    pub fn discover(venv_path: Option<&Utf8Path>) -> Self {
+        let virtual_env = std::env::var("VIRTUAL_ENV").ok().map(Utf8PathBuf::from);
         Self::discover_from_sources(venv_path, virtual_env.as_deref())
     }
 
-    fn discover_from_sources(venv_path: Option<&str>, virtual_env: Option<&str>) -> Self {
+    fn discover_from_sources(venv_path: Option<&Utf8Path>, virtual_env: Option<&Utf8Path>) -> Self {
         venv_path
             .or(virtual_env)
-            .map_or(Self::Auto, |path| Self::VenvPath(path.to_string()))
+            .map_or(Self::Auto, |path| Self::VenvPath(path.to_path_buf()))
     }
 
     pub(crate) fn site_packages_path(
@@ -38,12 +38,15 @@ impl Interpreter {
         project_root: &Utf8Path,
     ) -> Option<Utf8PathBuf> {
         match self {
-            Self::VenvPath(path) => Self::site_packages_path_in_venv(fs, Utf8Path::new(path)),
-            Self::Auto => Self::auto_venv_paths(project_root).find_map(|venv| {
-                fs.is_dir(&venv)
-                    .then(|| Self::site_packages_path_in_venv(fs, &venv))
-                    .flatten()
-            }),
+            Self::VenvPath(path) => Self::site_packages_path_in_venv(fs, path),
+            Self::Auto => [".venv", "venv", "env", ".env"]
+                .into_iter()
+                .map(|dir| project_root.join(dir))
+                .find_map(|venv| {
+                    fs.is_dir(&venv)
+                        .then(|| Self::site_packages_path_in_venv(fs, &venv))
+                        .flatten()
+                }),
             Self::InterpreterPath(_) => None,
         }
     }
@@ -108,12 +111,6 @@ impl Interpreter {
         fs.is_dir(&windows_site_packages)
             .then_some(windows_site_packages)
     }
-
-    fn auto_venv_paths(project_root: &Utf8Path) -> impl Iterator<Item = Utf8PathBuf> + '_ {
-        [".venv", "venv", "env", ".env"]
-            .into_iter()
-            .map(|dir| project_root.join(dir))
-    }
 }
 
 #[cfg(test)]
@@ -127,26 +124,33 @@ mod tests {
 
         #[test]
         fn test_discover_with_explicit_venv_path() {
-            let interpreter = Interpreter::discover_from_sources(Some("/path/to/venv"), None);
+            let interpreter =
+                Interpreter::discover_from_sources(Some(Utf8Path::new("/path/to/venv")), None);
             assert_eq!(
                 interpreter,
-                Interpreter::VenvPath("/path/to/venv".to_string())
+                Interpreter::VenvPath(Utf8PathBuf::from("/path/to/venv"))
             );
         }
 
         #[test]
         fn test_discover_with_virtual_env_var() {
-            let interpreter = Interpreter::discover_from_sources(None, Some("/env/path"));
-            assert_eq!(interpreter, Interpreter::VenvPath("/env/path".to_string()));
+            let interpreter =
+                Interpreter::discover_from_sources(None, Some(Utf8Path::new("/env/path")));
+            assert_eq!(
+                interpreter,
+                Interpreter::VenvPath(Utf8PathBuf::from("/env/path"))
+            );
         }
 
         #[test]
         fn test_discover_explicit_overrides_env_var() {
-            let interpreter =
-                Interpreter::discover_from_sources(Some("/explicit/path"), Some("/env/path"));
+            let interpreter = Interpreter::discover_from_sources(
+                Some(Utf8Path::new("/explicit/path")),
+                Some(Utf8Path::new("/env/path")),
+            );
             assert_eq!(
                 interpreter,
-                Interpreter::VenvPath("/explicit/path".to_string())
+                Interpreter::VenvPath(Utf8PathBuf::from("/explicit/path"))
             );
         }
 

--- a/crates/djls-project/src/python/search_paths.rs
+++ b/crates/djls-project/src/python/search_paths.rs
@@ -75,7 +75,9 @@ impl SearchPaths {
     #[must_use]
     pub(crate) fn root_only(root: &Utf8Path) -> Self {
         let mut search_paths = Self::default();
-        search_paths.push(SearchPath::first_party(root.to_path_buf()));
+        search_paths
+            .paths
+            .push(SearchPath::first_party(root.to_path_buf()));
         search_paths
     }
 
@@ -84,29 +86,32 @@ impl SearchPaths {
         fs: &dyn FileSystem,
         root: &Utf8Path,
         interpreter: &Interpreter,
-        pythonpath: &[String],
+        pythonpath: &[Utf8PathBuf],
     ) -> Self {
         let mut search_paths = Self::default();
-        search_paths.push(SearchPath::first_party(root.to_path_buf()));
+        search_paths
+            .paths
+            .push(SearchPath::first_party(root.to_path_buf()));
         let discovered_site_packages = interpreter.site_packages_path(fs, root);
 
         for path in pythonpath {
-            let path = Utf8PathBuf::from(path);
-            if !fs.is_dir(&path) || search_paths.contains_path(&path) {
+            if !fs.is_dir(path) || search_paths.contains_path(path) {
                 continue;
             }
 
-            search_paths.push(SearchPath::from_pythonpath(
+            search_paths.paths.push(SearchPath::from_pythonpath(
                 root,
                 discovered_site_packages.as_deref(),
-                path,
+                path.clone(),
             ));
         }
 
         if let Some(site_packages) = discovered_site_packages
             && !search_paths.contains_path(&site_packages)
         {
-            search_paths.push(SearchPath::site_packages(site_packages));
+            search_paths
+                .paths
+                .push(SearchPath::site_packages(site_packages));
         }
 
         search_paths
@@ -131,10 +136,6 @@ impl SearchPaths {
 
     pub fn iter(&self) -> impl Iterator<Item = &SearchPath> {
         self.paths.iter()
-    }
-
-    fn push(&mut self, search_path: SearchPath) {
-        self.paths.push(search_path);
     }
 
     fn contains_path(&self, path: &Utf8Path) -> bool {

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use djls_project::testing::compute_django_discovery;
 use djls_project::testing::model_modules;
 use djls_project::*;
@@ -110,9 +111,9 @@ fn search_paths_keep_site_packages_external_inside_project_root() {
     );
 
     let pythonpath = vec![
-        "/project/src".to_string(),
-        "/outside".to_string(),
-        "/project/.venv/lib/python3.12/site-packages".to_string(),
+        Utf8PathBuf::from("/project/src"),
+        Utf8PathBuf::from("/outside"),
+        Utf8PathBuf::from("/project/.venv/lib/python3.12/site-packages"),
     ];
     let search_paths = SearchPaths::from_project_settings(
         &fs,
@@ -176,7 +177,7 @@ fn model_modules_use_first_party_search_path_relative_names() {
         "from django.db import models\nclass Article(models.Model):\n    pass\n",
     );
 
-    let pythonpath = vec!["/project/src".to_string()];
+    let pythonpath = vec![Utf8PathBuf::from("/project/src")];
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
@@ -204,7 +205,7 @@ fn registering_search_paths_removes_obsolete_external_roots() {
     let db = TestDatabase::new();
     db.add_file("/external/pkg/models.py", "");
 
-    let pythonpath = vec!["/external".to_string()];
+    let pythonpath = vec![Utf8PathBuf::from("/external")];
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
@@ -239,7 +240,7 @@ fn model_modules_tolerate_unregistered_search_paths() {
         "from django.db import models\nclass SharedArticle(models.Model):\n    pass\n",
     );
 
-    let pythonpath = vec!["/shared".to_string()];
+    let pythonpath = vec![Utf8PathBuf::from("/shared")];
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
@@ -594,7 +595,10 @@ fn external_model_graph_preserves_pythonpath_precedence() {
         "from django.db import models\nclass Duplicate(models.Model):\n    pass\n",
     );
 
-    let pythonpath = vec!["/zfirst".to_string(), "/afallback".to_string()];
+    let pythonpath = vec![
+        Utf8PathBuf::from("/zfirst"),
+        Utf8PathBuf::from("/afallback"),
+    ];
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
@@ -684,7 +688,7 @@ fn external_model_graph_reads_extra_pythonpath_models() {
         "from django.db import models\nclass SharedArticle(models.Model):\n    pass\n",
     );
 
-    let pythonpath = vec!["/shared".to_string()];
+    let pythonpath = vec![Utf8PathBuf::from("/shared")];
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
@@ -907,11 +911,13 @@ fn project_model_discovery_skips_registered_non_first_party_paths() {
         "from django.db import models\nclass Lib(models.Model): pass\n",
     );
 
-    let pythonpath = vec!["/project/venv/lib/python3.12/site-packages".to_string()];
+    let pythonpath = vec![Utf8PathBuf::from(
+        "/project/venv/lib/python3.12/site-packages",
+    )];
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
-        &Interpreter::InterpreterPath("/usr/bin/python".to_string()),
+        &Interpreter::InterpreterPath(Utf8PathBuf::from("/usr/bin/python")),
         &pythonpath,
     );
     search_paths.register_roots(&db);

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -467,7 +467,7 @@ fn template_dirs_resolve_apps_from_site_packages_search_path() {
         db.file_system(),
         Utf8Path::new("/proj"),
         &Interpreter::Auto,
-        &["/site".to_string()],
+        &[Utf8PathBuf::from("/site")],
     );
     search_paths.register_roots(&db);
     let project = ProjectFixture::new("/proj")

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -429,11 +429,8 @@ pythonpath = ["{config_extra_path}"]
                 .map(djls_project::PythonModuleName::as_str),
             Some("client.settings")
         );
-        assert_eq!(project.pythonpath(db), &vec![client_extra_path.to_string()]);
-        assert_eq!(
-            project.interpreter(db),
-            &Interpreter::VenvPath(venv_path.to_string())
-        );
+        assert_eq!(project.pythonpath(db), &vec![client_extra_path]);
+        assert_eq!(project.interpreter(db), &Interpreter::VenvPath(venv_path));
         assert!(project.env_vars(db).is_empty());
 
         let search_paths: Vec<_> = project

--- a/crates/djls-testing/src/fixtures.rs
+++ b/crates/djls-testing/src/fixtures.rs
@@ -422,7 +422,7 @@ pub struct ProjectFixture {
     root: Utf8PathBuf,
     files: Vec<(Utf8PathBuf, String)>,
     django_settings_module: Option<PythonModuleName>,
-    pythonpath: Vec<String>,
+    pythonpath: Vec<Utf8PathBuf>,
     env_vars: Vec<(String, String)>,
     interpreter: Interpreter,
     search_paths: Option<SearchPaths>,


### PR DESCRIPTION
## Summary

Mechanical path-typing slice ahead of the resolver work (plan: python-foundation 002, Step 2; audit RS-02 / decision record `thoughts/shared/decisions/2026-05-17-static-project-model-python-resolver-strategy.md`).

`Interpreter::{VenvPath, InterpreterPath}` stored `String` and `pythonpath` flowed as `&[String]`, reparsed into `Utf8PathBuf` per entry inside `SearchPaths::discover` — violating the crate's camino-canonical rule right where the upcoming resolver slice needs typed roots.

- `djls-conf::Settings` now deserializes `venv_path`/`pythonpath` directly as `Utf8PathBuf`, so paths are typed once at the config boundary and stay typed through `Project`, `Interpreter`, and `SearchPaths`.
- No behavior change: `VIRTUAL_ENV` handling is unchanged (non-Unicode values were ignored before via `std::env::var` and still are); no resolver/API-shape changes — those are gated behind the plan's design-review memo.
- Two single-caller wrappers in the touched files were inlined per the slop census: `Interpreter::auto_venv_paths` (2-line iterator) and `SearchPaths::push` (wrapped `Vec::push`).

## Noted, not changed

`Interpreter::InterpreterPath` is unreachable from user config (`djls-conf` only exposes `venv_path`) and is only constructed in tests; `site_packages_path` maps it to `None`. Kept as-is here — whether it survives is a resolver-slice (Step 4) surface decision, not a typing PR's.

## Verification

- `cargo test -q` (full workspace) — green, no pending `.snap.new` artifacts.
- `just clippy`, `just fmt --check`, `just lint` — green.
