### PR TITLE
Extract and resolve template context processors from settings

### DIFF
--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -68,6 +68,8 @@ pub use templates::TagArgument;
 pub use templates::TagArgumentKind;
 pub use templates::TagRule;
 pub use templates::TagRuleMap;
+pub use templates::TemplateContextProcessor;
+pub use templates::TemplateContextProcessors;
 pub use templates::TemplateDoesNotExist;
 pub use templates::TemplateInventoryStatus;
 pub use templates::TemplateLibraries;
@@ -87,6 +89,7 @@ pub use templates::extract_block_specs;
 pub use templates::extract_filter_arities;
 pub use templates::extract_tag_rules;
 pub use templates::resolve_relative_name;
+pub use templates::template_context_processors;
 pub use templates::template_libraries;
 pub use templates::template_resolution;
 

--- a/crates/djls-project/src/settings.rs
+++ b/crates/djls-project/src/settings.rs
@@ -10,6 +10,7 @@ pub(crate) use types::DjangoSettings;
 pub(crate) use types::SettingsImport;
 pub(crate) use types::SettingsSource;
 pub(crate) use types::SettingsSourceResolver;
+pub(crate) use types::TemplateContextProcessorPath;
 pub(crate) use types::TemplateDirPath;
 
 use crate::db::Db as ProjectDb;

--- a/crates/djls-project/src/settings/extraction/templates.rs
+++ b/crates/djls-project/src/settings/extraction/templates.rs
@@ -1,10 +1,13 @@
+use djls_source::Spanned;
 use ruff_python_ast as ast;
 
 use crate::ast::ExprExt;
+use crate::ast::RangedExt;
 use crate::python::PythonModuleName;
 use crate::settings::extraction::bindings::ExtractedList;
 use crate::settings::extraction::env::EvalEnv;
 use crate::settings::types::TemplateBackend;
+use crate::settings::types::TemplateContextProcessorPath;
 use crate::settings::types::TemplateDirPath;
 
 pub(super) enum AssignmentEffect {
@@ -120,6 +123,7 @@ fn evaluate_template_dirs(value: &ast::Expr, env: &EvalEnv<'_>, backend: &mut Te
 fn evaluate_template_options(value: &ast::Expr, backend: &mut TemplateBackend) {
     backend.libraries.clear();
     backend.builtins.clear();
+    backend.context_processors.clear();
     let ast::Expr::Dict(dict) = value else {
         backend.mark_partial();
         return;
@@ -146,6 +150,13 @@ fn evaluate_template_options(value: &ast::Expr, backend: &mut TemplateBackend) {
                 let builtins = extract_python_module_name_list(&item.value);
                 backend.builtins.extend(builtins.values);
                 if !builtins.status.is_complete() {
+                    backend.mark_partial();
+                }
+            }
+            "context_processors" => {
+                let context_processors = extract_context_processor_path_list(&item.value);
+                backend.context_processors.extend(context_processors.values);
+                if !context_processors.status.is_complete() {
                     backend.mark_partial();
                 }
             }
@@ -188,6 +199,27 @@ fn extract_python_module_name_list(value: &ast::Expr) -> ExtractedList<PythonMod
         };
         match PythonModuleName::parse(value) {
             Ok(module_name) => extracted.values.push(module_name),
+            Err(_) => extracted.status.mark_incomplete(),
+        }
+    }
+    extracted
+}
+
+fn extract_context_processor_path_list(
+    value: &ast::Expr,
+) -> ExtractedList<Spanned<TemplateContextProcessorPath>> {
+    let ast::Expr::List(list) = value else {
+        return ExtractedList::incomplete(Vec::new());
+    };
+
+    let mut extracted = ExtractedList::complete(Vec::new());
+    for element in &list.elts {
+        let Some(value) = element.string_literal() else {
+            extracted.status.mark_incomplete();
+            continue;
+        };
+        match TemplateContextProcessorPath::parse(value) {
+            Ok(path) => extracted.values.push(Spanned::new(path, element.span())),
             Err(_) => extracted.status.mark_incomplete(),
         }
     }

--- a/crates/djls-project/src/settings/types.rs
+++ b/crates/djls-project/src/settings/types.rs
@@ -1,9 +1,11 @@
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use djls_source::Spanned;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 
 use crate::ExtractionStatus;
+use crate::python::InvalidModuleName;
 use crate::python::PythonModuleName;
 use crate::python::PythonPathBindings;
 
@@ -111,6 +113,7 @@ pub(crate) struct TemplateBackend {
     pub(crate) app_dirs: Option<bool>,
     pub(crate) libraries: Vec<(String, PythonModuleName)>,
     pub(crate) builtins: Vec<PythonModuleName>,
+    pub(crate) context_processors: Vec<Spanned<TemplateContextProcessorPath>>,
     pub(crate) extraction: ExtractionStatus,
 }
 
@@ -122,6 +125,7 @@ impl Default for TemplateBackend {
             app_dirs: None,
             libraries: Vec::new(),
             builtins: Vec::new(),
+            context_processors: Vec::new(),
             extraction: ExtractionStatus::Complete,
         }
     }
@@ -144,6 +148,22 @@ impl TemplateBackend {
 
     pub(crate) fn mark_partial(&mut self) {
         self.extraction = ExtractionStatus::Partial;
+    }
+}
+
+/// A dotted context processor callable path from `TEMPLATES[*]["OPTIONS"]`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+pub(crate) struct TemplateContextProcessorPath(String);
+
+impl TemplateContextProcessorPath {
+    pub(crate) fn parse(path: &str) -> Result<Self, InvalidModuleName> {
+        let name = PythonModuleName::parse(path)?;
+        Ok(Self(name.into_string()))
+    }
+
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
     }
 }
 

--- a/crates/djls-project/src/templates.rs
+++ b/crates/djls-project/src/templates.rs
@@ -1,4 +1,5 @@
 mod candidates;
+mod context_processors;
 mod filters;
 mod libraries;
 mod names;
@@ -8,6 +9,9 @@ mod symbols;
 mod tags;
 
 pub(crate) use candidates::discover_templatetag_candidate_paths;
+pub use context_processors::TemplateContextProcessor;
+pub use context_processors::TemplateContextProcessors;
+pub use context_processors::template_context_processors;
 pub use filters::FilterArity;
 pub use filters::FilterArityExtraction;
 pub use filters::FilterArityMap;

--- a/crates/djls-project/src/templates/context_processors.rs
+++ b/crates/djls-project/src/templates/context_processors.rs
@@ -1,0 +1,104 @@
+use djls_source::Spanned;
+
+use crate::db::Db as ProjectDb;
+use crate::project::Project;
+use crate::python::PythonModule;
+use crate::python::resolve_prefix;
+use crate::settings::TemplateContextProcessorPath;
+use crate::settings::django_settings;
+use crate::settings::settings_module_file;
+use crate::templates::libraries::TemplateInventoryStatus;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemplateContextProcessors {
+    status: TemplateInventoryStatus,
+    processors: Vec<TemplateContextProcessor>,
+}
+
+impl Default for TemplateContextProcessors {
+    fn default() -> Self {
+        Self {
+            status: TemplateInventoryStatus::NotDiscovered,
+            processors: Vec::new(),
+        }
+    }
+}
+
+impl TemplateContextProcessors {
+    #[must_use]
+    pub fn status(&self) -> TemplateInventoryStatus {
+        self.status
+    }
+
+    #[must_use]
+    pub fn processors(&self) -> &[TemplateContextProcessor] {
+        &self.processors
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemplateContextProcessor {
+    path: Spanned<TemplateContextProcessorPath>,
+    module: Option<PythonModule>,
+    unresolved_tail: Vec<String>,
+}
+
+impl TemplateContextProcessor {
+    #[must_use]
+    pub fn path_str(&self) -> &str {
+        self.path.value().as_str()
+    }
+
+    #[must_use]
+    pub fn module(&self) -> Option<&PythonModule> {
+        self.module.as_ref()
+    }
+
+    #[must_use]
+    pub fn unresolved_tail(&self) -> &[String] {
+        &self.unresolved_tail
+    }
+}
+
+#[salsa::tracked(returns(ref))]
+pub fn template_context_processors(
+    db: &dyn ProjectDb,
+    project: Project,
+) -> TemplateContextProcessors {
+    project.touch_search_path_roots(db);
+
+    if settings_module_file(db, project).is_none() {
+        return TemplateContextProcessors::default();
+    }
+
+    let settings = django_settings(db, project);
+    let backend_count = settings.templates.backends.len();
+    let mut status = if settings.templates.is_fully_extracted() {
+        TemplateInventoryStatus::Complete
+    } else {
+        TemplateInventoryStatus::Incomplete
+    };
+    let mut processors = Vec::new();
+
+    for backend in settings
+        .templates
+        .backends
+        .iter()
+        .filter(|backend| backend.is_django_templates_backend(backend_count))
+    {
+        if !backend.is_fully_extracted() {
+            status = TemplateInventoryStatus::Incomplete;
+        }
+
+        for path in &backend.context_processors {
+            let resolved = resolve_prefix(db, project, path.value().as_str());
+            processors.push(TemplateContextProcessor {
+                path: path.clone(),
+                module: resolved.module,
+                unresolved_tail: resolved.unresolved_tail,
+            });
+        }
+    }
+
+    TemplateContextProcessors { status, processors }
+}

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -452,6 +452,107 @@ fn template_dirs_demote_broken_app_config_entry_to_partial() {
 }
 
 #[test]
+fn template_context_processors_complete_settings_mark_inventory_complete() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            ("/proj/django/template/__init__.py", ""),
+            ("/proj/django/template/context_processors.py", ""),
+            (
+                "/proj/myproject/settings.py",
+                "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'context_processors': ['django.template.context_processors.request']}}]\n",
+            ),
+        ],
+    );
+
+    let processors = template_context_processors(&db, project);
+
+    assert_eq!(processors.status(), TemplateInventoryStatus::Complete);
+}
+
+#[test]
+fn template_context_processors_invalid_entry_marks_inventory_incomplete() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[(
+            "/proj/myproject/settings.py",
+            "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'context_processors': ['django.template.context_processors.request', object()]}}]\n",
+        )],
+    );
+
+    let processors = template_context_processors(&db, project);
+
+    assert_eq!(processors.status(), TemplateInventoryStatus::Incomplete);
+}
+
+#[test]
+fn template_context_processors_without_usable_settings_are_not_discovered() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj").install(&mut db);
+
+    let processors = template_context_processors(&db, project);
+
+    assert_eq!(processors.status(), TemplateInventoryStatus::NotDiscovered);
+}
+
+#[test]
+fn template_context_processors_resolve_module_prefix_and_callable_tail() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[
+            ("/proj/django/template/__init__.py", ""),
+            ("/proj/django/template/context_processors.py", ""),
+            (
+                "/proj/myproject/settings.py",
+                "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'context_processors': ['django.template.context_processors.request']}}]\n",
+            ),
+        ],
+    );
+
+    let processors = template_context_processors(&db, project);
+    let processor = processors.processors().first().unwrap();
+
+    assert_eq!(
+        processor.path_str(),
+        "django.template.context_processors.request"
+    );
+    assert_eq!(
+        processor.module().map(|module| module.name().as_str()),
+        Some("django.template.context_processors")
+    );
+    assert_eq!(processor.unresolved_tail(), ["request"]);
+}
+
+#[test]
+fn template_context_processors_keep_unresolved_facts_with_tail() {
+    let mut db = TestDatabase::new();
+    let project = project_with_settings(
+        &mut db,
+        "myproject.settings",
+        &[(
+            "/proj/myproject/settings.py",
+            "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'context_processors': ['missing.context.processor']}}]\n",
+        )],
+    );
+
+    let processors = template_context_processors(&db, project);
+    let processor = processors.processors().first().unwrap();
+
+    assert_eq!(processor.path_str(), "missing.context.processor");
+    assert!(processor.module().is_none());
+    assert_eq!(
+        processor.unresolved_tail(),
+        ["missing", "context", "processor"]
+    );
+}
+
+#[test]
 fn template_dirs_resolve_apps_from_site_packages_search_path() {
     let mut db = TestDatabase::new();
     db.add_file("/site/pkg/__init__.py", "");

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -320,3 +320,125 @@ TEMPLATES = [{"DIRS": [], "APP_DIRS": True}]
 
     insta::assert_yaml_snapshot!(django_settings(&db, project));
 }
+
+#[test]
+fn template_context_processors_literal_entries_extract() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file(
+            "/proj/myproject/settings.py",
+            r#"
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+"#,
+        )
+        .install(&mut db);
+
+    insta::assert_yaml_snapshot!(django_settings(&db, project));
+}
+
+#[test]
+fn template_context_processors_mixed_invalid_entries_extract_partial() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file(
+            "/proj/myproject/settings.py",
+            r#"
+UNKNOWN_PROCESSOR = "project.context_processors.dynamic"
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "project.context_processors.site",
+                42,
+                UNKNOWN_PROCESSOR,
+                "bad-module.processor",
+                "project.context_processors.request",
+            ],
+        },
+    },
+]
+"#,
+        )
+        .install(&mut db);
+
+    insta::assert_yaml_snapshot!(django_settings(&db, project));
+}
+
+#[test]
+fn template_context_processors_non_list_extracts_partial_backend() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file(
+            "/proj/myproject/settings.py",
+            r#"
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {"context_processors": "project.context_processors.site"},
+    },
+]
+"#,
+        )
+        .install(&mut db);
+
+    insta::assert_yaml_snapshot!(django_settings(&db, project));
+}
+
+#[test]
+fn template_context_processors_conditional_assignment_keeps_both_branch_facts_partial() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file(
+            "/proj/myproject/settings.py",
+            r#"
+if FLAG:
+    TEMPLATES = [
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [],
+            "APP_DIRS": True,
+            "OPTIONS": {"context_processors": ["project.context_processors.site"]},
+        },
+    ]
+else:
+    TEMPLATES = [
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [],
+            "APP_DIRS": True,
+            "OPTIONS": {"context_processors": ["project.context_processors.site"]},
+        },
+    ]
+"#,
+        )
+        .install(&mut db);
+
+    insta::assert_yaml_snapshot!(django_settings(&db, project));
+}

--- a/crates/djls-project/tests/snapshots/settings_extraction__ambiguous_branch_alias_extracts_partial_installed_apps.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__ambiguous_branch_alias_extracts_partial_installed_apps.snap
@@ -15,5 +15,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__baseline_literal_installed_apps_and_templates.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__baseline_literal_installed_apps_and_templates.snap
@@ -20,5 +20,6 @@ templates:
           - blog.templatetags.custom
       builtins:
         - django.templatetags.static
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__composed_app_lists_via_literal_aliases_extract.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__composed_app_lists_via_literal_aliases_extract.snap
@@ -15,5 +15,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__duplicate_template_dirs_keys_use_last_value.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__duplicate_template_dirs_keys_use_last_value.snap
@@ -15,5 +15,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__non_star_import_from_extra_search_path_is_not_followed.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__non_star_import_from_extra_search_path_is_not_followed.snap
@@ -13,5 +13,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_aliased_non_star_import_feeds_installed_apps.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_aliased_non_star_import_feeds_installed_apps.snap
@@ -15,5 +15,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_cyclic_non_star_import_does_not_hang.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_cyclic_non_star_import_does_not_hang.snap
@@ -14,5 +14,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_chain_resolves_imported_setting.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_chain_resolves_imported_setting.snap
@@ -15,5 +15,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_resolves_imported_setting.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_non_star_import_resolves_imported_setting.snap
@@ -16,5 +16,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__split_settings_star_import_resolves_base_settings.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__split_settings_star_import_resolves_base_settings.snap
@@ -17,5 +17,6 @@ templates:
       app_dirs: true
       libraries: []
       builtins: []
+      context_processors: []
       extraction: complete
   extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_conditional_assignment_keeps_both_branch_facts_partial.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_conditional_assignment_keeps_both_branch_facts_partial.snap
@@ -1,0 +1,33 @@
+---
+source: crates/djls-project/tests/settings_extraction.rs
+expression: "django_settings(&db, project)"
+---
+parse_status: parsed
+installed_apps:
+  values: []
+  extraction: partial
+templates:
+  backends:
+    - backend: django.template.backends.django.DjangoTemplates
+      dirs: []
+      app_dirs: true
+      libraries: []
+      builtins: []
+      context_processors:
+        - value: project.context_processors.site
+          span:
+            start: 213
+            length: 33
+      extraction: complete
+    - backend: django.template.backends.django.DjangoTemplates
+      dirs: []
+      app_dirs: true
+      libraries: []
+      builtins: []
+      context_processors:
+        - value: project.context_processors.site
+          span:
+            start: 476
+            length: 33
+      extraction: complete
+  extraction: partial

--- a/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_literal_entries_extract.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_literal_entries_extract.snap
@@ -1,0 +1,34 @@
+---
+source: crates/djls-project/tests/settings_extraction.rs
+expression: "django_settings(&db, project)"
+---
+parse_status: parsed
+installed_apps:
+  values: []
+  extraction: partial
+templates:
+  backends:
+    - backend: django.template.backends.django.DjangoTemplates
+      dirs: []
+      app_dirs: true
+      libraries: []
+      builtins: []
+      context_processors:
+        - value: django.template.context_processors.debug
+          span:
+            start: 210
+            length: 42
+        - value: django.template.context_processors.request
+          span:
+            start: 270
+            length: 44
+        - value: django.contrib.auth.context_processors.auth
+          span:
+            start: 332
+            length: 45
+        - value: django.contrib.messages.context_processors.messages
+          span:
+            start: 395
+            length: 53
+      extraction: complete
+  extraction: complete

--- a/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_mixed_invalid_entries_extract_partial.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_mixed_invalid_entries_extract_partial.snap
@@ -1,0 +1,26 @@
+---
+source: crates/djls-project/tests/settings_extraction.rs
+expression: "django_settings(&db, project)"
+---
+parse_status: parsed
+installed_apps:
+  values: []
+  extraction: partial
+templates:
+  backends:
+    - backend: django.template.backends.django.DjangoTemplates
+      dirs: []
+      app_dirs: true
+      libraries: []
+      builtins: []
+      context_processors:
+        - value: project.context_processors.site
+          span:
+            start: 267
+            length: 33
+        - value: project.context_processors.request
+          span:
+            start: 413
+            length: 36
+      extraction: partial
+  extraction: partial

--- a/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_non_list_extracts_partial_backend.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__template_context_processors_non_list_extracts_partial_backend.snap
@@ -4,12 +4,11 @@ expression: "django_settings(&db, project)"
 ---
 parse_status: parsed
 installed_apps:
-  values:
-    - blog
-  extraction: complete
+  values: []
+  extraction: partial
 templates:
   backends:
-    - backend: ~
+    - backend: django.template.backends.django.DjangoTemplates
       dirs: []
       app_dirs: true
       libraries: []


### PR DESCRIPTION
Django settings extraction now watches `TEMPLATES[*]["OPTIONS"]["context_processors"]`.

The OPTIONS evaluator captures each dotted callable path as a span-bearing fact on the template backend (`Spanned<TemplateContextProcessorPath>`), alongside the existing `libraries`/`builtins` handling. A new tracked query, `template_context_processors`, resolves each path to its module prefix and callable tail via the module resolver and reports an inventory status (`TemplateInventoryStatus`) with the facts — an unresolved processor is still a fact, carrying its unresolved tail.

Degradation follows the existing conventions: a non-list `context_processors` value or a non-string/invalid entry marks the backend partial while valid entries are kept.

One behavioral note: conditional branches that assign textually identical `TEMPLATES` now produce one backend fact per branch rather than deduplicating. Span-bearing facts born at different source locations are distinct facts, and each keeps its true origin span (the joined result is still marked partial). Span-less backends dedupe exactly as before.

Tests cover literal entries, mixed invalid entries, non-list values, conditional assignment, resolver success/failure, and the inventory status contract (complete / incomplete / not discovered).