### PR TITLE
Add module resolution facts behind identity/detail projections

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -213,6 +213,9 @@ mod invalidation_tests {
     use djls_conf::Settings;
     use djls_project::Db as ProjectDb;
     use djls_project::Project;
+    use djls_project::PythonModule;
+    use djls_project::PythonModuleName;
+    use djls_project::resolve_module_detail;
     use djls_semantic::Db as SemanticDb;
     use djls_semantic::SemanticOffsetContext;
     use djls_semantic::template_inheritance;
@@ -736,6 +739,137 @@ mod invalidation_tests {
         assert!(
             !was_executed(&db, &events, "template_dirs"),
             "template_dirs should stay cached after an unrelated file revision changes"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn module_detail_perturbations_do_not_recompute_settings_identity_consumers() {
+        let event_log = EventLog::default();
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        let vendor = root.join("vendor");
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            format!("django_settings_module = \"unrelated\"\npythonpath = [\"{vendor}\"]\n"),
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        let unrelated_path = root.join("unrelated.py");
+
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(root.join("manage.py"), String::new());
+            fs.add_file(
+                unrelated_path.clone(),
+                "INSTALLED_APPS = []\nTEMPLATES = []\n".to_string(),
+            );
+            fs.add_file(vendor.join("anchor.py"), String::new());
+        }
+
+        let mut db = DjangoDatabase {
+            fs: fs.clone(),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            storage: salsa::Storage::new(Some(Box::new({
+                let log = event_log.clone();
+                move |event| {
+                    log.events.lock().unwrap().push(event);
+                }
+            }))),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
+        let name = PythonModuleName::parse("unrelated").unwrap();
+
+        let module = PythonModule::resolve(&db, project, name.clone())
+            .expect("unrelated should resolve from the project root");
+        assert_eq!(module.path(), unrelated_path.as_path());
+        assert_eq!(
+            resolve_module_detail(&db, project, name.clone())
+                .candidates
+                .len(),
+            1
+        );
+        assert_eq!(
+            djls_project::testing::settings_module_file(&db, project)
+                .expect("settings module should resolve")
+                .path(&db),
+            unrelated_path.as_path()
+        );
+        assert_eq!(
+            djls_project::testing::django_settings_template_backend_count(&db, project),
+            0
+        );
+        let vendor_root = db
+            .files()
+            .root(&db, vendor.as_path())
+            .expect("vendor search path root should be registered");
+        event_log.take();
+
+        fs.lock()
+            .unwrap()
+            .add_file(vendor.join("unrelated/marker.txt"), String::new());
+        db.bump_file_root_revision(vendor_root);
+
+        let detail = resolve_module_detail(&db, project, name.clone());
+        assert_eq!(detail.candidates.len(), 2);
+        assert_eq!(
+            djls_project::testing::settings_module_file(&db, project)
+                .expect("settings module should stay resolved")
+                .path(&db),
+            unrelated_path.as_path()
+        );
+        assert_eq!(
+            djls_project::testing::django_settings_template_backend_count(&db, project),
+            0
+        );
+        let events = event_log.take();
+        assert!(
+            was_executed(&db, &events, "resolve_module_detail"),
+            "resolve_module_detail should re-execute after a lower-priority namespace portion appears"
+        );
+        assert!(
+            !was_executed(&db, &events, "settings_module_file"),
+            "settings_module_file should backdate through unchanged module identity"
+        );
+        assert!(
+            !was_executed(&db, &events, "django_settings"),
+            "django_settings should not recompute for detail-only module candidate churn"
+        );
+
+        fs.lock()
+            .unwrap()
+            .add_file(vendor.join("unrelated.py"), String::new());
+        db.bump_file_root_revision(vendor_root);
+
+        let detail = resolve_module_detail(&db, project, name);
+        assert_eq!(detail.candidates.len(), 2);
+        assert_eq!(
+            djls_project::testing::settings_module_file(&db, project)
+                .expect("settings module should stay resolved")
+                .path(&db),
+            unrelated_path.as_path()
+        );
+        assert_eq!(
+            djls_project::testing::django_settings_template_backend_count(&db, project),
+            0
+        );
+        let events = event_log.take();
+        assert!(
+            was_executed(&db, &events, "resolve_module_detail"),
+            "resolve_module_detail should re-execute after a lower-priority regular module appears"
+        );
+        assert!(
+            !was_executed(&db, &events, "settings_module_file"),
+            "settings_module_file should backdate through unchanged first-root identity"
+        );
+        assert!(
+            !was_executed(&db, &events, "django_settings"),
+            "django_settings should not recompute when the selected module identity is unchanged"
         );
     }
 

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -22,12 +22,19 @@ pub use models::ModelId;
 pub use models::compute_model_graph;
 pub use models::model_modules;
 pub use project::Project;
+pub use python::CandidateKind;
+pub use python::CandidateLocation;
 pub use python::Interpreter;
 pub use python::InvalidModuleName;
+pub use python::PackageDirs;
 pub use python::PythonModule;
 pub use python::PythonModuleName;
+pub use python::ResolutionDetail;
 pub use python::SearchPath;
 pub use python::SearchPaths;
+pub use python::UnresolvedReason;
+pub use python::resolve_module_detail;
+pub use python::resolve_package_dirs;
 pub use templates::ArgumentCountConstraint;
 pub use templates::AsVar;
 pub use templates::BlockSpec;
@@ -82,6 +89,23 @@ pub mod testing {
     pub use crate::models::extract_model_graph;
     pub use crate::models::model_modules;
     pub use crate::templates::TemplateInventoryStatus;
+
+    pub fn settings_module_file(
+        db: &dyn super::Db,
+        project: super::Project,
+    ) -> Option<djls_source::File> {
+        crate::settings::settings_module_file(db, project)
+    }
+
+    pub fn django_settings_template_backend_count(
+        db: &dyn super::Db,
+        project: super::Project,
+    ) -> usize {
+        crate::settings::django_settings(db, project)
+            .templates
+            .backends
+            .len()
+    }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum TemplateLibraryInput {

--- a/crates/djls-project/src/python.rs
+++ b/crates/djls-project/src/python.rs
@@ -6,9 +6,16 @@ mod path_eval;
 mod search_paths;
 
 pub use interpreter::Interpreter;
+pub use module::CandidateKind;
+pub use module::CandidateLocation;
+pub use module::PackageDirs;
 pub(crate) use module::PythonImport;
 pub use module::PythonModule;
 pub(crate) use module::PythonPackage;
+pub use module::ResolutionDetail;
+pub use module::UnresolvedReason;
+pub use module::resolve_module_detail;
+pub use module::resolve_package_dirs;
 pub use name::InvalidModuleName;
 pub use name::PythonModuleName;
 pub(crate) use parse::parse_python_module;

--- a/crates/djls-project/src/python/interpreter.rs
+++ b/crates/djls-project/src/python/interpreter.rs
@@ -14,8 +14,6 @@ pub enum Interpreter {
     Auto,
     /// Use specific virtual environment path
     VenvPath(Utf8PathBuf),
-    /// Use specific interpreter executable path
-    InterpreterPath(Utf8PathBuf),
 }
 
 impl Interpreter {
@@ -47,7 +45,6 @@ impl Interpreter {
                         .then(|| Self::site_packages_path_in_venv(fs, &venv))
                         .flatten()
                 }),
-            Self::InterpreterPath(_) => None,
         }
     }
 

--- a/crates/djls-project/src/python/module.rs
+++ b/crates/djls-project/src/python/module.rs
@@ -9,6 +9,7 @@ use crate::db::Db as ProjectDb;
 use crate::project::Project;
 use crate::python::InvalidModuleName;
 use crate::python::PythonModuleName;
+use crate::python::search_paths::SearchPath;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct PythonModule {
@@ -22,6 +23,55 @@ pub(crate) struct PythonPackage {
     name: PythonModuleName,
     dir: Utf8PathBuf,
     init_file: Option<File>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolutionDetail {
+    pub selected_root: Option<SearchPath>,
+    pub candidates: Vec<CandidateLocation>,
+    pub unresolved_reason: Option<UnresolvedReason>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CandidateLocation {
+    pub root: SearchPath,
+    pub path: Utf8PathBuf,
+    pub kind: CandidateKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CandidateKind {
+    RegularPackage,
+    FileModule,
+    NamespacePortion,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnresolvedReason {
+    NotFound,
+    NamespaceOnly,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PackageDirs {
+    pub dirs: Vec<Utf8PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PythonModuleCandidate {
+    RegularPackage {
+        root: SearchPath,
+        dir: Utf8PathBuf,
+        init_file: Utf8PathBuf,
+    },
+    FileModule {
+        root: SearchPath,
+        path: Utf8PathBuf,
+    },
+    NamespacePortion {
+        root: SearchPath,
+        dir: Utf8PathBuf,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -45,6 +95,125 @@ pub(crate) enum PythonImportError {
     ImporterIsNotPythonSource(String),
     #[error("relative import has too many leading dots")]
     TooManyDots,
+}
+
+fn python_module_candidates(
+    db: &dyn ProjectDb,
+    project: Project,
+    name: &PythonModuleName,
+) -> Vec<PythonModuleCandidate> {
+    let relative = name.as_str().replace('.', "/");
+    let mut candidates = Vec::new();
+
+    for search_path in project.search_paths(db).iter() {
+        let root = search_path.clone();
+        let dir = search_path.path().join(&relative);
+        let init_file = dir.join("__init__.py");
+        if db.path_is_file(&init_file) {
+            candidates.push(PythonModuleCandidate::RegularPackage {
+                root,
+                dir,
+                init_file,
+            });
+            continue;
+        }
+
+        let py_file = dir.with_extension("py");
+        if db.path_is_file(&py_file) {
+            candidates.push(PythonModuleCandidate::FileModule {
+                root,
+                path: py_file,
+            });
+            continue;
+        }
+
+        if db.path_is_dir(&dir) {
+            candidates.push(PythonModuleCandidate::NamespacePortion { root, dir });
+        }
+    }
+
+    candidates
+}
+
+// Salsa tracked-query keys are by-value; `name` is a key, not a borrow.
+#[allow(clippy::needless_pass_by_value)]
+#[salsa::tracked]
+pub fn resolve_module_detail(
+    db: &dyn ProjectDb,
+    project: Project,
+    name: PythonModuleName,
+) -> ResolutionDetail {
+    project.touch_search_path_roots(db);
+
+    let candidates = python_module_candidates(db, project, &name);
+    let selected_root = candidates.iter().find_map(|candidate| match candidate {
+        PythonModuleCandidate::RegularPackage { root, .. }
+        | PythonModuleCandidate::FileModule { root, .. } => Some(root.clone()),
+        PythonModuleCandidate::NamespacePortion { .. } => None,
+    });
+    let unresolved_reason = if selected_root.is_some() {
+        None
+    } else if candidates.is_empty() {
+        Some(UnresolvedReason::NotFound)
+    } else {
+        Some(UnresolvedReason::NamespaceOnly)
+    };
+    let candidates = candidates
+        .into_iter()
+        .map(|candidate| match candidate {
+            PythonModuleCandidate::RegularPackage {
+                root, init_file, ..
+            } => CandidateLocation {
+                root,
+                path: init_file,
+                kind: CandidateKind::RegularPackage,
+            },
+            PythonModuleCandidate::FileModule { root, path } => CandidateLocation {
+                root,
+                path,
+                kind: CandidateKind::FileModule,
+            },
+            PythonModuleCandidate::NamespacePortion { root, dir } => CandidateLocation {
+                root,
+                path: dir,
+                kind: CandidateKind::NamespacePortion,
+            },
+        })
+        .collect();
+
+    ResolutionDetail {
+        selected_root,
+        candidates,
+        unresolved_reason,
+    }
+}
+
+// Salsa tracked-query keys are by-value; `name` is a key, not a borrow.
+#[allow(clippy::needless_pass_by_value)]
+#[salsa::tracked]
+pub fn resolve_package_dirs(
+    db: &dyn ProjectDb,
+    project: Project,
+    name: PythonModuleName,
+) -> PackageDirs {
+    project.touch_search_path_roots(db);
+
+    let mut namespace_dirs = Vec::new();
+    for candidate in python_module_candidates(db, project, &name) {
+        match candidate {
+            PythonModuleCandidate::RegularPackage { dir, .. } => {
+                return PackageDirs { dirs: vec![dir] };
+            }
+            PythonModuleCandidate::FileModule { .. } => {
+                return PackageDirs { dirs: Vec::new() };
+            }
+            PythonModuleCandidate::NamespacePortion { dir, .. } => namespace_dirs.push(dir),
+        }
+    }
+
+    PackageDirs {
+        dirs: namespace_dirs,
+    }
 }
 
 impl PythonModule {
@@ -130,28 +299,14 @@ impl PythonModule {
 #[salsa::tracked]
 impl PythonModule {
     #[salsa::tracked]
-    pub(crate) fn resolve(
-        db: &dyn ProjectDb,
-        project: Project,
-        name: PythonModuleName,
-    ) -> Option<Self> {
+    pub fn resolve(db: &dyn ProjectDb, project: Project, name: PythonModuleName) -> Option<Self> {
         project.touch_search_path_roots(db);
 
-        for search_path in project.search_paths(db).iter() {
-            let mut candidate = search_path.path().to_path_buf();
-            for part in name.as_str().split('.') {
-                candidate.push(part);
-            }
-
-            let py_file = candidate.with_extension("py");
-            let path = if db.path_is_file(&py_file) {
-                py_file
-            } else {
-                let init_file = candidate.join("__init__.py");
-                if !db.path_is_file(&init_file) {
-                    continue;
-                }
-                init_file
+        for candidate in python_module_candidates(db, project, &name) {
+            let path = match candidate {
+                PythonModuleCandidate::RegularPackage { init_file, .. } => init_file,
+                PythonModuleCandidate::FileModule { path, .. } => path,
+                PythonModuleCandidate::NamespacePortion { .. } => continue,
             };
 
             let file = db.get_or_create_file(&path);

--- a/crates/djls-project/src/python/search_paths.rs
+++ b/crates/djls-project/src/python/search_paths.rs
@@ -2,6 +2,8 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_source::FileRootKind;
 use djls_source::FileSystem;
+use djls_source::WalkEntryKind;
+use djls_source::WalkOptions;
 
 use crate::db::Db as ProjectDb;
 use crate::python::Interpreter;
@@ -11,21 +13,10 @@ pub enum SearchPath {
     FirstParty(Utf8PathBuf),
     Extra(Utf8PathBuf),
     SitePackages(Utf8PathBuf),
+    Editable(Utf8PathBuf),
 }
 
 impl SearchPath {
-    fn first_party(path: Utf8PathBuf) -> Self {
-        Self::FirstParty(path)
-    }
-
-    fn extra(path: Utf8PathBuf) -> Self {
-        Self::Extra(path)
-    }
-
-    fn site_packages(path: Utf8PathBuf) -> Self {
-        Self::SitePackages(path)
-    }
-
     fn from_pythonpath(
         root: &Utf8Path,
         discovered_site_packages: Option<&Utf8Path>,
@@ -36,18 +27,21 @@ impl SearchPath {
                 .components()
                 .any(|component| matches!(component.as_str(), "site-packages" | "dist-packages"))
         {
-            Self::site_packages(path)
+            Self::SitePackages(path)
         } else if path.starts_with(root) {
-            Self::first_party(path)
+            Self::FirstParty(path)
         } else {
-            Self::extra(path)
+            Self::Extra(path)
         }
     }
 
     #[must_use]
     pub fn path(&self) -> &Utf8Path {
         match self {
-            Self::FirstParty(path) | Self::Extra(path) | Self::SitePackages(path) => path,
+            Self::FirstParty(path)
+            | Self::Extra(path)
+            | Self::SitePackages(path)
+            | Self::Editable(path) => path,
         }
     }
 
@@ -61,7 +55,7 @@ impl SearchPath {
             // Extra pythonpath entries are user-edited code, so they get the
             // same low-durability treatment as project files.
             Self::FirstParty(_) | Self::Extra(_) => FileRootKind::Project,
-            Self::SitePackages(_) => FileRootKind::SearchPath,
+            Self::SitePackages(_) | Self::Editable(_) => FileRootKind::SearchPath,
         }
     }
 }
@@ -77,7 +71,7 @@ impl SearchPaths {
         let mut search_paths = Self::default();
         search_paths
             .paths
-            .push(SearchPath::first_party(root.to_path_buf()));
+            .push(SearchPath::FirstParty(root.to_path_buf()));
         search_paths
     }
 
@@ -91,7 +85,13 @@ impl SearchPaths {
         let mut search_paths = Self::default();
         search_paths
             .paths
-            .push(SearchPath::first_party(root.to_path_buf()));
+            .push(SearchPath::FirstParty(root.to_path_buf()));
+
+        let src_root = root.join("src");
+        if fs.is_dir(&src_root) {
+            search_paths.paths.push(SearchPath::FirstParty(src_root));
+        }
+
         let discovered_site_packages = interpreter.site_packages_path(fs, root);
 
         for path in pythonpath {
@@ -99,11 +99,19 @@ impl SearchPaths {
                 continue;
             }
 
-            search_paths.paths.push(SearchPath::from_pythonpath(
+            let search_path = SearchPath::from_pythonpath(
                 root,
                 discovered_site_packages.as_deref(),
                 path.clone(),
-            ));
+            );
+            let site_packages = match &search_path {
+                SearchPath::SitePackages(path) => Some(path.clone()),
+                _ => None,
+            };
+            search_paths.paths.push(search_path);
+            if let Some(site_packages) = site_packages {
+                search_paths.add_pth_editable_roots(fs, &site_packages);
+            }
         }
 
         if let Some(site_packages) = discovered_site_packages
@@ -111,7 +119,8 @@ impl SearchPaths {
         {
             search_paths
                 .paths
-                .push(SearchPath::site_packages(site_packages));
+                .push(SearchPath::SitePackages(site_packages.clone()));
+            search_paths.add_pth_editable_roots(fs, &site_packages);
         }
 
         search_paths
@@ -140,5 +149,45 @@ impl SearchPaths {
 
     fn contains_path(&self, path: &Utf8Path) -> bool {
         self.iter().any(|search_path| search_path.path() == path)
+    }
+
+    fn add_pth_editable_roots(&mut self, fs: &dyn FileSystem, site_packages: &Utf8Path) {
+        let Ok(entries) = fs.walk_entries(site_packages, &WalkOptions::shallow()) else {
+            return;
+        };
+
+        let mut pth_files: Vec<_> = entries
+            .into_iter()
+            .filter(|entry| entry.kind == WalkEntryKind::File)
+            .filter(|entry| entry.path.extension() == Some("pth"))
+            .collect();
+        pth_files.sort_by(|left, right| left.path.cmp(&right.path));
+
+        for pth_file in pth_files {
+            let Ok(contents) = fs.read_to_string(&pth_file.path) else {
+                continue;
+            };
+
+            for line in contents.lines() {
+                let line = line.trim_end();
+                if line.is_empty()
+                    || line.starts_with('#')
+                    || line.starts_with("import ")
+                    || line.starts_with("import\t")
+                {
+                    continue;
+                }
+
+                let path = Utf8Path::new(line);
+                let path = if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    site_packages.join(path)
+                };
+                if fs.is_dir(&path) && !self.contains_path(&path) {
+                    self.paths.push(SearchPath::Editable(path));
+                }
+            }
+        }
     }
 }

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -961,6 +961,201 @@ fn model_modules_finds_models_package_files() {
 }
 
 #[test]
+fn python_module_resolve_prefers_regular_package_over_sibling_file() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app.py", "")
+        .file("/project/app/__init__.py", "")
+        .build(&db);
+
+    let module = PythonModule::resolve(&db, project, PythonModuleName::parse("app").unwrap())
+        .expect("app should resolve");
+
+    assert_eq!(module.path(), Utf8Path::new("/project/app/__init__.py"));
+}
+
+#[test]
+fn python_module_resolve_uses_first_regular_hit_across_roots() {
+    let mut db = TestDatabase::new();
+    db.add_file("/project/app.py", "");
+    db.add_file("/project/vendor/app/__init__.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/project/vendor")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let module = PythonModule::resolve(&db, project, PythonModuleName::parse("app").unwrap())
+        .expect("app should resolve");
+
+    assert_eq!(module.path(), Utf8Path::new("/project/app.py"));
+}
+
+#[test]
+fn python_module_resolve_returns_none_for_namespace_only_directory() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/views.py", "")
+        .build(&db);
+
+    let module = PythonModule::resolve(&db, project, PythonModuleName::parse("app").unwrap());
+
+    assert!(module.is_none());
+}
+
+#[test]
+fn resolve_module_detail_lists_shadowed_regular_candidates_in_root_order() {
+    let mut db = TestDatabase::new();
+    db.add_file("/project/app.py", "");
+    db.add_file("/project/vendor/app.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/project/vendor")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+    let name = PythonModuleName::parse("app").unwrap();
+
+    let module = PythonModule::resolve(&db, project, name.clone()).expect("app should resolve");
+    let detail = resolve_module_detail(&db, project, name);
+
+    assert_eq!(module.path(), Utf8Path::new("/project/app.py"));
+    assert_eq!(
+        detail.selected_root,
+        Some(SearchPath::FirstParty(Utf8PathBuf::from("/project")))
+    );
+    assert_eq!(detail.unresolved_reason, None);
+    assert_eq!(
+        detail.candidates,
+        vec![
+            CandidateLocation {
+                root: SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+                path: Utf8PathBuf::from("/project/app.py"),
+                kind: CandidateKind::FileModule,
+            },
+            CandidateLocation {
+                root: SearchPath::FirstParty(Utf8PathBuf::from("/project/vendor")),
+                path: Utf8PathBuf::from("/project/vendor/app.py"),
+                kind: CandidateKind::FileModule,
+            },
+        ]
+    );
+}
+
+#[test]
+fn resolve_module_detail_reports_namespace_only() {
+    let mut db = TestDatabase::new();
+    db.add_file("/project/app/views.py", "");
+    db.add_file("/vendor/app/models.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/vendor")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let detail = resolve_module_detail(&db, project, PythonModuleName::parse("app").unwrap());
+
+    assert_eq!(detail.selected_root, None);
+    assert_eq!(
+        detail.unresolved_reason,
+        Some(UnresolvedReason::NamespaceOnly)
+    );
+    assert_eq!(
+        detail.candidates,
+        vec![
+            CandidateLocation {
+                root: SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+                path: Utf8PathBuf::from("/project/app"),
+                kind: CandidateKind::NamespacePortion,
+            },
+            CandidateLocation {
+                root: SearchPath::Extra(Utf8PathBuf::from("/vendor")),
+                path: Utf8PathBuf::from("/vendor/app"),
+                kind: CandidateKind::NamespacePortion,
+            },
+        ]
+    );
+}
+
+#[test]
+fn resolve_module_detail_reports_not_found() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project").build(&db);
+
+    let detail = resolve_module_detail(&db, project, PythonModuleName::parse("missing").unwrap());
+
+    assert_eq!(detail.selected_root, None);
+    assert!(detail.candidates.is_empty());
+    assert_eq!(detail.unresolved_reason, Some(UnresolvedReason::NotFound));
+}
+
+#[test]
+fn resolve_package_dirs_returns_regular_package_dir() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/__init__.py", "")
+        .build(&db);
+
+    let dirs = resolve_package_dirs(&db, project, PythonModuleName::parse("app").unwrap());
+
+    assert_eq!(dirs.dirs, vec![Utf8PathBuf::from("/project/app")]);
+}
+
+#[test]
+fn resolve_package_dirs_merges_namespace_portions_in_root_order() {
+    let mut db = TestDatabase::new();
+    db.add_file("/project/app/views.py", "");
+    db.add_file("/vendor/app/models.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/vendor")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let dirs = resolve_package_dirs(&db, project, PythonModuleName::parse("app").unwrap());
+
+    assert_eq!(
+        dirs.dirs,
+        vec![
+            Utf8PathBuf::from("/project/app"),
+            Utf8PathBuf::from("/vendor/app"),
+        ]
+    );
+}
+
+#[test]
+fn resolve_package_dirs_returns_empty_for_file_module() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app.py", "")
+        .file("/project/app/templates/base.html", "")
+        .build(&db);
+
+    let dirs = resolve_package_dirs(&db, project, PythonModuleName::parse("app").unwrap());
+
+    assert!(dirs.dirs.is_empty());
+}
+
+#[test]
 fn module_name_from_init_file() {
     let path = Utf8Path::new("myapp/models/__init__.py");
     let module_name = PythonModuleName::from_relative_source_path(path).unwrap();
@@ -1015,7 +1210,7 @@ fn project_model_discovery_skips_registered_non_first_party_paths() {
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
         Utf8Path::new("/project"),
-        &Interpreter::InterpreterPath(Utf8PathBuf::from("/usr/bin/python")),
+        &Interpreter::Auto,
         &pythonpath,
     );
     search_paths.register_roots(&db);

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -101,6 +101,104 @@ fn django_template_settings(installed_apps: &[&str], builtins: &[&str]) -> Strin
 }
 
 #[test]
+fn search_paths_detect_top_level_src_after_project_root() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file("/project/src/app.py".into(), String::new());
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+            SearchPath::FirstParty(Utf8PathBuf::from("/project/src")),
+        ]
+    );
+}
+
+#[test]
+fn search_paths_do_not_detect_top_level_src_when_absent() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file("/project/app.py".into(), String::new());
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![SearchPath::FirstParty(Utf8PathBuf::from("/project"))]
+    );
+}
+
+#[test]
+fn search_paths_add_simple_pth_entries_as_editable_roots() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/django/__init__.py".into(),
+        String::new(),
+    );
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/editable_relative/pkg.py".into(),
+        String::new(),
+    );
+    fs.add_file("/editable_absolute/pkg.py".into(), String::new());
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/editable.pth".into(),
+        "# comment\n\nimport site\neditable_relative\n/editable_absolute\nmissing\n".to_string(),
+    );
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+            SearchPath::SitePackages(Utf8PathBuf::from(
+                "/project/.venv/lib/python3.12/site-packages"
+            )),
+            SearchPath::Editable(Utf8PathBuf::from(
+                "/project/.venv/lib/python3.12/site-packages/editable_relative"
+            )),
+            SearchPath::Editable(Utf8PathBuf::from("/editable_absolute")),
+        ]
+    );
+}
+
+#[test]
+fn search_paths_skip_pth_entries_that_duplicate_existing_roots() {
+    let mut fs = InMemoryFileSystem::new();
+    fs.add_file("/project/src/app.py".into(), String::new());
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/django/__init__.py".into(),
+        String::new(),
+    );
+    fs.add_file(
+        "/project/.venv/lib/python3.12/site-packages/editable.pth".into(),
+        "/project/src\n".to_string(),
+    );
+
+    let search_paths =
+        SearchPaths::from_project_settings(&fs, Utf8Path::new("/project"), &Interpreter::Auto, &[]);
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            SearchPath::FirstParty(Utf8PathBuf::from("/project")),
+            SearchPath::FirstParty(Utf8PathBuf::from("/project/src")),
+            SearchPath::SitePackages(Utf8PathBuf::from(
+                "/project/.venv/lib/python3.12/site-packages"
+            )),
+        ]
+    );
+}
+
+#[test]
 fn search_paths_keep_site_packages_external_inside_project_root() {
     let mut fs = InMemoryFileSystem::new();
     fs.add_file("/project/src/app/__init__.py".into(), String::new());


### PR DESCRIPTION
## Summary

The resolver facts slice (plan: python-foundation 002, Step 4; design memo `memo-resolved-module-shape.md`, accepted 2026-07-04; decision record `thoughts/shared/decisions/2026-05-17-static-project-model-python-resolver-strategy.md`). Stacked on #735.

Per the accepted memo, resolution splits into projections aligned with their consumers instead of one rich struct — identity stays small, richer facts live in sibling Salsa queries that fact extraction never reads:

- **Candidate walk** (private, non-tracked): walks roots in order collecting per-root candidates — `RegularPackage` / `FileModule` / `NamespacePortion`. Both identity and detail build on it; keeping it non-tracked is a memo invariant (a shared tracked scan would re-braid the dependency graphs the split exists to separate).
- **CPython precedence fix** in `PythonModule::resolve` (identity, signature unchanged): within a root, a regular package (`app/__init__.py`) now beats a sibling file module (`app.py`) — previous code checked `.py` first, diverging from CPython's `FileFinder`. Across roots, first regular hit wins (`sys.path` shadowing semantics). Namespace-only hits stay `None` for identity.
- **`resolve_module_detail`** (new tracked query): `ResolutionDetail { selected_root, candidates, unresolved_reason }` — every hit in root order including shadowed ones, `NotFound`/`NamespaceOnly` reasons. Diagnostic surface only; no fact-extraction code reads it. No confidence field: no first-slice consumer branches on one (memo §3e).
- **`resolve_package_dirs`** (new tracked query): regular package → its one dir; PEP-420 namespace portions merged across roots when no regular hit anywhere; file module → empty (a file module has no package dir). This is where installed-app dir scanning migrates in Step 7.
- **`Interpreter::InterpreterPath` deleted**: unreachable from user config (djls-conf only exposes `venv_path`) and mapped to no site-packages — dead surface flagged in #734.

## Salsa isolation, proven by event test

`module_detail_perturbations_do_not_recompute_settings_identity_consumers` (djls-db): with `unrelated.py` resolved from the project root, (1) adding a namespace dir `unrelated/` under a lower-priority root, then (2) adding a regular `unrelated.py` under that root, each re-execute `resolve_module_detail` — while `settings_module_file` and `django_settings` show **zero recomputation events** (identity value backdate-equal both times). This is the memo §6 falsifiability test: it fails if any identity consumer ever reads the detail query, directly or transitively.

## Tests

- Sibling collision fixture: `app.py` + `app/__init__.py` under one root → resolves to the package (pins the CPython-conformance flip).
- Cross-root: higher-priority root's regular hit wins; the shadowed duplicate still appears in detail candidates.
- Namespace-only → identity `None`, reason `NamespaceOnly`, dirs merged across roots in `resolve_package_dirs`; `NotFound` and file-module-empty-dirs cases covered.

## Not in this PR (later steps of the same plan)

`resolve_source_path` rework (Step 5), AppConfig prefix resolution replacing the `.apps.` string surgery (Step 6), consumer migration off `PythonPackage::resolve` + fixture projects (Step 7).

## Verification

- `cargo test -q` (full workspace) — green; zero corpus snapshot churn, no `.snap.new` artifacts.
- `just lint`, `just fmt --check`, `just clippy` — green.
- `just hawk` — reviewed: new public surface is the two queries + their return types (`ResolutionDetail`, `CandidateLocation`, `CandidateKind`, `UnresolvedReason`, `PackageDirs`) and `PythonModule::resolve` widening to `pub` (db-consuming precedence tests live in `tests/` per repo convention, which requires public linkage). One pre-existing unrelated finding (djls-testing `mdtest::Scenario::name`).
