### PR TITLE
Distinguish unparseable sources from empty extraction results

### DIFF
--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -1180,10 +1180,10 @@ def my_filter(value, arg):
         // Should extract the filter
         let key = djls_project::SymbolKey::filter("test.project.tags", "my_filter");
         assert!(
-            result.contains_key(&key),
+            result.arities().contains_key(&key),
             "should extract filter from file content"
         );
-        assert!(result[&key].expects_arg);
+        assert!(result.arities()[&key].expects_arg);
 
         let other_module_result = djls_project::extract_filter_arities(
             &db,
@@ -1191,8 +1191,8 @@ def my_filter(value, arg):
             djls_project::PythonModuleName::parse("other.project.tags").unwrap(),
         );
         let other_key = djls_project::SymbolKey::filter("other.project.tags", "my_filter");
-        assert!(other_module_result.contains_key(&other_key));
-        assert!(!other_module_result.contains_key(&key));
+        assert!(other_module_result.arities().contains_key(&other_key));
+        assert!(!other_module_result.arities().contains_key(&key));
     }
 
     fn settings_with_custom_library(module_name: &str) -> String {

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 mod ast;
 mod db;
 mod discovery;
@@ -52,6 +54,7 @@ pub use templates::ExtractedDiagnosticMessage;
 pub use templates::ExtractedMessageArg;
 pub use templates::ExtractedMessageTemplate;
 pub use templates::FilterArity;
+pub use templates::FilterArityExtraction;
 pub use templates::FilterArityMap;
 pub use templates::FindTemplateResult;
 pub use templates::InvalidTemplateIdentifier;
@@ -87,6 +90,14 @@ pub use templates::resolve_relative_name;
 pub use templates::template_libraries;
 pub use templates::template_resolution;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ExtractionStatus {
+    Complete,
+    Partial,
+    Unparseable,
+}
+
 // Test and benchmark support only; not part of the stable Project Facts façade.
 #[doc(hidden)]
 pub mod testing {
@@ -104,6 +115,22 @@ pub mod testing {
         module_name: super::PythonModuleName,
     ) -> &super::ModelGraph {
         crate::models::extract_models(db, file, module_name).graph()
+    }
+
+    pub fn model_status(
+        db: &dyn djls_source::Db,
+        file: djls_source::File,
+        module_name: super::PythonModuleName,
+    ) -> impl serde::Serialize {
+        crate::models::extract_models(db, file, module_name).status()
+    }
+
+    pub fn filter_arity_status(
+        db: &dyn djls_source::Db,
+        file: djls_source::File,
+        module_name: super::PythonModuleName,
+    ) -> impl serde::Serialize {
+        crate::templates::extract_filter_arities(db, file, module_name).status()
     }
 
     #[must_use]

--- a/crates/djls-project/src/models.rs
+++ b/crates/djls-project/src/models.rs
@@ -72,7 +72,7 @@ pub fn extract_models(
     module_name: PythonModuleName,
 ) -> ModelExtraction {
     let Some(parsed) = parse_python_module(db, file) else {
-        return ModelExtraction::default();
+        return ModelExtraction::unparseable();
     };
 
     let imports = import_table(db, file, module_name.clone());

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -9,6 +9,7 @@ use ruff_python_ast::Expr;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtClassDef;
 
+use crate::ExtractionStatus;
 use crate::ast::ExprExt;
 use crate::ast::RangedExt;
 use crate::ast::Recurse;
@@ -26,16 +27,30 @@ use crate::python::ImportTable;
 use crate::python::ModuleKind;
 use crate::python::PythonModuleName;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ModelExtraction {
     pub(super) graph: ModelGraph,
     pub(super) deferred: Vec<DeferredModel>,
+    status: ExtractionStatus,
 }
 
 impl ModelExtraction {
+    pub(crate) fn unparseable() -> Self {
+        Self {
+            graph: ModelGraph::new(),
+            deferred: Vec::new(),
+            status: ExtractionStatus::Unparseable,
+        }
+    }
+
     #[must_use]
     pub(crate) fn graph(&self) -> &ModelGraph {
         &self.graph
+    }
+
+    #[must_use]
+    pub(crate) fn status(&self) -> ExtractionStatus {
+        self.status
     }
 }
 
@@ -225,6 +240,8 @@ pub(super) fn extract_models_impl(
     ModelExtraction {
         graph: collector.graph,
         deferred,
+        // Model extraction skips unsupported bases and dynamic constructs in v1.
+        status: ExtractionStatus::Partial,
     }
 }
 

--- a/crates/djls-project/src/settings/extraction.rs
+++ b/crates/djls-project/src/settings/extraction.rs
@@ -24,6 +24,7 @@ use rustc_hash::FxHashSet;
 use crate::settings::extraction::bindings::SettingsBindings;
 use crate::settings::extraction::traversal::SettingsBindingsCollector;
 use crate::settings::types::DjangoSettings;
+use crate::settings::types::SettingsParseStatus;
 use crate::settings::types::SettingsSource;
 use crate::settings::types::SettingsSourceResolver;
 
@@ -37,9 +38,11 @@ pub(crate) fn extract_settings(
     module_path: &Utf8Path,
     resolver: &mut dyn SettingsSourceResolver,
 ) -> DjangoSettings {
-    SettingsExtraction::default()
-        .extract_module(source, module_path, resolver)
-        .to_settings()
+    let mut extraction = SettingsExtraction::default();
+    let (bindings, parse_status) = extraction.extract_module(source, module_path, resolver);
+    let mut settings = bindings.to_settings();
+    settings.parse_status = parse_status;
+    settings
 }
 
 #[derive(Debug, Default)]
@@ -54,28 +57,33 @@ impl SettingsExtraction {
         source: &str,
         module_path: &Utf8Path,
         resolver: &mut dyn SettingsSourceResolver,
-    ) -> Arc<SettingsBindings> {
+    ) -> (Arc<SettingsBindings>, SettingsParseStatus) {
         let path = module_path.to_path_buf();
         if let Some(cached) = self.cache.get(&path) {
-            return Arc::clone(cached);
+            return (Arc::clone(cached), SettingsParseStatus::Parsed);
         }
         if !self.active.insert(path.clone()) {
-            return Arc::new(SettingsBindings::default());
+            return (
+                Arc::new(SettingsBindings::default()),
+                SettingsParseStatus::Parsed,
+            );
         }
 
         let mut collector = SettingsBindingsCollector::new(module_path, resolver, self);
 
-        if let Ok(parsed) = parse_module(source) {
+        let parse_status = if let Ok(parsed) = parse_module(source) {
             let module = parsed.into_syntax();
             collector.walk_body(&module.body);
+            SettingsParseStatus::Parsed
         } else {
             collector.mark_syntax_error();
-        }
+            SettingsParseStatus::Unparseable
+        };
 
         let bindings = Arc::new(collector.into_bindings());
         self.active.remove(&path);
         self.cache.insert(path, Arc::clone(&bindings));
-        bindings
+        (bindings, parse_status)
     }
 
     fn extract_import_source(
@@ -86,7 +94,10 @@ impl SettingsExtraction {
         if self.active.contains(&imported.path) {
             return None;
         }
-        Some(self.extract_module(&imported.source, &imported.path, resolver))
+        Some(
+            self.extract_module(&imported.source, &imported.path, resolver)
+                .0,
+        )
     }
 }
 
@@ -97,7 +108,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use super::*;
-    use crate::settings::types::SettingExtraction;
+    use crate::ExtractionStatus;
     use crate::settings::types::SettingsImport;
     use crate::settings::types::TemplateDirPath;
 
@@ -190,7 +201,10 @@ mod tests {
     #[test]
     fn literal_tuple_assignment_is_full() {
         let settings = extract("INSTALLED_APPS = ('django.contrib.auth', 'app')");
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(
             settings.installed_apps.values,
             ["django.contrib.auth", "app"]
@@ -200,7 +214,10 @@ mod tests {
     #[test]
     fn annotated_assignment_is_full() {
         let settings = extract("INSTALLED_APPS: list[str] = ['app']");
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["app"]);
     }
 
@@ -265,7 +282,7 @@ mod tests {
         let settings = extract("INSTALLED_APPS = ['a', env('EXTRA'), 'b']");
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
         assert_eq!(settings.installed_apps.values, ["a", "b"]);
     }
@@ -275,7 +292,7 @@ mod tests {
         let settings = extract("INSTALLED_APPS = get_apps()");
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Unsupported
+            ExtractionStatus::Partial
         );
         assert!(settings.installed_apps.values.is_empty());
     }
@@ -321,7 +338,7 @@ mod tests {
         );
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
         assert_eq!(settings.installed_apps.values, ["base", "debug", "prod"]);
     }
@@ -335,7 +352,10 @@ mod tests {
             Utf8Path::new("/project/config/settings.py"),
             &mut resolver,
         );
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["local"]);
     }
 
@@ -351,7 +371,7 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.templates.extraction, SettingExtraction::Partial);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Partial);
         assert_eq!(
             settings.templates.backends[0].dirs,
             [TemplateDirPath::Unknown]
@@ -370,7 +390,7 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.templates.extraction, SettingExtraction::Full);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Complete);
         assert_eq!(
             settings.templates.backends[0].dirs,
             [TemplateDirPath::Resolved(Utf8PathBuf::from(
@@ -389,7 +409,10 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["local"]);
     }
 
@@ -398,9 +421,9 @@ mod tests {
         let settings = extract("from missing import *");
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
-        assert_eq!(settings.templates.extraction, SettingExtraction::Partial);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Partial);
     }
 
     #[test]
@@ -412,7 +435,10 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["base", "local"]);
     }
 
@@ -427,7 +453,7 @@ mod tests {
 
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Unsupported
+            ExtractionStatus::Partial
         );
         assert!(settings.installed_apps.values.is_empty());
     }
@@ -440,7 +466,7 @@ mod tests {
              TEMPLATES = [{'DIRS': [BASE_DIR / 'templates']}]",
         );
 
-        assert_eq!(settings.templates.extraction, SettingExtraction::Full);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Complete);
         assert_eq!(
             settings.templates.backends[0].dirs,
             [TemplateDirPath::Resolved(Utf8PathBuf::from(
@@ -459,7 +485,7 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.templates.extraction, SettingExtraction::Full);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Complete);
         assert_eq!(
             settings.templates.backends[0].dirs,
             [TemplateDirPath::Resolved(Utf8PathBuf::from(
@@ -482,7 +508,10 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["common", "base"]);
     }
 
@@ -498,7 +527,10 @@ mod tests {
             &mut resolver,
         );
 
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["local"]);
     }
 
@@ -506,7 +538,10 @@ mod tests {
     fn tuple_literal_local_can_feed_installed_apps() {
         let settings = extract("LOCAL_APPS = ('a', 'b')\nINSTALLED_APPS = LOCAL_APPS");
 
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["a", "b"]);
     }
 
@@ -517,7 +552,7 @@ mod tests {
 
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
         assert!(settings.installed_apps.values.is_empty());
     }
@@ -557,10 +592,10 @@ mod tests {
     #[test]
     fn non_literal_backend_is_partial() {
         let settings = extract("TEMPLATES = [{'BACKEND': backend_name}]");
-        assert_eq!(settings.templates.extraction, SettingExtraction::Partial);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Partial);
         assert_eq!(
             settings.templates.backends[0].extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
     }
 
@@ -568,7 +603,7 @@ mod tests {
     fn template_backend_spread_then_reset_keeps_later_key_fact() {
         let settings = extract("TEMPLATES = [{'DIRS': ['a'], **extra, 'DIRS': ['b']}]");
 
-        assert_eq!(settings.templates.extraction, SettingExtraction::Partial);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Partial);
         assert_eq!(settings.templates.backends[0].dirs.len(), 1);
         assert_eq!(
             settings.templates.backends[0].dirs[0],
@@ -595,7 +630,7 @@ mod tests {
     #[test]
     fn unknown_path_call_becomes_unknown_path_value() {
         let settings = extract("TEMPLATES = [{'DIRS': [dynamic_path()]}]");
-        assert_eq!(settings.templates.extraction, SettingExtraction::Partial);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Partial);
         assert!(matches!(
             settings.templates.backends[0].dirs[0],
             TemplateDirPath::Unknown
@@ -608,7 +643,7 @@ mod tests {
             extract("INSTALLED_APPS = ['base']\nif FLAG:\n    INSTALLED_APPS = ['debug']");
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
         assert_eq!(settings.installed_apps.values, ["debug", "base"]);
     }
@@ -621,7 +656,7 @@ mod tests {
 
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
         assert_eq!(settings.installed_apps.values, ["a", "b"]);
     }
@@ -629,7 +664,10 @@ mod tests {
     #[test]
     fn unsupported_assignment_then_valid_assignment_is_full() {
         let settings = extract("INSTALLED_APPS = get_apps()\nINSTALLED_APPS = ['blog']");
-        assert_eq!(settings.installed_apps.extraction, SettingExtraction::Full);
+        assert_eq!(
+            settings.installed_apps.extraction,
+            ExtractionStatus::Complete
+        );
         assert_eq!(settings.installed_apps.values, ["blog"]);
     }
 
@@ -638,7 +676,7 @@ mod tests {
         let settings = extract("INSTALLED_APPS = get_apps()\nfrom missing import *");
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Unsupported
+            ExtractionStatus::Partial
         );
         assert!(settings.installed_apps.values.is_empty());
     }
@@ -648,8 +686,8 @@ mod tests {
         let settings = extract("INSTALLED_APPS = [");
         assert_eq!(
             settings.installed_apps.extraction,
-            SettingExtraction::Partial
+            ExtractionStatus::Partial
         );
-        assert_eq!(settings.templates.extraction, SettingExtraction::Partial);
+        assert_eq!(settings.templates.extraction, ExtractionStatus::Partial);
     }
 }

--- a/crates/djls-project/src/settings/extraction/bindings.rs
+++ b/crates/djls-project/src/settings/extraction/bindings.rs
@@ -1,10 +1,11 @@
 use rustc_hash::FxHashSet;
 
+use crate::ExtractionStatus;
 use crate::settings::types::DjangoSettings;
 use crate::settings::types::InstalledAppsSetting;
 use crate::settings::types::LocalBindings;
 use crate::settings::types::LocalListBinding;
-use crate::settings::types::SettingExtraction;
+use crate::settings::types::SettingsParseStatus;
 use crate::settings::types::TemplateBackend;
 use crate::settings::types::TemplateSettings;
 
@@ -18,14 +19,15 @@ pub(super) struct SettingsBindings {
 impl SettingsBindings {
     pub(super) fn to_settings(&self) -> DjangoSettings {
         DjangoSettings {
+            parse_status: SettingsParseStatus::default(),
             installed_apps: self
                 .installed_apps
                 .clone()
-                .unwrap_or_else(InstalledAppsSetting::unsupported),
+                .unwrap_or_else(InstalledAppsSetting::partial),
             templates: self
                 .templates
                 .clone()
-                .unwrap_or_else(TemplateSettings::unsupported),
+                .unwrap_or_else(TemplateSettings::partial),
         }
     }
 
@@ -50,13 +52,11 @@ impl SettingsBindings {
         let setting = self
             .installed_apps
             .get_or_insert_with(InstalledAppsSetting::partial);
-        setting.mark_unsupported();
+        setting.clear_to_partial();
     }
 
     pub(super) fn can_mutate_installed_apps(&self) -> bool {
-        self.installed_apps
-            .as_ref()
-            .is_some_and(InstalledAppsSetting::is_usable_for_app_scan)
+        self.installed_apps.is_some()
     }
 
     pub(super) fn mark_templates_partial(&mut self) {
@@ -68,7 +68,7 @@ impl SettingsBindings {
 
     pub(super) fn mark_templates_unsupported(&mut self) {
         let templates = self.templates.get_or_insert_with(TemplateSettings::partial);
-        templates.mark_unsupported();
+        templates.clear_to_partial();
     }
 
     pub(super) fn join_ambiguous(
@@ -82,7 +82,7 @@ impl SettingsBindings {
         if writes.templates {
             self.templates = Some(TemplateSettings {
                 backends: join_template_backends(branch_bindings),
-                extraction: SettingExtraction::Partial,
+                extraction: ExtractionStatus::Partial,
             });
         }
         join_local_lists(&mut self, branch_bindings, &writes.locals);
@@ -163,7 +163,7 @@ fn join_installed_apps(branch_bindings: &[SettingsBindings]) -> InstalledAppsSet
 
     InstalledAppsSetting {
         values,
-        extraction: SettingExtraction::Partial,
+        extraction: ExtractionStatus::Partial,
     }
 }
 

--- a/crates/djls-project/src/settings/extraction/installed_apps.rs
+++ b/crates/djls-project/src/settings/extraction/installed_apps.rs
@@ -6,7 +6,6 @@ use crate::settings::extraction::bindings::ExtractedList;
 use crate::settings::extraction::bindings::ExtractedListStatus;
 use crate::settings::extraction::env::EvalEnv;
 use crate::settings::types::LocalListBinding;
-use crate::settings::types::SettingExtraction;
 
 pub(super) enum AssignmentEffect {
     Assign(ExtractedList<String>),
@@ -168,10 +167,7 @@ impl From<ExtractedList<String>> for LocalListBinding {
         if value.status.is_complete() {
             Self::full(value.values)
         } else {
-            Self {
-                values: value.values,
-                extraction: SettingExtraction::Partial,
-            }
+            Self::partial(value.values)
         }
     }
 }

--- a/crates/djls-project/src/settings/extraction/traversal.rs
+++ b/crates/djls-project/src/settings/extraction/traversal.rs
@@ -16,7 +16,6 @@ use crate::settings::extraction::installed_apps;
 use crate::settings::extraction::templates;
 use crate::settings::types::InstalledAppsSetting;
 use crate::settings::types::LocalListBinding;
-use crate::settings::types::SettingExtraction;
 use crate::settings::types::SettingsImport;
 use crate::settings::types::SettingsSourceResolver;
 use crate::settings::types::TemplateDirPath;
@@ -364,9 +363,7 @@ impl<'a> SettingsBindingsCollector<'a> {
                     self.mark_definition_name(bound_name);
                     return;
                 };
-                if matches!(setting.extraction, SettingExtraction::Unsupported) {
-                    self.mark_definition_name(bound_name);
-                } else if bound_name == INSTALLED_APPS {
+                if bound_name == INSTALLED_APPS {
                     self.bindings.installed_apps = Some(setting.clone());
                 } else {
                     let list = if setting.is_fully_extracted() {

--- a/crates/djls-project/src/settings/types.rs
+++ b/crates/djls-project/src/settings/types.rs
@@ -3,30 +3,30 @@ use camino::Utf8PathBuf;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 
+use crate::ExtractionStatus;
 use crate::python::PythonModuleName;
 use crate::python::PythonPathBindings;
 
 const DJANGO_TEMPLATES_BACKEND: &str = "django.template.backends.django.DjangoTemplates";
 
-/// How completely a watched settings value was extracted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub(crate) enum SettingExtraction {
-    Full,
-    Partial,
-    Unsupported,
+pub(crate) enum SettingsParseStatus {
+    #[default]
+    Parsed,
+    Unparseable,
 }
 
 /// A best-effort string list setting such as `INSTALLED_APPS`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct InstalledAppsSetting {
     pub(crate) values: Vec<String>,
-    pub(crate) extraction: SettingExtraction,
+    pub(crate) extraction: ExtractionStatus,
 }
 
 impl Default for InstalledAppsSetting {
     fn default() -> Self {
-        Self::unsupported()
+        Self::partial()
     }
 }
 
@@ -34,43 +34,29 @@ impl InstalledAppsSetting {
     pub(crate) fn full(values: Vec<String>) -> Self {
         Self {
             values,
-            extraction: SettingExtraction::Full,
+            extraction: ExtractionStatus::Complete,
         }
     }
 
     pub(crate) fn partial() -> Self {
         Self {
             values: Vec::new(),
-            extraction: SettingExtraction::Partial,
-        }
-    }
-
-    pub(crate) fn unsupported() -> Self {
-        Self {
-            values: Vec::new(),
-            extraction: SettingExtraction::Unsupported,
+            extraction: ExtractionStatus::Partial,
         }
     }
 
     #[must_use]
     pub(crate) fn is_fully_extracted(&self) -> bool {
-        matches!(self.extraction, SettingExtraction::Full)
-    }
-
-    #[must_use]
-    pub(crate) fn is_usable_for_app_scan(&self) -> bool {
-        !matches!(self.extraction, SettingExtraction::Unsupported)
+        self.extraction == ExtractionStatus::Complete
     }
 
     pub(crate) fn mark_partial(&mut self) {
-        if !matches!(self.extraction, SettingExtraction::Unsupported) {
-            self.extraction = SettingExtraction::Partial;
-        }
+        self.extraction = ExtractionStatus::Partial;
     }
 
-    pub(crate) fn mark_unsupported(&mut self) {
+    pub(crate) fn clear_to_partial(&mut self) {
         self.values.clear();
-        self.extraction = SettingExtraction::Unsupported;
+        self.extraction = ExtractionStatus::Partial;
     }
 }
 
@@ -78,12 +64,12 @@ impl InstalledAppsSetting {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct TemplateSettings {
     pub(crate) backends: Vec<TemplateBackend>,
-    pub(crate) extraction: SettingExtraction,
+    pub(crate) extraction: ExtractionStatus,
 }
 
 impl Default for TemplateSettings {
     fn default() -> Self {
-        Self::unsupported()
+        Self::partial()
     }
 }
 
@@ -91,38 +77,29 @@ impl TemplateSettings {
     pub(crate) fn full(backends: Vec<TemplateBackend>) -> Self {
         Self {
             backends,
-            extraction: SettingExtraction::Full,
+            extraction: ExtractionStatus::Complete,
         }
     }
 
     pub(crate) fn partial() -> Self {
         Self {
             backends: Vec::new(),
-            extraction: SettingExtraction::Partial,
-        }
-    }
-
-    pub(crate) fn unsupported() -> Self {
-        Self {
-            backends: Vec::new(),
-            extraction: SettingExtraction::Unsupported,
+            extraction: ExtractionStatus::Partial,
         }
     }
 
     #[must_use]
     pub(crate) fn is_fully_extracted(&self) -> bool {
-        matches!(self.extraction, SettingExtraction::Full)
+        self.extraction == ExtractionStatus::Complete
     }
 
     pub(crate) fn mark_partial(&mut self) {
-        if !matches!(self.extraction, SettingExtraction::Unsupported) {
-            self.extraction = SettingExtraction::Partial;
-        }
+        self.extraction = ExtractionStatus::Partial;
     }
 
-    pub(crate) fn mark_unsupported(&mut self) {
+    pub(crate) fn clear_to_partial(&mut self) {
         self.backends.clear();
-        self.extraction = SettingExtraction::Unsupported;
+        self.extraction = ExtractionStatus::Partial;
     }
 }
 
@@ -134,7 +111,7 @@ pub(crate) struct TemplateBackend {
     pub(crate) app_dirs: Option<bool>,
     pub(crate) libraries: Vec<(String, PythonModuleName)>,
     pub(crate) builtins: Vec<PythonModuleName>,
-    pub(crate) extraction: SettingExtraction,
+    pub(crate) extraction: ExtractionStatus,
 }
 
 impl Default for TemplateBackend {
@@ -145,7 +122,7 @@ impl Default for TemplateBackend {
             app_dirs: None,
             libraries: Vec::new(),
             builtins: Vec::new(),
-            extraction: SettingExtraction::Full,
+            extraction: ExtractionStatus::Complete,
         }
     }
 }
@@ -153,7 +130,7 @@ impl Default for TemplateBackend {
 impl TemplateBackend {
     #[must_use]
     pub(crate) fn is_fully_extracted(&self) -> bool {
-        matches!(self.extraction, SettingExtraction::Full)
+        self.extraction == ExtractionStatus::Complete
     }
 
     #[must_use]
@@ -166,15 +143,14 @@ impl TemplateBackend {
     }
 
     pub(crate) fn mark_partial(&mut self) {
-        if !matches!(self.extraction, SettingExtraction::Unsupported) {
-            self.extraction = SettingExtraction::Partial;
-        }
+        self.extraction = ExtractionStatus::Partial;
     }
 }
 
 /// The statically extracted subset of a Django settings module.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub(crate) struct DjangoSettings {
+    pub(crate) parse_status: SettingsParseStatus,
     pub(crate) installed_apps: InstalledAppsSetting,
     pub(crate) templates: TemplateSettings,
 }
@@ -221,27 +197,27 @@ pub(crate) trait SettingsSourceResolver {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LocalListBinding {
     pub(crate) values: Vec<String>,
-    pub(crate) extraction: SettingExtraction,
+    extraction: ExtractionStatus,
 }
 
 impl LocalListBinding {
     pub(crate) fn full(values: Vec<String>) -> Self {
         Self {
             values,
-            extraction: SettingExtraction::Full,
+            extraction: ExtractionStatus::Complete,
         }
     }
 
     pub(crate) fn partial(values: Vec<String>) -> Self {
         Self {
             values,
-            extraction: SettingExtraction::Partial,
+            extraction: ExtractionStatus::Partial,
         }
     }
 
     #[must_use]
     pub(crate) fn is_fully_extracted(&self) -> bool {
-        matches!(self.extraction, SettingExtraction::Full)
+        self.extraction == ExtractionStatus::Complete
     }
 }
 

--- a/crates/djls-project/src/templates.rs
+++ b/crates/djls-project/src/templates.rs
@@ -9,6 +9,7 @@ mod tags;
 
 pub(crate) use candidates::discover_templatetag_candidate_paths;
 pub use filters::FilterArity;
+pub use filters::FilterArityExtraction;
 pub use filters::FilterArityMap;
 pub use filters::extract_filter_arities;
 pub use libraries::TemplateInventoryStatus;

--- a/crates/djls-project/src/templates/filters.rs
+++ b/crates/djls-project/src/templates/filters.rs
@@ -4,12 +4,31 @@ use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::ExtractionStatus;
 use crate::python::PythonModuleName;
 use crate::python::parse_python_module;
 use crate::templates::SymbolKey;
 use crate::templates::for_each_registration;
 
 pub type FilterArityMap = FxHashMap<SymbolKey, FilterArity>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FilterArityExtraction {
+    arities: FilterArityMap,
+    status: ExtractionStatus,
+}
+
+impl FilterArityExtraction {
+    #[must_use]
+    pub fn arities(&self) -> &FilterArityMap {
+        &self.arities
+    }
+
+    #[must_use]
+    pub(crate) fn status(&self) -> ExtractionStatus {
+        self.status
+    }
+}
 
 /// Filter argument arity extracted from the filter function's signature.
 ///
@@ -32,9 +51,12 @@ pub fn extract_filter_arities(
     db: &dyn djls_source::Db,
     file: File,
     registration_module: PythonModuleName,
-) -> FilterArityMap {
+) -> FilterArityExtraction {
     let Some(parsed) = parse_python_module(db, file) else {
-        return FilterArityMap::default();
+        return FilterArityExtraction {
+            arities: FilterArityMap::default(),
+            status: ExtractionStatus::Unparseable,
+        };
     };
 
     let registration_module = registration_module.into_string();
@@ -46,7 +68,11 @@ pub fn extract_filter_arities(
         }
     });
 
-    filter_arities
+    FilterArityExtraction {
+        arities: filter_arities,
+        // Filter extraction skips unsupported signature shapes in v1.
+        status: ExtractionStatus::Partial,
+    }
 }
 
 /// Extract filter argument arity from a filter function's signature.

--- a/crates/djls-project/src/templates/libraries.rs
+++ b/crates/djls-project/src/templates/libraries.rs
@@ -556,20 +556,17 @@ pub fn template_libraries(db: &dyn ProjectDb, project: Project) -> TemplateLibra
         libraries.insert_library(TemplateLibrary::installed(load_name, module, symbols));
     }
 
-    if settings.installed_apps.is_usable_for_app_scan() {
-        for installed_app in &settings.installed_apps.values {
-            let Some(package_module) = installed_app_package_module(db, project, installed_app)
-            else {
-                inventory_complete = false;
-                continue;
-            };
-            let (scan_complete, discovered_libraries) =
-                templatetag_package_libraries(db, project, &package_module);
-            inventory_complete &= scan_complete;
-            for (load_name, module, symbols) in discovered_libraries {
-                installed_template_library_modules.insert(module.name().clone());
-                libraries.insert_library(TemplateLibrary::installed(load_name, module, symbols));
-            }
+    for installed_app in &settings.installed_apps.values {
+        let Some(package_module) = installed_app_package_module(db, project, installed_app) else {
+            inventory_complete = false;
+            continue;
+        };
+        let (scan_complete, discovered_libraries) =
+            templatetag_package_libraries(db, project, &package_module);
+        inventory_complete &= scan_complete;
+        for (load_name, module, symbols) in discovered_libraries {
+            installed_template_library_modules.insert(module.name().clone());
+            libraries.insert_library(TemplateLibrary::installed(load_name, module, symbols));
         }
     }
 

--- a/crates/djls-project/tests/extraction_status.rs
+++ b/crates/djls-project/tests/extraction_status.rs
@@ -1,0 +1,115 @@
+use camino::Utf8Path;
+use djls_project::PythonModuleName;
+use djls_project::testing::django_settings;
+use djls_project::testing::extract_model_graph;
+use djls_project::testing::filter_arity_status;
+use djls_project::testing::model_status;
+use djls_testing::ProjectFixture;
+use djls_testing::TestDatabase;
+
+#[test]
+fn entry_settings_syntax_error_sets_parse_status_unparseable() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file("/proj/myproject/settings.py", "INSTALLED_APPS = [")
+        .install(&mut db);
+
+    let settings = serde_json::to_value(django_settings(&db, project)).unwrap();
+
+    assert_eq!(settings["parse_status"], "unparseable");
+    assert_eq!(settings["installed_apps"]["values"], serde_json::json!([]));
+    assert_eq!(settings["installed_apps"]["extraction"], "partial");
+    assert_eq!(settings["templates"]["backends"], serde_json::json!([]));
+    assert_eq!(settings["templates"]["extraction"], "partial");
+}
+
+#[test]
+fn imported_settings_syntax_error_keeps_entry_parse_status_parsed() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings.local")
+        .file("/proj/myproject/__init__.py", "")
+        .file("/proj/myproject/settings/__init__.py", "")
+        .file("/proj/myproject/settings/base.py", "INSTALLED_APPS = [")
+        .file(
+            "/proj/myproject/settings/local.py",
+            "from .base import INSTALLED_APPS, TEMPLATES",
+        )
+        .install(&mut db);
+
+    let settings = serde_json::to_value(django_settings(&db, project)).unwrap();
+
+    assert_eq!(settings["parse_status"], "parsed");
+    assert_eq!(settings["installed_apps"]["values"], serde_json::json!([]));
+    assert_eq!(settings["installed_apps"]["extraction"], "partial");
+    assert_eq!(settings["templates"]["backends"], serde_json::json!([]));
+    assert_eq!(settings["templates"]["extraction"], "partial");
+}
+
+#[test]
+fn model_parse_failure_is_unparseable_with_empty_graph() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/proj/blog/models.py");
+    db.add_file(path.as_str(), "class Broken(");
+    let file = db.get_or_create_file(path);
+    let module_name = PythonModuleName::parse("blog.models").unwrap();
+
+    let graph = extract_model_graph(&db, file, module_name.clone());
+    let status = serde_json::to_value(model_status(&db, file, module_name)).unwrap();
+
+    assert!(graph.is_empty());
+    assert_eq!(status, serde_json::json!("unparseable"));
+}
+
+#[test]
+fn successful_model_parse_is_partial() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/proj/blog/models.py");
+    db.add_file(
+        path.as_str(),
+        "from django.db import models\nclass Post(models.Model):\n    pass\n",
+    );
+    let file = db.get_or_create_file(path);
+    let module_name = PythonModuleName::parse("blog.models").unwrap();
+
+    let graph = extract_model_graph(&db, file, module_name.clone());
+    let status = serde_json::to_value(model_status(&db, file, module_name)).unwrap();
+
+    assert!(!graph.is_empty());
+    assert_eq!(status, serde_json::json!("partial"));
+}
+
+#[test]
+fn filter_arity_parse_failure_is_unparseable_with_empty_map() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/proj/blog/templatetags/blog.py");
+    db.add_file(path.as_str(), "def broken(");
+    let file = db.get_or_create_file(path);
+    let module_name = PythonModuleName::parse("blog.templatetags.blog").unwrap();
+
+    let extraction = djls_project::extract_filter_arities(&db, file, module_name.clone());
+    let status = serde_json::to_value(filter_arity_status(&db, file, module_name)).unwrap();
+
+    assert!(extraction.arities().is_empty());
+    assert_eq!(status, serde_json::json!("unparseable"));
+}
+
+#[test]
+fn successful_filter_arity_parse_is_partial() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/proj/blog/templatetags/blog.py");
+    db.add_file(
+        path.as_str(),
+        "from django import template\nregister = template.Library()\n@register.filter\ndef shout(value):\n    return value\n",
+    );
+    let file = db.get_or_create_file(path);
+    let module_name = PythonModuleName::parse("blog.templatetags.blog").unwrap();
+
+    let extraction = djls_project::extract_filter_arities(&db, file, module_name.clone());
+    let status = serde_json::to_value(filter_arity_status(&db, file, module_name)).unwrap();
+
+    assert!(!extraction.arities().is_empty());
+    assert_eq!(status, serde_json::json!("partial"));
+}

--- a/crates/djls-project/tests/snapshots/settings_extraction__ambiguous_branch_alias_extracts_partial_installed_apps.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__ambiguous_branch_alias_extracts_partial_installed_apps.snap
@@ -2,6 +2,7 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - a
@@ -14,5 +15,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__baseline_literal_installed_apps_and_templates.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__baseline_literal_installed_apps_and_templates.snap
@@ -2,11 +2,12 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.admin
     - blog.apps.BlogConfig
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: django.template.backends.django.DjangoTemplates
@@ -19,5 +20,5 @@ templates:
           - blog.templatetags.custom
       builtins:
         - django.templatetags.static
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__composed_app_lists_via_literal_aliases_extract.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__composed_app_lists_via_literal_aliases_extract.snap
@@ -2,11 +2,12 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.admin
     - myapp
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~
@@ -14,5 +15,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__duplicate_template_dirs_keys_use_last_value.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__duplicate_template_dirs_keys_use_last_value.snap
@@ -2,10 +2,11 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: django.template.backends.django.DjangoTemplates
@@ -14,5 +15,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__non_star_import_from_extra_search_path_is_not_followed.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__non_star_import_from_extra_search_path_is_not_followed.snap
@@ -2,9 +2,10 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values: []
-  extraction: unsupported
+  extraction: partial
 templates:
   backends:
     - backend: ~
@@ -12,5 +13,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_aliased_non_star_import_feeds_installed_apps.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_aliased_non_star_import_feeds_installed_apps.snap
@@ -2,11 +2,12 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.auth
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~
@@ -14,5 +15,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_cyclic_non_star_import_does_not_hang.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_cyclic_non_star_import_does_not_hang.snap
@@ -2,10 +2,11 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.auth
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~
@@ -13,5 +14,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_chain_resolves_imported_setting.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_chain_resolves_imported_setting.snap
@@ -2,11 +2,12 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.auth
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~
@@ -14,5 +15,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_resolves_imported_setting.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_resolves_imported_setting.snap
@@ -2,11 +2,12 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.admin
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~
@@ -15,5 +16,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_star_import_resolves_base_settings.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_star_import_resolves_base_settings.snap
@@ -2,11 +2,12 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - django.contrib.auth
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~
@@ -16,5 +17,5 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
-      extraction: full
-  extraction: full
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__template_backend_spread_erases_prior_keys.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__template_backend_spread_erases_prior_keys.snap
@@ -2,10 +2,11 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends:
     - backend: ~

--- a/crates/djls-project/tests/snapshots/settings_extraction__unsupported_template_dirs_insert_mutation_degrades_templates.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__unsupported_template_dirs_insert_mutation_degrades_templates.snap
@@ -2,10 +2,11 @@
 source: crates/djls-project/tests/settings_extraction.rs
 expression: "django_settings(&db, project)"
 ---
+parse_status: parsed
 installed_apps:
   values:
     - blog
-  extraction: full
+  extraction: complete
 templates:
   backends: []
-  extraction: unsupported
+  extraction: partial

--- a/crates/djls-semantic/src/filters.rs
+++ b/crates/djls-semantic/src/filters.rs
@@ -63,8 +63,8 @@ pub fn compute_filter_arity_specs(db: &dyn Db, project: Project) -> FilterArityS
     let mut specs = FilterAritySpecs::new();
 
     for library in template_libraries(db, project).active_libraries() {
-        let filter_arities =
-            extract_filter_arities(db, library.file(), library.module_name().clone());
+        let extraction = extract_filter_arities(db, library.file(), library.module_name().clone());
+        let filter_arities = extraction.arities();
         if !filter_arities.is_empty() {
             specs.merge_filter_arities(filter_arities);
         }

--- a/crates/djls-testing/src/extraction.rs
+++ b/crates/djls-testing/src/extraction.rs
@@ -34,7 +34,9 @@ pub fn extract_bundle(
     let tag_rules =
         djls_project::extract_tag_rules(db, file, registration_module.clone()).to_owned();
     let filter_arities =
-        djls_project::extract_filter_arities(db, file, registration_module.clone()).to_owned();
+        djls_project::extract_filter_arities(db, file, registration_module.clone())
+            .arities()
+            .to_owned();
     let block_specs = djls_project::extract_block_specs(db, file, registration_module).to_owned();
 
     ExtractionBundle {


### PR DESCRIPTION
The three Python fact extractors disagreed about what a syntax error means: settings extraction marked watched settings partial, while model graph and filter arity extraction returned empty results indistinguishable from a file that genuinely defines nothing. A future consumer could read that emptiness as negative evidence ("this class is not a model") when the truth is "this file could not be read at all".

All three extractors now share one status vocabulary:

- **Complete** — every construct affecting the fact family was understood; absence of a fact IS negative evidence.
- **Partial** — emitted facts are true, but unevaluated constructs may hide more; absence proves nothing.
- **Unparseable** — the source failed to parse; no claims are made, not even emptiness.

The contract guarantees **soundness, not precision**: a producer may report Partial where Complete would be honest, never the reverse — so consumers can never be misled into false negative evidence.

Per family:

- **Settings.** The former `Full`/`Partial`/`Unsupported` vocabulary collapses into the shared type. `Unsupported` becomes Partial with facts still cleared at the overwrite site (the zero-false-positive guarantee lives in the fact clearing, not the status name); the only consumer that distinguished the two scanned installed apps, and scanning an always-empty list is identical to skipping the scan, so the predicate is deleted. Extracted settings additionally carry a parse status for the **entry settings module only** — a syntax error in an *imported* settings module degrades the names bound from it to partial exactly like an unresolvable import, a deliberate limitation until a consumer needs per-dependency statuses.
- **Model graph.** Extraction reports Unparseable on parse failure, otherwise Partial — never Complete, because extraction silently skips unrecognized bases and dynamic constructs, and claiming completeness would let a consumer wrongly conclude "class X is not a model". Complete becomes claimable once skipped-construct bookkeeping exists, paid for by the first consumer that wants negative model evidence.
- **Filter arity.** Same shape: Unparseable on parse failure, otherwise Partial (unsupported signature shapes are silently skipped).

No consumer branches on the new statuses yet; no diagnostics or completions change behavior. Snapshot spellings flip mechanically from `full`/`unsupported` to `complete`/`partial`; no extracted fact changes.
