### PR TITLE
Detect src/ roots and honor simple .pth entries

### DIFF
--- a/crates/djls-project/src/python/search_paths.rs
+++ b/crates/djls-project/src/python/search_paths.rs
@@ -2,6 +2,8 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_source::FileRootKind;
 use djls_source::FileSystem;
+use djls_source::WalkEntryKind;
+use djls_source::WalkOptions;
 
 use crate::db::Db as ProjectDb;
 use crate::python::Interpreter;
@@ -11,21 +13,10 @@ pub enum SearchPath {
     FirstParty(Utf8PathBuf),
     Extra(Utf8PathBuf),
     SitePackages(Utf8PathBuf),
+    Editable(Utf8PathBuf),
 }
 
 impl SearchPath {
-    fn first_party(path: Utf8PathBuf) -> Self {
-        Self::FirstParty(path)
-    }
-
-    fn extra(path: Utf8PathBuf) -> Self {
-        Self::Extra(path)
-    }
-
-    fn site_packages(path: Utf8PathBuf) -> Self {
-        Self::SitePackages(path)
-    }
-
     fn from_pythonpath(
         root: &Utf8Path,
         discovered_site_packages: Option<&Utf8Path>,
@@ -36,18 +27,21 @@ impl SearchPath {
                 .components()
                 .any(|component| matches!(component.as_str(), "site-packages" | "dist-packages"))
         {
-            Self::site_packages(path)
+            Self::SitePackages(path)
         } else if path.starts_with(root) {
-            Self::first_party(path)
+            Self::FirstParty(path)
         } else {
-            Self::extra(path)
+            Self::Extra(path)
         }
     }
 
     #[must_use]
     pub fn path(&self) -> &Utf8Path {
         match self {
-            Self::FirstParty(path) | Self::Extra(path) | Self::SitePackages(path) => path,
+            Self::FirstParty(path)
+            | Self::Extra(path)
+            | Self::SitePackages(path)
+            | Self::Editable(path) => path,
         }
     }
 
@@ -61,7 +55,7 @@ impl SearchPath {
             // Extra pythonpath entries are user-edited code, so they get the
             // same low-durability treatment as project files.
             Self::FirstParty(_) | Self::Extra(_) => FileRootKind::Project,
-            Self::SitePackages(_) => FileRootKind::SearchPath,
+            Self::SitePackages(_) | Self::Editable(_) => FileRootKind::SearchPath,
         }
     }
 }
@@ -77,7 +71,7 @@ impl SearchPaths {
         let mut search_paths = Self::default();
         search_paths
             .paths
-            .push(SearchPath::first_party(root.to_path_buf()));
+            .push(SearchPath::FirstParty(root.to_path_buf()));
         search_paths
     }
 
@@ -91,7 +85,13 @@ impl SearchPaths {
         let mut search_paths = Self::default();
         search_paths
             .paths
-            .push(SearchPath::first_party(root.to_path_buf()));
+            .push(SearchPath::FirstParty(root.to_path_buf()));
+
+        let src_root = root.join("src");
+        if fs.is_dir(&src_root) {
+            search_paths.paths.push(SearchPath::FirstParty(src_root));
+        }
+
         let discovered_site_packages = interpreter.site_packages_path(fs, root);
 
         for path in pythonpath {
@@ -99,11 +99,19 @@ impl SearchPaths {
                 continue;
             }
 
-            search_paths.paths.push(SearchPath::from_pythonpath(
+            let search_path = SearchPath::from_pythonpath(
                 root,
                 discovered_site_packages.as_deref(),
                 path.clone(),
-            ));
+            );
+            let site_packages = match &search_path {
+                SearchPath::SitePackages(path) => Some(path.clone()),
+                _ => None,
+            };
+            search_paths.paths.push(search_path);
+            if let Some(site_packages) = site_packages {
+                search_paths.add_pth_editable_roots(fs, &site_packages);
+            }
         }
 
         if let Some(site_packages) = discovered_site_packages
@@ -111,7 +119,8 @@ impl SearchPaths {
         {
             search_paths
                 .paths
-                .push(SearchPath::site_packages(site_packages));
+                .push(SearchPath::SitePackages(site_packages.clone()));
+            search_paths.add_pth_editable_roots(fs, &site_packages);
         }
 
         search_paths
@@ -140,5 +149,45 @@ impl SearchPaths {
 
     fn contains_path(&self, path: &Utf8Path) -> bool {
         self.iter().any(|search_path| search_path.path() == path)
+    }
+
+    fn add_pth_editable_roots(&mut self, fs: &dyn FileSystem, site_packages: &Utf8Path) {
+        let Ok(entries) = fs.walk_entries(site_packages, &WalkOptions::shallow()) else {
+            return;
+        };
+
+        let mut pth_files: Vec<_> = entries
+            .into_iter()
+            .filter(|entry| entry.kind == WalkEntryKind::File)
+            .filter(|entry| entry.path.extension() == Some("pth"))
+            .collect();
+        pth_files.sort_by(|left, right| left.path.cmp(&right.path));
+
+        for pth_file in pth_files {
+            let Ok(contents) = fs.read_to_string(&pth_file.path) else {
+                continue;
+            };
+
+            for line in contents.lines() {
+                let line = line.trim_end();
+                if line.is_empty()
+                    || line.starts_with('#')
+                    || line.starts_with("import ")
+                    || line.starts_with("import\t")
+                {
+                    continue;
+                }
+
+                let path = Utf8Path::new(line);
+                let path = if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    site_packages.join(path)
+                };
+                if fs.is_dir(&path) && !self.contains_path(&path) {
+                    self.paths.push(SearchPath::Editable(path));
+                }
+            }
+        }
     }
 }

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -101,6 +101,104 @@ fn django_template_settings(installed_apps: &[&str], builtins: &[&str]) -> Strin
 }
 
 #[test]
+fn search_paths_detect_top_level_src_after_project_root() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file("/project/src/app.py".into(), String::new());
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+            SearchPath::FirstParty(Utf8PathBuf::from("/project/src")),
+        ]
+    );
+}
+
+#[test]
+fn search_paths_do_not_detect_top_level_src_when_absent() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file("/project/app.py".into(), String::new());
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![SearchPath::FirstParty(Utf8PathBuf::from("/project"))]
+    );
+}
+
+#[test]
+fn search_paths_add_simple_pth_entries_as_editable_roots() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/django/__init__.py".into(),
+        String::new(),
+    );
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/editable_relative/pkg.py".into(),
+        String::new(),
+    );
+    fs.add_file("/editable_absolute/pkg.py".into(), String::new());
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/editable.pth".into(),
+        "# comment\n\nimport site\neditable_relative\n/editable_absolute\nmissing\n".to_string(),
+    );
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+            SearchPath::SitePackages(Utf8PathBuf::from(
+                "/project/.venv/lib/python3.12/site-packages"
+            )),
+            SearchPath::Editable(Utf8PathBuf::from(
+                "/project/.venv/lib/python3.12/site-packages/editable_relative"
+            )),
+            SearchPath::Editable(Utf8PathBuf::from("/editable_absolute")),
+        ]
+    );
+}
+
+#[test]
+fn search_paths_skip_pth_entries_that_duplicate_existing_roots() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file("/project/src/app.py".into(), String::new());
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/django/__init__.py".into(),
+        String::new(),
+    );
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/editable.pth".into(),
+        "/project/src\n".to_string(),
+    );
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+            SearchPath::FirstParty(Utf8PathBuf::from("/project/src")),
+            SearchPath::SitePackages(Utf8PathBuf::from(
+                "/project/.venv/lib/python3.12/site-packages"
+            )),
+        ]
+    );
+}
+
+#[test]
 fn search_paths_keep_site_packages_external_inside_project_root() {
     let mut fs = InMemoryFileSystem::new();
     fs.add_file("/project/src/app/__init__.py".into(), String::new());


### PR DESCRIPTION
## Summary

Search-path completeness ahead of the resolver rewrite (plan: python-foundation 002, Step 3; decision record `thoughts/shared/decisions/2026-05-17-static-project-model-python-resolver-strategy.md` first-slice items "automatic top-level `src/` detection" and "simple non-executable `.pth` entries"). Stacked on #734 (path typing).

- **`src/` detection**: if `<project_root>/src` is a directory, it joins the roots as first-party, ordered right after the project root — static first-party roots before dynamic/site-packages roots, per ty's ordering.
- **`.pth` editable roots**: discovered site-packages directories (and pythonpath entries classified as site-packages) are scanned for `*.pth` files, alphabetically, following ty's parsing rules (`reference/ruff` `ty_module_resolver/src/resolve.rs` `PthFile`/`PthFileIterator`): lines are `trim_end`ed; blanks, `#` comments, and executable `import ` / `import\t` lines are skipped; remaining lines resolve against the site-packages dir (absolute kept as-is) and join as `SearchPath::Editable` roots when the directory exists. Editable roots get `FileRootKind::SearchPath` durability, same as site-packages.
- Dedup: `.pth` entries duplicating an existing root are skipped; the discovered-site-packages guard covers the pth scan too, so a site-packages dir reachable both ways is scanned once.
- Census cleanup in the touched file: the delegation-only `SearchPath::{first_party, extra, site_packages}` constructor wrappers are collapsed to direct variant construction (rather than adding a fourth wrapper for `Editable`).

The corpus source-root survey behind the decision record found source-root stripping affects 85/432 surveyed model files and 74/331 templatetag files — this is the slice that starts fixing those.

## Tests

Fixture-backed in `crates/djls-project/tests/resolve.rs`, all asserting the full ordered root list:

- `search_paths_detect_top_level_src_after_project_root` / `..._do_not_detect_top_level_src_when_absent` — presence, absence, and root-then-src ordering.
- `search_paths_add_simple_pth_entries_as_editable_roots` — one `.pth` mixing a comment, blank line, `import` line, valid relative entry, valid absolute entry, and a nonexistent path; exactly the two valid dirs become editable roots.
- `search_paths_skip_pth_entries_that_duplicate_existing_roots` — a `.pth` entry pointing at the detected `src/` root is not added twice.

## Verification

- `cargo test -q` (full workspace) — green, no `.snap.new` artifacts.
- `just clippy`, `just fmt --check`, `just lint` — green.
