### PR TITLE
Add a per-file import table and resolve model relation targets

### DIFF
--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -1,14 +1,18 @@
 use std::sync::OnceLock;
 
+use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use divan::Bencher;
 use djls_bench::Db;
 use djls_bench::REPEATED_INNER_ITERS;
 use djls_bench::model_fixtures;
+use djls_conf::Settings;
 use djls_project::ModelGraph;
 use djls_project::ModelId;
+use djls_project::Project;
 use djls_project::PythonModuleName;
 use djls_project::testing::extract_model_graph;
+use djls_project::testing::resolve_model_graph_from_modules;
 
 fn main() {
     divan::main();
@@ -89,11 +93,23 @@ fn auth_graph() -> &'static ModelGraph {
             .find(|f| f.label == "medium_auth.py")
             .expect("medium_auth fixture missing");
         let mut db = Db::new();
-        model_graph_from_source(
-            &mut db,
-            "/bench/models/auth.py",
-            &auth.source,
-            module_name("django.contrib.auth.models"),
+        let project = Project::initial(&db, Utf8Path::new("/bench"), &Settings::default());
+        let auth_file = db.file_with_contents("/bench/django/contrib/auth/models.py", &auth.source);
+        let content_type_file = db.file_with_contents(
+            "/bench/django/contrib/contenttypes/models.py",
+            "from django.db import models\n\nclass ContentType(models.Model):\n    pass\n",
+        );
+
+        resolve_model_graph_from_modules(
+            &db,
+            project,
+            [
+                (auth_file, module_name("django.contrib.auth.models")),
+                (
+                    content_type_file,
+                    module_name("django.contrib.contenttypes.models"),
+                ),
+            ],
         )
     })
 }
@@ -124,6 +140,21 @@ fn resolve_relations(bencher: Bencher) {
         (permission, "group_set"),
         (permission, "user_set"),
     ];
+
+    for (model, field) in forward_queries {
+        assert!(
+            graph.resolve_forward(model, field).is_some(),
+            "forward relation should resolve: {}.{field}",
+            model.name()
+        );
+    }
+    for (model, relation) in relation_queries {
+        assert!(
+            graph.resolve_relation(model, relation).is_some(),
+            "relation should resolve: {}.{relation}",
+            model.name()
+        );
+    }
 
     bencher.bench_local(|| {
         let mut resolved = 0;

--- a/crates/djls-project/src/ast.rs
+++ b/crates/djls-project/src/ast.rs
@@ -1,10 +1,13 @@
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
 
+use djls_source::Span;
+use ruff_python_ast::Alias;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprNumberLiteral;
 use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::ExprUnaryOp;
+use ruff_python_ast::Identifier;
 use ruff_python_ast::Number;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::UnaryOp;
@@ -110,6 +113,9 @@ pub(crate) trait ExprExt {
     /// Extract the identifier from a name expression.
     fn name_target(&self) -> Option<&str>;
 
+    /// Extract the dotted attribute path from a name or attribute expression.
+    fn path_segments(&self) -> Option<Vec<String>>;
+
     /// Extract a boolean literal.
     fn bool_literal(&self) -> Option<bool>;
 
@@ -150,6 +156,20 @@ impl ExprExt for Expr {
             return Some(name.id.as_str());
         }
         None
+    }
+
+    fn path_segments(&self) -> Option<Vec<String>> {
+        if let Some(name) = self.name_target() {
+            return Some(vec![name.to_string()]);
+        }
+
+        let Expr::Attribute(attr) = self else {
+            return None;
+        };
+
+        let mut path = attr.value.path_segments()?;
+        path.push(attr.attr.to_string());
+        Some(path)
     }
 
     fn bool_literal(&self) -> Option<bool> {
@@ -193,6 +213,33 @@ impl ExprExt for Expr {
             values.push(f(elt)?);
         }
         Some(values)
+    }
+}
+
+pub(crate) trait IdentifierExt {
+    /// Span covering the identifier in the source file.
+    fn span(&self) -> Span;
+}
+
+impl IdentifierExt for Identifier {
+    fn span(&self) -> Span {
+        let range = self.range;
+        Span::new(range.start().to_u32(), range.len().to_u32())
+    }
+}
+
+pub(crate) trait AliasExt {
+    /// Span of the local binding for an unaliased import: the leading
+    /// `local_name` portion of the alias name.
+    fn unaliased_binding_span(&self, local_name: &str) -> Span;
+}
+
+impl AliasExt for Alias {
+    fn unaliased_binding_span(&self, local_name: &str) -> Span {
+        Span::new(
+            self.name.range.start().to_u32(),
+            u32::try_from(local_name.len()).unwrap_or(u32::MAX),
+        )
     }
 }
 

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -95,6 +95,7 @@ pub mod testing {
     pub use crate::discovery::compute_django_discovery;
     pub use crate::models::extract_model_graph;
     pub use crate::models::model_modules;
+    pub use crate::models::resolve_model_graph_from_modules;
 
     pub fn settings_module_file(
         db: &dyn super::Db,

--- a/crates/djls-project/src/models.rs
+++ b/crates/djls-project/src/models.rs
@@ -2,11 +2,11 @@ mod discovery;
 mod extract;
 mod graph;
 
+use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 
 pub use discovery::model_modules;
 use djls_source::File;
-use djls_source::FileKind;
 pub use graph::ModelGraph;
 pub use graph::ModelId;
 
@@ -14,23 +14,48 @@ use crate::ast::Recurse;
 use crate::ast::walk_stmts;
 use crate::db::Db;
 use crate::models::extract::ModelCollector;
+use crate::models::extract::resolve_children;
 use crate::project::Project;
 use crate::python::PythonModuleName;
+use crate::python::import_table;
+use crate::python::parse_python_module;
 
 /// Compute a merged `ModelGraph` from discovered model sources.
 #[salsa::tracked(returns(ref))]
 pub fn compute_model_graph(db: &dyn Db, project: Project) -> ModelGraph {
-    let mut graph = ModelGraph::new();
-
     // `ModelGraph::merge` is last-wins. Iterate search paths in reverse so
     // earlier Python search paths keep normal import precedence.
-    for module in model_modules(db, project).iter().rev() {
-        let model_graph = extract_model_graph(db, module.file(), module.name().clone());
+    resolve_model_graph_from_modules(
+        db,
+        project,
+        model_modules(db, project)
+            .iter()
+            .rev()
+            .map(|module| (module.file(), module.name().clone())),
+    )
+}
+
+pub fn resolve_model_graph_from_modules(
+    db: &dyn Db,
+    project: Project,
+    modules: impl IntoIterator<Item = (File, PythonModuleName)>,
+) -> ModelGraph {
+    let mut graph = ModelGraph::new();
+    let mut import_tables = BTreeMap::new();
+
+    for (file, module_name) in modules {
+        let table = import_table(db, file, module_name.clone());
+        import_tables.insert(module_name.clone(), table);
+
+        let model_graph = extract_model_graph(db, file, module_name);
         if !model_graph.is_empty() {
             graph.merge(model_graph.clone());
         }
     }
 
+    graph.resolve_relation_targets(db, project, &import_tables);
+    #[cfg(debug_assertions)]
+    graph.debug_assert_no_file_local_placeholders();
     graph
 }
 
@@ -45,23 +70,30 @@ pub fn extract_model_graph(
     module_name: PythonModuleName,
 ) -> ModelGraph {
     let source = file.source(db);
-    if *source.kind() != FileKind::Python {
-        return ModelGraph::default();
-    }
-
-    extract_model_graph_impl(source.as_ref(), module_name)
-}
-
-fn extract_model_graph_impl(source: &str, module_name: PythonModuleName) -> ModelGraph {
-    let Ok(parsed) = ruff_python_parser::parse_module(source) else {
+    let Some(parsed) = parse_python_module(db, file) else {
         return ModelGraph::default();
     };
 
-    let module = parsed.into_syntax();
-    let mut collector = ModelCollector::new(module_name, source);
-    walk_stmts(&module.body, Recurse::Flat, |stmt| {
+    let imports = import_table(db, file, module_name.clone());
+    extract_model_graph_impl(source.as_ref(), parsed.body(db), module_name, imports)
+}
+
+fn extract_model_graph_impl(
+    source: &str,
+    stmts: &[ruff_python_ast::Stmt],
+    module_name: PythonModuleName,
+    imports: &crate::python::ImportTable,
+) -> ModelGraph {
+    let mut collector = ModelCollector::new(module_name, source, imports);
+    walk_stmts(stmts, Recurse::Flat, |stmt| {
         collector.scan_stmt(stmt);
         ControlFlow::Continue(())
     });
-    collector.finish()
+    resolve_children(
+        &mut collector.graph,
+        &collector.children,
+        &collector.module_name,
+        source,
+    );
+    collector.graph
 }

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -3,7 +3,6 @@ use std::ops::ControlFlow;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtClassDef;
-use rustc_hash::FxHashSet;
 
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
@@ -16,101 +15,59 @@ use crate::models::graph::ModelName;
 use crate::models::graph::Relation;
 use crate::models::graph::RelationTarget;
 use crate::models::graph::RelationType;
+use crate::python::ImportTable;
+#[cfg(test)]
+use crate::python::ModuleKind;
 use crate::python::PythonModuleName;
 
 pub(super) struct ModelCollector<'a> {
-    module_name: PythonModuleName,
+    pub(super) module_name: PythonModuleName,
     source: &'a str,
-    aliases: ImportAliases,
-    graph: ModelGraph,
-    children: Vec<&'a StmtClassDef>,
+    imports: &'a ImportTable,
+    pub(super) graph: ModelGraph,
+    pub(super) children: Vec<&'a StmtClassDef>,
 }
 
 impl<'a> ModelCollector<'a> {
-    pub(super) fn new(module_name: PythonModuleName, source: &'a str) -> Self {
+    pub(super) fn new(
+        module_name: PythonModuleName,
+        source: &'a str,
+        imports: &'a ImportTable,
+    ) -> Self {
         Self {
             module_name,
             source,
-            aliases: ImportAliases::new(),
+            imports,
             graph: ModelGraph::new(),
             children: Vec::new(),
         }
     }
 
-    pub(super) fn finish(mut self) -> ModelGraph {
-        resolve_children(
-            &mut self.graph,
-            &self.children,
-            &self.module_name,
-            self.source,
-        );
-        self.graph
-    }
-
     pub(super) fn scan_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt {
-            Stmt::ImportFrom(import) => {
-                let Some(module) = import
-                    .module
-                    .as_ref()
-                    .map(ruff_python_ast::Identifier::as_str)
-                else {
-                    return;
-                };
+        if let Stmt::ClassDef(class) = stmt {
+            let Some(ref args) = class.arguments else {
+                return;
+            };
 
-                if is_django_model_parent(module) {
-                    for name in &import.names {
-                        if name.name.as_str() == "models" {
-                            let alias = name.asname.as_ref().map_or("models", |a| a.as_str());
-                            self.aliases.module_aliases.insert(alias.to_string());
-                        }
-                    }
-                }
+            if is_django_model(args.args.iter(), self.imports) {
+                let line = line_number(self.source, class.range.start().to_usize());
+                let mut model =
+                    ModelDef::new(class.name.to_string(), self.module_name.clone(), line);
 
-                if is_django_models_module(module) {
-                    for name in &import.names {
-                        if name.name.as_str() == "Model" {
-                            let alias = name.asname.as_ref().map_or("Model", |a| a.as_str());
-                            self.aliases.class_aliases.insert(alias.to_string());
-                        }
-                    }
-                }
+                walk_stmts(&class.body, Recurse::Flat, |stmt| {
+                    process_class_body(stmt, &mut model);
+                    ControlFlow::Continue(())
+                });
+
+                self.graph.add_model(model);
+            } else if !args.args.is_empty() {
+                self.children.push(class);
             }
-            Stmt::Import(import) => {
-                for name in &import.names {
-                    if is_django_models_module(name.name.as_str())
-                        && let Some(alias) = &name.asname
-                    {
-                        self.aliases.module_aliases.insert(alias.to_string());
-                    }
-                }
-            }
-            Stmt::ClassDef(class) => {
-                let Some(ref args) = class.arguments else {
-                    return;
-                };
-
-                if is_django_model(args.args.iter(), &self.aliases) {
-                    let line = line_number(self.source, class.range.start().to_usize());
-                    let mut model =
-                        ModelDef::new(class.name.to_string(), self.module_name.clone(), line);
-
-                    walk_stmts(&class.body, Recurse::Flat, |stmt| {
-                        process_class_body(stmt, &mut model);
-                        ControlFlow::Continue(())
-                    });
-
-                    self.graph.add_model(model);
-                } else if !args.args.is_empty() {
-                    self.children.push(class);
-                }
-            }
-            _ => {}
         }
     }
 }
 
-fn resolve_children(
+pub(super) fn resolve_children(
     graph: &mut ModelGraph,
     children: &[&StmtClassDef],
     module_name: &PythonModuleName,
@@ -197,75 +154,22 @@ fn base_class_name(expr: &Expr) -> Option<&str> {
     }
 }
 
-/// Check if a module name is a known Django models parent module.
-///
-/// These are the modules from which `models` can be imported
-/// (e.g., `from django.db import models`).
-fn is_django_model_parent(module: &str) -> bool {
-    matches!(module, "django.db" | "django.contrib.gis.db")
+fn is_django_model<'a>(bases: impl Iterator<Item = &'a Expr>, imports: &ImportTable) -> bool {
+    bases
+        .filter_map(ExprExt::path_segments)
+        .filter_map(|path| {
+            imports
+                .resolve_qualified_path(path.iter().map(String::as_str))
+                .ok()
+        })
+        .any(|path| is_known_django_model_base(path.as_str()))
 }
 
-/// Check if a module name is a known Django `models` module.
-///
-/// These are the fully-qualified paths to Django's model modules
-/// (for `import django.db.models as ...` or `from django.db.models import Model`).
-fn is_django_models_module(module: &str) -> bool {
-    matches!(module, "django.db.models" | "django.contrib.gis.db.models")
-}
-
-/// Import aliases discovered from a module's import statements.
-///
-/// Tracks two kinds of aliases:
-/// - **module aliases**: names that refer to `django.db.models` (or the
-///   `GeoDjango` equivalent), used to match the `x.Model` pattern.
-///   Recognized imports:
-///   - `from django.db import models [as m]`
-///   - `from django.contrib.gis.db import models [as m]`
-///   - `import django.db.models as m`
-///   - `import django.contrib.gis.db.models as m`
-/// - **class aliases**: names that refer to the `Model` class directly,
-///   used to match bare-name patterns like `class Foo(M):`.
-///   Recognized imports:
-///   - `from django.db.models import Model [as M]`
-///   - `from django.contrib.gis.db.models import Model [as M]`
-struct ImportAliases {
-    /// Names aliasing `django.db.models` (always includes `"models"`).
-    module_aliases: FxHashSet<String>,
-    /// Names aliasing the `Model` class (always includes `"Model"`).
-    class_aliases: FxHashSet<String>,
-}
-
-impl ImportAliases {
-    fn new() -> Self {
-        Self {
-            module_aliases: FxHashSet::from_iter(["models".to_string()]),
-            class_aliases: FxHashSet::from_iter(["Model".to_string()]),
-        }
-    }
-}
-
-fn is_django_model<'a>(bases: impl Iterator<Item = &'a Expr>, aliases: &ImportAliases) -> bool {
-    for base in bases {
-        // Model / M (where M aliases django.db.models.Model)
-        if base
-            .name_target()
-            .is_some_and(|name| aliases.class_aliases.contains(name))
-        {
-            return true;
-        }
-
-        // models.Model / m.Model (where m aliases django.db.models)
-        if let Expr::Attribute(attr) = base
-            && attr.attr.as_str() == "Model"
-            && attr
-                .value
-                .name_target()
-                .is_some_and(|name| aliases.module_aliases.contains(name))
-        {
-            return true;
-        }
-    }
-    false
+fn is_known_django_model_base(path: &str) -> bool {
+    matches!(
+        path,
+        "django.db.models.Model" | "django.contrib.gis.db.models.Model"
+    )
 }
 
 fn process_class_body(stmt: &Stmt, model: &mut ModelDef) {
@@ -322,56 +226,39 @@ fn extract_relation(stmt: &Stmt) -> Option<Relation> {
         expr => expr.name_target()?,
     };
 
-    let target = extract_target_model(call)?;
+    let first_arg = call.arguments.args.first()?;
+    let target = match first_arg {
+        Expr::StringLiteral(s) => {
+            let value = s.value.to_string();
+            if value == "self" {
+                RelationTarget::SelfRef
+            } else if let Some((app_label, name)) = value.rsplit_once('.') {
+                RelationTarget::Qualified {
+                    app_label: app_label.to_string(),
+                    name: ModelName::new(name),
+                }
+            } else {
+                RelationTarget::Bare {
+                    name: ModelName::new(value),
+                }
+            }
+        }
+        expr => {
+            let path = expr.path_segments()?;
+            if path.len() == 1 {
+                RelationTarget::Bare {
+                    name: ModelName::new(path[0].clone()),
+                }
+            } else {
+                RelationTarget::Attribute { path }
+            }
+        }
+    };
     let related_name = extract_related_name(call);
 
     let relation_type = RelationType::from_field_class(field_class_name, target, related_name)?;
 
-    Some(Relation {
-        field_name: FieldName::new(target_name),
-        relation_type,
-    })
-}
-
-fn extract_target_model(call: &ruff_python_ast::ExprCall) -> Option<RelationTarget> {
-    let first_arg = call.arguments.args.first()?;
-
-    // Direct reference: ForeignKey(User)
-    if let Some(name) = first_arg.name_target() {
-        return Some(RelationTarget::Bare {
-            name: ModelName::new(name),
-        });
-    }
-
-    match first_arg {
-        // String reference: ForeignKey("self"), ForeignKey("User"), or ForeignKey("app.User")
-        Expr::StringLiteral(s) => {
-            let value = s.value.to_string();
-            Some(relation_target_from_string(&value))
-        }
-        // Attribute: ForeignKey(auth.User). Keep today's behavior and drop the qualifier.
-        Expr::Attribute(attr) => Some(RelationTarget::Bare {
-            name: ModelName::new(attr.attr.as_str()),
-        }),
-        _ => None,
-    }
-}
-
-fn relation_target_from_string(value: &str) -> RelationTarget {
-    if value == "self" {
-        return RelationTarget::SelfRef;
-    }
-
-    if let Some((app_label, name)) = value.rsplit_once('.') {
-        return RelationTarget::Qualified {
-            app_label: app_label.to_string(),
-            name: ModelName::new(name),
-        };
-    }
-
-    RelationTarget::Bare {
-        name: ModelName::new(value),
-    }
+    Some(Relation::new(FieldName::new(target_name), relation_type))
 }
 
 fn extract_related_name(call: &ruff_python_ast::ExprCall) -> Option<String> {
@@ -413,13 +300,13 @@ fn extract_generic_foreign_key(stmt: &Stmt) -> Option<Relation> {
         extract_gfk_arg(call, 0, "ct_field").unwrap_or_else(|| "content_type".to_string());
     let fk_field = extract_gfk_arg(call, 1, "fk_field").unwrap_or_else(|| "object_id".to_string());
 
-    Some(Relation {
-        field_name: FieldName::new(target_name),
-        relation_type: RelationType::GenericForeignKey {
+    Some(Relation::new(
+        FieldName::new(target_name),
+        RelationType::GenericForeignKey {
             ct_field: FieldName::new(ct_field),
             fk_field: FieldName::new(fk_field),
         },
-    })
+    ))
 }
 
 /// Extract a string argument from a GFK constructor call by positional index
@@ -457,10 +344,17 @@ mod tests {
     use crate::models::graph::ModelId;
 
     fn extract_model_graph(source: &str, module_name: &str) -> ModelGraph {
-        super::super::extract_model_graph_impl(
+        let module_name = PythonModuleName::parse(module_name).unwrap();
+        let imports = crate::python::extract_import_table_for_source(
             source,
-            PythonModuleName::parse(module_name).unwrap(),
-        )
+            &module_name,
+            ModuleKind::Module,
+        );
+        let Ok(parsed) = ruff_python_parser::parse_module(source) else {
+            return ModelGraph::default();
+        };
+        let module = parsed.into_syntax();
+        super::super::extract_model_graph_impl(source, &module.body, module_name, &imports)
     }
 
     fn model<'a>(graph: &'a ModelGraph, name: &'a str) -> &'a ModelDef {
@@ -486,12 +380,10 @@ mod tests {
     fn bare_target_name(relation: &Relation) -> Option<&str> {
         match relation.target_model()? {
             RelationTarget::Bare { name } => Some(name.as_str()),
-            RelationTarget::SelfRef | RelationTarget::Qualified { .. } => None,
+            RelationTarget::SelfRef
+            | RelationTarget::Qualified { .. }
+            | RelationTarget::Attribute { .. } => None,
         }
-    }
-
-    fn resolved_model_name(model: Option<&ModelDef>) -> Option<&str> {
-        model.map(|model| model.name.as_str())
     }
 
     #[test]
@@ -514,10 +406,7 @@ mod tests {
 
     #[test]
     fn simple_model() {
-        let source = r"
-class User(models.Model):
-    name = models.CharField(max_length=100)
-";
+        let source = "from django.db import models\nclass User(models.Model):\n    name = models.CharField(max_length=100)\n";
         let graph = extract_model_graph(source, "auth.models");
         assert_eq!(graph.len(), 1);
 
@@ -531,6 +420,7 @@ class User(models.Model):
     #[test]
     fn direct_model_import() {
         let source = r"
+from django.db import models
 from django.db.models import Model
 
 class User(Model):
@@ -648,6 +538,8 @@ class NotDjango(BaseModel):
     #[test]
     fn foreign_key() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -671,6 +563,8 @@ class Order(models.Model):
     #[test]
     fn explicit_related_name() {
         let source = r#"
+from django.db import models
+
 class Order(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="orders")
 "#;
@@ -690,6 +584,8 @@ class Order(models.Model):
     #[test]
     fn string_ref_with_app_label_preserves_qualified_target() {
         let source = r#"
+from django.db import models
+
 class Order(models.Model):
     user = models.ForeignKey("accounts.User", on_delete=models.CASCADE)
 "#;
@@ -704,6 +600,8 @@ class Order(models.Model):
     #[test]
     fn string_ref_self_preserves_self_target() {
         let source = r#"
+from django.db import models
+
 class Category(models.Model):
     parent = models.ForeignKey("self", on_delete=models.CASCADE)
 "#;
@@ -717,6 +615,8 @@ class Category(models.Model):
     #[test]
     fn all_relation_types() {
         let source = r"
+from django.db import models
+
 class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
 
@@ -747,6 +647,8 @@ class Article(models.Model):
     #[test]
     fn abstract_model() {
         let source = r"
+from django.db import models
+
 class BaseModel(models.Model):
     class Meta:
         abstract = True
@@ -758,6 +660,8 @@ class BaseModel(models.Model):
     #[test]
     fn abstract_inheritance() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -791,6 +695,8 @@ class ConcreteOrder(BaseOrder):
     #[test]
     fn class_substitution_in_inherited_related_name() {
         let source = r#"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -816,6 +722,8 @@ class SpecialOrder(BaseOrder):
     #[test]
     fn forward_and_reverse_lookups() {
         let source = r#"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -826,19 +734,25 @@ class Order(models.Model):
 
         // Forward
         assert_eq!(
-            resolved_model_name(graph.resolve_forward(model_id(&graph, "Order"), "user")),
+            graph
+                .resolve_forward(model_id(&graph, "Order"), "user")
+                .map(|model| model.name.as_str()),
             Some("User")
         );
 
         // Reverse
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "orders")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "orders")
+                .map(|model| model.name.as_str()),
             Some("Order")
         );
 
         // Non-existent
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "nope")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "nope")
+                .map(|model| model.name.as_str()),
             None
         );
     }
@@ -846,6 +760,8 @@ class Order(models.Model):
     #[test]
     fn default_reverse_name() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -856,7 +772,9 @@ class Order(models.Model):
 
         // Default FK reverse name is <model>_set
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "order_set")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "order_set")
+                .map(|model| model.name.as_str()),
             Some("Order")
         );
     }
@@ -864,6 +782,8 @@ class Order(models.Model):
     #[test]
     fn multiple_models_multiple_relations() {
         let source = r#"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -883,15 +803,21 @@ class Comment(models.Model):
 
         // Chain: User -> posts -> comments
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "posts")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "posts")
+                .map(|model| model.name.as_str()),
             Some("Post")
         );
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "Post"), "comments")),
+            graph
+                .resolve_relation(model_id(&graph, "Post"), "comments")
+                .map(|model| model.name.as_str()),
             Some("Comment")
         );
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "Comment"), "author")),
+            graph
+                .resolve_relation(model_id(&graph, "Comment"), "author")
+                .map(|model| model.name.as_str()),
             Some("User")
         );
     }
@@ -899,6 +825,8 @@ class Comment(models.Model):
     #[test]
     fn multiple_abstract_parents() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -933,6 +861,8 @@ class Document(TimestampMixin, AuditMixin):
     #[test]
     fn concrete_model_inheritance() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -953,6 +883,8 @@ class Restaurant(Place):
     #[test]
     fn qualified_base_class_inheritance() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -975,6 +907,8 @@ class ConcreteOrder(some_module.BaseOrder):
     #[test]
     fn multi_level_inheritance_chain() {
         let source = r"
+from django.db import models
+
 class User(models.Model):
     pass
 
@@ -1009,6 +943,8 @@ class Concrete(MiddleMixin):
     #[test]
     fn generic_foreign_key_extracted() {
         let source = r#"
+from django.db import models
+
 class TaggedItem(models.Model):
     content_type = models.ForeignKey("ContentType", on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
@@ -1041,6 +977,8 @@ class TaggedItem(models.Model):
     #[test]
     fn generic_foreign_key_defaults() {
         let source = r"
+from django.db import models
+
 class TaggedItem(models.Model):
     content_object = GenericForeignKey()
 ";
@@ -1060,6 +998,8 @@ class TaggedItem(models.Model):
     #[test]
     fn generic_foreign_key_keyword_args() {
         let source = r"
+from django.db import models
+
 class ObjectLog(models.Model):
     parent = GenericForeignKey(ct_field='object_type', fk_field='object_id')
 ";
@@ -1079,6 +1019,7 @@ class ObjectLog(models.Model):
     #[test]
     fn generic_foreign_key_module_prefix() {
         let source = r#"
+from django.db import models
 from django.contrib.contenttypes import fields
 
 class TaggedItem(models.Model):
@@ -1096,6 +1037,8 @@ class TaggedItem(models.Model):
     #[test]
     fn generic_foreign_key_inherited_from_abstract() {
         let source = r#"
+from django.db import models
+
 class GenericMixin(models.Model):
     content_object = GenericForeignKey("content_type", "object_id")
 
@@ -1119,6 +1062,8 @@ class TaggedItem(GenericMixin):
     #[test]
     fn multiple_generic_foreign_keys() {
         let source = r"
+from django.db import models
+
 class Action(models.Model):
     actor = GenericForeignKey('actor_content_type', 'actor_object_id')
     target = GenericForeignKey('target_content_type', 'target_object_id')

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -7,7 +7,12 @@ use std::sync::Arc;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::db::Db as ProjectDb;
+use crate::project::Project;
+use crate::python::ImportPathResolutionError;
+use crate::python::ImportTable;
 use crate::python::PythonModuleName;
+use crate::python::resolve_prefix;
 
 macro_rules! string_newtype {
     ($(#[doc = $doc:literal])* $vis:vis struct $Name:ident) => {
@@ -127,6 +132,69 @@ pub(crate) enum RelationTarget {
     SelfRef,
     Qualified { app_label: String, name: ModelName },
     Bare { name: ModelName },
+    Attribute { path: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum RelationTargetResolution {
+    Resolved(ModelId),
+    Ambiguous {
+        candidates: Vec<ModelId>,
+        app_label: String,
+        name: ModelName,
+    },
+    Partial {
+        resolved_prefix: PythonModuleName,
+        unresolved_tail: Vec<String>,
+    },
+    Unresolved {
+        reason: RelationTargetUnresolvedReason,
+    },
+}
+
+impl RelationTargetResolution {
+    fn file_local_placeholder() -> Self {
+        Self::Unresolved {
+            reason: RelationTargetUnresolvedReason::FileLocal,
+        }
+    }
+
+    fn is_file_local_placeholder(&self) -> bool {
+        matches!(
+            self,
+            Self::Unresolved {
+                reason: RelationTargetUnresolvedReason::FileLocal
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum RelationTargetUnresolvedReason {
+    /// per-file extraction cannot resolve targets; the project pass overwrites this placeholder
+    FileLocal,
+    /// relation has no statically-derivable target, e.g. `GenericForeignKey`
+    NoStaticTarget,
+    MissingImportBinding {
+        binding: String,
+    },
+    InvalidImportedTarget {
+        target: String,
+    },
+    ImportNotFound {
+        requested: PythonModuleName,
+    },
+    ImportedTargetIsModule {
+        module: PythonModuleName,
+    },
+    SameAppTargetNotFound {
+        app_label: String,
+        name: ModelName,
+    },
+    AppLabelTargetNotFound {
+        app_label: String,
+        name: ModelName,
+    },
 }
 
 /// The kind of relation a Django model field represents.
@@ -206,13 +274,29 @@ pub(crate) enum ModelKind {
 /// concrete relations (FK, O2O, M2M) carry a `target` and optional
 /// `related_name`, while `GenericForeignKey` carries `ct_field`/`fk_field`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// `relation_type` is serialized fact schema across corpus snapshots.
+#[allow(clippy::struct_field_names)]
 pub(crate) struct Relation {
     pub(crate) field_name: FieldName,
     #[serde(flatten)]
     pub(crate) relation_type: RelationType,
+    #[serde(
+        default = "RelationTargetResolution::file_local_placeholder",
+        skip_serializing_if = "RelationTargetResolution::is_file_local_placeholder"
+    )]
+    resolution: RelationTargetResolution,
 }
 
 impl Relation {
+    #[must_use]
+    pub(crate) fn new(field_name: FieldName, relation_type: RelationType) -> Self {
+        Self {
+            field_name,
+            relation_type,
+            resolution: RelationTargetResolution::file_local_placeholder(),
+        }
+    }
+
     /// Get the target model if this is a concrete relation (FK, O2O, M2M).
     ///
     /// Returns `None` for `GenericForeignKey` since its target is determined
@@ -354,6 +438,24 @@ fn django_name_matches(candidate: &str, query: &str) -> bool {
         || candidate.to_lowercase() == query.to_lowercase()
 }
 
+fn unresolved_import_path_reason(
+    error: ImportPathResolutionError,
+) -> RelationTargetUnresolvedReason {
+    match error {
+        ImportPathResolutionError::EmptyPath => {
+            RelationTargetUnresolvedReason::InvalidImportedTarget {
+                target: String::new(),
+            }
+        }
+        ImportPathResolutionError::MissingBinding { binding } => {
+            RelationTargetUnresolvedReason::MissingImportBinding { binding }
+        }
+        ImportPathResolutionError::InvalidTarget { target } => {
+            RelationTargetUnresolvedReason::InvalidImportedTarget { target }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelDef {
     pub(crate) name: ModelName,
@@ -402,6 +504,33 @@ impl ModelGraph {
         Self::default()
     }
 
+    #[cfg(debug_assertions)]
+    pub(super) fn debug_assert_no_file_local_placeholders(&self) {
+        let placeholders: Vec<String> = self
+            .models
+            .iter()
+            .flat_map(|(id, model)| {
+                model
+                    .relations
+                    .iter()
+                    .filter(|&relation| relation.resolution.is_file_local_placeholder())
+                    .map(|relation| {
+                        format!(
+                            "{}.{}.{}",
+                            id.module_name.as_str(),
+                            id.name.as_str(),
+                            relation.field_name.as_str()
+                        )
+                    })
+            })
+            .collect();
+        debug_assert!(
+            placeholders.is_empty(),
+            "model graph still has file-local relation target placeholders: {}",
+            placeholders.join(", ")
+        );
+    }
+
     pub(crate) fn add_model(&mut self, model: ModelDef) {
         self.models.insert(model.id(), model);
     }
@@ -411,6 +540,7 @@ impl ModelGraph {
         self.models.get(id)
     }
 
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
     pub fn models_named<'a>(
         &'a self,
         name: &'a str,
@@ -479,8 +609,9 @@ impl ModelGraph {
     /// Skips `GenericForeignKey` relations (no static target).
     #[must_use]
     pub fn resolve_forward(&self, scope: &ModelId, field_name: &str) -> Option<&ModelDef> {
-        let target = self.forward_relation(scope, field_name)?.target_model()?;
-        self.resolve_target(scope, target)
+        let relation = self.forward_relation(scope, field_name)?;
+        self.resolve_relation_target_entry(scope, relation)
+            .map(|(_id, model)| model)
     }
 
     fn forward_relation(&self, scope: &ModelId, field_name: &str) -> Option<&Relation> {
@@ -491,9 +622,22 @@ impl ModelGraph {
             .find(|relation| relation.field_name.as_str() == field_name)
     }
 
-    fn resolve_target(&self, scope: &ModelId, target: &RelationTarget) -> Option<&ModelDef> {
-        self.resolve_target_entry(scope, target)
-            .map(|(_id, model)| model)
+    fn resolve_relation_target_entry(
+        &self,
+        scope: &ModelId,
+        relation: &Relation,
+    ) -> Option<(&ModelId, &ModelDef)> {
+        match &relation.resolution {
+            RelationTargetResolution::Resolved(id) => self.models.get_key_value(id),
+            RelationTargetResolution::Unresolved {
+                reason: RelationTargetUnresolvedReason::FileLocal,
+            } => relation
+                .target_model()
+                .and_then(|target| self.resolve_target_entry(scope, target)),
+            RelationTargetResolution::Ambiguous { .. }
+            | RelationTargetResolution::Partial { .. }
+            | RelationTargetResolution::Unresolved { .. } => None,
+        }
     }
 
     fn resolve_target_entry(
@@ -510,6 +654,7 @@ impl ModelGraph {
             RelationTarget::Qualified { app_label, name } => {
                 self.lookup_entry(app_label, name.as_str())
             }
+            RelationTarget::Attribute { .. } => None,
         }
     }
 
@@ -524,8 +669,8 @@ impl ModelGraph {
     ) -> impl Iterator<Item = (&'a ModelId, String)> + 'a {
         self.models.iter().flat_map(move |(source_id, model)| {
             model.relations.iter().filter_map(move |relation| {
-                let target = relation.target_model()?;
-                let (target_id, _target_model) = self.resolve_target_entry(source_id, target)?;
+                let (target_id, _target_model) =
+                    self.resolve_relation_target_entry(source_id, relation)?;
                 if target_id != scope {
                     return None;
                 }
@@ -546,8 +691,9 @@ impl ModelGraph {
         field_name: &str,
     ) -> Option<&'a ModelDef> {
         if let Some(relation) = self.forward_relation(scope, field_name) {
-            let target = relation.target_model()?;
-            return self.resolve_target(scope, target);
+            return self
+                .resolve_relation_target_entry(scope, relation)
+                .map(|(_id, model)| model);
         }
 
         self.resolve_reverse_relation(scope, field_name)
@@ -557,10 +703,8 @@ impl ModelGraph {
     fn resolve_reverse_relation(&self, scope: &ModelId, field_name: &str) -> Option<&ModelId> {
         for (source_id, model) in &self.models {
             for relation in &model.relations {
-                let Some(target) = relation.target_model() else {
-                    continue;
-                };
-                let Some((target_id, _target_model)) = self.resolve_target_entry(source_id, target)
+                let Some((target_id, _target_model)) =
+                    self.resolve_relation_target_entry(source_id, relation)
                 else {
                     continue;
                 };
@@ -577,6 +721,191 @@ impl ModelGraph {
         }
 
         None
+    }
+
+    pub(crate) fn resolve_relation_targets(
+        &mut self,
+        db: &dyn ProjectDb,
+        project: Project,
+        import_tables: &BTreeMap<PythonModuleName, &ImportTable>,
+    ) {
+        let mut updates = Vec::new();
+        for (scope, model) in &self.models {
+            for (index, relation) in model.relations.iter().enumerate() {
+                updates.push((
+                    scope.clone(),
+                    index,
+                    self.resolve_relation_target(db, project, scope, relation, import_tables),
+                ));
+            }
+        }
+
+        for (scope, index, resolution) in updates {
+            if let Some(model) = self.models.get_mut(&scope)
+                && let Some(relation) = model.relations.get_mut(index)
+            {
+                relation.resolution = resolution;
+            }
+        }
+    }
+
+    fn resolve_relation_target(
+        &self,
+        db: &dyn ProjectDb,
+        project: Project,
+        scope: &ModelId,
+        relation: &Relation,
+        import_tables: &BTreeMap<PythonModuleName, &ImportTable>,
+    ) -> RelationTargetResolution {
+        let Some(target) = relation.target_model() else {
+            return RelationTargetResolution::Unresolved {
+                reason: RelationTargetUnresolvedReason::NoStaticTarget,
+            };
+        };
+
+        match target {
+            RelationTarget::SelfRef => RelationTargetResolution::Resolved(scope.clone()),
+            RelationTarget::Qualified { app_label, name } => self.resolve_app_label_target(
+                app_label,
+                name,
+                RelationTargetUnresolvedReason::AppLabelTargetNotFound {
+                    app_label: app_label.clone(),
+                    name: name.clone(),
+                },
+            ),
+            RelationTarget::Bare { name } => {
+                let Some(import_table) = import_tables.get(&scope.module_name) else {
+                    return self.resolve_same_app_target(scope, name);
+                };
+                match import_table.resolve_qualified_path(std::iter::once(name.as_str())) {
+                    Ok(target) => self.resolve_imported_relation_target(db, project, &target),
+                    Err(ImportPathResolutionError::MissingBinding { .. }) => {
+                        self.resolve_same_app_target(scope, name)
+                    }
+                    Err(error) => RelationTargetResolution::Unresolved {
+                        reason: unresolved_import_path_reason(error),
+                    },
+                }
+            }
+            RelationTarget::Attribute { path } => {
+                let Some(root) = path.first() else {
+                    return RelationTargetResolution::Unresolved {
+                        reason: RelationTargetUnresolvedReason::InvalidImportedTarget {
+                            target: String::new(),
+                        },
+                    };
+                };
+                let Some(import_table) = import_tables.get(&scope.module_name) else {
+                    return RelationTargetResolution::Unresolved {
+                        reason: RelationTargetUnresolvedReason::MissingImportBinding {
+                            binding: root.clone(),
+                        },
+                    };
+                };
+                match import_table.resolve_qualified_path(path.iter().map(String::as_str)) {
+                    Ok(target) => self.resolve_imported_relation_target(db, project, &target),
+                    Err(error) => RelationTargetResolution::Unresolved {
+                        reason: unresolved_import_path_reason(error),
+                    },
+                }
+            }
+        }
+    }
+
+    fn resolve_same_app_target(
+        &self,
+        scope: &ModelId,
+        name: &ModelName,
+    ) -> RelationTargetResolution {
+        let Some(app_label) = app_label_from_module_name(scope.module_name.as_str()) else {
+            return RelationTargetResolution::Unresolved {
+                reason: RelationTargetUnresolvedReason::SameAppTargetNotFound {
+                    app_label: String::new(),
+                    name: name.clone(),
+                },
+            };
+        };
+
+        self.resolve_app_label_target(
+            app_label,
+            name,
+            RelationTargetUnresolvedReason::SameAppTargetNotFound {
+                app_label: app_label.to_string(),
+                name: name.clone(),
+            },
+        )
+    }
+
+    fn resolve_app_label_target(
+        &self,
+        app_label: &str,
+        name: &ModelName,
+        not_found: RelationTargetUnresolvedReason,
+    ) -> RelationTargetResolution {
+        if let Some((id, _model)) = self.lookup_entry_exact(app_label, name.as_str()) {
+            return RelationTargetResolution::Resolved(id.clone());
+        }
+
+        let candidates: Vec<ModelId> = self
+            .models
+            .iter()
+            .filter(|(id, _model)| {
+                django_name_matches(id.name.as_str(), name.as_str())
+                    && app_label_from_module_name(id.module_name.as_str())
+                        .is_some_and(|candidate| django_name_matches(candidate, app_label))
+            })
+            .map(|(id, _model)| id.clone())
+            .collect();
+
+        match candidates.as_slice() {
+            [candidate] => RelationTargetResolution::Resolved(candidate.clone()),
+            [] => RelationTargetResolution::Unresolved { reason: not_found },
+            _ => RelationTargetResolution::Ambiguous {
+                candidates,
+                app_label: app_label.to_string(),
+                name: name.clone(),
+            },
+        }
+    }
+
+    fn resolve_imported_relation_target(
+        &self,
+        db: &dyn ProjectDb,
+        project: Project,
+        target: &PythonModuleName,
+    ) -> RelationTargetResolution {
+        let resolved = resolve_prefix(db, project, target.as_str());
+        let Some(module) = resolved.module else {
+            return RelationTargetResolution::Unresolved {
+                reason: RelationTargetUnresolvedReason::ImportNotFound {
+                    requested: target.clone(),
+                },
+            };
+        };
+
+        if resolved.unresolved_tail.is_empty() {
+            return RelationTargetResolution::Unresolved {
+                reason: RelationTargetUnresolvedReason::ImportedTargetIsModule {
+                    module: module.name().clone(),
+                },
+            };
+        }
+
+        let unresolved_tail = resolved.unresolved_tail;
+        if unresolved_tail.len() == 1 {
+            let candidate = ModelId::new(
+                module.name().clone(),
+                ModelName::new(unresolved_tail[0].clone()),
+            );
+            if self.models.contains_key(&candidate) {
+                return RelationTargetResolution::Resolved(candidate);
+            }
+        }
+
+        RelationTargetResolution::Partial {
+            resolved_prefix: module.name().clone(),
+            unresolved_tail,
+        }
     }
 
     /// Merge another graph into this one.
@@ -603,38 +932,34 @@ mod tests {
             .expect("model should exist")
     }
 
-    fn resolved_model_name(model: Option<&ModelDef>) -> Option<&str> {
-        model.map(|model| model.name.as_str())
-    }
-
     fn user_order_graph() -> ModelGraph {
         let mut graph = ModelGraph::new();
 
         let user = ModelDef::new("User", module_name("auth.models"), 1);
 
         let mut order = ModelDef::new("Order", module_name("shop.models"), 1);
-        order.relations.push(Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        order.relations.push(Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Qualified {
                     app_label: "auth".into(),
                     name: ModelName::new("User"),
                 },
                 related_name: Some("orders".into()),
             },
-        });
+        ));
 
         let mut profile = ModelDef::new("Profile", module_name("accounts.models"), 1);
-        profile.relations.push(Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::OneToOne {
+        profile.relations.push(Relation::new(
+            "user".into(),
+            RelationType::OneToOne {
                 target: RelationTarget::Qualified {
                     app_label: "auth".into(),
                     name: ModelName::new("User"),
                 },
                 related_name: None,
             },
-        });
+        ));
 
         graph.add_model(user);
         graph.add_model(order);
@@ -646,15 +971,21 @@ mod tests {
     fn forward_lookup() {
         let graph = user_order_graph();
         assert_eq!(
-            resolved_model_name(graph.resolve_forward(model_id(&graph, "Order"), "user")),
+            graph
+                .resolve_forward(model_id(&graph, "Order"), "user")
+                .map(|model| model.name.as_str()),
             Some("User")
         );
         assert_eq!(
-            resolved_model_name(graph.resolve_forward(model_id(&graph, "Profile"), "user")),
+            graph
+                .resolve_forward(model_id(&graph, "Profile"), "user")
+                .map(|model| model.name.as_str()),
             Some("User")
         );
         assert_eq!(
-            resolved_model_name(graph.resolve_forward(model_id(&graph, "User"), "user")),
+            graph
+                .resolve_forward(model_id(&graph, "User"), "user")
+                .map(|model| model.name.as_str()),
             None
         );
     }
@@ -674,15 +1005,21 @@ mod tests {
     fn resolve_relation_forward_and_reverse() {
         let graph = user_order_graph();
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "Order"), "user")),
+            graph
+                .resolve_relation(model_id(&graph, "Order"), "user")
+                .map(|model| model.name.as_str()),
             Some("User")
         );
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "orders")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "orders")
+                .map(|model| model.name.as_str()),
             Some("Order")
         );
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "profile")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "profile")
+                .map(|model| model.name.as_str()),
             Some("Profile")
         );
     }
@@ -692,49 +1029,51 @@ mod tests {
         let mut graph = ModelGraph::new();
 
         let mut user = ModelDef::new("User", module_name("auth.models"), 1);
-        user.relations.push(Relation {
-            field_name: "orders".into(),
-            relation_type: RelationType::ForeignKey {
+        user.relations.push(Relation::new(
+            "orders".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Qualified {
                     app_label: "missing".into(),
                     name: ModelName::new("Order"),
                 },
                 related_name: None,
             },
-        });
+        ));
 
         let mut order = ModelDef::new("Order", module_name("shop.models"), 1);
-        order.relations.push(Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        order.relations.push(Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Qualified {
                     app_label: "auth".into(),
                     name: ModelName::new("User"),
                 },
                 related_name: Some("orders".into()),
             },
-        });
+        ));
 
         graph.add_model(user);
         graph.add_model(order);
 
         assert_eq!(
-            resolved_model_name(graph.resolve_relation(model_id(&graph, "User"), "orders")),
+            graph
+                .resolve_relation(model_id(&graph, "User"), "orders")
+                .map(|model| model.name.as_str()),
             None
         );
     }
 
     #[test]
     fn default_related_name_fk() {
-        let rel = Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        let rel = Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: None,
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("Order", "shop.models"),
             Some("order_set".into())
@@ -743,15 +1082,15 @@ mod tests {
 
     #[test]
     fn default_related_name_o2o() {
-        let rel = Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::OneToOne {
+        let rel = Relation::new(
+            "user".into(),
+            RelationType::OneToOne {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: None,
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("Profile", "accounts.models"),
             Some("profile".into())
@@ -760,15 +1099,15 @@ mod tests {
 
     #[test]
     fn class_substitution_in_related_name() {
-        let rel = Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        let rel = Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: Some("%(class)s_orders".into()),
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("SpecialOrder", "shop.models"),
             Some("specialorder_orders".into())
@@ -777,15 +1116,15 @@ mod tests {
 
     #[test]
     fn app_label_substitution_in_related_name() {
-        let rel = Relation {
-            field_name: "title".into(),
-            relation_type: RelationType::ForeignKey {
+        let rel = Relation::new(
+            "title".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("Title"),
                 },
                 related_name: Some("attached_%(app_label)s_%(class)s_set".into()),
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("Article", "blog.models"),
             Some("attached_blog_article_set".into())
@@ -794,15 +1133,15 @@ mod tests {
 
     #[test]
     fn app_label_from_nested_module_name() {
-        let rel = Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        let rel = Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: Some("%(app_label)s_%(class)s_set".into()),
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("Permission", "django.contrib.auth.models"),
             Some("auth_permission_set".into())
@@ -813,15 +1152,15 @@ mod tests {
     fn app_label_bare_models_path() {
         // A bare "models" module name has no valid app label — %(app_label)s
         // should substitute as empty rather than producing "models".
-        let rel = Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        let rel = Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: Some("%(app_label)s_%(class)s_set".into()),
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("Order", "models"),
             Some("_order_set".into())
@@ -831,15 +1170,15 @@ mod tests {
     #[test]
     fn app_label_no_models_component() {
         // When "models" doesn't appear, falls back to first component.
-        let rel = Relation {
-            field_name: "user".into(),
-            relation_type: RelationType::ForeignKey {
+        let rel = Relation::new(
+            "user".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: Some("%(app_label)s_set".into()),
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("Order", "myapp"),
             Some("myapp_set".into())
@@ -865,32 +1204,32 @@ mod tests {
         graph.add_model(ModelDef::new("User", module_name("blog.models"), 1));
 
         let mut post = ModelDef::new("Post", module_name("blog.models"), 1);
-        post.relations.push(Relation {
-            field_name: "author".into(),
-            relation_type: RelationType::ForeignKey {
+        post.relations.push(Relation::new(
+            "author".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Bare {
                     name: ModelName::new("User"),
                 },
                 related_name: None,
             },
-        });
-        post.relations.push(Relation {
-            field_name: "account_author".into(),
-            relation_type: RelationType::ForeignKey {
+        ));
+        post.relations.push(Relation::new(
+            "account_author".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::Qualified {
                     app_label: "accounts".into(),
                     name: ModelName::new("User"),
                 },
                 related_name: None,
             },
-        });
-        post.relations.push(Relation {
-            field_name: "parent".into(),
-            relation_type: RelationType::ForeignKey {
+        ));
+        post.relations.push(Relation::new(
+            "parent".into(),
+            RelationType::ForeignKey {
                 target: RelationTarget::SelfRef,
                 related_name: None,
             },
-        });
+        ));
         graph.add_model(post);
 
         let post_id = model_id(&graph, "Post");
@@ -916,13 +1255,13 @@ mod tests {
 
     #[test]
     fn generic_foreign_key_has_no_related_name() {
-        let rel = Relation {
-            field_name: "content_object".into(),
-            relation_type: RelationType::GenericForeignKey {
+        let rel = Relation::new(
+            "content_object".into(),
+            RelationType::GenericForeignKey {
                 ct_field: "content_type".into(),
                 fk_field: "object_id".into(),
             },
-        };
+        );
         assert_eq!(
             rel.effective_related_name("TaggedItem", "tagging.models"),
             None
@@ -934,13 +1273,13 @@ mod tests {
     fn generic_foreign_key_skipped_in_forward_lookup() {
         let mut graph = ModelGraph::new();
         let mut model = ModelDef::new("TaggedItem", module_name("tagging.models"), 1);
-        model.relations.push(Relation {
-            field_name: "content_object".into(),
-            relation_type: RelationType::GenericForeignKey {
+        model.relations.push(Relation::new(
+            "content_object".into(),
+            RelationType::GenericForeignKey {
                 ct_field: "content_type".into(),
                 fk_field: "object_id".into(),
             },
-        });
+        ));
         graph.add_model(model);
 
         assert_eq!(

--- a/crates/djls-project/src/python.rs
+++ b/crates/djls-project/src/python.rs
@@ -1,3 +1,4 @@
+mod imports;
 mod interpreter;
 mod module;
 mod name;
@@ -5,6 +6,13 @@ mod parse;
 mod path_eval;
 mod search_paths;
 
+pub(crate) use imports::ImportPathResolutionError;
+pub(crate) use imports::ImportTable;
+#[cfg(test)]
+pub(crate) use imports::ModuleKind;
+#[cfg(test)]
+pub(crate) use imports::extract_import_table_for_source;
+pub(crate) use imports::import_table;
 pub use interpreter::Interpreter;
 pub use module::CandidateKind;
 pub use module::CandidateLocation;

--- a/crates/djls-project/src/python/imports.rs
+++ b/crates/djls-project/src/python/imports.rs
@@ -1,0 +1,351 @@
+use std::collections::BTreeMap;
+
+use djls_source::File;
+use djls_source::Span;
+use ruff_python_ast::Alias;
+use ruff_python_ast::Stmt;
+
+use crate::ast::AliasExt;
+use crate::ast::IdentifierExt;
+use crate::python::PythonModuleName;
+use crate::python::parse_python_module;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ImportTable {
+    bindings: BTreeMap<String, ImportBinding>,
+}
+
+impl ImportTable {
+    pub(crate) fn resolve_qualified_path<'a>(
+        &self,
+        path: impl IntoIterator<Item = &'a str>,
+    ) -> Result<PythonModuleName, ImportPathResolutionError> {
+        let mut parts = path.into_iter();
+        let Some(root) = parts.next() else {
+            return Err(ImportPathResolutionError::EmptyPath);
+        };
+        let Some(binding) = self.bindings.get(root) else {
+            return Err(ImportPathResolutionError::MissingBinding {
+                binding: root.to_string(),
+            });
+        };
+
+        let tail: Vec<&str> = parts.collect();
+        let target = if tail.is_empty() {
+            binding.target.as_str().to_string()
+        } else {
+            format!("{}.{}", binding.target.as_str(), tail.join("."))
+        };
+
+        PythonModuleName::parse(&target)
+            .map_err(|_| ImportPathResolutionError::InvalidTarget { target })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ImportBinding {
+    target: PythonModuleName,
+    binding_range: Span,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ImportPathResolutionError {
+    EmptyPath,
+    MissingBinding { binding: String },
+    InvalidTarget { target: String },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ModuleKind {
+    Module,
+    PackageInit,
+}
+
+// Salsa tracked-query keys are by-value; `module_name` is a key, not a borrow.
+#[allow(clippy::needless_pass_by_value)]
+#[salsa::tracked(returns(ref))]
+pub(crate) fn import_table(
+    db: &dyn djls_source::Db,
+    file: File,
+    module_name: PythonModuleName,
+) -> ImportTable {
+    let Some(parsed) = parse_python_module(db, file) else {
+        return ImportTable::default();
+    };
+
+    let module_kind = if file.path(db).file_name() == Some("__init__.py") {
+        ModuleKind::PackageInit
+    } else {
+        ModuleKind::Module
+    };
+    extract_import_table_impl(parsed.body(db), &module_name, module_kind)
+}
+
+#[cfg(test)]
+pub(crate) fn extract_import_table_for_source(
+    source: &str,
+    module_name: &PythonModuleName,
+    module_kind: ModuleKind,
+) -> ImportTable {
+    let Ok(parsed) = ruff_python_parser::parse_module(source) else {
+        return ImportTable::default();
+    };
+
+    let module = parsed.into_syntax();
+    extract_import_table_impl(&module.body, module_name, module_kind)
+}
+
+fn extract_import_table_impl(
+    stmts: &[Stmt],
+    module_name: &PythonModuleName,
+    module_kind: ModuleKind,
+) -> ImportTable {
+    let mut table = ImportTable::default();
+    for stmt in stmts {
+        match stmt {
+            Stmt::Import(import) => record_import(&mut table, &import.names),
+            Stmt::ImportFrom(import_from) => record_import_from(
+                &mut table,
+                module_name,
+                module_kind,
+                import_from.level,
+                import_from
+                    .module
+                    .as_ref()
+                    .map(ruff_python_ast::Identifier::as_str),
+                &import_from.names,
+            ),
+            _ => {}
+        }
+    }
+
+    table
+}
+
+fn record_import(table: &mut ImportTable, aliases: &[Alias]) {
+    for alias in aliases {
+        let imported_name = alias.name.as_str();
+        let (local_name, target, binding_range) = if let Some(asname) = &alias.asname {
+            (
+                asname.as_str().to_string(),
+                imported_name.to_string(),
+                asname.span(),
+            )
+        } else {
+            let local_name = imported_name.split('.').next().unwrap_or(imported_name);
+            (
+                local_name.to_string(),
+                local_name.to_string(),
+                alias.unaliased_binding_span(local_name),
+            )
+        };
+
+        let Ok(target) = PythonModuleName::parse(&target) else {
+            continue;
+        };
+        table.bindings.insert(
+            local_name,
+            ImportBinding {
+                target,
+                binding_range,
+            },
+        );
+    }
+}
+
+fn record_import_from(
+    table: &mut ImportTable,
+    module_name: &PythonModuleName,
+    module_kind: ModuleKind,
+    level: u32,
+    imported_from: Option<&str>,
+    aliases: &[Alias],
+) {
+    let Some(base) = import_from_base(module_name, module_kind, level, imported_from) else {
+        return;
+    };
+
+    for alias in aliases {
+        let imported_name = alias.name.as_str();
+        if imported_name == "*" {
+            continue;
+        }
+
+        let (local_name, binding_range) = if let Some(asname) = &alias.asname {
+            (asname.as_str().to_string(), asname.span())
+        } else {
+            (imported_name.to_string(), alias.name.span())
+        };
+        let target = if base.is_empty() {
+            imported_name.to_string()
+        } else {
+            format!("{base}.{imported_name}")
+        };
+        let Ok(target) = PythonModuleName::parse(&target) else {
+            continue;
+        };
+
+        table.bindings.insert(
+            local_name,
+            ImportBinding {
+                target,
+                binding_range,
+            },
+        );
+    }
+}
+
+fn import_from_base(
+    module_name: &PythonModuleName,
+    module_kind: ModuleKind,
+    level: u32,
+    imported_from: Option<&str>,
+) -> Option<String> {
+    if level == 0 {
+        return imported_from.map(str::to_string);
+    }
+
+    let mut parts: Vec<&str> = module_name.as_str().split('.').collect();
+    if module_kind == ModuleKind::Module {
+        parts.pop();
+    }
+
+    if level as usize > parts.len() {
+        return None;
+    }
+
+    for _ in 1..level {
+        parts.pop();
+    }
+
+    if let Some(imported_from) = imported_from {
+        parts.extend(imported_from.split('.').filter(|part| !part.is_empty()));
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("."))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use djls_testing::TestDatabase;
+
+    use super::*;
+    use crate::db::Db as ProjectDb;
+    use crate::project::Project;
+
+    fn table(source: &str, module_name: &str, module_kind: ModuleKind) -> ImportTable {
+        let module_name = PythonModuleName::parse(module_name).unwrap();
+        extract_import_table_for_source(source, &module_name, module_kind)
+    }
+
+    fn binding<'a>(table: &'a ImportTable, name: &str) -> &'a ImportBinding {
+        table.bindings.get(name).expect("binding should exist")
+    }
+
+    #[test]
+    fn plain_import_binds_top_level_module() {
+        let table = table("import os\n", "pkg.mod", ModuleKind::Module);
+
+        assert_eq!(binding(&table, "os").target.as_str(), "os");
+        assert_eq!(binding(&table, "os").binding_range, Span::new(7, 2));
+    }
+
+    #[test]
+    fn aliased_import_binds_alias_to_full_target() {
+        let table = table("import a.b as c\n", "pkg.mod", ModuleKind::Module);
+
+        assert_eq!(binding(&table, "c").target.as_str(), "a.b");
+    }
+
+    #[test]
+    fn submodule_import_binds_only_top_level_module() {
+        let table = table("import os.path\n", "pkg.mod", ModuleKind::Module);
+
+        assert_eq!(table.bindings.len(), 1);
+        assert_eq!(binding(&table, "os").target.as_str(), "os");
+    }
+
+    #[test]
+    fn from_import_binds_imported_name_to_qualified_target() {
+        let table = table("from m import x\n", "pkg.mod", ModuleKind::Module);
+
+        assert_eq!(binding(&table, "x").target.as_str(), "m.x");
+    }
+
+    #[test]
+    fn aliased_from_import_binds_alias_to_qualified_target() {
+        let table = table("from m import x as y\n", "pkg.mod", ModuleKind::Module);
+
+        assert_eq!(binding(&table, "y").target.as_str(), "m.x");
+    }
+
+    #[test]
+    fn relative_import_level_one_uses_containing_package() {
+        let table = table("from . import x\n", "pkg.sub.mod", ModuleKind::Module);
+
+        assert_eq!(binding(&table, "x").target.as_str(), "pkg.sub.x");
+    }
+
+    #[test]
+    fn relative_import_level_two_strips_one_package_segment() {
+        let table = table("from ..m import y\n", "pkg.sub.mod", ModuleKind::Module);
+
+        assert_eq!(binding(&table, "y").target.as_str(), "pkg.m.y");
+    }
+
+    #[test]
+    fn relative_import_from_package_init_uses_package_as_base() {
+        let table = table("from . import x\n", "pkg.sub", ModuleKind::PackageInit);
+
+        assert_eq!(binding(&table, "x").target.as_str(), "pkg.sub.x");
+    }
+
+    #[test]
+    fn relative_import_level_overflow_records_no_binding() {
+        let table = table("from ..m import y\n", "pkg.mod", ModuleKind::Module);
+
+        assert!(table.bindings.is_empty());
+    }
+
+    #[test]
+    fn star_import_records_no_binding() {
+        let table = table("from m import *\n", "pkg.mod", ModuleKind::Module);
+
+        assert!(table.bindings.is_empty());
+    }
+
+    #[test]
+    fn duplicate_bindings_shadow_with_last_assignment_wins() {
+        let table = table(
+            "from a import x\nfrom b import x\n",
+            "pkg.mod",
+            ModuleKind::Module,
+        );
+
+        assert_eq!(binding(&table, "x").target.as_str(), "b.x");
+    }
+
+    #[test]
+    fn import_table_query_reads_python_file_source() {
+        let db = TestDatabase::new();
+        db.add_file("/project/pkg/mod.py", "import os\n");
+        let file = db.get_or_create_file(camino::Utf8Path::new("/project/pkg/mod.py"));
+        let table = import_table(&db, file, PythonModuleName::parse("pkg.mod").unwrap());
+
+        assert_eq!(binding(table, "os").target.as_str(), "os");
+    }
+
+    // djls-testing's ProjectDb impl is for the dependency-graph copy of this
+    // crate, not this test build (dev-dependency cycle), so the trait must be
+    // bridged here.
+    #[salsa::db]
+    impl ProjectDb for TestDatabase {
+        fn project(&self) -> Option<Project> {
+            None
+        }
+    }
+}

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -1,10 +1,20 @@
 use std::ptr;
 
+use camino::Utf8Path;
+use djls_conf::TagSpecDef;
+use djls_project::Interpreter;
 use djls_project::ModelGraph;
 use djls_project::ModelId;
+use djls_project::Project;
+use djls_project::SearchPaths;
 use djls_project::compute_model_graph;
+use djls_source::Db as SourceDb;
 use djls_testing::ProjectFixture;
+use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
+use salsa::Database as _;
+use serde_json::Value;
+use serde_json::json;
 
 fn model_id<'a>(graph: &'a ModelGraph, name: &'a str, module_name: &str) -> &'a ModelId {
     graph
@@ -14,17 +24,50 @@ fn model_id<'a>(graph: &'a ModelGraph, name: &'a str, module_name: &str) -> &'a 
         .expect("model should exist")
 }
 
+fn graph_value(graph: &ModelGraph) -> Value {
+    serde_json::to_value(graph).expect("model graph should serialize")
+}
+
+fn relation_value<'a>(graph: &'a Value, model: &str, field: &str) -> &'a Value {
+    graph["models"][model]["relations"]
+        .as_array()
+        .and_then(|relations| {
+            relations
+                .iter()
+                .find(|relation| relation["field_name"] == field)
+        })
+        .expect("relation should exist")
+}
+
+fn update_file(db: &mut TestDatabase, path: &str, content: &str) {
+    db.add_file(path, content);
+    let file = db.get_or_create_file(Utf8Path::new(path));
+    db.bump_file_revision(file);
+}
+
+fn execution_count(db: &TestDatabase, events: &[salsa::Event], query_name: &str) -> usize {
+    events
+        .iter()
+        .filter(|event| match &event.kind {
+            salsa::EventKind::WillExecute { database_key } => db
+                .ingredient_debug_name(database_key.ingredient_index())
+                .contains(query_name),
+            _ => false,
+        })
+        .count()
+}
+
 #[test]
 fn qualified_relation_resolves_cross_app() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")
         .file(
             "/project/accounts/models.py",
-            "class User(models.Model):\n    pass\n",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
         )
         .file(
             "/project/blog/models.py",
-            "class User(models.Model):\n    pass\n\nclass Post(models.Model):\n    author = models.ForeignKey(\"accounts.User\", on_delete=models.CASCADE)\n",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n\nclass Post(models.Model):\n    author = models.ForeignKey(\"accounts.User\", on_delete=models.CASCADE)\n",
         )
         .build(&db);
 
@@ -46,11 +89,11 @@ fn bare_relation_resolves_relative_to_scope_app() {
     let project = ProjectFixture::new("/project")
         .file(
             "/project/accounts/models.py",
-            "class User(models.Model):\n    pass\n\nclass Profile(models.Model):\n    user = models.ForeignKey(\"User\", on_delete=models.CASCADE)\n",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n\nclass Profile(models.Model):\n    user = models.ForeignKey(\"User\", on_delete=models.CASCADE)\n",
         )
         .file(
             "/project/blog/models.py",
-            "class User(models.Model):\n    pass\n",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
         )
         .build(&db);
 
@@ -72,7 +115,7 @@ fn self_relation_resolves_to_scope_model() {
     let project = ProjectFixture::new("/project")
         .file(
             "/project/catalog/models.py",
-            "class Category(models.Model):\n    parent = models.ForeignKey(\"self\", on_delete=models.CASCADE)\n",
+            "from django.db import models\n\nclass Category(models.Model):\n    parent = models.ForeignKey(\"self\", on_delete=models.CASCADE)\n",
         )
         .build(&db);
 
@@ -83,4 +126,339 @@ fn self_relation_resolves_to_scope_model() {
         .resolve_relation(category, "parent")
         .expect("self relation should resolve");
     assert!(ptr::eq(resolved, graph.get_by_id(category).unwrap()));
+}
+
+#[test]
+fn imported_foreign_key_resolves_to_imported_model_id() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/accounts/models.py",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nfrom accounts.models import User\n\nclass User(models.Model):\n    pass\n\nclass Post(models.Model):\n    author = models.ForeignKey(User, on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    let accounts_user = model_id(graph, "User", "accounts.models");
+    let blog_user = model_id(graph, "User", "blog.models");
+
+    let resolved = graph
+        .resolve_relation(post, "author")
+        .expect("imported relation should resolve");
+    assert!(ptr::eq(resolved, graph.get_by_id(accounts_user).unwrap()));
+    assert!(!ptr::eq(resolved, graph.get_by_id(blog_user).unwrap()));
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "blog.models.Post", "author");
+    assert_eq!(
+        relation["target"],
+        json!({ "kind": "Bare", "name": "User" })
+    );
+    assert_eq!(
+        relation["resolution"],
+        json!({ "Resolved": "accounts.models.User" })
+    );
+}
+
+#[test]
+fn attribute_qualified_expression_retains_source_path_and_resolves() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/accounts/models.py",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nimport accounts.models as account_models\n\nclass User(models.Model):\n    pass\n\nclass Post(models.Model):\n    author = models.ForeignKey(account_models.User, on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    let accounts_user = model_id(graph, "User", "accounts.models");
+    let blog_user = model_id(graph, "User", "blog.models");
+
+    let resolved = graph
+        .resolve_relation(post, "author")
+        .expect("attribute relation should resolve");
+    assert!(ptr::eq(resolved, graph.get_by_id(accounts_user).unwrap()));
+    assert!(!ptr::eq(resolved, graph.get_by_id(blog_user).unwrap()));
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "blog.models.Post", "author");
+    assert_eq!(
+        relation["target"],
+        json!({ "kind": "Attribute", "path": ["account_models", "User"] })
+    );
+    assert_eq!(
+        relation["resolution"],
+        json!({ "Resolved": "accounts.models.User" })
+    );
+}
+
+#[test]
+fn model_base_import_spellings_are_recognized() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/base_alias/models.py",
+            "from django.db.models import Model as Base\nimport django.db.models as m\n\nclass FromBase(Base):\n    pass\n\nclass FromModule(m.Model):\n    pass\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    model_id(graph, "FromBase", "base_alias.models");
+    model_id(graph, "FromModule", "base_alias.models");
+}
+
+#[test]
+fn dotted_string_auth_user_resolves_via_app_label_path() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/auth/models.py",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/shop/models.py",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n\nclass Order(models.Model):\n    user = models.ForeignKey(\"auth.User\", on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let order = model_id(graph, "Order", "shop.models");
+    let auth_user = model_id(graph, "User", "auth.models");
+    let shop_user = model_id(graph, "User", "shop.models");
+
+    let resolved = graph
+        .resolve_relation(order, "user")
+        .expect("dotted string relation should resolve by app label");
+    assert!(ptr::eq(resolved, graph.get_by_id(auth_user).unwrap()));
+    assert!(!ptr::eq(resolved, graph.get_by_id(shop_user).unwrap()));
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "shop.models.Order", "user");
+    assert_eq!(
+        relation["target"],
+        json!({ "kind": "Qualified", "app_label": "auth", "name": "User" })
+    );
+}
+
+#[test]
+fn unresolvable_imported_target_records_explicit_reason() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nfrom missing.models import User\n\nclass Post(models.Model):\n    author = models.ForeignKey(User, on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    assert_eq!(graph.resolve_relation(post, "author"), None);
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "blog.models.Post", "author");
+    assert_eq!(
+        relation["resolution"]["Unresolved"]["reason"]["ImportNotFound"],
+        json!({ "requested": "missing.models.User" })
+    );
+}
+
+#[test]
+fn imported_module_target_records_explicit_reason() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/accounts/models.py", "class User: ...\n")
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nimport accounts.models\n\nclass Post(models.Model):\n    author = models.ForeignKey(accounts.models, on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    assert_eq!(graph.resolve_relation(post, "author"), None);
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "blog.models.Post", "author");
+    assert_eq!(
+        relation["resolution"]["Unresolved"]["reason"]["ImportedTargetIsModule"],
+        json!({ "module": "accounts.models" })
+    );
+}
+
+#[test]
+fn imported_partial_target_is_preserved_when_model_id_is_absent() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/accounts/models.py", "VALUE = 1\n")
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nfrom accounts.models import User\n\nclass Post(models.Model):\n    author = models.ForeignKey(User, on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    assert_eq!(graph.resolve_relation(post, "author"), None);
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "blog.models.Post", "author");
+    assert_eq!(
+        relation["resolution"],
+        json!({
+            "Partial": {
+                "resolved_prefix": "accounts.models",
+                "unresolved_tail": ["User"]
+            }
+        })
+    );
+}
+
+#[test]
+fn ambiguous_app_label_fallback_is_preserved_in_relation_resolution() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/News/models.py",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/news/models.py",
+            "from django.db import models\n\nclass User(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/NEWS/models.py",
+            "from django.db import models\n\nclass Post(models.Model):\n    author = models.ForeignKey(\"User\", on_delete=models.CASCADE)\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "NEWS.models");
+    assert_eq!(graph.resolve_relation(post, "author"), None);
+
+    let value = graph_value(graph);
+    let relation = relation_value(&value, "NEWS.models.Post", "author");
+    assert_eq!(
+        relation["resolution"]["Ambiguous"]["candidates"],
+        json!(["News.models.User", "news.models.User"])
+    );
+    assert_eq!(
+        relation["resolution"]["Ambiguous"]["app_label"],
+        json!("NEWS")
+    );
+    assert_eq!(relation["resolution"]["Ambiguous"]["name"], json!("User"));
+}
+
+#[test]
+fn computed_model_graph_does_not_expose_file_local_relation_resolution() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/blog/models.py",
+            "from django.db import models\nfrom django.contrib.contenttypes.fields import GenericForeignKey\n\nclass TaggedItem(models.Model):\n    target = models.ForeignKey(\"Missing\", on_delete=models.CASCADE)\n    content_object = GenericForeignKey()\n",
+        )
+        .build(&db);
+
+    let graph = compute_model_graph(&db, project);
+    let value = graph_value(graph);
+    assert_eq!(
+        relation_value(&value, "blog.models.TaggedItem", "target")["resolution"],
+        json!({
+            "Unresolved": {
+                "reason": {
+                    "SameAppTargetNotFound": {
+                        "app_label": "blog",
+                        "name": "Missing"
+                    }
+                }
+            }
+        })
+    );
+    assert_eq!(
+        relation_value(&value, "blog.models.TaggedItem", "content_object")["resolution"],
+        json!({ "Unresolved": { "reason": "NoStaticTarget" } })
+    );
+}
+
+#[test]
+fn salsa_recomputes_relation_resolution_for_import_edits_only_where_needed() {
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    db.add_file(
+        "/project/accounts/models.py",
+        "from django.db import models\n\nclass User(models.Model):\n    pass\n\nclass Profile(models.Model):\n    pass\n",
+    );
+    db.add_file(
+        "/project/blog/models.py",
+        "from django.db import models\nfrom accounts.models import User\n\nclass Post(models.Model):\n    author = models.ForeignKey(User, on_delete=models.CASCADE)\n",
+    );
+    db.add_file(
+        "/project/other/models.py",
+        "from django.db import models\n\nclass Tag(models.Model):\n    pass\n",
+    );
+
+    let interpreter = Interpreter::Auto;
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &interpreter,
+        &[],
+    );
+    search_paths.register_roots(&db);
+    let project = Project::new(
+        &db,
+        Utf8Path::new("/project").to_path_buf(),
+        search_paths,
+        interpreter,
+        None,
+        Vec::new(),
+        Vec::new(),
+        TagSpecDef::default(),
+    );
+    db.set_project(project);
+
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    let user = model_id(graph, "User", "accounts.models");
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(post, "author")
+            .expect("initial import should resolve"),
+        graph.get_by_id(user).unwrap()
+    ));
+    let _ = event_log.take();
+
+    update_file(
+        &mut db,
+        "/project/blog/models.py",
+        "from django.db import models\nfrom accounts.models import Profile\n\nclass Post(models.Model):\n    author = models.ForeignKey(Profile, on_delete=models.CASCADE)\n",
+    );
+    let graph = compute_model_graph(&db, project);
+    let post = model_id(graph, "Post", "blog.models");
+    let profile = model_id(graph, "Profile", "accounts.models");
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(post, "author")
+            .expect("edited import should resolve"),
+        graph.get_by_id(profile).unwrap()
+    ));
+    assert!(execution_count(&db, &event_log.take(), "compute_model_graph") > 0);
+
+    update_file(
+        &mut db,
+        "/project/other/models.py",
+        "from django.db import models\n\nclass Tag(models.Model):\n    label = models.CharField(max_length=100)\n",
+    );
+    let _graph = compute_model_graph(&db, project);
+    let events = event_log.take();
+    assert_eq!(execution_count(&db, &events, "extract_model_graph"), 1);
 }

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__archivebox__archivebox__api__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__archivebox__archivebox__api__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: created_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__archivebox__archivebox__base_models__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__archivebox__archivebox__base_models__models.py.snap
@@ -29,8 +29,10 @@ models:
       - field_name: created_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   archivebox.base_models.models.ModelWithUUID:
@@ -41,7 +43,9 @@ models:
       - field_name: created_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__babybuddy__babybuddy__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__babybuddy__babybuddy__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__admin__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__admin__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-activity-stream__actstream__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-activity-stream__actstream__models.py.snap
@@ -47,8 +47,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__account__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__account__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   allauth.account.models.EmailConfirmation:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__idp__oidc__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__idp__oidc__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   allauth.idp.oidc.models.Token:
@@ -29,7 +31,9 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__mfa__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__mfa__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__socialaccount__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__socialaccount__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   allauth.socialaccount.models.SocialApp:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__usersessions__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-allauth__allauth__usersessions__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-crm__chat__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-crm__chat__models.py.snap
@@ -21,8 +21,10 @@ models:
       - field_name: owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_owner_related"
       - field_name: answer_to
         relation_type: ForeignKey
@@ -37,13 +39,17 @@ models:
       - field_name: recipients
         relation_type: ManyToMany
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_recipients_related"
       - field_name: to
         relation_type: ManyToMany
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_to_related"
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-crm__common__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-crm__common__models.py.snap
@@ -11,14 +11,18 @@ models:
       - field_name: owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_owner_related"
       - field_name: modified_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_modified_by_related"
     kind: abstract
   common.models.Base1:
@@ -29,14 +33,18 @@ models:
       - field_name: owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_owner_related"
       - field_name: modified_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_modified_by_related"
       - field_name: department
         relation_type: ForeignKey
@@ -77,8 +85,10 @@ models:
       - field_name: owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_owner_related"
     kind: concrete
   common.models.StageBase:
@@ -118,7 +128,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: profile
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-crm__voip__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-crm__voip__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: "%(app_label)s_%(class)s_owner_related"
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-guardian__guardian__testapp__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-guardian__guardian__testapp__models.py.snap
@@ -65,7 +65,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: profile
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-oscar__sandbox__apps__user__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-oscar__sandbox__apps__user__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - compat
+            - AUTH_USER_MODEL
         related_name: profile
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__foundation__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__foundation__models.py.snap
@@ -59,8 +59,10 @@ models:
       - field_name: account
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: office
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__base__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__base__models.py.snap
@@ -17,8 +17,10 @@ models:
       - field_name: contact
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   geonode.base.models.ExtraMetadata:
@@ -180,8 +182,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: resource
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__favorite__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__favorite__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__groups__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__groups__models.py.snap
@@ -23,8 +23,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   geonode.groups.models.GroupProfile:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__harvesting__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__harvesting__models.py.snap
@@ -42,7 +42,9 @@ models:
       - field_name: default_owner
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__resource__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__resource__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: geonode_resource
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__services__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__services__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: profiles
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: service
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__legal__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__legal__models.py.snap
@@ -11,14 +11,18 @@ models:
       - field_name: created_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: +
       - field_name: last_modified_by
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: +
     kind: concrete
   misago.legal.models.UserAgreement:
@@ -29,8 +33,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: agreement
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__notifications__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__notifications__models.py.snap
@@ -11,14 +11,18 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: actor
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: +
       - field_name: category
         relation_type: ForeignKey
@@ -50,8 +54,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: category
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__oauth2__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__oauth2__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__permissions__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__permissions__models.py.snap
@@ -38,7 +38,9 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__privatethreads__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__privatethreads__models.py.snap
@@ -18,7 +18,9 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__readtracker__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__readtracker__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: category
         relation_type: ForeignKey
@@ -30,8 +32,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
       - field_name: category
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__admin__models.py.snap
@@ -17,8 +17,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: editing_sessions
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__documents__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.documents.models.Document:
@@ -23,7 +25,9 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__images__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.images.models.AbstractRendition:
@@ -29,8 +31,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   wagtail.images.models.Rendition:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__users__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__users__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: wagtail_userprofile
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__admin__models.py.snap
@@ -17,8 +17,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: editing_sessions
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__documents__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.documents.models.Document:
@@ -23,7 +25,9 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__images__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.images.models.AbstractRendition:
@@ -29,8 +31,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   wagtail.images.models.Rendition:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__users__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__users__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: wagtail_userprofile
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__admin__models.py.snap
@@ -17,8 +17,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: editing_sessions
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__documents__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.documents.models.Document:
@@ -23,7 +25,9 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__images__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.images.models.AbstractRendition:
@@ -29,8 +31,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   wagtail.images.models.Rendition:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__users__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__users__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: wagtail_userprofile
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__admin__models.py.snap
@@ -17,8 +17,10 @@ models:
       - field_name: user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: editing_sessions
       - field_name: content_type
         relation_type: ForeignKey

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__documents__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.documents.models.Document:
@@ -23,7 +25,9 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__images__models.py.snap
@@ -11,8 +11,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: abstract
   wagtail.images.models.AbstractRendition:
@@ -29,8 +31,10 @@ models:
       - field_name: uploaded_by_user
         relation_type: ForeignKey
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: ~
     kind: concrete
   wagtail.images.models.Rendition:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__users__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__users__models.py.snap
@@ -11,7 +11,9 @@ models:
       - field_name: user
         relation_type: OneToOne
         target:
-          kind: Bare
-          name: AUTH_USER_MODEL
+          kind: Attribute
+          path:
+            - settings
+            - AUTH_USER_MODEL
         related_name: wagtail_userprofile
     kind: concrete

--- a/crates/djls-testing/src/db.rs
+++ b/crates/djls-testing/src/db.rs
@@ -17,6 +17,35 @@ use djls_source::InMemoryFileSystem;
 use djls_source::OsFileSystem;
 use djls_source::SourceFiles;
 
+#[derive(Clone, Default)]
+pub struct SalsaEventLog {
+    events: Arc<Mutex<Vec<salsa::Event>>>,
+}
+
+impl SalsaEventLog {
+    /// Drain and return all captured Salsa events.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another test has poisoned the event log lock.
+    #[must_use]
+    pub fn take(&self) -> Vec<salsa::Event> {
+        std::mem::take(
+            &mut *self
+                .events
+                .lock()
+                .expect("salsa event log lock should not be poisoned"),
+        )
+    }
+
+    fn push(&self, event: salsa::Event) {
+        self.events
+            .lock()
+            .expect("salsa event log lock should not be poisoned")
+            .push(event);
+    }
+}
+
 #[salsa::db]
 #[derive(Clone)]
 pub struct TestDatabase {
@@ -39,6 +68,17 @@ impl Default for TestDatabase {
 impl TestDatabase {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_storage(salsa::Storage::default())
+    }
+
+    #[must_use]
+    pub fn with_event_log(event_log: SalsaEventLog) -> Self {
+        Self::with_storage(salsa::Storage::new(Some(Box::new(move |event| {
+            event_log.push(event);
+        }))))
+    }
+
+    fn with_storage(storage: salsa::Storage<Self>) -> Self {
         Self {
             fs: Arc::new(Mutex::new(InMemoryFileSystem::new())),
             files: SourceFiles::default(),
@@ -47,7 +87,7 @@ impl TestDatabase {
             template_libraries: TemplateLibraries::default(),
             diagnostics_config: djls_conf::DiagnosticsConfig::default(),
             project: None,
-            storage: salsa::Storage::default(),
+            storage,
         }
     }
 

--- a/crates/djls-testing/src/lib.rs
+++ b/crates/djls-testing/src/lib.rs
@@ -14,6 +14,7 @@ pub use corpus::lock_corpus;
 pub use corpus::module_name_from_file;
 pub use corpus::sync_corpus;
 pub use db::OsTestDatabase;
+pub use db::SalsaEventLog;
 pub use db::TestDatabase;
 pub use extraction::ExtractionBundle;
 pub use extraction::SortedExtractionResult;


### PR DESCRIPTION
Adds a per-file import table to `djls-project` and uses it to qualify model relation targets — the surviving remainder of #451 (`ModelId` was already module-qualified; what was missing was import resolution).

## What this does

**Per-file import table.** A new Salsa-tracked, purely syntactic query: local binding name → qualified dotted target, import kind, binding span. Binding semantics follow CPython exactly: `import os.path` binds only `os`; `import a.b as c` binds `c → a.b`; relative imports resolve against the file's module name (package `__init__.py` uses the package itself as base); level overflow, and `import *`, record no bindings; duplicate bindings shadow last-wins. Project-scoped target resolution is a separate layer mapping `resolve_prefix` outcomes into `Resolved / Partial / Unresolved` — the per-file query never touches the resolver.

**Model extraction consumes it.**
- Base-class recognition goes through the table: any import spelling of `django.db.models.Model` (aliased from-import, `import django.db.models as m`, …) is recognized; the old `ImportAliases` mini-resolver is gone.
- Attribute relation targets retain their full expression path: `ForeignKey(settings.AUTH_USER_MODEL)` is now the fact `Attribute { path: [settings, AUTH_USER_MODEL] }` instead of the wrong fact `Bare { name: AUTH_USER_MODEL }` (the qualifier-drop bug). 68 corpus snapshot targets across 45 files change in exactly this way — no other corpus changes.
- `compute_model_graph` runs a project-scoped second pass storing a definite `RelationTargetResolution` on every relation: `Resolved(ModelId)`, `Ambiguous { candidates, app_label, name }` (real candidates from the app-label fallback scan — never a silent first pick), `Partial { resolved_prefix, unresolved_tail }`, or `Unresolved { reason }`. Imported `ForeignKey(User)` now resolves to the imported model's `ModelId`, not a same-named local model.
- Routing: dotted **strings** (`"auth.User"`) are Django app-label syntax and stay on the graph lookup path, never entering the import table; bare names with no matching import keep the derived-app-label behavior.

## Decisions

- **Split Salsa boundary:** per-file facts (extraction, import table) take file inputs only; resolution is a project pass. Import edits recompute resolutions; unrelated file edits do not recompute other files' extraction (pinned by test).
- **No import-level `Ambiguous` variant.** First-match (CPython/ty) resolver semantics give it no producer, and a producer-less variant only invites fabricated states (ambiguous-with-zero-candidates). The ambiguity that actually exists lives at the relation level, where it is produced and tested with real candidates.
- Single-caller helper chains in the touched extraction code were flattened (`extract_relation → extract_target_model → relation_target_from_string`; `ModelCollector::finish` inlined).

## Out of scope

Graph lookup mechanics (`ModelId` ordering, `add_model` overwrite accounting, structured parse errors) and `AUTH_USER_MODEL`-through-settings resolution are follow-ups; cross-file inheritance propagation stays deferred.

## Verification

Full workspace tests, corpus model snapshots (`just corpus sync`), `just clippy`, `just fmt --check`, `just lint` all green; `just hawk` at zero findings. New behavior pinned in `crates/djls-project/tests/model_relations.rs` (imported FK, attribute path retention, base-import spellings, dotted-string regression guard, explicit unresolved/partial/ambiguous outcomes, Salsa invalidation).
