### PR TITLE
Tighten lint suppressions and trim the public export surface

### DIFF
--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -26,7 +26,6 @@ pub use crate::tagspecs::ArgKindDef;
 pub use crate::tagspecs::ArgTypeDef;
 pub use crate::tagspecs::EndTagDef;
 pub use crate::tagspecs::IntermediateTagDef;
-pub use crate::tagspecs::PositionDef;
 pub use crate::tagspecs::TagArgDef;
 pub use crate::tagspecs::TagDef;
 pub use crate::tagspecs::TagLibraryDef;

--- a/crates/djls-conf/src/tagspecs.rs
+++ b/crates/djls-conf/src/tagspecs.rs
@@ -117,7 +117,7 @@ pub struct IntermediateTagDef {
 /// Intermediate tag positioning
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
-pub enum PositionDef {
+pub(crate) enum PositionDef {
     /// Can appear anywhere
     Any,
     /// Must be last before end tag

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -20,7 +20,6 @@ pub use discovery::django_discovery_phases;
 pub use models::ModelGraph;
 pub use models::ModelId;
 pub use models::compute_model_graph;
-pub use models::model_modules;
 pub use project::Project;
 pub use python::CandidateKind;
 pub use python::CandidateLocation;
@@ -96,7 +95,6 @@ pub mod testing {
     pub use crate::discovery::compute_django_discovery;
     pub use crate::models::extract_model_graph;
     pub use crate::models::model_modules;
-    pub use crate::templates::TemplateInventoryStatus;
 
     pub fn settings_module_file(
         db: &dyn super::Db,
@@ -137,7 +135,7 @@ pub mod testing {
     #[must_use]
     pub fn template_libraries(
         db: &dyn super::Db,
-        status: TemplateInventoryStatus,
+        status: super::TemplateInventoryStatus,
         inputs: Vec<TemplateLibraryInput>,
     ) -> super::TemplateLibraries {
         let libraries = inputs

--- a/crates/djls-project/src/templates/tags/analysis/expressions.rs
+++ b/crates/djls-project/src/templates/tags/analysis/expressions.rs
@@ -228,15 +228,20 @@ fn eval_pop_return(obj: &AbstractValue, args: &Arguments) -> AbstractValue {
 ///
 /// Positive indices use `TokenSplit::resolve_index` to account for front offset.
 /// Negative indices map directly to `SplitPosition::Backward`.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn i64_to_index_element(n: i64, split: &TokenSplit) -> AbstractValue {
     if n >= 0 {
+        let Ok(index) = usize::try_from(n) else {
+            return AbstractValue::Unknown;
+        };
         AbstractValue::SplitElement {
-            index: split.resolve_index(n as usize),
+            index: split.resolve_index(index),
         }
     } else {
+        let Ok(index) = usize::try_from(n.unsigned_abs()) else {
+            return AbstractValue::Unknown;
+        };
         AbstractValue::SplitElement {
-            index: SplitPosition::Backward(n.unsigned_abs() as usize),
+            index: SplitPosition::Backward(index),
         }
     }
 }
@@ -264,9 +269,11 @@ fn eval_subscript(base: &AbstractValue, slice: &Expr, env: &mut Env) -> Abstract
             }) = unary.operand.as_ref()
                 && let Some(n) = int_val.as_i64()
             {
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let Ok(index) = usize::try_from(n.unsigned_abs()) else {
+                    return AbstractValue::Unknown;
+                };
                 return AbstractValue::SplitElement {
-                    index: SplitPosition::Backward(n.unsigned_abs() as usize),
+                    index: SplitPosition::Backward(index),
                 };
             }
             AbstractValue::Unknown

--- a/crates/djls-source/src/lib.rs
+++ b/crates/djls-source/src/lib.rs
@@ -34,6 +34,5 @@ pub use position::Range;
 pub use position::Span;
 pub use protocol::PositionEncoding;
 pub use render::Diagnostic;
-pub use render::DiagnosticAnnotation;
 pub use render::DiagnosticRenderer;
 pub use render::Severity;

--- a/crates/djls-source/src/render.rs
+++ b/crates/djls-source/src/render.rs
@@ -23,7 +23,7 @@ pub enum Severity {
 /// The `primary` flag controls whether it gets `^^^` (primary) or `---` (context)
 /// underline treatment.
 #[derive(Debug, Clone)]
-pub struct DiagnosticAnnotation<'a> {
+pub(crate) struct DiagnosticAnnotation<'a> {
     span: Span,
     label: &'a str,
     primary: bool,

--- a/crates/djls-testing/src/mdtest.rs
+++ b/crates/djls-testing/src/mdtest.rs
@@ -20,7 +20,7 @@ const NO_DIAGNOSTICS_SNAPSHOT: &str = "✓ no diagnostics";
 
 #[derive(Debug)]
 pub struct Scenario {
-    pub name: String,
+    name: String,
     pub files: Vec<ScenarioFile>,
     primary_file_index: usize,
     snapshot: Option<String>,


### PR DESCRIPTION
## Summary

Follow-up cleanup from a lint-suppression and public-API audit of the resolver slice. Two suppressed lossy casts become checked conversions, and the export surface is trimmed so `pub` stops fooling dead-code analysis.

## Lint suppressions

- `templates/tags/analysis/expressions.rs`: both `allow(cast_possible_truncation, cast_sign_loss)` sites are gone. Signed Python-style indices now convert via `usize::try_from`, returning `AbstractValue::Unknown` on overflow instead of silently truncating. Negative-index semantics are unchanged.
- Everything else the audit flagged was verified against the ruff/ty reference and deliberately kept:
  - The `needless_pass_by_value` allows on salsa-tracked fns match ty exactly (`ty_python_semantic/src/types/overrides.rs` uses the identical `#[allow]` + `#[salsa::tracked]` + owned key pattern); tracked-query keys must be owned.
  - Workspace `missing_errors_doc = "allow"` matches ruff's workspace lint table verbatim.
  - `too_many_lines`/`similar_names` site allows are *stricter* than ruff, which allows both workspace-wide.

## Export surface

- `djls-testing`: `Scenario::name` demoted from `pub` to private — resolves the standing hawk finding; hawk is now at **zero findings**.
- `djls-project`: removed the dead root-level `model_modules` re-export (only the `testing::` façade export has users) and the unused `testing::TemplateInventoryStatus` re-export.
- `djls-conf`: `PositionDef` demoted to `pub(crate)` (only used internally by tagspec deserialization).
- `djls-source`: `DiagnosticAnnotation` demoted to `pub(crate)` (internal to the renderer).
- Verified-and-kept: `EndTagDef`/`IntermediateTagDef`/`TagArgDef` (public fields of exported tagspec types) and `SafeJoinError` (public error type of `safe_join`).

## Testing

- Full workspace `cargo test` green; no snapshot changes.
- `just clippy`, `just fmt --check`, `just lint` green.
- `just hawk`: 0 findings.
