### PR TITLE
Degrade known settings uniformly on unsupported statements

### DIFF
--- a/crates/djls-project/src/settings/extraction/traversal.rs
+++ b/crates/djls-project/src/settings/extraction/traversal.rs
@@ -170,6 +170,9 @@ impl<'a> SettingsBindingsCollector<'a> {
             return;
         };
         let ast::Expr::Attribute(attribute) = call.func.as_ref() else {
+            for setting in expr_touched_known_settings(expr) {
+                self.bindings.mark_unsupported(setting);
+            }
             return;
         };
 
@@ -204,8 +207,10 @@ impl<'a> SettingsBindingsCollector<'a> {
                 }
                 _ => self.bindings.mark_unsupported(KnownSetting::Templates),
             }
-        } else if let Some(setting) = expr_touched_known_settings(expr).next() {
-            self.bindings.mark_unsupported(setting);
+        } else {
+            for setting in expr_touched_known_settings(expr) {
+                self.bindings.mark_unsupported(setting);
+            }
         }
     }
 
@@ -851,7 +856,19 @@ fn expr_touches_name(expr: &ast::Expr, expected: &str) -> bool {
         expr if expr.name_target() == Some(expected) => true,
         ast::Expr::Attribute(attribute) => expr_touches_name(&attribute.value, expected),
         ast::Expr::Subscript(subscript) => expr_touches_name(&subscript.value, expected),
-        ast::Expr::Call(call) => expr_touches_name(&call.func, expected),
+        ast::Expr::Call(call) => {
+            expr_touches_name(&call.func, expected)
+                || call
+                    .arguments
+                    .args
+                    .iter()
+                    .any(|expr| expr_touches_name(expr, expected))
+                || call
+                    .arguments
+                    .keywords
+                    .iter()
+                    .any(|keyword| expr_touches_name(&keyword.value, expected))
+        }
         ast::Expr::BinOp(bin_op) => {
             expr_touches_name(&bin_op.left, expected) || expr_touches_name(&bin_op.right, expected)
         }

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -300,6 +300,44 @@ TEMPLATES[0]["DIRS"].insert(0, "first")
 }
 
 #[test]
+fn unsupported_plain_call_touching_known_settings_degrades_them() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file(
+            "/proj/myproject/settings.py",
+            r#"
+INSTALLED_APPS = ["a"]
+TEMPLATES = [{"BACKEND": "django.template.backends.django.DjangoTemplates"}]
+configure(INSTALLED_APPS, TEMPLATES)
+"#,
+        )
+        .install(&mut db);
+
+    insta::assert_yaml_snapshot!(django_settings(&db, project));
+}
+
+#[test]
+fn unsupported_attribute_call_touching_both_known_settings_degrades_both() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file("/proj/myproject/__init__.py", "")
+        .file(
+            "/proj/myproject/settings.py",
+            r#"
+INSTALLED_APPS = ["a"]
+TEMPLATES = [{"BACKEND": "django.template.backends.django.DjangoTemplates"}]
+helpers.configure(INSTALLED_APPS, TEMPLATES)
+"#,
+        )
+        .install(&mut db);
+
+    insta::assert_yaml_snapshot!(django_settings(&db, project));
+}
+
+#[test]
 fn ambiguous_branch_alias_extracts_partial_installed_apps() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")

--- a/crates/djls-project/tests/snapshots/settings_extraction__unsupported_attribute_call_touching_both_known_settings_degrades_both.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__unsupported_attribute_call_touching_both_known_settings_degrades_both.snap
@@ -1,0 +1,12 @@
+---
+source: crates/djls-project/tests/settings_extraction.rs
+assertion_line: 337
+expression: "django_settings(&db, project)"
+---
+parse_status: parsed
+installed_apps:
+  values: []
+  extraction: partial
+templates:
+  backends: []
+  extraction: partial

--- a/crates/djls-project/tests/snapshots/settings_extraction__unsupported_plain_call_touching_known_settings_degrades_them.snap
+++ b/crates/djls-project/tests/snapshots/settings_extraction__unsupported_plain_call_touching_known_settings_degrades_them.snap
@@ -1,0 +1,12 @@
+---
+source: crates/djls-project/tests/settings_extraction.rs
+assertion_line: 318
+expression: "django_settings(&db, project)"
+---
+parse_status: parsed
+installed_apps:
+  values: []
+  extraction: partial
+templates:
+  backends: []
+  extraction: partial


### PR DESCRIPTION
An unrecognized statement expression that touched known settings degraded only the first matched name, and only when the statement was an attribute call. Plain calls like `configure(INSTALLED_APPS, TEMPLATES)` were ignored entirely, leaving definite claims about values a callee may have mutated in place.

Unsupported statements now mark every known setting they touch as partial, whatever the call shape, and known-setting write detection sees call arguments and keywords as well as the callee. Claiming less is always sound; claiming Complete after an opaque mutation is not.

Two pinning tests cover the plain-call and attribute-call shapes.

Stacked on the known-setting catalog PR.
