### PR TITLE
Invalidate module resolution from per-path status facts

### DIFF
--- a/crates/djls-project/src/discovery.rs
+++ b/crates/djls-project/src/discovery.rs
@@ -6,7 +6,8 @@
 //! transport, and when to apply the payload.
 
 use camino::Utf8PathBuf;
-use djls_source::File;
+use djls_source::ChangeEvent;
+use djls_source::SourceChanges;
 use djls_source::path_to_file;
 use salsa::Setter;
 
@@ -356,7 +357,7 @@ pub fn apply_django_discovery(db: &mut dyn ProjectDb, discovery: DjangoDiscovery
         if current.as_str() != latest {
             db.bump_file_revision(file);
         }
-
-        File::sync_path(db, &path);
     }
+
+    SourceChanges::new([ChangeEvent::Rescan]).apply(db);
 }

--- a/crates/djls-project/src/python/module.rs
+++ b/crates/djls-project/src/python/module.rs
@@ -225,9 +225,10 @@ fn resolve_component(
     component: &str,
 ) -> Option<ResolvedComponent> {
     let dir = candidate.dir.join(component);
+    let dir_status = path_to_file(db, &dir);
     let init_file = dir.join("__init__.py");
-    if let Ok(file) = path_to_file(db, &init_file)
-        && path_case_matches(db, &init_file, &candidate.dir)
+    if matches!(dir_status, Err(FileError::IsADirectory))
+        && let Ok(file) = path_to_file(db, &init_file)
     {
         return Some(ResolvedComponent::RegularPackage {
             root: candidate.root.clone(),
@@ -238,9 +239,7 @@ fn resolve_component(
     }
 
     let py_file = dir.with_extension("py");
-    if let Ok(file) = path_to_file(db, &py_file)
-        && path_case_matches(db, &py_file, &candidate.dir)
-    {
+    if let Ok(file) = path_to_file(db, &py_file) {
         return Some(ResolvedComponent::FileModule {
             root: candidate.root.clone(),
             path: py_file,
@@ -248,9 +247,7 @@ fn resolve_component(
         });
     }
 
-    if matches!(path_to_file(db, &dir), Err(FileError::IsADirectory))
-        && path_case_matches(db, &dir, &candidate.dir)
-    {
+    if matches!(dir_status, Err(FileError::IsADirectory)) {
         return Some(ResolvedComponent::NamespacePortion(CandidateDirectory {
             root: candidate.root.clone(),
             dir,
@@ -455,8 +452,6 @@ pub fn resolve_package_dirs(
     project: Project,
     name: PythonModuleName,
 ) -> PackageDirs {
-    project.touch_search_path_roots(db);
-
     match resolve_name(db, project, &name) {
         ModuleResolution::RegularPackage { dir, .. } => PackageDirs { dirs: vec![dir] },
         ModuleResolution::FileModule { .. } | ModuleResolution::NotFound => {
@@ -476,8 +471,6 @@ pub fn file_to_module(
     project: Project,
     source_path: Utf8PathBuf,
 ) -> Option<PythonModule> {
-    project.touch_search_path_roots(db);
-
     let selected = file_module_names(db, project, source_path.as_path())
         .next()
         .map(|(root, name)| {
@@ -624,8 +617,6 @@ impl PythonModule {
 impl PythonModule {
     #[salsa::tracked]
     pub fn resolve(db: &dyn ProjectDb, project: Project, name: PythonModuleName) -> Option<Self> {
-        project.touch_search_path_roots(db);
-
         match resolve_name(db, project, &name) {
             ModuleResolution::RegularPackage {
                 init_file, file, ..

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -7,12 +7,16 @@ use djls_project::testing::compute_django_discovery;
 use djls_project::testing::model_modules;
 use djls_project::*;
 use djls_source::Db as _;
+use djls_source::File;
 use djls_source::FileRootKind;
 use djls_source::InMemoryFileSystem;
 use djls_source::OsFileSystem;
 use djls_testing::OsTestDatabase;
 use djls_testing::ProjectFixture;
+use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
+use salsa::Database as _;
+use salsa::Setter;
 
 struct TestModel {
     module_name: PythonModuleName,
@@ -83,6 +87,32 @@ fn apply_project_discovery(db: &mut TestDatabase) {
     let project = db.project().expect("project should be configured");
     let discovery = compute_django_discovery(db, project);
     apply_django_discovery(db, discovery);
+}
+
+fn will_execute_count(db: &TestDatabase, events: &[salsa::Event], query_name: &str) -> usize {
+    events
+        .iter()
+        .filter(|event| match &event.kind {
+            salsa::EventKind::WillExecute { database_key } => db
+                .ingredient_debug_name(database_key.ingredient_index())
+                .contains(query_name),
+            _ => false,
+        })
+        .count()
+}
+
+fn assert_no_will_execute_events(events: &[salsa::Event]) {
+    assert!(
+        events
+            .iter()
+            .all(|event| !matches!(event.kind, salsa::EventKind::WillExecute { .. })),
+        "expected no tracked queries to execute; events: {events:#?}"
+    );
+}
+
+fn set_project_search_paths(db: &mut TestDatabase, project: Project, search_paths: SearchPaths) {
+    search_paths.register_roots(db);
+    project.set_search_paths(db).to(search_paths);
 }
 
 fn django_template_settings(installed_apps: &[&str], builtins: &[&str]) -> String {
@@ -1127,6 +1157,272 @@ fn ty_module_search_path_priority() {
     );
 }
 
+// ty:resolve.rs::deleting_an_unrelated_file_doesnt_change_module_resolution
+#[test]
+fn ty_deleting_an_unrelated_file_doesnt_change_module_resolution() {
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    let project = ProjectFixture::new("/src")
+        .file("/src/foo.py", "x = 1")
+        .file("/src/bar.py", "y = 1")
+        .build(&db);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    let foo_path = foo_module.path().to_path_buf();
+    let _ = event_log.take();
+
+    db.remove_file("/src/bar.py");
+    File::sync_path(&mut db, Utf8Path::new("/src/bar.py"));
+
+    let foo_module = PythonModule::resolve(&db, project, foo_name).expect("foo should resolve");
+    let events = event_log.take();
+    assert_no_will_execute_events(&events);
+    assert_eq!(foo_module.path(), foo_path.as_path());
+}
+
+// ty:resolve.rs::adding_file_on_which_module_resolution_depends_invalidates_previously_failing_query_that_now_succeeds
+#[test]
+fn ty_adding_file_on_which_module_resolution_depends_invalidates_previously_failing_query_that_now_succeeds()
+ {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/src").build(&db);
+    let foo_bar_name = PythonModuleName::parse("foo.bar").unwrap();
+
+    assert_eq!(
+        PythonModule::resolve(&db, project, foo_bar_name.clone()),
+        None
+    );
+
+    db.add_file("/src/foo/bar.py", "x = 1");
+    File::sync_path(&mut db, Utf8Path::new("/src/foo/bar.py"));
+
+    let foo_bar_module = PythonModule::resolve(&db, project, foo_bar_name)
+        .expect("foo.bar should resolve after its file is created");
+    assert_eq!(foo_bar_module.path(), Utf8Path::new("/src/foo/bar.py"));
+}
+
+// ty:resolve.rs::removing_file_on_which_module_resolution_depends_invalidates_previously_successful_query_that_now_fails
+#[test]
+fn ty_removing_file_on_which_module_resolution_depends_invalidates_previously_successful_query_that_now_fails()
+ {
+    let mut db = TestDatabase::new();
+    db.add_file("/src/foo/__init__.py", "x = 2");
+    db.add_file("/src/foo.py", "x = 1");
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &[],
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo/__init__.py"));
+
+    db.remove_file("/src/foo/__init__.py");
+    File::sync_path(&mut db, Utf8Path::new("/src/foo/__init__.py"));
+    File::sync_path(&mut db, Utf8Path::new("/src/foo"));
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name).expect("foo should still resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+}
+
+// ty:resolve.rs::adding_file_to_search_path_with_lower_priority_does_not_invalidate_query
+#[test]
+fn ty_adding_file_to_search_path_with_lower_priority_does_not_invalidate_query() {
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    db.add_file("/src/foo.py", "x = 1");
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+    let _ = event_log.take();
+
+    db.add_file("/site-packages/foo.py", "x = 2");
+    File::sync_path(&mut db, Utf8Path::new("/site-packages/foo.py"));
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name).expect("foo should remain resolved");
+    let events = event_log.take();
+    assert_no_will_execute_events(&events);
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+}
+
+// ty:resolve.rs::adding_file_to_search_path_with_higher_priority_invalidates_the_query
+#[test]
+fn ty_adding_file_to_search_path_with_higher_priority_invalidates_the_query() {
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/foo.py", "x = 2");
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/site-packages/foo.py"));
+
+    db.add_file("/src/foo.py", "x = 1");
+    File::sync_path(&mut db, Utf8Path::new("/src/foo.py"));
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name).expect("foo should resolve from /src");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+}
+
+// ty:resolve.rs::deleting_file_from_higher_priority_search_path_invalidates_the_query
+#[test]
+fn ty_deleting_file_from_higher_priority_search_path_invalidates_the_query() {
+    let mut db = TestDatabase::new();
+    db.add_file("/src/foo.py", "x = 1");
+    db.add_file("/site-packages/foo.py", "x = 2");
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+
+    db.remove_file("/src/foo.py");
+    File::sync_path(&mut db, Utf8Path::new("/src/foo.py"));
+
+    let foo_module = PythonModule::resolve(&db, project, foo_name)
+        .expect("foo should resolve from lower-priority path");
+    assert_eq!(foo_module.path(), Utf8Path::new("/site-packages/foo.py"));
+}
+
+// ty:resolve.rs::module_resolution_paths_cached_between_different_module_resolutions (re-expressed: search paths are project input, not a tracked query)
+#[test]
+fn ty_module_resolution_paths_cached_between_different_module_resolutions_reexpressed() {
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    db.add_file("/src/foo.py", "");
+    db.add_file("/src/bar.py", "");
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/src"),
+        &Interpreter::Auto,
+        &[],
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/src", search_paths);
+
+    let foo_module = PythonModule::resolve(&db, project, PythonModuleName::parse("foo").unwrap())
+        .expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/src/foo.py"));
+    let _ = event_log.take();
+
+    let bar_module = PythonModule::resolve(&db, project, PythonModuleName::parse("bar").unwrap())
+        .expect("bar should resolve");
+    let events = event_log.take();
+    assert_eq!(bar_module.path(), Utf8Path::new("/src/bar.py"));
+    assert_eq!(
+        will_execute_count(&db, &events, "PythonModule::resolve_"),
+        1,
+        "expected resolving bar after foo to execute PythonModule::resolve_ exactly once; events: {events:#?}"
+    );
+}
+
+// ty:resolve.rs::deleting_pth_file_on_which_module_resolution_depends_invalidates_cache (re-expressed: .pth discovery runs when project search paths are constructed)
+#[test]
+fn ty_deleting_pth_file_on_which_module_resolution_depends_invalidates_cache_reexpressed() {
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/_foo.pth", "/x/src");
+    db.add_file("/x/src/foo.py", "");
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/x/src/foo.py"));
+
+    db.remove_file("/site-packages/_foo.pth");
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    set_project_search_paths(&mut db, project, search_paths);
+    File::sync_path(&mut db, Utf8Path::new("/site-packages/_foo.pth"));
+
+    assert_eq!(PythonModule::resolve(&db, project, foo_name), None);
+}
+
+// ty:resolve.rs::deleting_editable_install_on_which_module_resolution_depends_invalidates_cache (re-expressed: editable roots are search-path input, not a tracked dynamic-resolution query)
+#[test]
+fn ty_deleting_editable_install_on_which_module_resolution_depends_invalidates_cache_reexpressed() {
+    let mut db = TestDatabase::new();
+    db.add_file("/site-packages/_foo.pth", "/x/src");
+    db.add_file("/x/src/foo.py", "");
+    let pythonpath = vec![Utf8PathBuf::from("/site-packages")];
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    search_paths.register_roots(&db);
+    let project = project_for_search_paths(&mut db, "/project", search_paths);
+    let foo_name = PythonModuleName::parse("foo").unwrap();
+
+    let foo_module =
+        PythonModule::resolve(&db, project, foo_name.clone()).expect("foo should resolve");
+    assert_eq!(foo_module.path(), Utf8Path::new("/x/src/foo.py"));
+
+    db.remove_file("/x/src/foo.py");
+    let search_paths = SearchPaths::from_project_settings(
+        db.file_system(),
+        Utf8Path::new("/project"),
+        &Interpreter::Auto,
+        &pythonpath,
+    );
+    set_project_search_paths(&mut db, project, search_paths);
+    File::sync_path(&mut db, Utf8Path::new("/x/src/foo.py"));
+    File::sync_path(&mut db, Utf8Path::new("/x/src"));
+
+    assert_eq!(PythonModule::resolve(&db, project, foo_name), None);
+}
+
 // ty:resolve.rs::editable_install_absolute_path
 #[test]
 fn ty_editable_install_absolute_path() {
@@ -1548,6 +1844,25 @@ fn python_module_resolve_rejects_wrong_cased_package_component_on_case_insensiti
     let module = PythonModule::resolve(&db, project, PythonModuleName::parse("pkg.bar").unwrap())
         .expect("pkg.bar should resolve");
     assert_eq!(module.path(), Utf8Path::new("/project/pkg/bar.py"));
+}
+
+#[test]
+fn case_only_rename_invalidates_resolution_on_case_insensitive_fs() {
+    let mut db = TestDatabase::case_insensitive();
+    let project = ProjectFixture::new("/project")
+        .file("/project/Foo.py", "")
+        .build(&db);
+    let name = PythonModuleName::parse("foo").unwrap();
+
+    assert_eq!(PythonModule::resolve(&db, project, name.clone()), None);
+
+    db.remove_file("/project/Foo.py");
+    db.add_file("/project/foo.py", "");
+    File::sync_path(&mut db, Utf8Path::new("/project/foo.py"));
+
+    let module =
+        PythonModule::resolve(&db, project, name).expect("foo should resolve after rename");
+    assert_eq!(module.path(), Utf8Path::new("/project/foo.py"));
 }
 
 // ty:resolve.rs::case_sensitive_resolution_with_symlinked_directory

--- a/crates/djls-source/src/changes.rs
+++ b/crates/djls-source/src/changes.rs
@@ -3,6 +3,7 @@ use camino::Utf8PathBuf;
 
 use crate::Db;
 use crate::File;
+use crate::files::sync_known_paths;
 use crate::path_to_file;
 
 /// Source-visible filesystem changes applied after the backing filesystem view
@@ -36,6 +37,7 @@ impl SourceChanges {
                 }
                 ChangeEvent::ContentChanged(path) => apply_content_change(db, path),
                 ChangeEvent::Deleted(path) => apply_deleted_path(db, path),
+                ChangeEvent::Rescan => sync_known_paths(db),
             }
         }
     }
@@ -52,6 +54,12 @@ pub enum ChangeEvent {
     ContentChanged(Utf8PathBuf),
     /// A path stopped being visible to source queries.
     Deleted(Utf8PathBuf),
+    /// Refresh every already-tracked path when precise path events are unavailable.
+    ///
+    /// This does not discover new paths. It re-checks statuses for paths that
+    /// source queries have already interned, including missing paths recorded
+    /// during resolution.
+    Rescan,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/crates/djls-source/src/files.rs
+++ b/crates/djls-source/src/files.rs
@@ -44,10 +44,25 @@ pub enum FileError {
 
 fn file_status(db: &dyn Db, path: &Utf8Path) -> FileStatus {
     let file_system = db.file_system();
-    if file_system.is_file(path) {
+    let status = if file_system.is_file(path) {
         FileStatus::Exists
     } else if file_system.is_dir(path) {
         FileStatus::IsADirectory
+    } else {
+        FileStatus::NotFound
+    };
+
+    if matches!(status, FileStatus::NotFound) || file_system.case_sensitivity().is_case_sensitive()
+    {
+        return status;
+    }
+
+    let Some(parent) = path.parent() else {
+        return status;
+    };
+
+    if file_system.path_exists_case_sensitive(path, parent) {
+        status
     } else {
         FileStatus::NotFound
     }
@@ -102,20 +117,8 @@ impl File {
     }
 
     pub fn sync_path(db: &mut dyn Db, path: &Utf8Path) {
-        let Some(file) = db.files().try_file(path) else {
-            return;
-        };
-
-        let current_status = file.status(db);
-        let next_status = file_status(db, path);
-        if current_status == next_status {
-            return;
-        }
-
-        file.set_status(db).to(next_status);
-        if matches!(current_status, FileStatus::Exists) != matches!(next_status, FileStatus::Exists)
-        {
-            db.bump_file_revision(file);
+        for ancestor in path.ancestors() {
+            sync_file(db, ancestor);
         }
     }
 }
@@ -284,6 +287,15 @@ impl SourceFiles {
         self.0.by_path.get(path).map(|entry| *entry.value())
     }
 
+    #[must_use]
+    fn paths(&self) -> Vec<Utf8PathBuf> {
+        self.0
+            .by_path
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     fn roots(&self) -> RwLockReadGuard<'_, Vec<FileRoot>> {
         self.0
             .roots
@@ -383,5 +395,29 @@ impl SourceFiles {
     fn durability_for(&self, db: &dyn Db, path: &Utf8Path) -> Durability {
         self.root(db, path)
             .map_or(Durability::LOW, |root| root.kind(db).durability())
+    }
+}
+
+pub(crate) fn sync_known_paths(db: &mut dyn Db) {
+    let paths = db.files().paths();
+    for path in paths {
+        sync_file(db, &path);
+    }
+}
+
+fn sync_file(db: &mut dyn Db, path: &Utf8Path) {
+    let Some(file) = db.files().try_file(path) else {
+        return;
+    };
+
+    let current_status = file.status(db);
+    let next_status = file_status(db, path);
+    if current_status == next_status {
+        return;
+    }
+
+    file.set_status(db).to(next_status);
+    if matches!(current_status, FileStatus::Exists) != matches!(next_status, FileStatus::Exists) {
+        db.bump_file_revision(file);
     }
 }

--- a/crates/djls-source/tests/file_status.rs
+++ b/crates/djls-source/tests/file_status.rs
@@ -2,8 +2,11 @@ use camino::Utf8Path;
 use djls_source::Db as _;
 use djls_source::File;
 use djls_source::FileError;
+use djls_source::FileStatus;
 use djls_source::path_to_file;
+use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
+use salsa::Database as _;
 
 #[salsa::input]
 struct LookupPath {
@@ -25,6 +28,42 @@ fn lookup_outcome(db: &dyn djls_source::Db, lookup: LookupPath) -> LookupOutcome
         Err(FileError::IsADirectory) => LookupOutcome::IsADirectory,
         Err(FileError::NotFound) => LookupOutcome::NotFound,
     }
+}
+
+fn execution_count(db: &TestDatabase, events: &[salsa::Event], query_name: &str) -> usize {
+    events
+        .iter()
+        .filter(|event| match &event.kind {
+            salsa::EventKind::WillExecute { database_key } => db
+                .ingredient_debug_name(database_key.ingredient_index())
+                .contains(query_name),
+            _ => false,
+        })
+        .count()
+}
+
+#[test]
+fn ancestor_lookup_reexecutes_after_child_file_is_created_and_synced() {
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    let parent_path = Utf8Path::new("/project/foo");
+    let child_path = Utf8Path::new("/project/foo/bar.py");
+
+    let lookup = LookupPath::new(&db, parent_path.to_string());
+    assert_eq!(lookup_outcome(&db, lookup), LookupOutcome::NotFound);
+    let _ = event_log.take();
+
+    db.add_file(child_path.as_str(), "print('created')\n");
+    File::sync_path(&mut db, child_path);
+
+    let parent = db
+        .files()
+        .try_file(parent_path)
+        .expect("parent path should have been interned by the lookup");
+    assert_eq!(parent.status(&db), FileStatus::IsADirectory);
+    assert_eq!(lookup_outcome(&db, lookup), LookupOutcome::IsADirectory);
+    let events = event_log.take();
+    assert!(execution_count(&db, &events, "lookup_outcome") > 0);
 }
 
 #[test]


### PR DESCRIPTION
Module resolution queries previously read every search-path root revision, so any file change anywhere in the project re-ran every cached resolution. Resolution now depends on exactly what it observed:

- The precise queries (`PythonModule::resolve`, `resolve_package_dirs`, `file_to_module`) depend only on the project's search-path list and the tracked status of each path actually checked during the component walk. The diagnostic detail queries deliberately keep the coarse root-revision coupling.
- Syncing a path also refreshes its interned ancestors: creating `foo/bar.py` makes a previously-missing `foo/` spring into existence, and a failed resolution that observed it re-runs.
- Discovery apply syncs every interned path, so deletions between change events are observed; unchanged paths cause no invalidation.
- Exact-casing verification for the component walk moves into the tracked file status itself, so a rename that changes only casing invalidates a cached resolution like any other status change; the diagnostic candidate scan keeps its direct filesystem casing check under root-revision invalidation.

Tests port ty's invalidation suite: adding a file on a lower-priority root does not re-run a successful resolution (asserted on salsa execution events), higher-priority adds and deletes do, unrelated changes do not. The `.pth` and editable-install cases are re-expressed against search paths as project inputs rather than tracked queries.
