### PR TITLE
Resolve Python modules with a component-by-component walk

### DIFF
--- a/crates/djls-project/src/python/module.rs
+++ b/crates/djls-project/src/python/module.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_source::File;
+use djls_source::FileError;
 use djls_source::path_to_file;
 use thiserror::Error;
 
@@ -104,6 +105,47 @@ enum PythonModuleCandidate {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CandidateDirectory {
+    root: SearchPath,
+    dir: Utf8PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ModuleResolution {
+    RegularPackage {
+        root: SearchPath,
+        dir: Utf8PathBuf,
+        init_file: Utf8PathBuf,
+        file: File,
+    },
+    FileModule {
+        root: SearchPath,
+        path: Utf8PathBuf,
+        file: File,
+    },
+    NamespaceOnly {
+        portions: Vec<CandidateDirectory>,
+    },
+    NotFound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ResolvedComponent {
+    RegularPackage {
+        root: SearchPath,
+        dir: Utf8PathBuf,
+        init_file: Utf8PathBuf,
+        file: File,
+    },
+    FileModule {
+        root: SearchPath,
+        path: Utf8PathBuf,
+        file: File,
+    },
+    NamespacePortion(CandidateDirectory),
+}
+
 struct FileModuleDerivationResult {
     root: SearchPath,
     name: PythonModuleName,
@@ -134,7 +176,7 @@ pub(crate) enum PythonImportError {
     TooManyDots,
 }
 
-fn python_module_candidates(
+fn python_module_flat_candidates(
     db: &dyn ProjectDb,
     project: Project,
     name: &PythonModuleName,
@@ -170,6 +212,98 @@ fn python_module_candidates(
     }
 
     candidates
+}
+
+fn resolve_component(
+    db: &dyn ProjectDb,
+    candidate: &CandidateDirectory,
+    component: &str,
+) -> Option<ResolvedComponent> {
+    let dir = candidate.dir.join(component);
+    let init_file = dir.join("__init__.py");
+    if let Ok(file) = path_to_file(db, &init_file) {
+        return Some(ResolvedComponent::RegularPackage {
+            root: candidate.root.clone(),
+            dir,
+            init_file,
+            file,
+        });
+    }
+
+    let py_file = dir.with_extension("py");
+    if let Ok(file) = path_to_file(db, &py_file) {
+        return Some(ResolvedComponent::FileModule {
+            root: candidate.root.clone(),
+            path: py_file,
+            file,
+        });
+    }
+
+    if matches!(path_to_file(db, &dir), Err(FileError::IsADirectory)) {
+        return Some(ResolvedComponent::NamespacePortion(CandidateDirectory {
+            root: candidate.root.clone(),
+            dir,
+        }));
+    }
+
+    None
+}
+
+fn resolve_name(db: &dyn ProjectDb, project: Project, name: &PythonModuleName) -> ModuleResolution {
+    let mut candidate_dirs = project
+        .search_paths(db)
+        .iter()
+        .map(|search_path| CandidateDirectory {
+            root: search_path.clone(),
+            dir: search_path.path().to_path_buf(),
+        })
+        .collect::<Vec<_>>();
+    let components = name.as_str().split('.').collect::<Vec<_>>();
+
+    for (index, component) in components.iter().enumerate() {
+        let is_last = index + 1 == components.len();
+        let mut portions = Vec::new();
+        let mut next_dirs = None;
+
+        for candidate in &candidate_dirs {
+            match resolve_component(db, candidate, component) {
+                Some(ResolvedComponent::RegularPackage {
+                    root,
+                    dir,
+                    init_file,
+                    file,
+                }) => {
+                    if is_last {
+                        return ModuleResolution::RegularPackage {
+                            root,
+                            dir,
+                            init_file,
+                            file,
+                        };
+                    }
+                    next_dirs = Some(vec![CandidateDirectory { root, dir }]);
+                    break;
+                }
+                Some(ResolvedComponent::FileModule { root, path, file }) => {
+                    if is_last {
+                        return ModuleResolution::FileModule { root, path, file };
+                    }
+                    return ModuleResolution::NotFound;
+                }
+                Some(ResolvedComponent::NamespacePortion(portion)) => portions.push(portion),
+                None => {}
+            }
+        }
+
+        candidate_dirs = match next_dirs {
+            Some(dirs) => dirs,
+            None if portions.is_empty() => return ModuleResolution::NotFound,
+            None if is_last => return ModuleResolution::NamespaceOnly { portions },
+            None => portions,
+        };
+    }
+
+    ModuleResolution::NotFound
 }
 
 fn file_module_names<'a>(
@@ -260,19 +394,18 @@ pub fn resolve_module_detail(
 ) -> ResolutionDetail {
     project.touch_search_path_roots(db);
 
-    let candidates = python_module_candidates(db, project, &name);
-    let selected_root = candidates.iter().find_map(|candidate| match candidate {
-        PythonModuleCandidate::RegularPackage { root, .. }
-        | PythonModuleCandidate::FileModule { root, .. } => Some(root.clone()),
-        PythonModuleCandidate::NamespacePortion { .. } => None,
-    });
-    let unresolved_reason = if selected_root.is_some() {
-        None
-    } else if candidates.is_empty() {
-        Some(UnresolvedReason::NotFound)
-    } else {
-        Some(UnresolvedReason::NamespaceOnly)
+    let resolution = resolve_name(db, project, &name);
+    let selected_root = match &resolution {
+        ModuleResolution::RegularPackage { root, .. }
+        | ModuleResolution::FileModule { root, .. } => Some(root.clone()),
+        ModuleResolution::NamespaceOnly { .. } | ModuleResolution::NotFound => None,
     };
+    let unresolved_reason = match &resolution {
+        ModuleResolution::RegularPackage { .. } | ModuleResolution::FileModule { .. } => None,
+        ModuleResolution::NamespaceOnly { .. } => Some(UnresolvedReason::NamespaceOnly),
+        ModuleResolution::NotFound => Some(UnresolvedReason::NotFound),
+    };
+    let candidates = python_module_flat_candidates(db, project, &name);
     let candidates = candidates
         .into_iter()
         .map(|candidate| match candidate {
@@ -313,21 +446,14 @@ pub fn resolve_package_dirs(
 ) -> PackageDirs {
     project.touch_search_path_roots(db);
 
-    let mut namespace_dirs = Vec::new();
-    for candidate in python_module_candidates(db, project, &name) {
-        match candidate {
-            PythonModuleCandidate::RegularPackage { dir, .. } => {
-                return PackageDirs { dirs: vec![dir] };
-            }
-            PythonModuleCandidate::FileModule { .. } => {
-                return PackageDirs { dirs: Vec::new() };
-            }
-            PythonModuleCandidate::NamespacePortion { dir, .. } => namespace_dirs.push(dir),
+    match resolve_name(db, project, &name) {
+        ModuleResolution::RegularPackage { dir, .. } => PackageDirs { dirs: vec![dir] },
+        ModuleResolution::FileModule { .. } | ModuleResolution::NotFound => {
+            PackageDirs { dirs: Vec::new() }
         }
-    }
-
-    PackageDirs {
-        dirs: namespace_dirs,
+        ModuleResolution::NamespaceOnly { portions } => PackageDirs {
+            dirs: portions.into_iter().map(|portion| portion.dir).collect(),
+        },
     }
 }
 
@@ -489,18 +615,13 @@ impl PythonModule {
     pub fn resolve(db: &dyn ProjectDb, project: Project, name: PythonModuleName) -> Option<Self> {
         project.touch_search_path_roots(db);
 
-        for candidate in python_module_candidates(db, project, &name) {
-            let path = match candidate {
-                PythonModuleCandidate::RegularPackage { init_file, .. } => init_file,
-                PythonModuleCandidate::FileModule { path, .. } => path,
-                PythonModuleCandidate::NamespacePortion { .. } => continue,
-            };
-
-            let file = path_to_file(db, &path).ok()?;
-            return Some(Self::new(name, path, file));
+        match resolve_name(db, project, &name) {
+            ModuleResolution::RegularPackage {
+                init_file, file, ..
+            } => Some(Self::new(name, init_file, file)),
+            ModuleResolution::FileModule { path, file, .. } => Some(Self::new(name, path, file)),
+            ModuleResolution::NamespaceOnly { .. } | ModuleResolution::NotFound => None,
         }
-
-        None
     }
 }
 

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -1004,6 +1004,551 @@ fn model_modules_finds_models_package_files() {
     assert!(module_names.contains(&"myapp.models.order"));
 }
 
+// ty:resolve.rs::first_party_module
+#[test]
+fn ty_first_party_module() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo.py", "print('Hello, world!')")
+        .build(&db);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.name().as_str(), "foo");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo.py")),
+        Some(foo_module)
+    );
+}
+
+// ty:resolve.rs::resolve_package
+#[test]
+fn ty_resolve_package() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/__init__.py", "print('Hello, world!')")
+        .build(&db);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.name().as_str(), "foo");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo/__init__.py"));
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo/__init__.py")),
+        Some(foo_module)
+    );
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo")),
+        None
+    );
+}
+
+// ty:resolve.rs::package_priority_over_module
+#[test]
+fn ty_package_priority_over_module() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/__init__.py", "print('Hello, world!')")
+        .file("/src/foo.py", "print('Hello, world!')")
+        .build(&db);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo/__init__.py"));
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo/__init__.py")),
+        Some(foo_module)
+    );
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo.py")),
+        None
+    );
+}
+
+// ty:resolve.rs::sub_packages
+#[test]
+fn ty_sub_packages() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/__init__.py", "")
+        .file("/src/foo/bar/__init__.py", "")
+        .file("/src/foo/bar/baz.py", "print('Hello, world!')")
+        .build(&db);
+
+    let baz_module = PythonModule::resolve(
+        &db,
+        project,
+        PythonModuleName::parse("foo.bar.baz").unwrap(),
+    )
+    .expect("foo.bar.baz should resolve");
+
+    assert_eq!(baz_module.path(), Utf8Path::new("/src/foo/bar/baz.py"));
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo/bar/baz.py")),
+        Some(baz_module)
+    );
+}
+
+// ty:resolve.rs::module_search_path_priority
+#[test]
+fn ty_module_search_path_priority() {
+    let mut db = TestDatabase::new();
+    db.add_file("/src/foo.py", "");
+    db.add_file("/site-packages/foo.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo.py")),
+        Some(foo_module)
+    );
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/site-packages/foo.py")),
+        None
+    );
+}
+
+// ty:resolve.rs::editable_install_absolute_path
+#[test]
+fn ty_editable_install_absolute_path() {
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/_foo.pth", "/x/src");
+    db.add_file("/x/src/foo/__init__.py", "");
+    db.add_file("/x/src/foo/bar.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+    let foo_bar_module =
+        PythonModule::resolve(&db, project, PythonModuleName::parse("foo.bar").unwrap())
+            .expect("foo.bar should resolve");
+
+    assert_eq!(foo_module.path(), Utf8Path::new("/x/src/foo/__init__.py"));
+    assert_eq!(foo_bar_module.path(), Utf8Path::new("/x/src/foo/bar.py"));
+}
+
+// ty:resolve.rs::editable_install_pth_file_with_whitespace
+#[test]
+fn ty_editable_install_pth_file_with_whitespace() {
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/_foo.pth", "        /x/src");
+    db.add_file("/site-packages/_bar.pth", "/y/src        ");
+    db.add_file("/x/src/foo.py", "");
+    db.add_file("/y/src/bar.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    assert_eq!(
+        PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap()),
+        None
+    );
+    let bar_module = PythonModule::resolve(&db, project, PythonModuleName::parse("bar").unwrap())
+        .expect("bar should resolve");
+    assert_eq!(bar_module.path(), Utf8Path::new("/y/src/bar.py"));
+}
+
+// ty:resolve.rs::editable_install_relative_path
+#[test]
+fn ty_editable_install_relative_path() {
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/_foo.pth", "../../x/../x/y/src");
+    db.add_file("/x/y/src/foo.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.path(), Utf8Path::new("/x/y/src/foo.py"));
+}
+
+// ty:resolve.rs::editable_install_multiple_pth_files_with_multiple_paths
+#[test]
+fn ty_editable_install_multiple_pth_files_with_multiple_paths() {
+    let complex_pth_file = "\
+/
+
+# a comment
+/baz
+
+import not_an_editable_install; do_something_else_crazy_dynamic()
+
+# another comment
+spam
+
+not_a_directory
+";
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/_foo.pth", "../../x/../x/y/src");
+    db.add_file("/site-packages/_lots_of_others.pth", complex_pth_file);
+    db.add_file("/x/y/src/foo.py", "");
+    db.add_file("/site-packages/spam/spam.py", "");
+    db.add_file("/a.py", "");
+    db.add_file("/baz/b.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+    let a_module = PythonModule::resolve(&db, project, PythonModuleName::parse("a").unwrap())
+        .expect("a should resolve");
+    let b_module = PythonModule::resolve(&db, project, PythonModuleName::parse("b").unwrap())
+        .expect("b should resolve");
+    let spam_module = PythonModule::resolve(&db, project, PythonModuleName::parse("spam").unwrap())
+        .expect("spam should resolve");
+
+    assert_eq!(foo_module.path(), Utf8Path::new("/x/y/src/foo.py"));
+    assert_eq!(a_module.path(), Utf8Path::new("/a.py"));
+    assert_eq!(b_module.path(), Utf8Path::new("/baz/b.py"));
+    assert_eq!(
+        spam_module.path(),
+        Utf8Path::new("/site-packages/spam/spam.py")
+    );
+}
+
+// ty:resolve.rs::no_duplicate_search_paths_added
+#[test]
+fn ty_no_duplicate_search_paths_added() {
+    let db = TestDatabase::new();
+    db.add_file("/src/foo.py", "");
+    db.add_file("/site-packages/_foo.pth", "/src");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    let paths: Vec<_> = search_paths.iter().cloned().collect();
+
+    assert!(paths.contains(&SearchPath::FirstParty(Utf8PathBuf::from("/src"))));
+    assert!(!paths.contains(&SearchPath::Editable(Utf8PathBuf::from("/src"))));
+}
+
+// ty:resolve.rs::multiple_site_packages_with_editables
+#[test]
+fn ty_multiple_site_packages_with_editables() {
+    let mut db = TestDatabase::new();
+    db.add_file("/venv/site-packages/foo.pth", "/x/y");
+    db.add_file("/x/y/a.py", "");
+    db.add_file("/system/site-packages/a.py", "");
+
+    let pythonpath = vec![
+        Utf8PathBuf::from("/venv/site-packages"),
+        Utf8PathBuf::from("/system/site-packages"),
+    ];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let a_module = PythonModule::resolve(&db, project, PythonModuleName::parse("a").unwrap())
+        .expect("a should resolve");
+
+    assert_eq!(a_module.path(), Utf8Path::new("/x/y/a.py"));
+}
+
+// ty:resolve.rs::stubs_over_module_source
+#[test]
+fn ty_stubs_over_module_source_runtime_uses_py() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo.py", "")
+        .file("/src/foo.pyi", "")
+        .build(&db);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.name().as_str(), "foo");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+}
+
+// ty:resolve.rs::stubs_over_package_source
+#[test]
+fn ty_stubs_over_package_source_runtime_uses_package() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/__init__.py", "")
+        .file("/src/foo.pyi", "")
+        .build(&db);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.name().as_str(), "foo");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo/__init__.py"));
+}
+
+// ty:resolve.rs::typing_stub_over_module
+#[test]
+fn ty_typing_stub_over_module_runtime_uses_py() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo.py", "print('Hello, world!')")
+        .file("/src/foo.pyi", "x: int")
+        .build(&db);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+    assert_eq!(
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo.py")),
+        Some(foo_module)
+    );
+}
+
+// ty:list.rs::namespace_package
+#[test]
+fn ty_namespace_package_reexpressed() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/bar.py", "")
+        .build(&db);
+
+    assert_eq!(
+        PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap()),
+        None
+    );
+    let dirs = resolve_package_dirs(&db, project, PythonModuleName::parse("foo").unwrap());
+    assert_eq!(dirs.dirs, vec![Utf8PathBuf::from("/src/foo")]);
+}
+
+// ty:list.rs::namespace_package_precedence
+#[test]
+fn ty_namespace_package_precedence_reexpressed() {
+    let mut db = TestDatabase::new();
+    db.add_file("/src/foo/bar.py", "");
+    db.add_file("/site-packages/foo.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve from site-packages");
+    assert_eq!(foo_module.path(), Utf8Path::new("/site-packages/foo.py"));
+    assert!(
+        resolve_package_dirs(&db, project, PythonModuleName::parse("foo").unwrap())
+            .dirs
+            .is_empty()
+    );
+
+    let mut db = TestDatabase::new();
+    db.add_file("/src/foo.py", "");
+    db.add_file("/site-packages/foo/bar.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve from first party");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+    assert!(
+        resolve_package_dirs(&db, project, PythonModuleName::parse("foo").unwrap())
+            .dirs
+            .is_empty()
+    );
+}
+
+// ty:path.rs::module_name_1_part
+#[test]
+fn ty_module_name_1_part_file_to_module() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo.py", "")
+        .build(&db);
+    let foo_module = file_to_module(&db, project, Utf8PathBuf::from("/src/foo.py"))
+        .expect("foo.py should map to foo");
+    assert_eq!(foo_module.name().as_str(), "foo");
+
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/__init__.py", "")
+        .build(&db);
+    let foo_module = file_to_module(&db, project, Utf8PathBuf::from("/src/foo/__init__.py"))
+        .expect("foo/__init__.py should map to foo");
+    assert_eq!(foo_module.name().as_str(), "foo");
+}
+
+// ty:path.rs::module_name_2_parts
+#[test]
+fn ty_module_name_2_parts_file_to_module() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/bar.py", "")
+        .build(&db);
+    let foo_bar_module = file_to_module(&db, project, Utf8PathBuf::from("/src/foo/bar.py"))
+        .expect("foo/bar.py should map to foo.bar");
+    assert_eq!(foo_bar_module.name().as_str(), "foo.bar");
+
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/bar/__init__.py", "")
+        .build(&db);
+    let foo_bar_module =
+        file_to_module(&db, project, Utf8PathBuf::from("/src/foo/bar/__init__.py"))
+            .expect("foo/bar/__init__.py should map to foo.bar");
+    assert_eq!(foo_bar_module.name().as_str(), "foo.bar");
+}
+
+// ty:path.rs::module_name_3_parts
+#[test]
+fn ty_module_name_3_parts_file_to_module() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/bar/baz.py", "")
+        .build(&db);
+    let foo_bar_baz_module = file_to_module(&db, project, Utf8PathBuf::from("/src/foo/bar/baz.py"))
+        .expect("foo/bar/baz.py should map to foo.bar.baz");
+    assert_eq!(foo_bar_baz_module.name().as_str(), "foo.bar.baz");
+
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo/bar/baz/__init__.py", "")
+        .build(&db);
+    let foo_bar_baz_module = file_to_module(
+        &db,
+        project,
+        Utf8PathBuf::from("/src/foo/bar/baz/__init__.py"),
+    )
+    .expect("foo/bar/baz/__init__.py should map to foo.bar.baz");
+    assert_eq!(foo_bar_baz_module.name().as_str(), "foo.bar.baz");
+}
+
+#[test]
+fn python_module_resolve_applies_regular_package_terminality_across_roots() {
+    let mut db = TestDatabase::new();
+    db.add_file("/root_a/foo/__init__.py", "");
+    db.add_file("/root_b/foo/bar.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/root_a"), Utf8PathBuf::from("/root_b")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/root_a/foo/__init__.py"));
+    assert_eq!(
+        PythonModule::resolve(&db, project, PythonModuleName::parse("foo.bar").unwrap()),
+        None
+    );
+    assert_eq!(
+        resolve_module_detail(&db, project, PythonModuleName::parse("foo.bar").unwrap())
+            .unresolved_reason,
+        Some(UnresolvedReason::NotFound)
+    );
+}
+
+#[test]
+fn python_module_resolve_traverses_namespace_portions_across_roots() {
+    let mut db = TestDatabase::new();
+    db.add_file("/root_a/foo/spam.txt", "");
+    db.add_file("/root_b/foo/bar.py", "");
+
+    let pythonpath = vec![Utf8PathBuf::from("/root_a"), Utf8PathBuf::from("/root_b")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+
+    assert_eq!(
+        PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap()),
+        None
+    );
+    let foo_bar_module =
+        PythonModule::resolve(&db, project, PythonModuleName::parse("foo.bar").unwrap())
+            .expect("foo.bar should resolve through the namespace package");
+    assert_eq!(foo_bar_module.path(), Utf8Path::new("/root_b/foo/bar.py"));
+
+    let dirs = resolve_package_dirs(&db, project, PythonModuleName::parse("foo").unwrap());
+    assert_eq!(
+        dirs.dirs,
+        vec![
+            Utf8PathBuf::from("/root_a/foo"),
+            Utf8PathBuf::from("/root_b/foo"),
+        ]
+    );
+}
+
 #[test]
 fn python_module_resolve_prefers_regular_package_over_sibling_file() {
     let db = TestDatabase::new();


### PR DESCRIPTION
The resolver previously matched a dotted module name against each search root as a single relative path (`foo/bar.py`), which diverges from CPython's import semantics in two ways: a regular package in a higher-priority root did not terminate the search — `foo.bar` could leak into a different root's `foo/__init__.py` even though the first root's `foo/__init__.py` owns the name — and namespace packages could not accumulate portions across roots.

Resolution now walks the dotted name component by component, mirroring CPython:

- a regular package (`__init__.py`) narrows the remaining walk to that package's directory; later roots are no longer candidates for its submodules;
- a file module terminates the walk: `foo.py` cannot have submodules;
- plain directories accumulate as namespace portions across all roots (PEP 420), and submodule resolution continues through all of them;
- a namespace-only name still resolves to no file — identity queries answer "which file is this module," and a namespace package has no file — while `resolve_package_dirs` lists its portions.

The diagnostic detail queries keep the flat candidate scan so they can report every plausible file for a name.

Tests port ty's resolver corpus (astral-sh/ruff) where its semantics match runtime imports, each marked with a `// ty:` provenance comment; expectations are corrected where typechecker semantics differ (stub files never win over `.py` at runtime), plus CPython-derived tests for cross-root terminality and namespace traversal.
