### PR TITLE
Track file existence as a Salsa input synced at change boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,6 +981,7 @@ dependencies = [
  "annotate-snippets",
  "camino",
  "dashmap",
+ "djls-testing",
  "ignore",
  "insta",
  "rustc-hash",

--- a/crates/djls-bench/src/db.rs
+++ b/crates/djls-bench/src/db.rs
@@ -17,6 +17,7 @@ use djls_source::SourceFiles;
 use djls_source::WalkEntry;
 use djls_source::WalkEntryKind;
 use djls_source::WalkOptions;
+use djls_source::path_to_file;
 use salsa::Setter;
 
 #[derive(Clone)]
@@ -152,10 +153,15 @@ impl Db {
         self
     }
 
+    /// Add source content and return the corresponding tracked file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inserted benchmark source is not visible through the filesystem.
     pub fn file_with_contents(&mut self, path: impl Into<Utf8PathBuf>, contents: &str) -> File {
         let path = path.into();
         self.fs.sources.insert(path.clone(), contents.to_string());
-        self.get_or_create_file(&path)
+        path_to_file(self, &path).expect("inserted benchmark source should be visible")
     }
 
     pub fn set_file_contents(&mut self, file: File, contents: &str, revision: u64) {

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -226,6 +226,7 @@ mod invalidation_tests {
     use djls_source::Offset;
     use djls_source::OsFileSystem;
     use djls_source::SourceFiles;
+    use djls_source::path_to_file;
     use djls_templates::parse_template;
     use salsa::Database;
     use salsa::Setter;
@@ -279,8 +280,11 @@ mod invalidation_tests {
         let event_log = EventLog::default();
         let settings = Settings::default();
 
+        let mut fs = InMemoryFileSystem::new();
+        fs.add_file("/test/project/tags.py".into(), String::new());
+
         let mut db = DjangoDatabase {
-            fs: Arc::new(InMemoryFileSystem::new()),
+            fs: Arc::new(fs),
             files: SourceFiles::default(),
             project: None,
             settings: Arc::new(Mutex::new(settings.clone())),
@@ -366,9 +370,9 @@ mod invalidation_tests {
         };
         let project = Project::bootstrap(&db, root.as_path(), &settings);
         db.project = Some(project);
-        let child_file = db.get_or_create_file(&child_path);
-        let parent_file = db.get_or_create_file(&parent_path);
-        let other_file = db.get_or_create_file(&other_path);
+        let child_file = path_to_file(&db, &child_path).expect("child fixture should exist");
+        let parent_file = path_to_file(&db, &parent_path).expect("parent fixture should exist");
+        let other_file = path_to_file(&db, &other_path).expect("other fixture should exist");
 
         TemplateInheritanceFixture {
             _tempdir: tempdir,
@@ -456,7 +460,7 @@ mod invalidation_tests {
         );
         event_log.take();
 
-        let settings_file = db.get_or_create_file(&settings_path);
+        let settings_file = path_to_file(&db, &settings_path).expect("fixture file should exist");
         fs.lock().unwrap().add_file(
             settings_path,
             "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'builtins': []}}]\n".to_string(),
@@ -513,7 +517,7 @@ mod invalidation_tests {
         let project = db.project.unwrap();
 
         let child_path = Utf8Path::new("/test/project/templates/child.html");
-        let child = db.get_or_create_file(child_path);
+        let child = path_to_file(&db, child_path).expect("fixture file should exist");
         let offset = Offset::try_from(source.find("base.html").unwrap()).unwrap();
         {
             let SemanticOffsetContext::TemplateReference { name, .. } =
@@ -669,7 +673,7 @@ mod invalidation_tests {
         assert_eq!(db.template_dirs().unwrap(), vec![templates_dir.clone()]);
         event_log.take();
 
-        let settings_file = db.get_or_create_file(&settings_path);
+        let settings_file = path_to_file(&db, &settings_path).expect("fixture file should exist");
         fs.lock().unwrap().add_file(
             settings_path,
             format!(
@@ -731,7 +735,7 @@ mod invalidation_tests {
         assert_eq!(db.template_dirs().unwrap(), vec![templates_dir]);
         event_log.take();
 
-        let other_file = db.get_or_create_file(&other_path);
+        let other_file = path_to_file(&db, &other_path).expect("fixture file should exist");
         db.bump_file_revision(other_file);
 
         assert_eq!(db.template_dirs().unwrap(), vec![root.join("templates")]);
@@ -1068,10 +1072,8 @@ env_file = ".env.local"
         let (db, event_log) = test_db_with_project();
 
         // Create a Python file and track it
-        let file = djls_source::Db::get_or_create_file(
-            &db,
-            camino::Utf8Path::new("/test/project/tags.py"),
-        );
+        let file = path_to_file(&db, camino::Utf8Path::new("/test/project/tags.py"))
+            .expect("fixture file should exist");
 
         // First extraction
         let _result1 = djls_project::extract_filter_arities(
@@ -1103,10 +1105,8 @@ env_file = ".env.local"
         let (mut db, event_log) = test_db_with_project();
 
         // Create and extract from a file (file doesn't exist, source is empty)
-        let file = djls_source::Db::get_or_create_file(
-            &db,
-            camino::Utf8Path::new("/test/project/tags.py"),
-        );
+        let file = path_to_file(&db, camino::Utf8Path::new("/test/project/tags.py"))
+            .expect("fixture file should exist");
         let _result = djls_project::extract_filter_arities(
             &db,
             file,
@@ -1167,10 +1167,8 @@ def my_filter(value, arg):
             logs: Arc::new(Mutex::new(None)),
         };
 
-        let file = djls_source::Db::get_or_create_file(
-            &db,
-            camino::Utf8Path::new("/test/project/tags.py"),
-        );
+        let file = path_to_file(&db, camino::Utf8Path::new("/test/project/tags.py"))
+            .expect("fixture file should exist");
         let result = djls_project::extract_filter_arities(
             &db,
             file,
@@ -1335,7 +1333,8 @@ def my_filter(value, arg):
                 .installed_library_str("custom")
                 .is_none()
         );
-        let extra_file = djls_source::Db::get_or_create_file(&db, &extra_settings_path);
+        let extra_file =
+            path_to_file(&db, &extra_settings_path).expect("fixture file should exist");
         assert!(extra_file.source(&db).as_str().contains("old_tags"));
 
         {
@@ -1402,7 +1401,7 @@ def my_filter(value, arg):
         let file_revisions: Vec<_> = file_paths
             .iter()
             .map(|path| {
-                let file = db.get_or_create_file(path);
+                let file = path_to_file(&db, path).expect("fixture file should exist");
                 (path.clone(), file.revision(&db))
             })
             .collect();
@@ -1422,7 +1421,7 @@ def my_filter(value, arg):
         let unchanged_file_revisions: Vec<_> = file_paths
             .iter()
             .map(|path| {
-                let file = db.get_or_create_file(path);
+                let file = path_to_file(&db, path).expect("fixture file should exist");
                 (path.clone(), file.revision(&db))
             })
             .collect();
@@ -1544,7 +1543,7 @@ def my_filter(value, arg):
         );
         event_log.take();
 
-        let tag_file = db.get_or_create_file(&tag_path);
+        let tag_file = path_to_file(&db, &tag_path).expect("fixture file should exist");
         fs.lock().unwrap().add_file(
             tag_path,
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef new_tag():\n    pass\n".to_string(),
@@ -1653,7 +1652,7 @@ def my_filter(value, arg):
             "both model files should be extracted on first model graph computation"
         );
 
-        let first_model = db.get_or_create_file(&first_model_path);
+        let first_model = path_to_file(&db, &first_model_path).expect("fixture file should exist");
         fs.lock().unwrap().add_file(
             first_model_path,
             "from django.db import models\nclass FirstRenamed(models.Model):\n    pass\n"

--- a/crates/djls-ide/tests/code_actions.rs
+++ b/crates/djls-ide/tests/code_actions.rs
@@ -76,7 +76,7 @@ fn db_with_source_and_config(source: &str, diagnostics_config: DiagnosticsConfig
 }
 
 fn file(db: &TestDatabase) -> djls_source::File {
-    db.get_or_create_file(Utf8Path::new(TEMPLATE_PATH))
+    db.file(Utf8Path::new(TEMPLATE_PATH))
 }
 
 fn template_uri() -> ls_types::Uri {

--- a/crates/djls-ide/tests/completions.rs
+++ b/crates/djls-ide/tests/completions.rs
@@ -83,7 +83,7 @@ fn completion_items(
     let template_libraries = template_libraries(&db);
     let db = db.with_template_libraries(template_libraries);
     db.add_file("template.html", &source);
-    let file = db.get_or_create_file(Utf8Path::new("template.html"));
+    let file = db.file(Utf8Path::new("template.html"));
 
     let Some(response) = completion(&db, file, offset, PositionEncoding::Utf16, false) else {
         return Vec::new();
@@ -173,7 +173,7 @@ fn template_name_completions_use_resolvable_project_names() {
     let (source, offset) = source_and_offset(r#"{% extends "§" %}"#);
     let child_path = "/test/project/templates/child.html";
     install_template_completion_project(&mut db, child_path, &source);
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
 
     let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
         .expect("template names should complete inside quoted references");
@@ -205,7 +205,7 @@ fn template_name_completion_replaces_quoted_argument_interior() {
     let (source, offset) = source_and_offset(r#"{% extends "acc§ount/detail.html" %}"#);
     let child_path = "/test/project/templates/child.html";
     install_template_completion_project(&mut db, child_path, &source);
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
 
     let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
         .expect("template names should complete inside quoted references");
@@ -240,7 +240,7 @@ fn template_name_completion_preserves_existing_full_close_after_open_quote() {
     let (source, offset) = source_and_offset(r#"{% extends "ba§ %}"#);
     let child_path = "/test/project/templates/child.html";
     install_template_completion_project(&mut db, child_path, &source);
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
 
     let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
         .expect("template names should complete inside quoted references");
@@ -275,7 +275,7 @@ fn template_name_completion_repairs_autopaired_quote_before_lone_brace() {
     let (source, offset) = source_and_offset(r#"{% include "ba§"}"#);
     let child_path = "/test/project/templates/child.html";
     install_template_completion_project(&mut db, child_path, &source);
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
 
     let response = completion(&db, file, offset, PositionEncoding::Utf16, false)
         .expect("template names should complete inside quoted references");

--- a/crates/djls-ide/tests/document_links.rs
+++ b/crates/djls-ide/tests/document_links.rs
@@ -31,7 +31,7 @@ fn document_links_resolve_template_references_with_interior_ranges() {
         .template_file("partials/card.html", partial_path, "partial")
         .install(&mut db);
 
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
     let links = document_links(&db, file);
 
     assert_eq!(links.len(), 2);
@@ -86,7 +86,7 @@ fn document_links_resolve_relative_include_to_sibling_template() {
         .template_file("dir/x.html", target_path, "target")
         .install(&mut db);
 
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
     let links = document_links(&db, file);
 
     assert_eq!(
@@ -129,7 +129,7 @@ fn document_links_resolve_load_libraries_with_argument_ranges() {
     );
 
     db.add_file(template_path, source);
-    let file = db.get_or_create_file(Utf8Path::new(template_path));
+    let file = db.file(Utf8Path::new(template_path));
     let links = document_links(&db, file);
 
     assert_eq!(

--- a/crates/djls-ide/tests/folding.rs
+++ b/crates/djls-ide/tests/folding.rs
@@ -29,7 +29,7 @@ fn folding_ranges_include_top_level_and_nested_template_blocks() {
 ";
     let db = TestDatabase::new();
     db.add_file("template.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("template.html"));
+    let file = db.file(Utf8Path::new("template.html"));
     let ranges = collect_folding_ranges(&db, file);
 
     assert!(ranges.iter().any(|range| {
@@ -65,7 +65,7 @@ body
 ";
     let db = TestDatabase::new();
     db.add_file("template.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("template.html"));
+    let file = db.file(Utf8Path::new("template.html"));
     let ranges = collect_folding_ranges(&db, file);
 
     assert!(ranges.iter().any(|range| {

--- a/crates/djls-ide/tests/formatting.rs
+++ b/crates/djls-ide/tests/formatting.rs
@@ -18,7 +18,7 @@ fn format_document_returns_full_document_edit() {
     let source = "<div style=\"background-image: url('{{ MEDIA_URL }}{{ picture }}');\">\n    Content\n</div>\n";
     let db = TestDatabase::new();
     db.add_file("template.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("template.html"));
+    let file = db.file(Utf8Path::new("template.html"));
     let options = formatting_options();
 
     let edits = format_document(

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -22,7 +22,7 @@ fn goto_definition_reports_location_link_with_origin_range() {
         .template_file("base.html", "/test/project/templates/base.html", "base")
         .install(&mut db);
 
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
     let response = goto_definition(
         &db,
         file,
@@ -63,7 +63,7 @@ fn goto_definition_falls_back_to_location_without_link_support() {
         .template_file("base.html", "/test/project/templates/base.html", "base")
         .install(&mut db);
 
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
     let response = goto_definition(
         &db,
         file,
@@ -99,7 +99,7 @@ fn find_references_reports_template_name_interior_range() {
         .template_file("base.html", "/test/project/templates/base.html", "base")
         .install(&mut db);
 
-    let file = db.get_or_create_file(Utf8Path::new(child_path));
+    let file = db.file(Utf8Path::new(child_path));
     let locations = find_references(
         &db,
         file,

--- a/crates/djls-project/src/db.rs
+++ b/crates/djls-project/src/db.rs
@@ -1,8 +1,6 @@
 //! Project-specific database capabilities.
 //!
-//! The trait exposes the runtime state that project-aware semantic code needs:
-//! the current `Project` input. Imperative synchronization lives outside the
-//! trait so it stays a capability boundary rather than a service object.
+//! The trait exposes the runtime state that project-aware semantic code needs.
 
 use camino::Utf8PathBuf;
 use djls_source::Db as SourceDb;

--- a/crates/djls-project/src/discovery.rs
+++ b/crates/djls-project/src/discovery.rs
@@ -6,6 +6,8 @@
 //! transport, and when to apply the payload.
 
 use camino::Utf8PathBuf;
+use djls_source::File;
+use djls_source::path_to_file;
 use salsa::Setter;
 
 use crate::db::Db as ProjectDb;
@@ -345,12 +347,16 @@ pub fn apply_django_discovery(db: &mut dyn ProjectDb, discovery: DjangoDiscovery
     }
 
     for path in file_paths {
-        let file = db.get_or_create_file(&path);
+        let Ok(file) = path_to_file(db, &path) else {
+            continue;
+        };
         let current = file.source(db);
         let latest = db.read_file(&path).unwrap_or_default();
 
         if current.as_str() != latest {
             db.bump_file_revision(file);
         }
+
+        File::sync_path(db, &path);
     }
 }

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -106,6 +106,7 @@ pub(crate) enum ExtractionStatus {
 pub mod testing {
     use camino::Utf8PathBuf;
     use djls_source::File;
+    use djls_source::FileStatus;
     use djls_source::Span;
 
     pub use crate::discovery::compute_django_discovery;
@@ -263,7 +264,10 @@ pub mod testing {
             "/__djls_testing__/{}.py",
             module_name.as_str().replace('.', "/")
         ));
-        let file = db.get_or_create_file(&path);
+        let file = File::builder(path.clone(), 0, FileStatus::Exists)
+            .durability(salsa::Durability::LOW)
+            .path_durability(salsa::Durability::HIGH)
+            .new(db);
         super::PythonModule::new(module_name, path, file)
     }
 }

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -555,7 +555,8 @@ mod tests {
 
     fn extract_model_graph(source: &str, module_name: &str) -> ModelGraph {
         let db = TestDatabase::new();
-        let file = db.get_or_create_file(Utf8Path::new("/test.py"));
+        db.add_file("/test.py", source);
+        let file = db.file(Utf8Path::new("/test.py"));
         let module_name = PythonModuleName::parse(module_name).unwrap();
         let imports = crate::python::extract_import_table_for_source(
             source,

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -1022,7 +1022,8 @@ mod tests {
 
     fn test_file() -> File {
         let db = TestDatabase::new();
-        db.get_or_create_file(Utf8Path::new("/test.py"))
+        db.add_file("/test.py", "");
+        db.file(Utf8Path::new("/test.py"))
     }
 
     fn test_span(start: u32) -> Span {

--- a/crates/djls-project/src/python/imports.rs
+++ b/crates/djls-project/src/python/imports.rs
@@ -333,7 +333,7 @@ mod tests {
     fn import_table_query_reads_python_file_source() {
         let db = TestDatabase::new();
         db.add_file("/project/pkg/mod.py", "import os\n");
-        let file = db.get_or_create_file(camino::Utf8Path::new("/project/pkg/mod.py"));
+        let file = db.file(camino::Utf8Path::new("/project/pkg/mod.py"));
         let table = import_table(&db, file, PythonModuleName::parse("pkg.mod").unwrap());
 
         assert_eq!(binding(table, "os").target.as_str(), "os");

--- a/crates/djls-project/src/python/module.rs
+++ b/crates/djls-project/src/python/module.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_source::File;
+use djls_source::path_to_file;
 use thiserror::Error;
 
 use crate::db::Db as ProjectDb;
@@ -495,7 +496,7 @@ impl PythonModule {
                 PythonModuleCandidate::NamespacePortion { .. } => continue,
             };
 
-            let file = db.get_or_create_file(&path);
+            let file = path_to_file(db, &path).ok()?;
             return Some(Self::new(name, path, file));
         }
 

--- a/crates/djls-project/src/templates/candidates.rs
+++ b/crates/djls-project/src/templates/candidates.rs
@@ -6,6 +6,7 @@ use djls_source::FileRootKind;
 use djls_source::FileSystem;
 use djls_source::WalkEntryKind;
 use djls_source::WalkOptions;
+use djls_source::path_to_file;
 use rustc_hash::FxHashMap;
 
 use crate::db::Db as ProjectDb;
@@ -29,15 +30,15 @@ pub(crate) struct TemplateTagCandidate {
 }
 
 impl TemplateTagCandidate {
-    fn from_source(db: &dyn ProjectDb, source: TemplateTagCandidateSource) -> Self {
+    fn from_source(db: &dyn ProjectDb, source: TemplateTagCandidateSource) -> Option<Self> {
         let module_name = templatetag_module(&source.app, &source.name)
             .expect("template tag candidate source should have a valid module name");
-        let file = db.get_or_create_file(&source.path);
-        Self {
+        let file = path_to_file(db, &source.path).ok()?;
+        Some(Self {
             app: source.app,
             name: source.name,
             module: PythonModule::new(module_name, source.path, file),
-        }
+        })
     }
 
     fn path(&self) -> &Utf8Path {
@@ -198,8 +199,9 @@ pub(crate) fn templatetag_package_candidates(
                 Some(package_module),
             ) {
                 CandidateSourceRecognition::Candidate(source) => {
-                    scan.candidates
-                        .push(TemplateTagCandidate::from_source(db, source));
+                    if let Some(candidate) = TemplateTagCandidate::from_source(db, source) {
+                        scan.candidates.push(candidate);
+                    }
                 }
                 CandidateSourceRecognition::InvalidIdentifier => scan.mark_incomplete(),
                 CandidateSourceRecognition::NotCandidate => {}
@@ -284,7 +286,7 @@ fn discover_templatetag_candidates(
     let mut results: Vec<_> = source_scan
         .sources
         .into_iter()
-        .map(|source| TemplateTagCandidate::from_source(db, source))
+        .filter_map(|source| TemplateTagCandidate::from_source(db, source))
         .collect();
 
     results.sort_by(TemplateTagCandidate::cmp_by_app_name_path);

--- a/crates/djls-project/src/templates/resolution.rs
+++ b/crates/djls-project/src/templates/resolution.rs
@@ -6,6 +6,7 @@ use djls_source::File;
 use djls_source::Utf8PathClean;
 use djls_source::WalkEntryKind;
 use djls_source::WalkOptions;
+use djls_source::path_to_file;
 use djls_source::safe_join;
 use rustc_hash::FxHashMap;
 
@@ -343,9 +344,9 @@ impl ProjectTemplateFiles {
         Self(
             templates
                 .into_iter()
-                .map(|(name, path)| {
-                    let file = db.get_or_create_file(&path);
-                    ProjectTemplateFile::new(name, path, file)
+                .filter_map(|(name, path)| {
+                    let file = path_to_file(db, &path).ok()?;
+                    Some(ProjectTemplateFile::new(name, path, file))
                 })
                 .collect(),
         )

--- a/crates/djls-project/src/templates/tags/analysis/calls.rs
+++ b/crates/djls-project/src/templates/tags/analysis/calls.rs
@@ -140,6 +140,7 @@ mod tests {
     use camino::Utf8Path;
     use djls_source::FileSystem;
     use djls_source::InMemoryFileSystem;
+    use djls_source::path_to_file;
     use ruff_python_ast::Stmt;
     use ruff_python_ast::StmtFunctionDef;
     use ruff_python_parser::parse_module;
@@ -173,7 +174,8 @@ mod tests {
                 .lock()
                 .unwrap()
                 .add_file(path.into(), source.to_string());
-            <Self as djls_source::Db>::get_or_create_file(self, Utf8Path::new(path))
+            path_to_file(self, Utf8Path::new(path))
+                .expect("inserted Python fixture should be visible")
         }
     }
 

--- a/crates/djls-project/tests/corpus.rs
+++ b/crates/djls-project/tests/corpus.rs
@@ -45,7 +45,7 @@ fn extraction_snapshots() {
         let source = std::fs::read_to_string(path.as_std_path()).unwrap();
         let module_name = module_name_from_file(&path);
         db.add_file(path.as_str(), &source);
-        let file = db.get_or_create_file(&path);
+        let file = db.file(&path);
         let bundle = extract_bundle(&db, file, PythonModuleName::parse(&module_name).unwrap());
 
         let relative = path.strip_prefix(corpus.root()).unwrap_or(&path);

--- a/crates/djls-project/tests/corpus_models.rs
+++ b/crates/djls-project/tests/corpus_models.rs
@@ -45,7 +45,7 @@ fn model_extraction_snapshots() {
     for path in targets {
         let source = std::fs::read_to_string(path.as_std_path()).unwrap();
         db.add_file(path.as_str(), &source);
-        let file = db.get_or_create_file(&path);
+        let file = db.file(&path);
         let module_name = module_name_from_file(&path);
         let Ok(module_name) = PythonModuleName::parse(&module_name) else {
             continue;

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -27,7 +27,7 @@ fn extract_source(source: &str, module_name: &str) -> ExtractionBundle {
     let db = TestDatabase::new();
     let path = Utf8Path::new("/test/extraction.py");
     db.add_file(path.as_str(), source);
-    let file = db.get_or_create_file(path);
+    let file = db.file(path);
     extract_bundle(&db, file, PythonModuleName::parse(module_name).unwrap())
 }
 

--- a/crates/djls-project/tests/extraction_status.rs
+++ b/crates/djls-project/tests/extraction_status.rs
@@ -53,7 +53,7 @@ fn model_parse_failure_is_unparseable_with_empty_graph() {
     let db = TestDatabase::new();
     let path = Utf8Path::new("/proj/blog/models.py");
     db.add_file(path.as_str(), "class Broken(");
-    let file = db.get_or_create_file(path);
+    let file = db.file(path);
     let module_name = PythonModuleName::parse("blog.models").unwrap();
 
     let graph = extract_model_graph(&db, file, module_name.clone());
@@ -71,7 +71,7 @@ fn successful_model_parse_is_partial() {
         path.as_str(),
         "from django.db import models\nclass Post(models.Model):\n    pass\n",
     );
-    let file = db.get_or_create_file(path);
+    let file = db.file(path);
     let module_name = PythonModuleName::parse("blog.models").unwrap();
 
     let graph = extract_model_graph(&db, file, module_name.clone());
@@ -86,7 +86,7 @@ fn filter_arity_parse_failure_is_unparseable_with_empty_map() {
     let db = TestDatabase::new();
     let path = Utf8Path::new("/proj/blog/templatetags/blog.py");
     db.add_file(path.as_str(), "def broken(");
-    let file = db.get_or_create_file(path);
+    let file = db.file(path);
     let module_name = PythonModuleName::parse("blog.templatetags.blog").unwrap();
 
     let extraction = djls_project::extract_filter_arities(&db, file, module_name.clone());
@@ -104,7 +104,7 @@ fn successful_filter_arity_parse_is_partial() {
         path.as_str(),
         "from django import template\nregister = template.Library()\n@register.filter\ndef shout(value):\n    return value\n",
     );
-    let file = db.get_or_create_file(path);
+    let file = db.file(path);
     let module_name = PythonModuleName::parse("blog.templatetags.blog").unwrap();
 
     let extraction = djls_project::extract_filter_arities(&db, file, module_name.clone());

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -44,7 +44,7 @@ fn relation_value<'a>(graph: &'a Value, model: &str, field: &str) -> &'a Value {
 
 fn update_file(db: &mut TestDatabase, path: &str, content: &str) {
     db.add_file(path, content);
-    let file = db.get_or_create_file(Utf8Path::new(path));
+    let file = db.file(Utf8Path::new(path));
     db.bump_file_revision(file);
 }
 
@@ -295,7 +295,7 @@ fn model_graph_records_model_and_relation_provenance_for_relation_forms() {
         .build(&db);
 
     let graph = compute_model_graph(&db, project);
-    let blog_file = db.get_or_create_file(Utf8Path::new("/project/blog/models.py"));
+    let blog_file = db.file(Utf8Path::new("/project/blog/models.py"));
     let (model_file, model_span) =
         model_location(graph, "blog.models", "Post").expect("Post model should have location");
     assert_eq!(model_file, blog_file);
@@ -365,8 +365,8 @@ fn model_graph_records_inherited_relation_provenance() {
         .build(&db);
 
     let graph = compute_model_graph(&db, project);
-    let same_file = db.get_or_create_file(Utf8Path::new("/project/inheritance/models.py"));
-    let base_file = db.get_or_create_file(Utf8Path::new("/project/base/models.py"));
+    let same_file = db.file(Utf8Path::new("/project/inheritance/models.py"));
+    let base_file = db.file(Utf8Path::new("/project/base/models.py"));
 
     for child in ["SameFileChild", "SameFileSibling"] {
         let locations = model_relation_locations(graph, "inheritance.models", child);

--- a/crates/djls-project/tests/templates.rs
+++ b/crates/djls-project/tests/templates.rs
@@ -229,7 +229,7 @@ fn template_names_for_file_returns_names_in_discovery_order() {
         ],
     );
 
-    let file = db.get_or_create_file(Utf8Path::new("/test/project/templates/account/detail.html"));
+    let file = db.file(Utf8Path::new("/test/project/templates/account/detail.html"));
     let names: Vec<_> = template_resolution(&db, project)
         .template_names_for_file(&db, file)
         .iter()

--- a/crates/djls-semantic/tests/corpus_inheritance.rs
+++ b/crates/djls-semantic/tests/corpus_inheritance.rs
@@ -56,7 +56,7 @@ fn corpus_template_inheritance_terminates() {
 
         let project = fixture.build(&db);
         for template_path in templates {
-            let file = db.get_or_create_file(&template_path);
+            let file = db.file(&template_path);
             if parse_template(&db, file).is_none() {
                 continue;
             }

--- a/crates/djls-semantic/tests/inheritance.rs
+++ b/crates/djls-semantic/tests/inheritance.rs
@@ -48,7 +48,7 @@ fn project_with_templates(
 
 fn symbols_for_source<'db>(db: &'db TestDatabase, source: &str) -> &'db TemplateSymbols {
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(db, file).expect("should parse");
     template_symbols(db, nodelist)
 }
@@ -119,7 +119,7 @@ fn self_extends_skips_visited_origin_and_uses_shadowed_template() {
             ),
         ],
     );
-    let file = db.get_or_create_file(Utf8Path::new(
+    let file = db.file(Utf8Path::new(
         "/test/project/templates/admin/base_site.html",
     ));
 
@@ -149,7 +149,7 @@ fn template_inheritance_resolves_relative_sibling_extends() {
             ),
         ],
     );
-    let file = db.get_or_create_file(Utf8Path::new("/test/project/templates/dir/child.html"));
+    let file = db.file(Utf8Path::new("/test/project/templates/dir/child.html"));
 
     let (ancestors, end) = inheritance_summary(&db, project, file);
 
@@ -168,7 +168,7 @@ fn template_inheritance_treats_escaping_relative_extends_as_unresolved() {
             "{% extends \"../../outside.html\" %}",
         )],
     );
-    let file = db.get_or_create_file(Utf8Path::new("/test/project/templates/page.html"));
+    let file = db.file(Utf8Path::new("/test/project/templates/page.html"));
 
     let (ancestors, end) = inheritance_summary(&db, project, file);
 
@@ -198,8 +198,8 @@ fn block_overrides_accepts_relative_winning_extends_target() {
             ),
         ],
     );
-    let parent = db.get_or_create_file(Utf8Path::new("/test/project/templates/dir/parent.html"));
-    let child = db.get_or_create_file(Utf8Path::new("/test/project/templates/dir/child.html"));
+    let parent = db.file(Utf8Path::new("/test/project/templates/dir/parent.html"));
+    let child = db.file(Utf8Path::new("/test/project/templates/dir/child.html"));
 
     let overrides = block_overrides(&db, project, parent, "content");
 
@@ -241,10 +241,8 @@ fn template_inheritance_follows_extends_role_not_builtin_name() {
             ),
         ],
     );
-    let custom_file =
-        db.get_or_create_file(Utf8Path::new("/test/project/templates/custom_child.html"));
-    let builtin_file =
-        db.get_or_create_file(Utf8Path::new("/test/project/templates/builtin_child.html"));
+    let custom_file = db.file(Utf8Path::new("/test/project/templates/custom_child.html"));
+    let builtin_file = db.file(Utf8Path::new("/test/project/templates/builtin_child.html"));
 
     let custom = inheritance_summary(&db, project, custom_file);
     let builtin = inheritance_summary(&db, project, builtin_file);

--- a/crates/djls-semantic/tests/mdtest_inheritance.rs
+++ b/crates/djls-semantic/tests/mdtest_inheritance.rs
@@ -35,7 +35,7 @@ fn render_inheritance(scenario: &Scenario) -> String {
 
     let primary = scenario.primary_file();
     let primary_path = template_path(&primary.path);
-    let file = db.get_or_create_file(Utf8Path::new(&primary_path));
+    let file = db.file(Utf8Path::new(&primary_path));
     let nodelist = parse_template(&db, file).expect("should parse");
     let symbols = template_symbols(&db, nodelist);
     let inheritance = template_inheritance(&db, project, file);

--- a/crates/djls-semantic/tests/offset.rs
+++ b/crates/djls-semantic/tests/offset.rs
@@ -17,7 +17,7 @@ fn context_for_source<'db>(
 ) -> SemanticOffsetContext<'db> {
     let path = "test.html";
     db.add_file(path, source);
-    let file = db.get_or_create_file(Utf8Path::new(path));
+    let file = db.file(Utf8Path::new(path));
     SemanticOffsetContext::from_offset(db, file, offset)
 }
 

--- a/crates/djls-semantic/tests/structure_opaque.rs
+++ b/crates/djls-semantic/tests/structure_opaque.rs
@@ -15,7 +15,7 @@ use djls_testing::TestDatabase;
 fn compute_regions(db: &TestDatabase, source: &str) -> OpaqueRegions {
     let path = "test.html";
     db.add_file(path, source);
-    let file = db.get_or_create_file(Utf8Path::new(path));
+    let file = db.file(Utf8Path::new(path));
     let nodelist = parse_template(db, file).expect("should parse");
     compute_opaque_regions(db, nodelist)
 }
@@ -42,7 +42,7 @@ fn opaque_opener_treats_intermediate_as_raw_content() {
     let path = "test.html";
     let source = "{% opaque_if %}first{% opaque_else %}second{% endopaque_if %}";
     db.add_file(path, source);
-    let file = db.get_or_create_file(Utf8Path::new(path));
+    let file = db.file(Utf8Path::new(path));
     let nodelist = parse_template(&db, file).expect("should parse");
     let regions = compute_opaque_regions(&db, nodelist);
     let first = u32::try_from(source.find("first").unwrap()).unwrap();
@@ -140,7 +140,7 @@ fn unclosed_opaque_block_creates_no_region() {
     let path = "test.html";
     let source = "{% verbatim %}body";
     db.add_file(path, source);
-    let file = db.get_or_create_file(Utf8Path::new(path));
+    let file = db.file(Utf8Path::new(path));
     let nodelist = parse_template(&db, file).expect("should parse");
     let regions = compute_opaque_regions(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist);

--- a/crates/djls-semantic/tests/structure_outline.rs
+++ b/crates/djls-semantic/tests/structure_outline.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHashMap;
 
 fn outline_for_source<'db>(db: &'db TestDatabase, source: &str) -> &'db Vec<OutlineItem> {
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(db, file).expect("should parse");
     let tree = build_template_tree(db, nodelist);
     build_template_outline(db, tree)

--- a/crates/djls-semantic/tests/structure_tree.rs
+++ b/crates/djls-semantic/tests/structure_tree.rs
@@ -272,7 +272,7 @@ fn test_template_tree_building() {
 "#;
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
 
     insta::assert_yaml_snapshot!("nodelist", nodelist_view(nodelist.nodelist(&db)));
@@ -285,7 +285,7 @@ fn test_template_tree_building() {
 
 fn tree_for_source<'db>(db: &'db TestDatabase, source: &str) -> TemplateTree<'db> {
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(db, file).expect("should parse");
     build_template_tree(db, nodelist)
 }
@@ -386,7 +386,7 @@ fn shared_intermediate_inside_opaque_block_has_no_structure() {
     let source = "{% opaque_if %}{% if cond %}first{% else %}second{% endif %}{% endopaque_if %}";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let tree = build_template_tree(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist);
@@ -445,7 +445,7 @@ fn opaque_closer_name_can_also_be_structured_opener() {
     let source = "{% raw %}body{% panel %}";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let tree = build_template_tree(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
@@ -465,7 +465,7 @@ fn opaque_closer_name_can_also_be_structured_opener() {
 
     let outside_source = "{% panel %}body{% endpanel %}";
     db.add_file("outside.html", outside_source);
-    let outside_file = db.get_or_create_file(Utf8Path::new("outside.html"));
+    let outside_file = db.file(Utf8Path::new("outside.html"));
     let outside_nodelist = parse_template(&db, outside_file).expect("should parse");
     let outside_tree = build_template_tree(&db, outside_nodelist);
     let outside_errors =
@@ -502,7 +502,7 @@ fn unclosed_optional_opaque_block_reports_unclosed_without_node() {
     let source = "{% raw %}body";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let tree = build_template_tree(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
@@ -530,7 +530,7 @@ fn known_opener_and_closer_inside_opaque_block_have_no_structure() {
     let source = "{% verbatim %}{% if x %}body{% endif %}{% endverbatim %}";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let tree = build_template_tree(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
@@ -558,7 +558,7 @@ fn outer_closer_inside_opaque_block_has_no_structure() {
     let source = "{% if outer %}{% verbatim %}{% endif %}{% endverbatim %}{% endif %}";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let tree = build_template_tree(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist)
@@ -704,7 +704,7 @@ fn malformed_recovery_is_best_effort() {
 {% endblock %}";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let tree = build_template_tree(&db, nodelist);
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist);
@@ -757,7 +757,7 @@ fn test_endblock_name_mismatch() {
 ";
 
     db.add_file("test.html", source);
-    let file = db.get_or_create_file(Utf8Path::new("test.html"));
+    let file = db.file(Utf8Path::new("test.html"));
     let nodelist = parse_template(&db, file).expect("should parse");
     let errors = build_template_tree::accumulated::<ValidationErrorAccumulator>(&db, nodelist);
     assert_eq!(errors.len(), 1);

--- a/crates/djls-server/src/document.rs
+++ b/crates/djls-server/src/document.rs
@@ -7,7 +7,6 @@
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_source::File;
 use djls_source::FileKind;
 use djls_source::LineIndex;
 use djls_source::PositionEncoding;
@@ -19,8 +18,6 @@ use djls_source::Range;
 /// version tracking for synchronization and pre-computed line indices for
 /// efficient position lookups.
 ///
-/// Links to the corresponding Salsa `File` for integration with incremental
-/// computation and invalidation tracking.
 #[derive(Clone)]
 pub(crate) struct TextDocument {
     /// The document's path.
@@ -33,19 +30,11 @@ pub(crate) struct TextDocument {
     kind: FileKind,
     /// Line index for efficient position and range lookups.
     line_index: LineIndex,
-    /// The Salsa file this document represents.
-    file: File,
 }
 
 impl TextDocument {
     #[must_use]
-    pub(crate) fn new(
-        path: Utf8PathBuf,
-        content: String,
-        version: i32,
-        kind: FileKind,
-        file: File,
-    ) -> Self {
+    pub(crate) fn new(path: Utf8PathBuf, content: String, version: i32, kind: FileKind) -> Self {
         let line_index = LineIndex::from(content.as_str());
         Self {
             path,
@@ -53,7 +42,6 @@ impl TextDocument {
             version,
             kind,
             line_index,
-            file,
         }
     }
 
@@ -70,11 +58,6 @@ impl TextDocument {
     #[must_use]
     pub(crate) fn kind(&self) -> FileKind {
         self.kind
-    }
-
-    #[must_use]
-    pub(crate) fn file(&self) -> File {
-        self.file
     }
 
     #[must_use]
@@ -151,57 +134,18 @@ impl DocumentChange {
 #[cfg(test)]
 mod tests {
     use camino::Utf8Path;
-    use djls_source::Db as _;
     use djls_source::FileKind;
-    use djls_source::FileSystem;
-    use djls_source::InMemoryFileSystem;
     use djls_source::LineCol;
-    use djls_source::SourceFiles;
 
     use super::*;
 
-    #[salsa::db]
-    #[derive(Clone)]
-    struct TestDb {
-        storage: salsa::Storage<Self>,
-        files: SourceFiles,
-        fs: InMemoryFileSystem,
-    }
-
-    impl Default for TestDb {
-        fn default() -> Self {
-            Self {
-                storage: salsa::Storage::new(None),
-                files: SourceFiles::default(),
-                fs: InMemoryFileSystem::new(),
-            }
-        }
-    }
-
-    #[salsa::db]
-    impl salsa::Database for TestDb {}
-
-    #[salsa::db]
-    impl djls_source::Db for TestDb {
-        fn files(&self) -> &SourceFiles {
-            &self.files
-        }
-
-        fn file_system(&self) -> &dyn FileSystem {
-            &self.fs
-        }
-    }
-
     fn text_document(content: &str, version: i32) -> TextDocument {
-        let db = TestDb::default();
         let path = Utf8Path::new("/test.txt");
-        let file = db.get_or_create_file(path);
         TextDocument::new(
             path.to_path_buf(),
             content.to_string(),
             version,
             FileKind::Other,
-            file,
         )
     }
 

--- a/crates/djls-server/src/reload.rs
+++ b/crates/djls-server/src/reload.rs
@@ -9,6 +9,7 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
+use camino::Utf8PathBuf;
 use djls_conf::Settings;
 use djls_db::DjangoDatabase;
 use djls_ide::WarmCachePart;
@@ -21,6 +22,7 @@ use djls_project::DjangoDiscoveryPart;
 use djls_project::Project;
 use djls_project::apply_django_discovery;
 use djls_project::django_discovery_phases;
+use djls_source::path_to_file;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
@@ -614,8 +616,8 @@ async fn republish_snapshot_diagnostics(
     }
 
     for document in documents {
-        let file = document.file();
-        let Some(diagnostics) = collect_snapshot_diagnostics(snapshot.clone(), file).await else {
+        let path = document.path().to_path_buf();
+        let Some(diagnostics) = collect_snapshot_diagnostics(snapshot.clone(), path).await else {
             continue;
         };
 
@@ -639,12 +641,14 @@ async fn republish_snapshot_diagnostics(
 
 async fn collect_snapshot_diagnostics(
     snapshot: SessionSnapshot,
-    file: djls_source::File,
+    path: Utf8PathBuf,
 ) -> Option<Vec<ls_types::Diagnostic>> {
     for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
         let snapshot = snapshot.clone();
+        let path = path.clone();
         let result = tokio::task::spawn_blocking(move || {
             salsa::Cancelled::catch(AssertUnwindSafe(|| {
+                let file = path_to_file(snapshot.db(), &path).ok()?;
                 djls_ide::collect_diagnostics(snapshot.db(), file)
             }))
         })

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -2,6 +2,7 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
 use djls_source::FileKind;
+use djls_source::path_to_file;
 use tokio::sync::Mutex;
 use tower_lsp_server::Client;
 use tower_lsp_server::LanguageServer;
@@ -104,9 +105,12 @@ impl DjangoLanguageServer {
             return;
         }
 
-        let file = document.file();
+        let path = document.path().to_path_buf();
         let Some(diagnostics) = self
-            .with_snapshot(move |snapshot| djls_ide::collect_diagnostics(snapshot.db(), file))
+            .with_snapshot(move |snapshot| {
+                let file = path_to_file(snapshot.db(), &path).ok()?;
+                djls_ide::collect_diagnostics(snapshot.db(), file)
+            })
             .await
         else {
             return;

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -3,14 +3,17 @@
 //! This module implements the LSP session abstraction that manages project-specific
 //! state and the Salsa database for incremental computation.
 
-#[cfg(test)]
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_db::DjangoDatabase;
-use djls_source::Db as SourceDb;
+use djls_source::ChangeEvent;
+use djls_source::Db as _;
 use djls_source::File;
+use djls_source::FileStatus;
 use djls_source::Offset;
+use djls_source::SourceChanges;
 use djls_source::Span;
+use djls_source::path_to_file;
 use tower_lsp_server::ls_types;
 
 use crate::client::ClientInfo;
@@ -106,8 +109,8 @@ impl Session {
 
     /// Open a document in the session.
     ///
-    /// Updates both the workspace buffers and database. Creates the file in
-    /// the database or invalidates it if it already exists.
+    /// Updates the workspace buffer first, then applies the project-visible
+    /// file event against the overlay-backed database.
     pub(crate) fn open_document(
         &mut self,
         text_document: &ls_types::TextDocumentItem,
@@ -118,14 +121,12 @@ impl Session {
         };
 
         let kind = text_document.language_id_to_file_kind(self.client_info.client());
-
-        Some(self.workspace.open_document(
-            &mut self.db,
-            &path,
-            &text_document.text,
-            text_document.version,
-            kind,
-        ))
+        let change = self.open_document_change(&path);
+        let document =
+            self.workspace
+                .open_document(&path, &text_document.text, text_document.version, kind);
+        SourceChanges::new([change]).apply(&mut self.db);
+        Some(document)
     }
 
     pub(crate) fn save_document(
@@ -137,7 +138,9 @@ impl Session {
             return None;
         };
 
-        self.workspace.save_document(&mut self.db, &path)
+        let document = self.workspace.save_document(&path)?;
+        SourceChanges::new([ChangeEvent::ContentChanged(path)]).apply(&mut self.db);
+        Some(document)
     }
 
     pub(crate) fn update_document(
@@ -150,19 +153,25 @@ impl Session {
             return None;
         };
 
-        self.workspace.update_document(
-            &mut self.db,
+        let change = if self.workspace.get_document(&path).is_some() {
+            ChangeEvent::ContentChanged(path.clone())
+        } else {
+            self.open_document_change(&path)
+        };
+        let document = self.workspace.update_document(
             &path,
             changes.to_document_changes(),
             text_document.version,
             self.client_info.position_encoding(),
-        )
+        )?;
+        SourceChanges::new([change]).apply(&mut self.db);
+        Some(document)
     }
 
     /// Close a document.
     ///
-    /// Removes from workspace buffers and triggers database invalidation to fall back to disk.
-    /// For template files, immediately re-parses from disk.
+    /// Removes the document from workspace buffers, invalidates cached source state,
+    /// and lets future reads fall back to disk.
     pub(crate) fn close_document(
         &mut self,
         text_document: &ls_types::TextDocumentIdentifier,
@@ -172,9 +181,37 @@ impl Session {
             return None;
         };
 
-        let document = self.workspace.close_document(&mut self.db, &path)?;
+        let change = self.close_document_change(&path);
+        let document = self.workspace.close_document(&path)?;
+        SourceChanges::new([change]).apply(&mut self.db);
 
         Some(document)
+    }
+
+    fn open_document_change(&self, path: &Utf8Path) -> ChangeEvent {
+        if !self.workspace.disk_is_file(path) {
+            return ChangeEvent::BecameVisible(path.to_path_buf());
+        }
+
+        match self
+            .db
+            .files()
+            .try_file(path)
+            .map(|file| file.status(&self.db))
+        {
+            Some(FileStatus::Exists) => ChangeEvent::Opened(path.to_path_buf()),
+            Some(FileStatus::IsADirectory | FileStatus::NotFound) | None => {
+                ChangeEvent::BecameVisible(path.to_path_buf())
+            }
+        }
+    }
+
+    fn close_document_change(&self, path: &Utf8Path) -> ChangeEvent {
+        if self.workspace.disk_is_file(path) {
+            ChangeEvent::ContentChanged(path.to_path_buf())
+        } else {
+            ChangeEvent::Deleted(path.to_path_buf())
+        }
     }
 
     /// Get a document from the buffer if it's open.
@@ -185,11 +222,7 @@ impl Session {
 
     /// Get all currently open documents.
     pub(crate) fn open_documents(&self) -> Vec<TextDocument> {
-        self.workspace
-            .buffers()
-            .iter()
-            .map(|(_path, document)| document)
-            .collect()
+        self.workspace.open_documents()
     }
 }
 
@@ -238,7 +271,7 @@ impl SessionSnapshot {
             return None;
         };
 
-        Some(self.db.get_or_create_file(&path))
+        path_to_file(&self.db, &path).ok()
     }
 
     /// Resolve an LSP positioned document request to a tracked file and byte offset.
@@ -290,7 +323,6 @@ impl SessionSnapshot {
 mod tests {
     use djls_project::Db as ProjectDb;
     use djls_project::Interpreter;
-    use djls_source::Db as SourceDb;
     use tempfile::tempdir;
 
     use super::*;
@@ -324,7 +356,7 @@ mod tests {
         assert!(session.get_document(&path).is_some());
 
         let db = session.db();
-        let file = db.get_or_create_file(&path);
+        let file = path_to_file(db, &path).expect("open buffer should be visible to the overlay");
         let content = file.source(db).to_string();
         assert_eq!(content, "print('hello')");
 
@@ -359,7 +391,7 @@ mod tests {
         assert_eq!(doc.version(), 2);
 
         let db = session.db();
-        let file = db.get_or_create_file(&path);
+        let file = path_to_file(db, &path).expect("open buffer should be visible to the overlay");
         let content = file.source(db).to_string();
         assert_eq!(content, "updated");
     }

--- a/crates/djls-server/src/workspace.rs
+++ b/crates/djls-server/src/workspace.rs
@@ -39,7 +39,6 @@ use std::sync::Arc;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_source::Db;
 use djls_source::FileKind;
 use djls_source::FileSystem;
 use djls_source::FxDashMap;
@@ -52,12 +51,11 @@ use djls_source::WalkOptions;
 use crate::document::DocumentChange;
 use crate::document::TextDocument;
 
-/// Workspace facade that coordinates open buffers with source invalidation.
+/// Workspace facade for open buffers and the filesystem overlay.
 ///
-/// `Workspace` provides the LSP/session boundary for document lifecycle events.
-/// It stores open documents, exposes an overlay filesystem to the database, and
-/// bumps the corresponding `djls_source::File` revision whenever buffered
-/// content changes.
+/// `Workspace` stores open documents and exposes an overlay filesystem to the
+/// database. `Session` applies the matching project-visible file events after
+/// mutating this buffer state.
 pub(crate) struct Workspace {
     /// Thread-safe shared buffer storage for open documents.
     buffers: Buffers,
@@ -87,82 +85,63 @@ impl Workspace {
         self.overlay.clone()
     }
 
-    /// Return the shared open-document buffers for session bookkeeping.
+    /// Return all currently open documents.
+    pub(crate) fn open_documents(&self) -> Vec<TextDocument> {
+        self.buffers
+            .iter()
+            .map(|(_path, document)| document)
+            .collect()
+    }
+
     #[must_use]
-    pub(crate) fn buffers(&self) -> &Buffers {
-        &self.buffers
+    pub(crate) fn disk_is_file(&self, path: &Utf8Path) -> bool {
+        self.overlay.disk.is_file(path)
     }
 
-    fn open_changes_file_set(&self, db: &dyn Db, path: &Utf8Path) -> bool {
-        !self.overlay.disk.is_file(path) || !db.files().contains_file(path)
-    }
-
-    fn close_changes_file_set(&self, path: &Utf8Path) -> bool {
-        !self.overlay.disk.is_file(path)
-    }
-
-    #[cfg(test)]
     #[must_use]
     pub(crate) fn get_document(&self, path: &Utf8Path) -> Option<TextDocument> {
         self.buffers.get(path)
     }
 
-    /// Open a document in memory and ensure a corresponding Salsa file exists.
+    /// Open a document in memory.
     pub(crate) fn open_document(
         &mut self,
-        db: &mut dyn Db,
         path: &Utf8Path,
         content: &str,
         version: i32,
         kind: FileKind,
     ) -> TextDocument {
-        let file_set_changes = self.open_changes_file_set(db, path);
-        let file = db.get_or_create_file(path);
-        let document =
-            TextDocument::new(path.to_path_buf(), content.to_string(), version, kind, file);
+        let document = TextDocument::new(path.to_path_buf(), content.to_string(), version, kind);
         debug_assert_eq!(document.kind(), kind);
-        db.bump_file_and_maybe_root_revision(document.file(), path, file_set_changes);
         self.buffers.open(path.to_path_buf(), document.clone());
         document
     }
 
-    /// Mark a saved open document as changed so cached source queries refresh.
-    pub(crate) fn save_document(
-        &mut self,
-        db: &mut dyn Db,
-        path: &Utf8Path,
-    ) -> Option<TextDocument> {
-        let document = self.buffers.get(path)?;
-        db.bump_file_revision(document.file());
-        Some(document)
+    /// Return the saved open document without changing buffered content.
+    pub(crate) fn save_document(&self, path: &Utf8Path) -> Option<TextDocument> {
+        self.buffers.get(path)
     }
 
-    /// Apply LSP text changes to an open document and bump its source revision.
+    /// Apply LSP text changes to an open document.
     pub(crate) fn update_document(
         &mut self,
-        db: &mut dyn Db,
         path: &Utf8Path,
         changes: Vec<DocumentChange>,
         version: i32,
         encoding: PositionEncoding,
     ) -> Option<TextDocument> {
         if let Some(mut document) = self.buffers.get(path) {
-            db.bump_file_revision(document.file());
             document.update(changes, version, encoding);
             self.buffers.update(path.to_path_buf(), document.clone());
             Some(document)
         } else if let Some(first_change) = changes.into_iter().next() {
             if first_change.range().is_none() {
-                let file_set_changes = self.open_changes_file_set(db, path);
-                let file = db.get_or_create_file(path);
                 let document = TextDocument::new(
                     path.to_path_buf(),
                     first_change.text().to_string(),
                     version,
                     FileKind::Other,
-                    file,
                 );
-                db.bump_file_and_maybe_root_revision(file, path, file_set_changes);
                 self.buffers.open(path.to_path_buf(), document.clone());
                 Some(document)
             } else {
@@ -173,16 +152,9 @@ impl Workspace {
         }
     }
 
-    /// Close a document, removing it from buffers and touching the tracked file.
-    pub(crate) fn close_document(
-        &mut self,
-        db: &mut dyn Db,
-        path: &Utf8Path,
-    ) -> Option<TextDocument> {
-        let file_set_changes = self.close_changes_file_set(path);
-        let document = self.buffers.close(path)?;
-        db.bump_file_and_maybe_root_revision(document.file(), path, file_set_changes);
-        Some(document)
+    /// Close a document, removing it from buffers.
+    pub(crate) fn close_document(&mut self, path: &Utf8Path) -> Option<TextDocument> {
+        self.buffers.close(path)
     }
 }
 
@@ -393,10 +365,13 @@ fn buffer_relative_path(root: &Utf8Path, path: &Utf8Path) -> Option<Utf8PathBuf>
 
 #[cfg(test)]
 mod tests {
+    use djls_source::ChangeEvent;
     use djls_source::Db as _;
     use djls_source::FileRootKind;
     use djls_source::InMemoryFileSystem;
+    use djls_source::SourceChanges;
     use djls_source::SourceFiles;
+    use djls_source::path_to_file;
     use tempfile::tempdir;
 
     use super::*;
@@ -433,15 +408,15 @@ mod tests {
         }
     }
 
-    fn text_document(db: &TestDb, path: &Utf8Path, content: &str) -> TextDocument {
-        let file = db.get_or_create_file(path);
-        TextDocument::new(
-            path.to_path_buf(),
-            content.to_string(),
-            1,
-            FileKind::Python,
-            file,
-        )
+    #[salsa::db]
+    impl djls_project::Db for TestDb {
+        fn project(&self) -> Option<djls_project::Project> {
+            None
+        }
+    }
+
+    fn text_document(_db: &TestDb, path: &Utf8Path, content: &str) -> TextDocument {
+        TextDocument::new(path.to_path_buf(), content.to_string(), 1, FileKind::Python)
     }
 
     #[test]
@@ -514,18 +489,14 @@ mod tests {
         let root = db
             .files()
             .try_add_root(&db, root.to_path_buf(), FileRootKind::Project);
-        db.get_or_create_file(&file_path);
+        let _ = path_to_file(&db, &file_path).expect("disk-backed fixture should exist");
 
-        workspace.open_document(
-            &mut db,
-            &file_path,
-            "buffer template",
-            1,
-            FileKind::Template,
-        );
+        workspace.open_document(&file_path, "buffer template", 1, FileKind::Template);
+        SourceChanges::new([ChangeEvent::Opened(file_path.clone())]).apply(&mut db);
         assert_eq!(root.revision(&db), 0);
 
-        workspace.close_document(&mut db, &file_path).unwrap();
+        workspace.close_document(&file_path).unwrap();
+        SourceChanges::new([ChangeEvent::ContentChanged(file_path.clone())]).apply(&mut db);
         assert_eq!(root.revision(&db), 0);
     }
 
@@ -542,16 +513,12 @@ mod tests {
             .files()
             .try_add_root(&db, root.to_path_buf(), FileRootKind::Project);
 
-        workspace.open_document(
-            &mut db,
-            &file_path,
-            "buffer template",
-            1,
-            FileKind::Template,
-        );
+        workspace.open_document(&file_path, "buffer template", 1, FileKind::Template);
+        SourceChanges::new([ChangeEvent::BecameVisible(file_path.clone())]).apply(&mut db);
         assert_eq!(root.revision(&db), 1);
 
-        workspace.close_document(&mut db, &file_path).unwrap();
+        workspace.close_document(&file_path).unwrap();
+        SourceChanges::new([ChangeEvent::ContentChanged(file_path.clone())]).apply(&mut db);
         assert_eq!(root.revision(&db), 1);
     }
 
@@ -567,16 +534,12 @@ mod tests {
             .files()
             .try_add_root(&db, root_path.to_path_buf(), FileRootKind::Project);
 
-        workspace.open_document(
-            &mut db,
-            &file_path,
-            "buffer template",
-            1,
-            FileKind::Template,
-        );
+        workspace.open_document(&file_path, "buffer template", 1, FileKind::Template);
+        SourceChanges::new([ChangeEvent::BecameVisible(file_path.clone())]).apply(&mut db);
         assert_eq!(root.revision(&db), 1);
 
-        workspace.close_document(&mut db, &file_path).unwrap();
+        workspace.close_document(&file_path).unwrap();
+        SourceChanges::new([ChangeEvent::Deleted(file_path.clone())]).apply(&mut db);
         assert_eq!(root.revision(&db), 2);
     }
 
@@ -588,28 +551,24 @@ mod tests {
 
         let mut workspace = Workspace::new();
         let mut db = TestDb::new(workspace.overlay());
-        let document = workspace.open_document(
-            &mut db,
-            &file_path,
-            "buffer template",
-            1,
-            FileKind::Template,
-        );
-        let file = document.file();
+        workspace.open_document(&file_path, "buffer template", 1, FileKind::Template);
+        SourceChanges::new([ChangeEvent::BecameVisible(file_path.clone())]).apply(&mut db);
+        let file = path_to_file(&db, &file_path).expect("opened document should be interned");
         assert_eq!(file.source(&db).as_str(), "buffer template");
 
         workspace
             .update_document(
-                &mut db,
                 &file_path,
                 vec![DocumentChange::new(None, "updated template".to_string())],
                 2,
                 PositionEncoding::Utf16,
             )
             .unwrap();
+        SourceChanges::new([ChangeEvent::ContentChanged(file_path.clone())]).apply(&mut db);
         assert_eq!(file.source(&db).as_str(), "updated template");
 
-        workspace.close_document(&mut db, &file_path).unwrap();
+        workspace.close_document(&file_path).unwrap();
+        SourceChanges::new([ChangeEvent::ContentChanged(file_path.clone())]).apply(&mut db);
         assert_eq!(file.source(&db).as_str(), "disk template");
     }
 }

--- a/crates/djls-source/Cargo.toml
+++ b/crates/djls-source/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+djls-testing = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/djls-source/src/changes.rs
+++ b/crates/djls-source/src/changes.rs
@@ -1,0 +1,95 @@
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+
+use crate::Db;
+use crate::File;
+use crate::path_to_file;
+
+/// Source-visible filesystem changes applied after the backing filesystem view
+/// has been updated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceChanges {
+    events: Vec<ChangeEvent>,
+}
+
+impl SourceChanges {
+    #[must_use]
+    pub fn new(events: impl IntoIterator<Item = ChangeEvent>) -> Self {
+        Self {
+            events: events.into_iter().collect(),
+        }
+    }
+
+    /// Apply these source-visible file changes to Salsa inputs.
+    ///
+    /// Callers must update the underlying filesystem view first. For LSP
+    /// documents, this means inserting or removing the editor buffer from the
+    /// overlay before applying the corresponding event.
+    pub fn apply(&self, db: &mut dyn Db) {
+        for change in &self.events {
+            match change {
+                ChangeEvent::Opened(path) => {
+                    apply_visible_path_change(db, path, FileSetMembership::Unchanged);
+                }
+                ChangeEvent::BecameVisible(path) => {
+                    apply_visible_path_change(db, path, FileSetMembership::Changed);
+                }
+                ChangeEvent::ContentChanged(path) => apply_content_change(db, path),
+                ChangeEvent::Deleted(path) => apply_deleted_path(db, path),
+            }
+        }
+    }
+}
+
+/// One source-visible filesystem change in a `SourceChanges` batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChangeEvent {
+    /// An existing visible file was opened in an editor buffer.
+    Opened(Utf8PathBuf),
+    /// A path became visible to source queries.
+    BecameVisible(Utf8PathBuf),
+    /// A visible file's content changed without changing the file set.
+    ContentChanged(Utf8PathBuf),
+    /// A path stopped being visible to source queries.
+    Deleted(Utf8PathBuf),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum FileSetMembership {
+    Changed,
+    Unchanged,
+}
+
+fn apply_visible_path_change(
+    db: &mut dyn Db,
+    path: &Utf8Path,
+    file_set_membership: FileSetMembership,
+) {
+    File::sync_path(db, path);
+    let Ok(file) = path_to_file(db, path) else {
+        return;
+    };
+
+    db.bump_file_and_maybe_root_revision(
+        file,
+        path,
+        matches!(file_set_membership, FileSetMembership::Changed),
+    );
+}
+
+fn apply_content_change(db: &mut dyn Db, path: &Utf8Path) {
+    let Some(file) = db.files().try_file(path) else {
+        return;
+    };
+
+    file.sync(db);
+    db.bump_file_revision(file);
+}
+
+fn apply_deleted_path(db: &mut dyn Db, path: &Utf8Path) {
+    File::sync_path(db, path);
+
+    if let Some(root) = db.files().root(db, path) {
+        db.bump_file_root_revision(root);
+    }
+}

--- a/crates/djls-source/src/db.rs
+++ b/crates/djls-source/src/db.rs
@@ -18,10 +18,6 @@ pub trait Db: salsa::Database {
         self.file_system().read_to_string(path)
     }
 
-    fn path_exists(&self, path: &Utf8Path) -> bool {
-        self.file_system().exists(path)
-    }
-
     fn path_is_file(&self, path: &Utf8Path) -> bool {
         self.file_system().is_file(path)
     }
@@ -36,11 +32,6 @@ pub trait Db: salsa::Database {
         options: &WalkOptions,
     ) -> std::io::Result<Vec<WalkEntry>> {
         self.file_system().walk_entries(root, options)
-    }
-
-    /// Get or create a tracked file for the given path.
-    fn get_or_create_file(&self, path: &Utf8Path) -> File {
-        self.files().get_or_create_file(self, path)
     }
 
     /// Bump the revision for a tracked file to invalidate dependent queries.

--- a/crates/djls-source/src/files.rs
+++ b/crates/djls-source/src/files.rs
@@ -7,6 +7,7 @@ use std::sync::RwLockWriteGuard;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use salsa::Durability;
+use salsa::Setter;
 
 use crate::collections::FxDashMap;
 use crate::db::Db;
@@ -23,6 +24,44 @@ pub struct File {
     pub path: Utf8PathBuf,
     /// The revision number for invalidation tracking
     pub revision: u64,
+    pub status: FileStatus,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FileStatus {
+    Exists,
+    IsADirectory,
+    NotFound,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FileError {
+    #[error("Is a directory")]
+    IsADirectory,
+    #[error("Not found")]
+    NotFound,
+}
+
+fn file_status(db: &dyn Db, path: &Utf8Path) -> FileStatus {
+    let file_system = db.file_system();
+    if file_system.is_file(path) {
+        FileStatus::Exists
+    } else if file_system.is_dir(path) {
+        FileStatus::IsADirectory
+    } else {
+        FileStatus::NotFound
+    }
+}
+
+/// Get or create a tracked file for `path` and return it if it exists.
+#[inline]
+pub fn path_to_file(db: &dyn Db, path: &Utf8Path) -> Result<File, FileError> {
+    let file = db.files().get_or_create_file(db, path);
+    match file.status(db) {
+        FileStatus::Exists => Ok(file),
+        FileStatus::IsADirectory => Err(FileError::IsADirectory),
+        FileStatus::NotFound => Err(FileError::NotFound),
+    }
 }
 
 #[salsa::input]
@@ -55,6 +94,29 @@ impl File {
         let source = self.source(db);
         let line_index = self.line_index(db);
         line_index.end_line_col(source.as_str(), encoding)
+    }
+
+    pub fn sync(self, db: &mut dyn Db) {
+        let path = self.path(db).clone();
+        Self::sync_path(db, &path);
+    }
+
+    pub fn sync_path(db: &mut dyn Db, path: &Utf8Path) {
+        let Some(file) = db.files().try_file(path) else {
+            return;
+        };
+
+        let current_status = file.status(db);
+        let next_status = file_status(db, path);
+        if current_status == next_status {
+            return;
+        }
+
+        file.set_status(db).to(next_status);
+        if matches!(current_status, FileStatus::Exists) != matches!(next_status, FileStatus::Exists)
+        {
+            db.bump_file_revision(file);
+        }
     }
 }
 
@@ -207,13 +269,10 @@ impl FileRootKind {
 
 impl SourceFiles {
     #[must_use]
-    pub(crate) fn get_or_create_file<SalsaDb>(&self, db: &SalsaDb, path: &Utf8Path) -> File
-    where
-        SalsaDb: salsa::Database + ?Sized,
-    {
+    fn get_or_create_file(&self, db: &dyn Db, path: &Utf8Path) -> File {
         let path = path.to_owned();
         *self.0.by_path.entry(path.clone()).or_insert_with(|| {
-            File::builder(path.clone(), 0)
+            File::builder(path.clone(), 0, file_status(db, &path))
                 .durability(self.durability_for(db, &path))
                 .path_durability(Durability::HIGH)
                 .new(db)
@@ -221,8 +280,8 @@ impl SourceFiles {
     }
 
     #[must_use]
-    pub fn contains_file(&self, path: &Utf8Path) -> bool {
-        self.0.by_path.contains_key(path)
+    pub fn try_file(&self, path: &Utf8Path) -> Option<File> {
+        self.0.by_path.get(path).map(|entry| *entry.value())
     }
 
     fn roots(&self) -> RwLockReadGuard<'_, Vec<FileRoot>> {
@@ -321,10 +380,7 @@ impl SourceFiles {
             .new(db)
     }
 
-    fn durability_for<SalsaDb>(&self, db: &SalsaDb, path: &Utf8Path) -> Durability
-    where
-        SalsaDb: salsa::Database + ?Sized,
-    {
+    fn durability_for(&self, db: &dyn Db, path: &Utf8Path) -> Durability {
         self.root(db, path)
             .map_or(Durability::LOW, |root| root.kind(db).durability())
     }

--- a/crates/djls-source/src/lib.rs
+++ b/crates/djls-source/src/lib.rs
@@ -1,3 +1,4 @@
+mod changes;
 mod collections;
 mod db;
 mod files;
@@ -8,14 +9,19 @@ mod position;
 mod protocol;
 mod render;
 
+pub use changes::ChangeEvent;
+pub use changes::SourceChanges;
 pub use collections::FxDashMap;
 pub use db::Db;
 pub use files::File;
+pub use files::FileError;
 pub use files::FileKind;
 pub use files::FileRoot;
 pub use files::FileRootKind;
+pub use files::FileStatus;
 pub use files::SourceFiles;
 pub use files::SourceText;
+pub use files::path_to_file;
 pub use fs::FileSystem;
 pub use fs::InMemoryFileSystem;
 pub use fs::OsFileSystem;

--- a/crates/djls-source/tests/file_status.rs
+++ b/crates/djls-source/tests/file_status.rs
@@ -1,0 +1,90 @@
+use camino::Utf8Path;
+use djls_source::Db as _;
+use djls_source::File;
+use djls_source::FileError;
+use djls_source::path_to_file;
+use djls_testing::TestDatabase;
+
+#[salsa::input]
+struct LookupPath {
+    #[returns(ref)]
+    path: String,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum LookupOutcome {
+    Ok,
+    IsADirectory,
+    NotFound,
+}
+
+#[salsa::tracked]
+fn lookup_outcome(db: &dyn djls_source::Db, lookup: LookupPath) -> LookupOutcome {
+    match path_to_file(db, Utf8Path::new(lookup.path(db))) {
+        Ok(_) => LookupOutcome::Ok,
+        Err(FileError::IsADirectory) => LookupOutcome::IsADirectory,
+        Err(FileError::NotFound) => LookupOutcome::NotFound,
+    }
+}
+
+#[test]
+fn path_to_file_missing_reexecutes_after_file_is_created_and_synced() {
+    let mut db = TestDatabase::new();
+    let path = "/project/app.py";
+
+    let lookup = LookupPath::new(&db, path.to_string());
+    assert_eq!(lookup_outcome(&db, lookup), LookupOutcome::NotFound);
+
+    db.add_file(path, "print('created')\n");
+    File::sync_path(&mut db, Utf8Path::new(path));
+
+    assert_eq!(lookup_outcome(&db, lookup), LookupOutcome::Ok);
+}
+
+#[test]
+fn path_to_file_directory_returns_is_a_directory() {
+    let db = TestDatabase::new();
+    let path = "/project/pkg";
+    db.add_file("/project/pkg/module.py", "");
+
+    assert_eq!(
+        path_to_file(&db, Utf8Path::new(path)),
+        Err(FileError::IsADirectory)
+    );
+}
+
+#[test]
+fn path_to_file_existing_file_returns_file_with_source() {
+    let db = TestDatabase::new();
+    let path = "/project/app.py";
+    db.add_file(path, "print('hello')\n");
+
+    let file = path_to_file(&db, Utf8Path::new(path)).expect("file should exist");
+
+    assert_eq!(file.source(&db).as_str(), "print('hello')\n");
+}
+
+#[test]
+fn sync_path_for_untracked_path_is_noop() {
+    let mut db = TestDatabase::new();
+    let path = Utf8Path::new("/project/never.py");
+
+    File::sync_path(&mut db, path);
+
+    assert!(db.files().try_file(path).is_none());
+}
+
+#[test]
+fn path_to_file_deletion_invalidates_dependent_lookup() {
+    let mut db = TestDatabase::new();
+    let path = "/project/app.py";
+    db.add_file(path, "print('present')\n");
+
+    let lookup = LookupPath::new(&db, path.to_string());
+    assert_eq!(lookup_outcome(&db, lookup), LookupOutcome::Ok);
+
+    db.remove_file(path);
+    File::sync_path(&mut db, Utf8Path::new(path));
+
+    assert_eq!(lookup_outcome(&db, lookup), LookupOutcome::NotFound);
+}

--- a/crates/djls-testing/src/db.rs
+++ b/crates/djls-testing/src/db.rs
@@ -11,11 +11,14 @@ use djls_semantic::Db as SemanticDb;
 use djls_semantic::FilterAritySpecs;
 use djls_semantic::TagSpecs;
 use djls_semantic::builtin_tag_specs;
+use djls_source::Db as SourceDb;
 use djls_source::File;
+use djls_source::FileStatus;
 use djls_source::FileSystem;
 use djls_source::InMemoryFileSystem;
 use djls_source::OsFileSystem;
 use djls_source::SourceFiles;
+use djls_source::path_to_file;
 
 #[derive(Clone, Default)]
 pub struct SalsaEventLog {
@@ -146,14 +149,23 @@ impl TestDatabase {
         self.project = Some(project);
     }
 
+    /// Return an existing fixture file from the test filesystem.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the fixture has not been added to the in-memory filesystem.
     #[must_use]
-    pub fn get_or_create_file(&self, path: &Utf8Path) -> File {
-        <Self as djls_source::Db>::get_or_create_file(self, path)
+    pub fn file(&self, path: &Utf8Path) -> File {
+        path_to_file(self, path).expect("test fixture file should exist; call add_file first")
     }
 
     #[must_use]
     pub(crate) fn create_file_with_revision(&self, path: &Utf8Path, revision: u64) -> File {
-        File::builder(path.to_owned(), revision)
+        debug_assert!(
+            self.file_system().is_file(path),
+            "fixture file should exist before creating tracked file: {path}"
+        );
+        File::builder(path.to_owned(), revision, FileStatus::Exists)
             .durability(salsa::Durability::LOW)
             .path_durability(salsa::Durability::HIGH)
             .new(self)

--- a/crates/djls-testing/src/fixtures.rs
+++ b/crates/djls-testing/src/fixtures.rs
@@ -608,7 +608,7 @@ pub fn extract_and_merge(
             continue;
         };
         db.add_file(file_path.as_str(), &source);
-        let file = db.get_or_create_file(file_path);
+        let file = db.file(file_path);
         let bundle = extract_bundle(&db, file, module_name);
 
         arities.merge_filter_arities(&bundle.filter_arities);

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -11,7 +11,6 @@ use clap::Parser;
 use djls_db::DjangoDatabase;
 use djls_semantic::ValidationError;
 use djls_semantic::ValidationErrorAccumulator;
-use djls_source::Db as _;
 use djls_source::Diagnostic;
 use djls_source::DiagnosticRenderer;
 use djls_source::File;
@@ -22,6 +21,7 @@ use djls_source::Severity;
 use djls_source::SourceText;
 use djls_source::Span;
 use djls_source::WalkOptions;
+use djls_source::path_to_file;
 use djls_templates::TemplateError;
 use djls_templates::TemplateErrorAccumulator;
 
@@ -281,7 +281,16 @@ fn check_stdin(
 
 /// Run validation and capture the source text for later rendering.
 fn check_file_with_source(db: &DjangoDatabase, path: &Utf8Path) -> FileCheckResult {
-    let file = db.get_or_create_file(path);
+    let Ok(file) = path_to_file(db, path) else {
+        return FileCheckResult {
+            path: path.to_owned(),
+            source: SourceText::default(),
+            check: CheckResult {
+                template_errors: Vec::new(),
+                validation_errors: Vec::new(),
+            },
+        };
+    };
     let source = file.source(db);
     let check = check_file(db, file);
 


### PR DESCRIPTION
Module resolution needs to observe files that do not exist: resolving `foo.bar` checks `foo/__init__.py`, `foo.py`, and `foo/` even when none are present, and creating one of them later must invalidate the cached answer. This gives the source layer that capability:

- `File` gains a tracked `status` field — `Exists`, `IsADirectory`, or `NotFound` — computed lazily when a path is first interned, so looking up a missing path records a dependency on its absence.
- `path_to_file(db, path)` is the public path-to-`File` API: it interns the path, returns `Ok(File)` only when the path is an existing file, and returns the failure kind (`FileError::NotFound` / `FileError::IsADirectory`) otherwise.
- `File::sync_path(db, path)` re-checks an interned path's status at path change boundaries.
- `File::sync(db)` handles the already-have-`File` case without making callers recover its path manually.

Status derivation and file interning now live entirely in `files.rs`: the `Db` trait slims to raw capability accessors — mirroring ruff's `ruff_db`, where the database supplies I/O and `files.rs` owns file semantics. The lower-level intern-regardless operation is private, so callers use `path_to_file` instead of reaching into `SourceFiles`.

Document lifecycle is applied through named source-layer operations instead of scattered `sync_path`/`path_to_file` sequences:

- `Workspace` owns open buffers and the overlay filesystem only.
- `Session` mutates the buffer state first, then classifies a source-visible `ChangeEvent`.
- `SourceChanges` owns batch application for source-visible lifecycle events and applies them to the database after the backing filesystem view has changed.

That keeps the buffer/overlay ordering explicit while keeping file-status lifecycle policy out of `Workspace` and keeping `Db` as a capability boundary rather than a service object.

`File::source` behavior is unchanged: a missing file still reads as empty text.

Wired into the server document open/close/change paths and the project discovery apply path.
