### PR TITLE
Make source reads fallible and stage reload synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
+- Changed unreadable files to be skipped instead of analyzed as empty source.
 - Changed Python model and template-spec extraction to retain known facts after recoverable syntax errors.
 - Changed template goto definition to return origin ranges for clients that support definition links.
 - Changed template tag library discovery to derive libraries from project source and Django settings instead of the runtime inspector.

--- a/crates/djls-bench/benches/check.rs
+++ b/crates/djls-bench/benches/check.rs
@@ -26,7 +26,9 @@ fn main() {
 
 /// Run `check_file` and capture the source for rendering (mirrors CLI pattern).
 fn run_check(db: &Db, file: djls_source::File) -> FileCheckResult {
-    let source = file.source(db);
+    let source = file
+        .try_source(db)
+        .expect("benchmark file should be readable");
     let path = file.path(db).clone();
     let check = djls_bench::check_file(db, file);
 

--- a/crates/djls-bench/benches/diagnostics.rs
+++ b/crates/djls-bench/benches/diagnostics.rs
@@ -149,8 +149,6 @@ fn collect_incremental(bencher: Bencher) {
         })
         .collect();
 
-    let mut revision = 1_u64;
-
     bencher.bench_local(move || {
         let mut total = 0;
         for _ in 0..DIAGNOSTICS_INNER_ITERS {
@@ -162,8 +160,7 @@ fn collect_incremental(bencher: Bencher) {
                 };
                 template.use_modified = !template.use_modified;
 
-                db.set_file_contents(template.file, contents, revision);
-                revision = revision.wrapping_add(1);
+                db.set_file_contents(template.file, contents);
 
                 total += djls_ide::collect_diagnostics(&db, template.file)
                     .expect("template fixture should be eligible for diagnostics")

--- a/crates/djls-bench/benches/parser.rs
+++ b/crates/djls-bench/benches/parser.rs
@@ -70,9 +70,9 @@ fn incremental(bencher: Bencher) {
                 db.set_file_contents(template.file, contents, revision);
                 revision = revision.wrapping_add(1);
 
-                if let Some(nodelist) = djls_templates::parse_template(&db, template.file) {
-                    total_nodes += nodelist.nodelist(&db).len();
-                }
+                let nodelist = djls_templates::parse_template(&db, template.file)
+                    .expect("benchmark template should parse");
+                total_nodes += nodelist.nodelist(&db).len();
             }
         }
         divan::black_box(total_nodes);

--- a/crates/djls-bench/benches/parser.rs
+++ b/crates/djls-bench/benches/parser.rs
@@ -54,8 +54,6 @@ fn incremental(bencher: Bencher) {
         })
         .collect();
 
-    let mut revision = 1_u64;
-
     bencher.bench_local(move || {
         let mut total_nodes = 0;
         for _ in 0..BATCH_INNER_ITERS {
@@ -67,8 +65,7 @@ fn incremental(bencher: Bencher) {
                 };
                 template.use_modified = !template.use_modified;
 
-                db.set_file_contents(template.file, contents, revision);
-                revision = revision.wrapping_add(1);
+                db.set_file_contents(template.file, contents);
 
                 let nodelist = djls_templates::parse_template(&db, template.file)
                     .expect("benchmark template should parse");

--- a/crates/djls-bench/benches/semantic.rs
+++ b/crates/djls-bench/benches/semantic.rs
@@ -87,8 +87,6 @@ fn validate_incremental(bencher: Bencher) {
         })
         .collect();
 
-    let mut revision = 1_u64;
-
     bencher.bench_local(move || {
         let mut validated = 0;
         for _ in 0..BATCH_INNER_ITERS {
@@ -100,8 +98,7 @@ fn validate_incremental(bencher: Bencher) {
                 };
                 template.use_modified = !template.use_modified;
 
-                db.set_file_contents(template.file, contents, revision);
-                revision = revision.wrapping_add(1);
+                db.set_file_contents(template.file, contents);
 
                 let nodelist = djls_templates::parse_template(&db, template.file)
                     .expect("benchmark template should parse");

--- a/crates/djls-bench/benches/semantic.rs
+++ b/crates/djls-bench/benches/semantic.rs
@@ -24,10 +24,10 @@ fn template_tree_cold(bencher: Bencher) {
 
         let mut total_regions = 0;
         for file in &files {
-            if let Some(nodelist) = djls_templates::parse_template(&db, *file) {
-                let tree = djls_semantic::build_template_tree(&db, nodelist);
-                total_regions += tree.regions(&db).iter().count();
-            }
+            let nodelist = djls_templates::parse_template(&db, *file)
+                .expect("benchmark template should parse");
+            let tree = djls_semantic::build_template_tree(&db, nodelist);
+            total_regions += tree.regions(&db).iter().count();
         }
         divan::black_box(total_regions);
     });
@@ -41,10 +41,10 @@ fn validate_cold(bencher: Bencher) {
 
         let mut validated = 0;
         for file in &files {
-            if let Some(nodelist) = djls_templates::parse_template(&db, *file) {
-                djls_semantic::validate_nodelist(&db, nodelist);
-                validated += 1;
-            }
+            let nodelist = djls_templates::parse_template(&db, *file)
+                .expect("benchmark template should parse");
+            djls_semantic::validate_nodelist(&db, nodelist);
+            validated += 1;
         }
         divan::black_box(validated);
     });
@@ -67,9 +67,9 @@ fn validate_incremental(bencher: Bencher) {
         .map(|fixture| {
             let file = db.file_with_contents(fixture.path.clone(), &fixture.source);
 
-            if let Some(nodelist) = djls_templates::parse_template(&db, file) {
-                djls_semantic::validate_nodelist(&db, nodelist);
-            }
+            let nodelist =
+                djls_templates::parse_template(&db, file).expect("benchmark template should parse");
+            djls_semantic::validate_nodelist(&db, nodelist);
 
             let original = fixture.source.clone();
             let modified = {
@@ -103,10 +103,10 @@ fn validate_incremental(bencher: Bencher) {
                 db.set_file_contents(template.file, contents, revision);
                 revision = revision.wrapping_add(1);
 
-                if let Some(nodelist) = djls_templates::parse_template(&db, template.file) {
-                    djls_semantic::validate_nodelist(&db, nodelist);
-                    validated += 1;
-                }
+                let nodelist = djls_templates::parse_template(&db, template.file)
+                    .expect("benchmark template should parse");
+                djls_semantic::validate_nodelist(&db, nodelist);
+                validated += 1;
             }
         }
         divan::black_box(validated);
@@ -121,10 +121,10 @@ fn opaque_regions_cold(bencher: Bencher) {
 
         let mut opaque_files = 0;
         for file in &files {
-            if let Some(nodelist) = djls_templates::parse_template(&db, *file) {
-                let regions = djls_semantic::compute_opaque_regions(&db, nodelist);
-                opaque_files += usize::from(!regions.is_empty());
-            }
+            let nodelist = djls_templates::parse_template(&db, *file)
+                .expect("benchmark template should parse");
+            let regions = djls_semantic::compute_opaque_regions(&db, nodelist);
+            opaque_files += usize::from(!regions.is_empty());
         }
         divan::black_box(opaque_files);
     });

--- a/crates/djls-bench/src/db.rs
+++ b/crates/djls-bench/src/db.rs
@@ -10,16 +10,17 @@ use djls_semantic::Db as SemanticDb;
 use djls_semantic::FilterAritySpecs;
 use djls_semantic::TagSpecs;
 use djls_source::CaseSensitivity;
+use djls_source::ChangeEvent;
 use djls_source::Db as SourceDb;
 use djls_source::File;
 use djls_source::FileSystem;
 use djls_source::FxDashMap;
+use djls_source::SourceChanges;
 use djls_source::SourceFiles;
 use djls_source::WalkEntry;
 use djls_source::WalkEntryKind;
 use djls_source::WalkOptions;
 use djls_source::path_to_file;
-use salsa::Setter;
 
 #[derive(Clone)]
 struct SourceMapFileSystem {
@@ -173,10 +174,10 @@ impl Db {
         path_to_file(self, &path).expect("inserted benchmark source should be visible")
     }
 
-    pub fn set_file_contents(&mut self, file: File, contents: &str, revision: u64) {
-        let path = file.path(self);
+    pub fn set_file_contents(&mut self, file: File, contents: &str) {
+        let path = file.path(self).clone();
         self.fs.sources.insert(path.clone(), contents.to_string());
-        file.set_revision(self).to(revision);
+        SourceChanges::new([ChangeEvent::ContentChanged(path)]).apply(self);
     }
 }
 

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -219,11 +219,13 @@ mod invalidation_tests {
     use djls_semantic::SemanticOffsetContext;
     use djls_semantic::template_inheritance;
     use djls_semantic::template_symbols;
+    use djls_source::ChangeEvent;
     use djls_source::Db as SourceDb;
     use djls_source::File;
     use djls_source::InMemoryFileSystem;
     use djls_source::Offset;
     use djls_source::OsFileSystem;
+    use djls_source::SourceChanges;
     use djls_source::SourceFiles;
     use djls_source::path_to_file;
     use djls_templates::parse_template;
@@ -464,7 +466,8 @@ mod invalidation_tests {
             settings_path,
             "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'builtins': []}}]\n".to_string(),
         );
-        db.bump_file_revision(settings_file);
+        SourceChanges::new([ChangeEvent::ContentChanged(settings_file.path(&db).clone())])
+            .apply(&mut db);
 
         let specs = db.tag_specs();
         assert!(
@@ -679,7 +682,8 @@ mod invalidation_tests {
                 "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['{other_templates_dir}'], 'APP_DIRS': False}}]\n"
             ),
         );
-        db.bump_file_revision(settings_file);
+        SourceChanges::new([ChangeEvent::ContentChanged(settings_file.path(&db).clone())])
+            .apply(&mut db);
 
         assert_eq!(db.template_dirs().unwrap(), vec![other_templates_dir]);
         let events = event_log.take();
@@ -933,6 +937,8 @@ env_file = ".env.local"
 
         let settings = Settings::new(root.as_path(), None).unwrap();
         db.apply_project_settings(settings);
+        let environment = djls_project::testing::compute_django_environment(&db, project);
+        djls_project::apply_django_environment(&mut db, environment);
 
         assert_eq!(db.project(), Some(project));
         assert_eq!(
@@ -1095,7 +1101,7 @@ env_file = ".env.local"
         // Bump the file revision — but the source is still empty (file not in FS)
         file.set_revision(&mut db).to(1);
 
-        // Salsa's backdate optimization: file.source() returns the same empty text,
+        // Salsa's backdate optimization: file.try_source() returns the same empty text,
         // so extract_filter_arities does NOT re-execute (correct behavior)
         let _result = djls_project::extract_filter_arities(
             &db,
@@ -1313,7 +1319,13 @@ def my_filter(value, arg):
         );
         let extra_file =
             path_to_file(&db, &extra_settings_path).expect("fixture file should exist");
-        assert!(extra_file.source(&db).as_str().contains("old_tags"));
+        assert!(
+            extra_file
+                .try_source(&db)
+                .expect("extra template tag file should be readable")
+                .as_str()
+                .contains("old_tags")
+        );
 
         {
             let mut fs = fs.lock().unwrap();
@@ -1328,14 +1340,76 @@ def my_filter(value, arg):
         assert_custom_library_module(&db, "new_tags");
     }
 
+    #[test]
+    fn one_reload_observes_deleted_and_recreated_settings_import() {
+        let tempdir = tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            "django_settings_module = \"settings\"\n",
+        )
+        .unwrap();
+        let settings = Settings::new(root.as_path(), None).unwrap();
+        let base_settings_path = root.join("base.py");
+
+        let fs = Arc::new(Mutex::new(InMemoryFileSystem::new()));
+        {
+            let mut fs = fs.lock().unwrap();
+            fs.add_file(root.join("manage.py"), String::new());
+            fs.add_file(
+                root.join("settings.py"),
+                "from .base import *\n".to_string(),
+            );
+            fs.add_file(
+                base_settings_path.clone(),
+                settings_with_custom_library("old_tags"),
+            );
+            fs.add_file(
+                root.join("old_tags.py"),
+                template_tag_library_source("old_tag"),
+            );
+            fs.add_file(
+                root.join("new_tags.py"),
+                template_tag_library_source("new_tag"),
+            );
+        }
+
+        let mut db = DjangoDatabase {
+            fs: fs.clone(),
+            files: SourceFiles::default(),
+            project: None,
+            settings: Arc::new(Mutex::new(settings.clone())),
+            storage: salsa::Storage::default(),
+            logs: Arc::new(Mutex::new(None)),
+        };
+        let project = Project::bootstrap(&db, root.as_path(), &settings);
+        db.project = Some(project);
+        assert_custom_library_module(&db, "old_tags");
+
+        fs.lock().unwrap().remove_file(&base_settings_path);
+        apply_project_discovery(&mut db);
+        assert!(
+            db.template_libraries()
+                .installed_library_str("custom")
+                .is_none()
+        );
+
+        fs.lock()
+            .unwrap()
+            .add_file(base_settings_path, settings_with_custom_library("new_tags"));
+        apply_project_discovery(&mut db);
+        assert_custom_library_module(&db, "new_tags");
+    }
+
     fn apply_project_discovery(db: &mut DjangoDatabase) {
         let project = db.project().expect("project should exist");
-        let discovery = djls_project::testing::compute_django_discovery(db, project);
-        djls_project::apply_django_discovery(db, discovery);
+        let environment = djls_project::testing::compute_django_environment(db, project);
+        djls_project::apply_django_environment(db, environment);
+        let _facts = djls_project::testing::compute_project_facts(db, project);
     }
 
     #[test]
-    fn apply_django_discovery_bumps_roots_but_not_unchanged_file_contents() {
+    fn environment_apply_bumps_roots_but_not_unchanged_file_contents() {
         let tempdir = tempdir().unwrap();
         let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
         std::fs::write(
@@ -1370,10 +1444,11 @@ def my_filter(value, arg):
         let project = Project::bootstrap(&db, root.as_path(), &settings);
         db.project = Some(project);
 
-        let discovery = djls_project::testing::compute_django_discovery(&db, project);
-        let file_paths: Vec<_> = discovery.file_paths().to_vec();
+        let environment = djls_project::testing::compute_django_environment(&db, project);
+        djls_project::apply_django_environment(&mut db, environment);
+        let facts = djls_project::testing::compute_project_facts(&db, project);
+        let file_paths: Vec<_> = facts.file_paths().to_vec();
         assert!(!file_paths.is_empty());
-        djls_project::apply_django_discovery(&mut db, discovery);
 
         let project = db.project().expect("project should exist");
         let file_revisions: Vec<_> = file_paths
@@ -1393,8 +1468,9 @@ def my_filter(value, arg):
             .collect();
         assert!(!root_revisions.is_empty());
 
-        let discovery = djls_project::testing::compute_django_discovery(&db, project);
-        djls_project::apply_django_discovery(&mut db, discovery);
+        let environment = djls_project::testing::compute_django_environment(&db, project);
+        djls_project::apply_django_environment(&mut db, environment);
+        let _facts = djls_project::testing::compute_project_facts(&db, project);
 
         let unchanged_file_revisions: Vec<_> = file_paths
             .iter()
@@ -1526,7 +1602,8 @@ def my_filter(value, arg):
             tag_path,
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef new_tag():\n    pass\n".to_string(),
         );
-        db.bump_file_revision(tag_file);
+        SourceChanges::new([ChangeEvent::ContentChanged(tag_file.path(&db).clone())])
+            .apply(&mut db);
 
         let libraries = db.template_libraries();
         let custom = libraries.installed_library_str("custom").unwrap();
@@ -1636,7 +1713,8 @@ def my_filter(value, arg):
             "from django.db import models\nclass FirstRenamed(models.Model):\n    pass\n"
                 .to_string(),
         );
-        db.bump_file_revision(first_model);
+        SourceChanges::new([ChangeEvent::ContentChanged(first_model.path(&db).clone())])
+            .apply(&mut db);
 
         let graph = db.model_graph();
         assert!(graph.models_named("First").next().is_none());
@@ -1685,7 +1763,8 @@ def my_filter(value, arg):
             child_path,
             "{% extends \"base.html\" %}\n{% block content %}{{ two }}{% endblock %}".to_string(),
         );
-        db.bump_file_revision(child_file);
+        SourceChanges::new([ChangeEvent::ContentChanged(child_file.path(&db).clone())])
+            .apply(&mut db);
 
         let nodelist = parse_template(&db, child_file).expect("child should parse");
         let symbols = template_symbols(&db, nodelist);
@@ -1725,7 +1804,8 @@ def my_filter(value, arg):
             child_path,
             "{% extends \"next.html\" %}\n{% block content %}{{ one }}{% endblock %}".to_string(),
         );
-        db.bump_file_revision(child_file);
+        SourceChanges::new([ChangeEvent::ContentChanged(child_file.path(&db).clone())])
+            .apply(&mut db);
 
         let inheritance = template_inheritance(&db, project, child_file);
         assert!(inheritance.ancestors(&db)[0].file(&db) == other_file);
@@ -1757,7 +1837,8 @@ def my_filter(value, arg):
             parent_path,
             "{% block sidebar %}Base{% endblock %}".to_string(),
         );
-        db.bump_file_revision(parent_file);
+        SourceChanges::new([ChangeEvent::ContentChanged(parent_file.path(&db).clone())])
+            .apply(&mut db);
 
         let inheritance = template_inheritance(&db, project, child_file);
         assert!(inheritance.ancestors(&db)[0].file(&db) == parent_file);

--- a/crates/djls-ide/src/code_actions.rs
+++ b/crates/djls-ide/src/code_actions.rs
@@ -26,13 +26,17 @@ pub fn code_actions(
     range: Span,
     encoding: PositionEncoding,
 ) -> Option<Vec<ls_types::CodeActionOrCommand>> {
-    let source = file.source(db);
+    let Ok(source) = file.try_source(db) else {
+        return None;
+    };
     if *source.kind() != FileKind::Template {
         return None;
     }
     let source_text = source.as_str();
 
-    let Some(parsed) = djls_templates::parse_template(db, file) else {
+    let djls_templates::TemplateParseResult::Parsed(parsed) =
+        djls_templates::parse_template(db, file)
+    else {
         return Some(Vec::new());
     };
 

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -476,12 +476,16 @@ pub fn completion(
     encoding: PositionEncoding,
     supports_snippets: bool,
 ) -> Option<ls_types::CompletionResponse> {
-    let source = file.source(db);
+    let Ok(source) = file.try_source(db) else {
+        return None;
+    };
     if *source.kind() != FileKind::Template {
         return None;
     }
 
-    let tokens = djls_templates::lex_template(db, file);
+    let Ok(tokens) = djls_templates::lex_template(db, file) else {
+        return None;
+    };
     let context = CompletionOffsetContext::new(*source.kind(), source.as_str(), tokens, offset);
     let template_libraries = db.template_libraries();
     let available_symbols =
@@ -587,8 +591,13 @@ fn available_symbols_for_completion(
     match context {
         CompletionOffsetContext::Template(
             TemplateCompletionContext::TagName { .. } | TemplateCompletionContext::Filter { .. },
-        ) => djls_templates::parse_template(db, file)
-            .map(|nodelist| djls_semantic::available_symbols_at(db, nodelist, offset.get())),
+        ) => match djls_templates::parse_template(db, file) {
+            djls_templates::TemplateParseResult::Parsed(nodelist) => Some(
+                djls_semantic::available_symbols_at(db, nodelist, offset.get()),
+            ),
+            djls_templates::TemplateParseResult::NotTemplate
+            | djls_templates::TemplateParseResult::Unreadable(_) => None,
+        },
         CompletionOffsetContext::Template(
             TemplateCompletionContext::Text
             | TemplateCompletionContext::TagArgument { .. }

--- a/crates/djls-ide/src/diagnostics.rs
+++ b/crates/djls-ide/src/diagnostics.rs
@@ -16,7 +16,10 @@ pub fn collect_diagnostics(
     db: &dyn djls_semantic::Db,
     file: File,
 ) -> Option<Vec<ls_types::Diagnostic>> {
-    if *file.source(db).kind() != FileKind::Template {
+    let Ok(source) = file.try_source(db) else {
+        return None;
+    };
+    if *source.kind() != FileKind::Template {
         return None;
     }
 

--- a/crates/djls-ide/src/folding.rs
+++ b/crates/djls-ide/src/folding.rs
@@ -13,11 +13,15 @@ pub fn collect_folding_ranges(
     db: &dyn djls_semantic::Db,
     file: File,
 ) -> Vec<ls_types::FoldingRange> {
-    let Some(nodelist) = djls_templates::parse_template(db, file) else {
+    let djls_templates::TemplateParseResult::Parsed(nodelist) =
+        djls_templates::parse_template(db, file)
+    else {
         return Vec::new();
     };
 
-    let source = file.source(db);
+    let Ok(source) = file.try_source(db) else {
+        return Vec::new();
+    };
     let template_tree = djls_semantic::build_template_tree(db, nodelist);
     let semantic_folds = djls_semantic::build_template_folds(db, template_tree);
     let folds =

--- a/crates/djls-ide/src/formatting.rs
+++ b/crates/djls-ide/src/formatting.rs
@@ -16,7 +16,9 @@ pub fn format_document(
     backend: FormatBackend,
     formatting_options: &ls_types::FormattingOptions,
 ) -> Vec<ls_types::TextEdit> {
-    let source = file.source(db);
+    let Ok(source) = file.try_source(db) else {
+        return Vec::new();
+    };
     let path = file.path(db);
 
     let indent_width = u8::try_from(formatting_options.tab_size)

--- a/crates/djls-ide/src/symbols.rs
+++ b/crates/djls-ide/src/symbols.rs
@@ -8,7 +8,9 @@ use crate::ext::SpanExt;
 
 #[must_use]
 pub fn document_symbols(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_types::DocumentSymbol> {
-    let Some(nodelist) = djls_templates::parse_template(db, file) else {
+    let djls_templates::TemplateParseResult::Parsed(nodelist) =
+        djls_templates::parse_template(db, file)
+    else {
         return Vec::new();
     };
 

--- a/crates/djls-project/src/discovery.rs
+++ b/crates/djls-project/src/discovery.rs
@@ -1,14 +1,13 @@
-//! Discover external Project Facts and synchronize them into Salsa inputs.
+//! Discover the Django Environment and Project Facts and synchronize them into Salsa.
 //!
-//! This module owns the closed set of Django Discovery phases, domain progress
-//! metadata, and the validated discovery payload. The server owns runtime
-//! orchestration and LSP presentation: concurrency, cancellation, progress
-//! transport, and when to apply the payload.
+//! Environment discovery must be computed and applied before Project Facts are
+//! computed. Applying the environment registers and invalidates source roots,
+//! then rescans known files. Project Facts can then be computed from a fresh
+//! database clone without a second invalidation wave.
 
 use camino::Utf8PathBuf;
 use djls_source::ChangeEvent;
 use djls_source::SourceChanges;
-use djls_source::path_to_file;
 use salsa::Setter;
 
 use crate::db::Db as ProjectDb;
@@ -20,16 +19,16 @@ use crate::settings::settings_sources;
 use crate::templates::discover_templatetag_candidate_paths;
 use crate::templates::template_libraries;
 
+/// The resolved Python environment for a Project.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DjangoDiscoveryData {
+pub struct DjangoEnvironmentData {
     search_paths: SearchPaths,
-    file_paths: Vec<Utf8PathBuf>,
 }
 
+/// The source identities reached while discovering Project Facts.
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum DjangoDiscoveryDataPart {
-    SearchPaths(SearchPaths),
-    FilePaths(Vec<Utf8PathBuf>),
+pub struct ProjectFactsData {
+    file_paths: Vec<Utf8PathBuf>,
 }
 
 /// Noun pair used when reporting a count for a Django Discovery phase.
@@ -55,10 +54,6 @@ pub enum EnvironmentPhase {
 }
 
 impl EnvironmentPhase {
-    fn all() -> impl Iterator<Item = Self> {
-        std::iter::successors(Some(Self::SearchPaths), |phase| (*phase).next())
-    }
-
     const fn next(self) -> Option<Self> {
         match self {
             Self::SearchPaths => None,
@@ -66,7 +61,7 @@ impl EnvironmentPhase {
     }
 
     #[must_use]
-    const fn progress(self) -> DjangoDiscoveryProgress {
+    pub const fn progress(self) -> DjangoDiscoveryProgress {
         match self {
             Self::SearchPaths => DjangoDiscoveryProgress {
                 message: "Resolving Python search paths",
@@ -78,18 +73,109 @@ impl EnvironmentPhase {
         }
     }
 
-    fn compute(self, db: &dyn ProjectDb, project: Project) -> DjangoDiscoveryDataPart {
+    #[must_use]
+    pub fn run(self, db: &dyn ProjectDb, project: Project) -> EnvironmentPart {
         match self {
             Self::SearchPaths => {
-                DjangoDiscoveryDataPart::SearchPaths(SearchPaths::from_project_settings(
+                let search_paths = SearchPaths::from_project_settings(
                     db.file_system(),
                     project.root(db),
                     project.interpreter(db),
                     project.pythonpath(db),
-                ))
+                );
+                EnvironmentPart {
+                    phase: self,
+                    count: search_paths.iter().count(),
+                    search_paths,
+                }
             }
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnvironmentPart {
+    phase: EnvironmentPhase,
+    count: usize,
+    search_paths: SearchPaths,
+}
+
+impl EnvironmentPart {
+    #[must_use]
+    pub const fn phase(&self) -> EnvironmentPhase {
+        self.phase
+    }
+
+    #[must_use]
+    pub const fn count(&self) -> usize {
+        self.count
+    }
+}
+
+pub fn environment_phases() -> impl Iterator<Item = EnvironmentPhase> {
+    std::iter::successors(Some(EnvironmentPhase::SearchPaths), |phase| phase.next())
+}
+
+impl DjangoEnvironmentData {
+    /// Build environment data from the closed set of Environment phase results.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the parts do not contain exactly one result for each phase.
+    #[must_use]
+    pub fn assemble(parts: impl IntoIterator<Item = EnvironmentPart>) -> Self {
+        let mut search_paths = None;
+
+        for part in parts {
+            match part.phase {
+                EnvironmentPhase::SearchPaths => {
+                    assert!(
+                        search_paths.is_none(),
+                        "environment data must not include duplicate phase results"
+                    );
+                    search_paths = Some(part.search_paths);
+                }
+            }
+        }
+
+        let Some(search_paths) = search_paths else {
+            panic!("environment data must include every Environment phase result")
+        };
+        Self { search_paths }
+    }
+}
+
+#[must_use]
+pub fn compute_django_environment(db: &dyn ProjectDb, project: Project) -> DjangoEnvironmentData {
+    DjangoEnvironmentData::assemble(environment_phases().map(|phase| phase.run(db, project)))
+}
+
+/// Apply the resolved environment and perform the reload's sole invalidation wave.
+///
+/// Search roots are registered before becoming active. Every active root is
+/// bumped, then all already-known paths are synchronized from the authoritative
+/// filesystem view (including editor overlays).
+pub fn apply_django_environment(db: &mut dyn ProjectDb, environment: DjangoEnvironmentData) {
+    let Some(project) = db.project() else {
+        return;
+    };
+    let DjangoEnvironmentData { search_paths } = environment;
+
+    if project.search_paths(db) != &search_paths {
+        search_paths.register_roots(db);
+        project.set_search_paths(db).to(search_paths);
+    }
+
+    let roots: Vec<_> = project
+        .search_paths(db)
+        .iter()
+        .filter_map(|search_path| db.files().root(db, search_path.path()))
+        .collect();
+    for root in roots {
+        db.bump_file_root_revision(root);
+    }
+
+    SourceChanges::new([ChangeEvent::Rescan]).apply(db);
 }
 
 /// Project Facts discovery phases.
@@ -102,10 +188,6 @@ pub enum ProjectFactsPhase {
 }
 
 impl ProjectFactsPhase {
-    fn all() -> impl Iterator<Item = Self> {
-        std::iter::successors(Some(Self::SettingsSources), |phase| (*phase).next())
-    }
-
     const fn next(self) -> Option<Self> {
         match self {
             Self::SettingsSources => Some(Self::ModelModules),
@@ -116,7 +198,7 @@ impl ProjectFactsPhase {
     }
 
     #[must_use]
-    const fn progress(self) -> DjangoDiscoveryProgress {
+    pub const fn progress(self) -> DjangoDiscoveryProgress {
         match self {
             Self::SettingsSources => DjangoDiscoveryProgress {
                 message: "Reading settings sources",
@@ -149,153 +231,88 @@ impl ProjectFactsPhase {
         }
     }
 
-    fn compute(self, db: &dyn ProjectDb, project: Project) -> DjangoDiscoveryDataPart {
-        match self {
+    #[must_use]
+    pub fn run(self, db: &dyn ProjectDb, project: Project) -> ProjectFactsPart {
+        let file_paths = match self {
             Self::SettingsSources => {
                 let sources: DjangoSettingsSources = settings_sources(db, project);
-                DjangoDiscoveryDataPart::FilePaths(
-                    sources
-                        .root()
-                        .into_iter()
-                        .chain(sources.files().iter().copied().skip(1))
-                        .map(|file| file.path(db).to_path_buf())
-                        .collect(),
-                )
+                sources
+                    .root()
+                    .into_iter()
+                    .chain(sources.files().iter().copied().skip(1))
+                    .map(|file| file.path(db).to_path_buf())
+                    .collect()
             }
-            Self::ModelModules => DjangoDiscoveryDataPart::FilePaths(
-                model_modules(db, project)
-                    .iter()
-                    .map(|module| module.path().to_path_buf())
-                    .collect(),
-            ),
-            Self::TemplateLibrarySources => DjangoDiscoveryDataPart::FilePaths(
-                template_libraries(db, project)
-                    .active_libraries()
-                    .map(|library| library.file().path(db).to_path_buf())
-                    .collect(),
-            ),
-            Self::TemplateTagCandidates => DjangoDiscoveryDataPart::FilePaths(
-                discover_templatetag_candidate_paths(db, project),
-            ),
-        }
-    }
-}
-
-/// Closed set of Django Discovery phases, with phase membership encoded by the
-/// variant that carries it.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DiscoveryPhase {
-    Environment(EnvironmentPhase),
-    ProjectFacts(ProjectFactsPhase),
-}
-
-impl DiscoveryPhase {
-    #[must_use]
-    pub fn environment_phase_count() -> usize {
-        EnvironmentPhase::all().count()
-    }
-
-    #[must_use]
-    pub fn project_facts_phase_count() -> usize {
-        ProjectFactsPhase::all().count()
-    }
-
-    #[must_use]
-    pub const fn progress(self) -> DjangoDiscoveryProgress {
-        match self {
-            Self::Environment(phase) => phase.progress(),
-            Self::ProjectFacts(phase) => phase.progress(),
-        }
-    }
-
-    #[must_use]
-    pub fn run(self, db: &dyn ProjectDb, project: Project) -> DjangoDiscoveryPart {
-        DjangoDiscoveryPart {
+            Self::ModelModules => model_modules(db, project)
+                .iter()
+                .map(|module| module.path().to_path_buf())
+                .collect(),
+            Self::TemplateLibrarySources => template_libraries(db, project)
+                .active_libraries()
+                .map(|library| library.file().path(db).to_path_buf())
+                .collect(),
+            Self::TemplateTagCandidates => discover_templatetag_candidate_paths(db, project),
+        };
+        ProjectFactsPart {
             phase: self,
-            part: self.compute(db, project),
-        }
-    }
-
-    fn compute(self, db: &dyn ProjectDb, project: Project) -> DjangoDiscoveryDataPart {
-        match self {
-            Self::Environment(phase) => phase.compute(db, project),
-            Self::ProjectFacts(phase) => phase.compute(db, project),
+            file_paths,
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DjangoDiscoveryPart {
-    phase: DiscoveryPhase,
-    part: DjangoDiscoveryDataPart,
+pub struct ProjectFactsPart {
+    phase: ProjectFactsPhase,
+    file_paths: Vec<Utf8PathBuf>,
 }
 
-impl DjangoDiscoveryPart {
+impl ProjectFactsPart {
     #[must_use]
-    pub const fn phase(&self) -> DiscoveryPhase {
+    pub const fn phase(&self) -> ProjectFactsPhase {
         self.phase
     }
 
     #[must_use]
     pub fn count(&self) -> usize {
-        match &self.part {
-            DjangoDiscoveryDataPart::SearchPaths(search_paths) => search_paths.iter().count(),
-            DjangoDiscoveryDataPart::FilePaths(paths) => paths.len(),
-        }
+        self.file_paths.len()
     }
 }
 
-pub fn django_discovery_phases() -> impl Iterator<Item = DiscoveryPhase> {
-    EnvironmentPhase::all()
-        .map(DiscoveryPhase::Environment)
-        .chain(ProjectFactsPhase::all().map(DiscoveryPhase::ProjectFacts))
+pub fn project_facts_phases() -> impl Iterator<Item = ProjectFactsPhase> {
+    std::iter::successors(Some(ProjectFactsPhase::SettingsSources), |phase| {
+        phase.next()
+    })
 }
 
-impl DjangoDiscoveryData {
-    /// Build discovery data from the closed set of Django Discovery phase results.
+impl ProjectFactsData {
+    /// Build Project Facts from the closed set of phase results.
     ///
     /// # Panics
     ///
-    /// Panics if the parts do not contain exactly one result for each Django
-    /// Discovery phase.
+    /// Panics if the parts do not contain exactly one result for each phase.
     #[must_use]
-    pub fn assemble(parts: impl IntoIterator<Item = DjangoDiscoveryPart>) -> Self {
+    pub fn assemble(parts: impl IntoIterator<Item = ProjectFactsPart>) -> Self {
         let mut seen = Vec::new();
-        let mut search_paths = None;
         let mut file_paths = Vec::new();
 
         for part in parts {
             assert!(
                 !seen.contains(&part.phase),
-                "discovery data must not include duplicate phase results"
+                "Project Facts must not include duplicate phase results"
             );
             seen.push(part.phase);
-
-            match part.part {
-                DjangoDiscoveryDataPart::SearchPaths(paths) => {
-                    search_paths = Some(paths);
-                }
-                DjangoDiscoveryDataPart::FilePaths(paths) => file_paths.extend(paths),
-            }
+            file_paths.extend(part.file_paths);
         }
-
-        for phase in django_discovery_phases() {
+        for phase in project_facts_phases() {
             assert!(
                 seen.contains(&phase),
-                "discovery data must include every Django Discovery phase result"
+                "Project Facts must include every Project Facts phase result"
             );
         }
-        let Some(search_paths) = search_paths else {
-            unreachable!("EnvironmentPhase::SearchPaths result was marked as seen")
-        };
 
         file_paths.sort();
         file_paths.dedup();
-
-        Self {
-            search_paths,
-            file_paths,
-        }
+        Self { file_paths }
     }
 
     #[must_use]
@@ -318,46 +335,6 @@ impl DjangoDiscoveryData {
 }
 
 #[must_use]
-pub fn compute_django_discovery(db: &dyn ProjectDb, project: Project) -> DjangoDiscoveryData {
-    DjangoDiscoveryData::assemble(django_discovery_phases().map(|phase| phase.run(db, project)))
-}
-
-pub fn apply_django_discovery(db: &mut dyn ProjectDb, discovery: DjangoDiscoveryData) {
-    let Some(project) = db.project() else {
-        return;
-    };
-    let DjangoDiscoveryData {
-        search_paths,
-        file_paths,
-    } = discovery;
-
-    let search_paths_changed = project.search_paths(db) != &search_paths;
-    if search_paths_changed {
-        search_paths.register_roots(db);
-        project.set_search_paths(db).to(search_paths);
-    }
-
-    let roots: Vec<_> = project
-        .search_paths(db)
-        .iter()
-        .filter_map(|search_path| db.files().root(db, search_path.path()))
-        .collect();
-
-    for root in roots {
-        db.bump_file_root_revision(root);
-    }
-
-    for path in file_paths {
-        let Ok(file) = path_to_file(db, &path) else {
-            continue;
-        };
-        let current = file.source(db);
-        let latest = db.read_file(&path).unwrap_or_default();
-
-        if current.as_str() != latest {
-            db.bump_file_revision(file);
-        }
-    }
-
-    SourceChanges::new([ChangeEvent::Rescan]).apply(db);
+pub fn compute_project_facts(db: &dyn ProjectDb, project: Project) -> ProjectFactsData {
+    ProjectFactsData::assemble(project_facts_phases().map(|phase| phase.run(db, project)))
 }

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -11,14 +11,16 @@ mod templates;
 
 pub use db::Db;
 pub use discovery::CountLabel;
-pub use discovery::DiscoveryPhase;
-pub use discovery::DjangoDiscoveryData;
-pub use discovery::DjangoDiscoveryPart;
 pub use discovery::DjangoDiscoveryProgress;
+pub use discovery::DjangoEnvironmentData;
+pub use discovery::EnvironmentPart;
 pub use discovery::EnvironmentPhase;
+pub use discovery::ProjectFactsData;
+pub use discovery::ProjectFactsPart;
 pub use discovery::ProjectFactsPhase;
-pub use discovery::apply_django_discovery;
-pub use discovery::django_discovery_phases;
+pub use discovery::apply_django_environment;
+pub use discovery::environment_phases;
+pub use discovery::project_facts_phases;
 pub use models::ModelGraph;
 pub use models::ModelId;
 pub use models::compute_model_graph;
@@ -101,7 +103,8 @@ pub mod testing {
     use djls_source::FileStatus;
     use djls_source::Span;
 
-    pub use crate::discovery::compute_django_discovery;
+    pub use crate::discovery::compute_django_environment;
+    pub use crate::discovery::compute_project_facts;
     pub use crate::models::model_modules;
     pub use crate::models::resolve_model_graph_from_modules;
     pub use crate::python::PythonSyntaxError;
@@ -243,6 +246,7 @@ pub mod testing {
             .durability(salsa::Durability::LOW)
             .path_durability(salsa::Durability::HIGH)
             .new(db);
+        db.files().register_file(db, file);
         super::PythonModule::new(
             module_name,
             path,

--- a/crates/djls-project/src/project.rs
+++ b/crates/djls-project/src/project.rs
@@ -121,19 +121,8 @@ impl Project {
         let interpreter = Interpreter::discover(settings.venv_path());
         let django_settings_module = django_settings_module_name(db.file_system(), &root, settings);
         let env_vars = load_env_file(db.file_system(), &root, settings);
-        let search_paths = SearchPaths::from_project_settings(
-            db.file_system(),
-            &root,
-            &interpreter,
-            settings.pythonpath(),
-        );
         let pythonpath = settings.pythonpath().to_vec();
         let tagspecs = settings.tagspecs().clone();
-
-        if self.search_paths(db) != &search_paths {
-            search_paths.register_roots(db);
-            self.set_search_paths(db).to(search_paths);
-        }
 
         if self.interpreter(db) != &interpreter {
             self.set_interpreter(db).to(interpreter);

--- a/crates/djls-project/src/python/import.rs
+++ b/crates/djls-project/src/python/import.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use camino::Utf8PathBuf;
 use djls_source::File;
+use djls_source::FileReadError;
 use djls_source::Span;
 use ruff_python_ast::Alias;
 use ruff_python_ast::Stmt;
@@ -21,7 +21,7 @@ pub(crate) enum ImportLoadResult {
     Loaded(PythonSource),
     Unresolved,
     SkippedExternal,
-    ReadFailed { file: File, path: Utf8PathBuf },
+    ReadFailed { file: File, error: FileReadError },
 }
 
 pub(crate) trait PythonImportLoader {
@@ -30,40 +30,22 @@ pub(crate) trait PythonImportLoader {
     fn load_named_import(&mut self, import: PythonImportRequest<'_>) -> ImportLoadResult;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SourceReadMode {
-    Tracked,
-    Discovery,
-}
-
 pub(crate) struct ProjectImportLoader<'db> {
     db: &'db dyn ProjectDb,
     project: Project,
-    mode: SourceReadMode,
 }
 
 impl<'db> ProjectImportLoader<'db> {
-    pub(crate) fn tracked(db: &'db dyn ProjectDb, project: Project) -> Self {
-        Self::new(db, project, SourceReadMode::Tracked)
+    pub(crate) const fn tracked(db: &'db dyn ProjectDb, project: Project) -> Self {
+        Self { db, project }
     }
 
-    pub(crate) fn discovery(db: &'db dyn ProjectDb, project: Project) -> Self {
-        Self::new(db, project, SourceReadMode::Discovery)
-    }
-
-    fn new(db: &'db dyn ProjectDb, project: Project, mode: SourceReadMode) -> Self {
-        Self { db, project, mode }
-    }
-
-    pub(crate) fn read_source(&self, file: File) -> Option<PythonSource> {
-        let source = match self.mode {
-            SourceReadMode::Tracked => file.source(self.db).as_str().to_string(),
-            SourceReadMode::Discovery => self.db.read_file(file.path(self.db)).ok()?,
-        };
-        Some(PythonSource::new(
+    pub(crate) fn read_source(&self, file: File) -> Result<PythonSource, FileReadError> {
+        let source = file.try_source(self.db)?;
+        Ok(PythonSource::new(
             file,
             file.path(self.db).to_path_buf(),
-            source,
+            source.as_str().to_string(),
         ))
     }
 
@@ -74,10 +56,7 @@ impl<'db> ProjectImportLoader<'db> {
     fn load_module_source(&mut self, module: &PythonModule) -> ImportLoadResult {
         let file = module.file();
         self.read_source(file).map_or_else(
-            || ImportLoadResult::ReadFailed {
-                file,
-                path: file.path(self.db).to_path_buf(),
-            },
+            |error| ImportLoadResult::ReadFailed { file, error },
             ImportLoadResult::Loaded,
         )
     }

--- a/crates/djls-project/src/python/parse.rs
+++ b/crates/djls-project/src/python/parse.rs
@@ -1,5 +1,6 @@
 use djls_source::File;
 use djls_source::FileKind;
+use djls_source::FileReadError;
 use djls_source::Span;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::PySourceType;
@@ -7,10 +8,11 @@ use ruff_python_ast::Stmt;
 
 use crate::ast::RangedExt;
 
-#[derive(Clone, Copy, PartialEq, Eq, salsa::Update)]
+#[derive(Clone, PartialEq, Eq, salsa::Update)]
 enum PythonParseResult<'db> {
     Parsed(PythonParse<'db>),
     NotPython,
+    Unreadable(FileReadError),
 }
 
 /// The internal product of one recovered Ruff parse.
@@ -35,17 +37,19 @@ impl<'db> RecoveredPythonModule<'db> {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, salsa::Update)]
+#[derive(Clone, PartialEq, Eq, salsa::Update)]
 pub(crate) enum RecoveredPythonModuleResult<'db> {
     Module(RecoveredPythonModule<'db>),
     NotPython,
+    Unreadable(FileReadError),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, salsa::Update)]
+#[derive(Clone, PartialEq, Eq, salsa::Update)]
 pub(crate) enum ExactPythonModule<'db> {
     Ready(RecoveredPythonModule<'db>),
     OrdinarySyntaxErrors,
     NotPython,
+    Unreadable(FileReadError),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -119,6 +123,7 @@ pub(crate) fn recovered_python_module(
             RecoveredPythonModuleResult::Module(RecoveredPythonModule { parse })
         }
         PythonParseResult::NotPython => RecoveredPythonModuleResult::NotPython,
+        PythonParseResult::Unreadable(error) => RecoveredPythonModuleResult::Unreadable(error),
     }
 }
 
@@ -131,6 +136,7 @@ pub(crate) fn exact_python_module(db: &dyn djls_source::Db, file: File) -> Exact
             ExactPythonModule::Ready(RecoveredPythonModule { parse })
         }
         PythonParseResult::NotPython => ExactPythonModule::NotPython,
+        PythonParseResult::Unreadable(error) => ExactPythonModule::Unreadable(error),
     }
 }
 
@@ -140,7 +146,7 @@ pub(crate) fn python_syntax_errors(
 ) -> Option<&Vec<PythonSyntaxError>> {
     match parse_python_file(db, file) {
         PythonParseResult::Parsed(parse) => Some(parse.syntax_errors(db)),
-        PythonParseResult::NotPython => None,
+        PythonParseResult::NotPython | PythonParseResult::Unreadable(_) => None,
     }
 }
 
@@ -152,7 +158,10 @@ fn has_ordinary_syntax_errors(errors: &[PythonSyntaxError]) -> bool {
 
 #[salsa::tracked]
 fn parse_python_file(db: &dyn djls_source::Db, file: File) -> PythonParseResult<'_> {
-    let source = file.source(db);
+    let source = match file.try_source(db) {
+        Ok(source) => source,
+        Err(error) => return PythonParseResult::Unreadable(error),
+    };
     if *source.kind() != FileKind::Python {
         return PythonParseResult::NotPython;
     }

--- a/crates/djls-project/src/python/semantic_model/source_graph/import_reachability.rs
+++ b/crates/djls-project/src/python/semantic_model/source_graph/import_reachability.rs
@@ -157,7 +157,8 @@ impl<'graph, 'resolver> PythonSourceGraphBuilder<'graph, 'resolver> {
                 state.apply_unresolved_import(import, kind);
                 PythonImportEdge::SkippedExternal { import: key, kind }
             }
-            ImportLoadResult::ReadFailed { file, path } => {
+            ImportLoadResult::ReadFailed { file, error } => {
+                let path = error.path().to_path_buf();
                 self.graph
                     .modules
                     .entry(file)

--- a/crates/djls-project/src/settings/sources.rs
+++ b/crates/djls-project/src/settings/sources.rs
@@ -15,7 +15,7 @@ pub(super) fn django_settings_from_file(
     file: File,
 ) -> DjangoSettings {
     let mut resolver = ProjectImportLoader::tracked(db, project);
-    let Some(source) = resolver.read_source(file) else {
+    let Ok(source) = resolver.read_source(file) else {
         return DjangoSettings::default();
     };
     extract_settings(&source, &mut resolver)
@@ -51,10 +51,8 @@ pub(crate) fn settings_sources(db: &dyn ProjectDb, project: Project) -> DjangoSe
         return DjangoSettingsSources::from_files(db, []);
     };
 
-    // The Django Discovery bump set must cover the same settings source graph
-    // the extractor would read against current disk content.
-    let mut resolver = ProjectImportLoader::discovery(db, project);
-    let Some(source) = resolver.read_source(file) else {
+    let mut resolver = ProjectImportLoader::tracked(db, project);
+    let Ok(source) = resolver.read_source(file) else {
         return DjangoSettingsSources::from_files(db, [file]);
     };
     let model = PythonSemanticModel::analyze(&source, &mut resolver);

--- a/crates/djls-project/tests/django_projects.rs
+++ b/crates/djls-project/tests/django_projects.rs
@@ -14,7 +14,7 @@ use djls_project::file_to_module_resolution;
 use djls_project::resolve_package_dirs;
 use djls_project::template_libraries;
 use djls_project::template_resolution;
-use djls_project::testing::compute_django_discovery;
+use djls_project::testing::compute_project_facts;
 use djls_testing::OsTestDatabase;
 
 fn fixture_root(name: &str) -> Utf8PathBuf {
@@ -67,7 +67,7 @@ fn src_layout_discovers_nested_roots_settings_models_and_libraries() {
         ]
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
     assert!(
         discovery
             .file_paths()

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -5,7 +5,8 @@ use djls_project::SymbolKey;
 use djls_project::extract_tag_rules;
 use djls_project::testing::PythonSyntaxErrorClass;
 use djls_project::testing::python_syntax_errors;
-use djls_source::Db as _;
+use djls_source::ChangeEvent;
+use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_testing::ExtractionBundle;
 use djls_testing::SalsaEventLog;
@@ -188,7 +189,7 @@ fn comment_only_edit_backdates_parsed_body_consumers() {
     let _ = event_log.take();
 
     db.add_file(path.as_str(), &format!("{source}# comment only\n"));
-    db.bump_file_revision(file);
+    SourceChanges::new([ChangeEvent::ContentChanged(path.to_path_buf())]).apply(&mut db);
 
     assert!(!extract_tag_rules(&db, file, module_name).is_empty());
     let events = event_log.take();

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -14,7 +14,9 @@ use djls_project::testing::extract_model_graph;
 use djls_project::testing::model_location;
 use djls_project::testing::model_relation_locations;
 use djls_project::testing::python_syntax_errors;
-use djls_source::Db as SourceDb;
+use djls_source::ChangeEvent;
+use djls_source::Db as _;
+use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_testing::ProjectFixture;
 use djls_testing::SalsaEventLog;
@@ -48,8 +50,7 @@ fn relation_value<'a>(graph: &'a Value, model: &str, field: &str) -> &'a Value {
 
 fn update_file(db: &mut TestDatabase, path: &str, content: &str) {
     db.add_file(path, content);
-    let file = db.file(Utf8Path::new(path));
-    db.bump_file_revision(file);
+    SourceChanges::new([ChangeEvent::ContentChanged(path.into())]).apply(db);
 }
 
 fn execution_count(db: &TestDatabase, events: &[salsa::Event], query_name: &str) -> usize {

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_conf::Settings;
-use djls_project::testing::compute_django_discovery;
+use djls_project::testing::compute_django_environment;
+use djls_project::testing::compute_project_facts;
 use djls_project::testing::model_modules;
 use djls_project::*;
 use djls_source::Db as _;
@@ -36,7 +37,10 @@ impl TestModelGraph {
 fn compute_model_graph(db: &TestDatabase, project: Project) -> TestModelGraph {
     let mut graph = TestModelGraph::default();
     for module in model_modules(db, project).iter().rev() {
-        let source = module.file().source(db);
+        let source = module
+            .file()
+            .try_source(db)
+            .expect("resolved module should be readable");
         for line in source.as_str().lines() {
             let Some(rest) = line.trim_start().strip_prefix("class ") else {
                 continue;
@@ -85,8 +89,9 @@ fn project_with_template_settings(
 
 fn apply_project_discovery(db: &mut TestDatabase) {
     let project = db.project().expect("project should be configured");
-    let discovery = compute_django_discovery(db, project);
-    apply_django_discovery(db, discovery);
+    let environment = compute_django_environment(db, project);
+    apply_django_environment(db, environment);
+    let _facts = compute_project_facts(db, project);
 }
 
 fn will_execute_count(db: &TestDatabase, events: &[salsa::Event], query_name: &str) -> usize {
@@ -931,7 +936,7 @@ fn django_discovery_discovers_site_packages_created_after_bootstrap() {
 }
 
 #[test]
-fn compute_and_apply_django_discovery_discovers_site_packages_created_after_bootstrap() {
+fn environment_then_project_facts_discovers_site_packages_created_after_bootstrap() {
     let mut db = TestDatabase::new();
     let search_paths = SearchPaths::from_project_settings(
         db.file_system(),
@@ -961,7 +966,7 @@ fn compute_and_apply_django_discovery_discovers_site_packages_created_after_boot
 }
 
 #[test]
-fn django_discovery_enumerates_new_empty_templatetag_candidate_before_root_bump() {
+fn project_facts_enumerate_new_empty_templatetag_candidate_before_root_bump() {
     let mut db = TestDatabase::new();
     db.add_file("/project/blog/__init__.py", "");
     db.add_file("/project/blog/templatetags/__init__.py", "");
@@ -975,14 +980,12 @@ fn django_discovery_enumerates_new_empty_templatetag_candidate_before_root_bump(
     search_paths.register_roots(&db);
     let project = project_for_search_paths(&mut db, "/project", search_paths);
 
-    let candidates =
-        DiscoveryPhase::ProjectFacts(ProjectFactsPhase::TemplateTagCandidates).run(&db, project);
+    let candidates = ProjectFactsPhase::TemplateTagCandidates.run(&db, project);
     assert_eq!(candidates.count(), 0);
 
     db.add_file("/project/blog/templatetags/future.py", "");
 
-    let candidates =
-        DiscoveryPhase::ProjectFacts(ProjectFactsPhase::TemplateTagCandidates).run(&db, project);
+    let candidates = ProjectFactsPhase::TemplateTagCandidates.run(&db, project);
     assert_eq!(candidates.count(), 1);
 }
 

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_project::testing::PythonSyntaxErrorClass;
-use djls_project::testing::compute_django_discovery;
+use djls_project::testing::compute_django_environment;
+use djls_project::testing::compute_project_facts;
 use djls_project::testing::django_settings;
 use djls_project::testing::python_syntax_errors;
 use djls_project::*;
@@ -207,8 +208,9 @@ fn project_with_settings(
 
 fn apply_project_discovery(db: &mut TestDatabase) {
     let project = db.project().expect("project should be configured");
-    let discovery = compute_django_discovery(db, project);
-    apply_django_discovery(db, discovery);
+    let environment = compute_django_environment(db, project);
+    apply_django_environment(db, environment);
+    let _facts = compute_project_facts(db, project);
 }
 
 #[test]
@@ -234,7 +236,7 @@ fn django_discovery_enumerates_settings_star_import_chain() {
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     let expected = [
         Utf8PathBuf::from("/proj/myproject/base.py"),
@@ -262,7 +264,7 @@ fn settings_sources_includes_semantically_reached_imports_and_excludes_unreachab
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -290,7 +292,7 @@ fn settings_sources_excludes_import_guarded_by_imported_false_flag() {
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -316,7 +318,7 @@ fn settings_sources_includes_import_after_unsupported_guard_touch() {
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -342,7 +344,7 @@ fn settings_sources_includes_import_after_loop_guard_change() {
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -368,7 +370,7 @@ fn settings_sources_plain_import_alias_makes_guarded_import_reachable() {
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -394,7 +396,7 @@ fn settings_sources_dedupes_duplicate_import_edges() {
         ],
     );
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -596,11 +598,10 @@ fn django_discovery_includes_deduped_unreadable_settings_source() {
     );
     db.set_project(project);
 
-    let settings_sources =
-        DiscoveryPhase::ProjectFacts(ProjectFactsPhase::SettingsSources).run(&db, project);
+    let settings_sources = ProjectFactsPhase::SettingsSources.run(&db, project);
     assert_eq!(settings_sources.count(), 3);
 
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     let expected = [
         Utf8PathBuf::from("/proj/myproject/base.py"),

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -3,7 +3,7 @@ use camino::Utf8PathBuf;
 use djls_project::Interpreter;
 use djls_project::Project;
 use djls_project::SearchPaths;
-use djls_project::testing::compute_django_discovery;
+use djls_project::testing::compute_project_facts;
 use djls_project::testing::django_settings;
 use djls_source::Db as _;
 use djls_testing::ProjectFixture;
@@ -901,7 +901,7 @@ fn unreachable_import_is_not_a_semantic_dependency() {
         "if False:\n    from base import INSTALLED_APPS\nelse:\n    INSTALLED_APPS = ['local']",
         &[("base", "INSTALLED_APPS = [")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -920,7 +920,7 @@ fn unreachable_elif_import_is_not_a_semantic_dependency() {
         "if FLAG:\n    INSTALLED_APPS = ['local']\nelif False:\n    from base import INSTALLED_APPS",
         &[("base", "INSTALLED_APPS = [")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -939,7 +939,7 @@ fn ambiguous_branch_import_effects_are_semantic_dependencies() {
         "if FLAG:\n    from base import INSTALLED_APPS\nelse:\n    INSTALLED_APPS = ['local']",
         &[("base", "INSTALLED_APPS = [")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -962,7 +962,7 @@ fn loop_import_effects_are_dependencies_without_accepting_values() {
         "for app in []:\n    from base import INSTALLED_APPS",
         &[("base", "INSTALLED_APPS = [")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -985,7 +985,7 @@ fn loop_star_import_degrades_existing_bindings_without_accepting_values() {
         "INSTALLED_APPS = ['local']\nfor app in PLUGINS:\n    from base import *",
         &[("base", "INSTALLED_APPS = ['base']")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -1007,7 +1007,7 @@ fn loop_nested_unreachable_star_import_does_not_degrade_bindings() {
         "INSTALLED_APPS = ['local']\nfor app in PLUGINS:\n    if False:\n        from base import *",
         &[("base", "INSTALLED_APPS = [")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),
@@ -1026,7 +1026,7 @@ fn while_false_body_import_is_not_a_semantic_dependency() {
         "while False:\n    from base import INSTALLED_APPS\nelse:\n    INSTALLED_APPS = ['local']",
         &[("base", "INSTALLED_APPS = [")],
     );
-    let discovery = compute_django_discovery(&db, project);
+    let discovery = compute_project_facts(&db, project);
 
     assert_eq!(
         discovery.file_paths(),

--- a/crates/djls-semantic/src/inheritance.rs
+++ b/crates/djls-semantic/src/inheritance.rs
@@ -10,6 +10,7 @@ use djls_source::File;
 use djls_source::Span;
 use djls_templates::NodeList;
 use djls_templates::TagBit;
+use djls_templates::TemplateParseResult;
 use djls_templates::TemplateString;
 use djls_templates::parse_template;
 use rustc_hash::FxHashSet;
@@ -36,7 +37,7 @@ pub fn template_inheritance(db: &dyn Db, project: Project, file: File) -> Templa
     let mut current_template_name = resolution.primary_template_name(db, file);
 
     let end = loop {
-        let Some(nodelist) = parse_template(db, current_file) else {
+        let TemplateParseResult::Parsed(nodelist) = parse_template(db, current_file) else {
             // Parser failures leave no observable extends target. Treat the
             // file as a root rather than claiming a resolution failure.
             break ChainEnd::Root;
@@ -130,7 +131,7 @@ pub fn inherited_blocks(db: &dyn Db, project: Project, file: File) -> Vec<(Strin
 
     for origin in template_inheritance(db, project, file).ancestors(db) {
         let ancestor_file = origin.file(db);
-        let Some(nodelist) = parse_template(db, ancestor_file) else {
+        let TemplateParseResult::Parsed(nodelist) = parse_template(db, ancestor_file) else {
             continue;
         };
         for block in template_symbols(db, nodelist).blocks() {
@@ -209,7 +210,7 @@ fn file_winning_extends_target_is<'db>(
     file: File,
     target_name: TemplateName<'db>,
 ) -> bool {
-    let Some(nodelist) = parse_template(db, file) else {
+    let TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
         return false;
     };
 
@@ -227,7 +228,9 @@ fn file_winning_extends_target_is<'db>(
 }
 
 fn first_block_site(db: &dyn Db, file: File, name: &str) -> Option<BlockSite> {
-    let nodelist = parse_template(db, file)?;
+    let TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
+        return None;
+    };
     template_symbols(db, nodelist)
         .blocks()
         .iter()

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -73,7 +73,9 @@ use crate::validation::TemplateValidator;
 /// need Django meaning for a file.
 #[salsa::tracked]
 pub fn validate_template_file(db: &dyn Db, file: djls_source::File) {
-    let Some(nodelist) = djls_templates::parse_template(db, file) else {
+    let djls_templates::TemplateParseResult::Parsed(nodelist) =
+        djls_templates::parse_template(db, file)
+    else {
         return;
     };
 

--- a/crates/djls-semantic/src/offset.rs
+++ b/crates/djls-semantic/src/offset.rs
@@ -47,7 +47,7 @@ pub enum SemanticOffsetContext<'db> {
 
 impl<'db> SemanticOffsetContext<'db> {
     pub fn from_offset(db: &'db dyn SemanticDb, file: File, offset: Offset) -> Self {
-        let Some(nodelist) = parse_template(db, file) else {
+        let djls_templates::TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
             return Self::None;
         };
 

--- a/crates/djls-semantic/src/references.rs
+++ b/crates/djls-semantic/src/references.rs
@@ -192,7 +192,7 @@ pub fn template_references_in_file(
     file: File,
 ) -> TemplateReferencesInFile<'_> {
     let tag_specs = compute_tag_specs(db, project);
-    let Some(nodelist) = parse_template(db, file) else {
+    let djls_templates::TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
         return TemplateReferencesInFile::new(db, Vec::new());
     };
     let tree = build_template_tree(db, nodelist);
@@ -217,7 +217,7 @@ pub fn template_library_references_in_file(
     db: &dyn SemanticDb,
     file: File,
 ) -> TemplateLibraryReferencesInFile<'_> {
-    let Some(nodelist) = parse_template(db, file) else {
+    let djls_templates::TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
         return TemplateLibraryReferencesInFile::new(db, Vec::new());
     };
     let tree = build_template_tree(db, nodelist);

--- a/crates/djls-semantic/tests/corpus_inheritance.rs
+++ b/crates/djls-semantic/tests/corpus_inheritance.rs
@@ -57,7 +57,10 @@ fn corpus_template_inheritance_terminates() {
         let project = fixture.build(&db);
         for template_path in templates {
             let file = db.file(&template_path);
-            if parse_template(&db, file).is_none() {
+            if !matches!(
+                parse_template(&db, file),
+                djls_templates::TemplateParseResult::Parsed(_)
+            ) {
                 continue;
             }
 

--- a/crates/djls-semantic/tests/inheritance.rs
+++ b/crates/djls-semantic/tests/inheritance.rs
@@ -12,9 +12,12 @@ use djls_semantic::TagSpecs;
 use djls_semantic::TemplateSymbols;
 use djls_semantic::block_overrides;
 use djls_semantic::builtin_tag_specs;
+use djls_semantic::inherited_blocks;
 use djls_semantic::template_inheritance;
 use djls_semantic::template_symbols;
+use djls_source::ChangeEvent;
 use djls_source::File;
+use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_templates::parse_template;
 use djls_testing::ProjectFixture;
@@ -97,6 +100,56 @@ fn extracts_partial_defs_from_partial_role_specs() {
             full_span: Span::saturating_from_bounds_usize(0, source.len()),
         }]
     );
+}
+
+#[test]
+fn unreadable_current_template_does_not_create_an_empty_tree() {
+    let mut db = TestDatabase::new();
+    let child_path = "/test/project/templates/child.html";
+    let project = project_with_templates(
+        &db,
+        vec!["/test/project/templates"],
+        vec![
+            (child_path, "{% extends 'base.html' %}"),
+            ("/test/project/templates/base.html", "base"),
+        ],
+    );
+    let child = db.file(Utf8Path::new(child_path));
+    assert_eq!(
+        template_inheritance(&db, project, child)
+            .ancestors(&db)
+            .len(),
+        1
+    );
+
+    db.remove_file(child_path);
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+
+    let inheritance = template_inheritance(&db, project, child);
+    assert!(inheritance.ancestors(&db).is_empty());
+    assert_eq!(inheritance.end(&db), ChainEnd::Root);
+}
+
+#[test]
+fn unreadable_ancestor_template_contributes_no_inherited_symbols() {
+    let mut db = TestDatabase::new();
+    let child_path = "/test/project/templates/child.html";
+    let base_path = "/test/project/templates/base.html";
+    let project = project_with_templates(
+        &db,
+        vec!["/test/project/templates"],
+        vec![
+            (child_path, "{% extends 'base.html' %}"),
+            (base_path, "{% block title %}Base{% endblock %}"),
+        ],
+    );
+    let child = db.file(Utf8Path::new(child_path));
+    assert_eq!(inherited_blocks(&db, project, child).len(), 1);
+
+    db.remove_file(base_path);
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+
+    assert!(inherited_blocks(&db, project, child).is_empty());
 }
 
 #[test]

--- a/crates/djls-semantic/tests/references.rs
+++ b/crates/djls-semantic/tests/references.rs
@@ -2,6 +2,8 @@ use djls_project::Project;
 use djls_project::TemplateName;
 use djls_semantic::TemplateReferenceKind;
 use djls_semantic::references_to_template_name;
+use djls_source::ChangeEvent;
+use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
@@ -65,6 +67,34 @@ fn template_references_record_extends_and_include_kinds() {
     );
     assert_eq!(partial_refs.len(), 1);
     assert_eq!(partial_refs[0].kind(&db), TemplateReferenceKind::Include);
+}
+
+#[test]
+fn unreadable_referencing_template_contributes_no_references() {
+    let mut db = TestDatabase::new();
+    let child_path = "/test/project/templates/child.html";
+    let project = project_with_templates(
+        &mut db,
+        vec!["/test/project/templates"],
+        vec![
+            ("child.html", child_path, "{% include 'partial.html' %}"),
+            (
+                "partial.html",
+                "/test/project/templates/partial.html",
+                "partial",
+            ),
+        ],
+    );
+    {
+        let partial = TemplateName::new(&db, "partial.html".to_string());
+        assert_eq!(references_to_template_name(&db, project, partial).len(), 1);
+    }
+
+    db.remove_file(child_path);
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+
+    let partial = TemplateName::new(&db, "partial.html".to_string());
+    assert!(references_to_template_name(&db, project, partial).is_empty());
 }
 
 #[test]

--- a/crates/djls-server/src/reload.rs
+++ b/crates/djls-server/src/reload.rs
@@ -16,12 +16,16 @@ use djls_ide::WarmCachePart;
 use djls_ide::WarmCachePhase;
 use djls_ide::warm_cache_phases;
 use djls_project::Db as ProjectDb;
-use djls_project::DiscoveryPhase;
-use djls_project::DjangoDiscoveryData;
-use djls_project::DjangoDiscoveryPart;
+use djls_project::DjangoEnvironmentData;
+use djls_project::EnvironmentPart;
+use djls_project::EnvironmentPhase;
 use djls_project::Project;
-use djls_project::apply_django_discovery;
-use djls_project::django_discovery_phases;
+use djls_project::ProjectFactsData;
+use djls_project::ProjectFactsPart;
+use djls_project::ProjectFactsPhase;
+use djls_project::apply_django_environment;
+use djls_project::environment_phases;
+use djls_project::project_facts_phases;
 use djls_source::path_to_file;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -130,7 +134,6 @@ impl From<djls_ide::CountLabel> for CountLabel {
 }
 
 struct DiscoveryJobCount {
-    phase: DiscoveryPhase,
     label: CountLabel,
     count: usize,
 }
@@ -155,26 +158,24 @@ async fn reload_project(session: Arc<Mutex<Session>>, client: Client, client_inf
         return;
     }
 
+    let Some(environment) =
+        compute_environment(&session, &progress, &mut environment_progress).await
+    else {
+        return;
+    };
+    if !apply_environment(&session, environment).await {
+        finish_progress(&mut environment_progress, ProgressEnd::Skipped).await;
+        return;
+    }
+    finish_progress(&mut environment_progress, ProgressEnd::Complete).await;
+
     let mut facts_progress = None;
-    let Some(discovery) = compute_project_discovery(
-        &session,
-        &progress,
-        &mut environment_progress,
-        &mut facts_progress,
-    )
-    .await
+    let Some(_facts) = compute_project_facts_data(&session, &progress, &mut facts_progress).await
     else {
         return;
     };
 
-    if facts_progress.is_none() {
-        facts_progress = Some(progress.begin(DISCOVER_PROJECT_FACTS_TITLE).await);
-    }
-    if let Some(progress) = facts_progress.as_ref() {
-        progress.report("Applying project facts").await;
-    }
-
-    let Some((snapshot, documents)) = apply_project_facts(&session, discovery).await else {
+    let Some((snapshot, documents)) = snapshot_session(&session).await else {
         finish_progress(&mut facts_progress, ProgressEnd::Skipped).await;
         return;
     };
@@ -226,18 +227,25 @@ async fn apply_project_settings(session: &Arc<Mutex<Session>>, settings: Setting
     true
 }
 
-async fn apply_project_facts(
+async fn apply_environment(
     session: &Arc<Mutex<Session>>,
-    discovery: DjangoDiscoveryData,
-) -> Option<(SessionSnapshot, Vec<TextDocument>)> {
+    environment: DjangoEnvironmentData,
+) -> bool {
     let mut session_lock = session.lock().await;
     let db = session_lock.db_mut();
-    db.project()?;
+    if db.project().is_none() {
+        return false;
+    }
 
-    let t = std::time::Instant::now();
-    apply_django_discovery(db, discovery);
-    tracing::info!("Django Discovery apply completed in {:?}", t.elapsed());
+    apply_django_environment(db, environment);
+    true
+}
 
+async fn snapshot_session(
+    session: &Arc<Mutex<Session>>,
+) -> Option<(SessionSnapshot, Vec<TextDocument>)> {
+    let session_lock = session.lock().await;
+    session_lock.db().project()?;
     Some((session_lock.snapshot(), session_lock.open_documents()))
 }
 
@@ -270,64 +278,170 @@ async fn load_project_settings(session: &Arc<Mutex<Session>>) -> Option<Settings
     }
 }
 
-type DiscoveryJobResult = Result<DjangoDiscoveryPart, salsa::Cancelled>;
-type DiscoveryJobSet = JoinSet<DiscoveryJobResult>;
+type EnvironmentJobResult = Result<EnvironmentPart, salsa::Cancelled>;
+type ProjectFactsJobResult = Result<ProjectFactsPart, salsa::Cancelled>;
 
-async fn compute_project_discovery(
+async fn compute_environment(
     session: &Arc<Mutex<Session>>,
-    progress: &ProgressReporter,
-    environment_progress: &mut Option<ProgressItem>,
-    facts_progress: &mut Option<ProgressItem>,
-) -> Option<DjangoDiscoveryData> {
-    // Cancellation here usually means a document edit, not a config change:
-    // nothing bumps the epoch or resubmits, so dropping the compute would lose
-    // the Django Discovery run. Retry with a fresh database clone instead,
-    // like the snapshot reads do.
+    reporter: &ProgressReporter,
+    progress: &mut Option<ProgressItem>,
+) -> Option<DjangoEnvironmentData> {
     for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
         let Some((compute_db, project)) = capture_discovery_db(session).await else {
-            finish_progress(environment_progress, ProgressEnd::Skipped).await;
-            finish_progress(facts_progress, ProgressEnd::Skipped).await;
+            finish_progress(progress, ProgressEnd::Skipped).await;
             return None;
         };
 
-        let handles = spawn_discovery_jobs(
-            compute_db,
-            project,
-            progress,
-            environment_progress,
-            facts_progress,
-        )
-        .await;
-        let result = collect_discovery_jobs(handles, environment_progress, facts_progress).await;
+        let mut jobs: JoinSet<EnvironmentJobResult> = JoinSet::new();
+        for phase in environment_phases() {
+            let db = compute_db.clone();
+            jobs.spawn_blocking(move || {
+                salsa::Cancelled::catch(AssertUnwindSafe(|| phase.run(&db, project)))
+            });
+            report_environment_phase(phase, reporter, progress).await;
+        }
 
+        let result = collect_environment_jobs(jobs, progress.as_ref()).await;
         match result {
-            Ok(discovery) => {
-                finish_progress(environment_progress, ProgressEnd::Complete).await;
-                return Some(discovery);
-            }
+            Ok(environment) => return Some(environment),
             Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
-                finish_progress(environment_progress, ProgressEnd::Retrying).await;
-                finish_progress(facts_progress, ProgressEnd::Retrying).await;
+                finish_progress(progress, ProgressEnd::Retrying).await;
                 tracing::debug!(
                     ?cancelled,
                     attempt = attempt + 1,
-                    "Django Discovery compute cancelled; retrying with fresh database clone"
+                    "Environment compute cancelled; retrying with fresh database clone"
                 );
             }
             Err(cancelled) => {
-                finish_progress(environment_progress, ProgressEnd::Cancelled).await;
-                finish_progress(facts_progress, ProgressEnd::Cancelled).await;
+                finish_progress(progress, ProgressEnd::Cancelled).await;
                 tracing::warn!(
                     ?cancelled,
                     retries = SNAPSHOT_CANCEL_RETRIES,
-                    "Django Discovery compute cancelled repeatedly; project facts may be stale until the next Django Discovery run"
+                    "Environment compute cancelled repeatedly; project reload cancelled"
                 );
                 return None;
             }
         }
     }
+    unreachable!("Environment retry loop must return")
+}
 
-    unreachable!("Django Discovery retry loop must return")
+async fn collect_environment_jobs(
+    mut jobs: JoinSet<EnvironmentJobResult>,
+    progress: Option<&ProgressItem>,
+) -> Result<DjangoEnvironmentData, salsa::Cancelled> {
+    let mut cancellation = None;
+    let mut parts = Vec::new();
+    let mut done = 0;
+    let total = environment_phases().count();
+
+    while let Some(joined) = jobs.join_next().await {
+        match joined.expect("Environment phase must not panic") {
+            Ok(part) => {
+                done += 1;
+                let phase_progress = part.phase().progress();
+                report_count(
+                    progress,
+                    done,
+                    total,
+                    part.count(),
+                    phase_progress.count_label.into(),
+                )
+                .await;
+                parts.push(part);
+            }
+            Err(cancelled) => remember_cancellation(&mut cancellation, cancelled),
+        }
+    }
+    cancellation.map_or_else(|| Ok(DjangoEnvironmentData::assemble(parts)), Err)
+}
+
+async fn compute_project_facts_data(
+    session: &Arc<Mutex<Session>>,
+    reporter: &ProgressReporter,
+    progress: &mut Option<ProgressItem>,
+) -> Option<ProjectFactsData> {
+    // Capture happens after Environment application, so every attempt observes
+    // registered, rescanned roots and overlay-authoritative file contents.
+    for attempt in 0..=SNAPSHOT_CANCEL_RETRIES {
+        let Some((compute_db, project)) = capture_discovery_db(session).await else {
+            finish_progress(progress, ProgressEnd::Skipped).await;
+            return None;
+        };
+
+        let mut jobs: JoinSet<ProjectFactsJobResult> = JoinSet::new();
+        for phase in project_facts_phases() {
+            let db = compute_db.clone();
+            jobs.spawn_blocking(move || {
+                salsa::Cancelled::catch(AssertUnwindSafe(|| phase.run(&db, project)))
+            });
+            report_project_facts_phase(phase, reporter, progress).await;
+        }
+
+        let result = collect_project_facts_jobs(jobs, progress.as_ref()).await;
+        match result {
+            Ok(facts) => return Some(facts),
+            Err(cancelled) if attempt < SNAPSHOT_CANCEL_RETRIES => {
+                finish_progress(progress, ProgressEnd::Retrying).await;
+                tracing::debug!(
+                    ?cancelled,
+                    attempt = attempt + 1,
+                    "Project Facts compute cancelled; retrying with fresh database clone"
+                );
+            }
+            Err(cancelled) => {
+                finish_progress(progress, ProgressEnd::Cancelled).await;
+                tracing::warn!(
+                    ?cancelled,
+                    retries = SNAPSHOT_CANCEL_RETRIES,
+                    "Project Facts compute cancelled repeatedly; project facts may be stale until the next reload"
+                );
+                return None;
+            }
+        }
+    }
+    unreachable!("Project Facts retry loop must return")
+}
+
+async fn collect_project_facts_jobs(
+    mut jobs: JoinSet<ProjectFactsJobResult>,
+    progress: Option<&ProgressItem>,
+) -> Result<ProjectFactsData, salsa::Cancelled> {
+    let mut cancellation = None;
+    let mut counts = Vec::new();
+    let mut parts = Vec::new();
+
+    while let Some(joined) = jobs.join_next().await {
+        match joined.expect("Project Facts phase must not panic") {
+            Ok(part) => {
+                let phase = part.phase();
+                counts.push(DiscoveryJobCount {
+                    label: phase.progress().count_label.into(),
+                    count: part.count(),
+                });
+                parts.push(part);
+            }
+            Err(cancelled) => remember_cancellation(&mut cancellation, cancelled),
+        }
+    }
+    if let Some(cancelled) = cancellation {
+        return Err(cancelled);
+    }
+
+    let facts = ProjectFactsData::assemble(parts);
+    let total = project_facts_phases().count() + 1;
+    for (index, summary) in counts.into_iter().enumerate() {
+        report_count(progress, index + 1, total, summary.count, summary.label).await;
+    }
+    report_count(
+        progress,
+        total,
+        total,
+        facts.discovered_file_count(),
+        ProjectFactsData::discovered_file_count_label().into(),
+    )
+    .await;
+    Ok(facts)
 }
 
 async fn capture_discovery_db(session: &Arc<Mutex<Session>>) -> Option<(DjangoDatabase, Project)> {
@@ -337,119 +451,49 @@ async fn capture_discovery_db(session: &Arc<Mutex<Session>>) -> Option<(DjangoDa
         tracing::info!("Task: No project configured, skipping initialization.");
         return None;
     };
-
     Some((db.clone(), project))
 }
 
-async fn spawn_discovery_jobs(
-    compute_db: DjangoDatabase,
-    project: Project,
+async fn report_environment_phase(
+    phase: EnvironmentPhase,
     reporter: &ProgressReporter,
-    environment_progress: &mut Option<ProgressItem>,
-    facts_progress: &mut Option<ProgressItem>,
-) -> DiscoveryJobSet {
-    let mut jobs = JoinSet::new();
-    for phase in django_discovery_phases() {
-        let db = compute_db.clone();
-        jobs.spawn_blocking(move || {
-            salsa::Cancelled::catch(AssertUnwindSafe(|| phase.run(&db, project)))
-        });
-    }
-
-    for phase in django_discovery_phases() {
-        report_discovery_phase(phase, reporter, environment_progress, facts_progress).await;
-    }
-
-    jobs
-}
-
-async fn collect_discovery_jobs(
-    mut jobs: DiscoveryJobSet,
-    environment_progress: &mut Option<ProgressItem>,
-    facts_progress: &mut Option<ProgressItem>,
-) -> Result<DjangoDiscoveryData, salsa::Cancelled> {
-    let mut cancellation = None;
-    let mut counts = Vec::new();
-    let mut parts = Vec::new();
-
-    while let Some(joined) = jobs.join_next().await {
-        match joined.expect("Django Discovery phase must not panic") {
-            Ok(part) => {
-                let phase = part.phase();
-                let progress = phase.progress();
-                counts.push(DiscoveryJobCount {
-                    phase,
-                    label: progress.count_label.into(),
-                    count: part.count(),
-                });
-                parts.push(part);
-            }
-            Err(cancelled) => remember_cancellation(&mut cancellation, cancelled),
-        }
-    }
-
-    if let Some(cancelled) = cancellation {
-        return Err(cancelled);
-    }
-
-    let discovery = DjangoDiscoveryData::assemble(parts);
-    report_discovery_job_counts(
-        counts,
-        discovery.discovered_file_count(),
-        environment_progress.as_ref(),
-        facts_progress.as_ref(),
-    )
-    .await;
-
-    Ok(discovery)
-}
-
-async fn report_discovery_job_counts(
-    counts: Vec<DiscoveryJobCount>,
-    discovered_file_count: usize,
-    environment_progress: Option<&ProgressItem>,
-    facts_progress: Option<&ProgressItem>,
+    progress: &mut Option<ProgressItem>,
 ) {
-    let environment_total = DiscoveryPhase::environment_phase_count();
-    let facts_total = DiscoveryPhase::project_facts_phase_count() + 1;
-    let mut environment_done = 0;
-    let mut facts_done = 0;
-
-    for summary in counts {
-        match summary.phase {
-            DiscoveryPhase::Environment(_) => {
-                environment_done += 1;
-                report_count(
-                    environment_progress,
-                    environment_done,
-                    environment_total,
-                    summary.count,
-                    summary.label,
-                )
-                .await;
-            }
-            DiscoveryPhase::ProjectFacts(_) => {
-                facts_done += 1;
-                report_count(
-                    facts_progress,
-                    facts_done,
-                    facts_total,
-                    summary.count,
-                    summary.label,
-                )
-                .await;
-            }
-        }
-    }
-
-    report_count(
-        facts_progress,
-        facts_total,
-        facts_total,
-        discovered_file_count,
-        DjangoDiscoveryData::discovered_file_count_label().into(),
+    report_discovery_phase(
+        phase.progress().message,
+        reporter,
+        progress,
+        RESOLVE_ENVIRONMENT_TITLE,
     )
     .await;
+}
+
+async fn report_project_facts_phase(
+    phase: ProjectFactsPhase,
+    reporter: &ProgressReporter,
+    progress: &mut Option<ProgressItem>,
+) {
+    report_discovery_phase(
+        phase.progress().message,
+        reporter,
+        progress,
+        DISCOVER_PROJECT_FACTS_TITLE,
+    )
+    .await;
+}
+
+async fn report_discovery_phase(
+    message: &str,
+    reporter: &ProgressReporter,
+    progress: &mut Option<ProgressItem>,
+    title: &'static str,
+) {
+    if progress.is_none() {
+        *progress = Some(reporter.begin(title).await);
+    }
+    if let Some(progress) = progress.as_ref() {
+        progress.report(message).await;
+    }
 }
 
 async fn report_count(
@@ -460,7 +504,6 @@ async fn report_count(
     label: CountLabel,
 ) {
     let message = count_message(count, label);
-
     if let Some(progress) = progress {
         progress.report_fraction(done, total, &message).await;
     }
@@ -478,34 +521,6 @@ fn count_message(count: usize, label: CountLabel) -> String {
 fn remember_cancellation(cancellation: &mut Option<salsa::Cancelled>, cancelled: salsa::Cancelled) {
     if cancellation.is_none() {
         *cancellation = Some(cancelled);
-    }
-}
-
-async fn report_discovery_phase(
-    phase: DiscoveryPhase,
-    reporter: &ProgressReporter,
-    environment_progress: &mut Option<ProgressItem>,
-    facts_progress: &mut Option<ProgressItem>,
-) {
-    let phase_progress = phase.progress();
-    let (progress, title) = discovery_phase_progress(phase, environment_progress, facts_progress);
-
-    if progress.is_none() {
-        *progress = Some(reporter.begin(title).await);
-    }
-    if let Some(progress) = progress.as_ref() {
-        progress.report(phase_progress.message).await;
-    }
-}
-
-fn discovery_phase_progress<'a>(
-    phase: DiscoveryPhase,
-    environment_progress: &'a mut Option<ProgressItem>,
-    facts_progress: &'a mut Option<ProgressItem>,
-) -> (&'a mut Option<ProgressItem>, &'static str) {
-    match phase {
-        DiscoveryPhase::Environment(_) => (environment_progress, RESOLVE_ENVIRONMENT_TITLE),
-        DiscoveryPhase::ProjectFacts(_) => (facts_progress, DISCOVER_PROJECT_FACTS_TITLE),
     }
 }
 
@@ -836,6 +851,67 @@ mod tests {
 
         assert_eq!(run_count.load(Ordering::SeqCst), 2);
         assert!(!overlap_detected.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn project_facts_use_fresh_post_environment_clone() {
+        let tempdir = tempdir().unwrap();
+        let base = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
+        let root = base.join("project");
+        let vendor = base.join("vendor");
+        std::fs::create_dir_all(root.as_std_path()).unwrap();
+        std::fs::create_dir_all(vendor.join("blog").as_std_path()).unwrap();
+        std::fs::write(vendor.join("blog/models.py").as_std_path(), "").unwrap();
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            format!(
+                "venv_path = \"{}\"\npythonpath = [\"{vendor}\"]\n",
+                root.join(".venv")
+            ),
+        )
+        .unwrap();
+
+        let params = ls_types::InitializeParams {
+            workspace_folders: Some(vec![ls_types::WorkspaceFolder {
+                uri: ls_types::Uri::from_file_path(root.as_std_path()).unwrap(),
+                name: "test_project".to_string(),
+            }]),
+            ..Default::default()
+        };
+        let session = Arc::new(Mutex::new(Session::new(&params)));
+        let settings = load_project_settings(&session)
+            .await
+            .expect("project settings should load");
+        assert!(apply_project_settings(&session, settings).await);
+
+        let (pre_environment_db, project) = capture_discovery_db(&session)
+            .await
+            .expect("project should exist");
+        assert!(
+            !project
+                .search_paths(&pre_environment_db)
+                .iter()
+                .any(|path| path.path() == vendor)
+        );
+        let environment = DjangoEnvironmentData::assemble(
+            environment_phases().map(|phase| phase.run(&pre_environment_db, project)),
+        );
+        drop(pre_environment_db);
+        assert!(apply_environment(&session, environment).await);
+
+        let (facts_db, project) = capture_discovery_db(&session)
+            .await
+            .expect("project should still exist");
+        assert!(
+            project
+                .search_paths(&facts_db)
+                .iter()
+                .any(|path| path.path() == vendor)
+        );
+        let facts = ProjectFactsData::assemble(
+            project_facts_phases().map(|phase| phase.run(&facts_db, project)),
+        );
+        assert!(facts.file_paths().contains(&vendor.join("blog/models.py")));
     }
 
     #[tokio::test]

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -285,7 +285,8 @@ impl LanguageServer for DjangoLanguageServer {
                 )?;
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return None;
                 }
 
@@ -309,7 +310,8 @@ impl LanguageServer for DjangoLanguageServer {
                 )?;
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return None;
                 }
 
@@ -336,7 +338,8 @@ impl LanguageServer for DjangoLanguageServer {
                 )?;
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return None;
                 }
 
@@ -394,7 +397,8 @@ impl LanguageServer for DjangoLanguageServer {
                 };
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return Vec::new();
                 }
 
@@ -418,7 +422,8 @@ impl LanguageServer for DjangoLanguageServer {
                 };
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return Vec::new();
                 }
 
@@ -442,7 +447,8 @@ impl LanguageServer for DjangoLanguageServer {
                 };
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return Vec::new();
                 }
 
@@ -466,7 +472,8 @@ impl LanguageServer for DjangoLanguageServer {
                 )?;
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return None;
                 }
 
@@ -495,7 +502,8 @@ impl LanguageServer for DjangoLanguageServer {
                 )?;
                 let db = snapshot.db();
 
-                if *file.source(db).kind() != FileKind::Template {
+                if !matches!(file.try_source(db), Ok(source) if *source.kind() == FileKind::Template)
+                {
                     return None;
                 }
 
@@ -524,7 +532,9 @@ impl LanguageServer for DjangoLanguageServer {
                     return Vec::new();
                 }
 
-                let source = file.source(db);
+                let Ok(source) = file.try_source(db) else {
+                    return Vec::new();
+                };
                 if *source.kind() != FileKind::Template {
                     return Vec::new();
                 }

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -282,7 +282,7 @@ impl SessionSnapshot {
         request: &str,
     ) -> Option<(File, Offset)> {
         let file = self.file_for_document_request(text_document, request)?;
-        let source = file.source(&self.db);
+        let source = file.try_source(&self.db).ok()?;
         let line_index = file.line_index(&self.db);
         let offset = position.to_offset(
             source.as_str(),
@@ -301,7 +301,7 @@ impl SessionSnapshot {
         request: &str,
     ) -> Option<(File, Span)> {
         let file = self.file_for_document_request(text_document, request)?;
-        let source = file.source(&self.db);
+        let source = file.try_source(&self.db).ok()?;
         let line_index = file.line_index(&self.db);
         let start = range.start.to_offset(
             source.as_str(),
@@ -357,7 +357,10 @@ mod tests {
 
         let db = session.db();
         let file = path_to_file(db, &path).expect("open buffer should be visible to the overlay");
-        let content = file.source(db).to_string();
+        let content = file
+            .try_source(db)
+            .expect("open buffer should be readable")
+            .to_string();
         assert_eq!(content, "print('hello')");
 
         let close_doc = ls_types::TextDocumentIdentifier { uri };
@@ -392,7 +395,10 @@ mod tests {
 
         let db = session.db();
         let file = path_to_file(db, &path).expect("open buffer should be visible to the overlay");
-        let content = file.source(db).to_string();
+        let content = file
+            .try_source(db)
+            .expect("open buffer should be readable")
+            .to_string();
         assert_eq!(content, "updated");
     }
 

--- a/crates/djls-server/src/workspace.rs
+++ b/crates/djls-server/src/workspace.rs
@@ -581,7 +581,21 @@ mod tests {
         workspace.open_document(&file_path, "buffer template", 1, FileKind::Template);
         SourceChanges::new([ChangeEvent::BecameVisible(file_path.clone())]).apply(&mut db);
         let file = path_to_file(&db, &file_path).expect("opened document should be interned");
-        assert_eq!(file.source(&db).as_str(), "buffer template");
+        assert_eq!(
+            file.try_source(&db)
+                .expect("buffer should be readable")
+                .as_str(),
+            "buffer template"
+        );
+
+        std::fs::write(file_path.as_std_path(), "changed disk template").unwrap();
+        SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+        assert_eq!(
+            file.try_source(&db)
+                .expect("overlay should remain authoritative during rescan")
+                .as_str(),
+            "buffer template"
+        );
 
         workspace
             .update_document(
@@ -592,10 +606,20 @@ mod tests {
             )
             .unwrap();
         SourceChanges::new([ChangeEvent::ContentChanged(file_path.clone())]).apply(&mut db);
-        assert_eq!(file.source(&db).as_str(), "updated template");
+        assert_eq!(
+            file.try_source(&db)
+                .expect("buffer should be readable")
+                .as_str(),
+            "updated template"
+        );
 
         workspace.close_document(&file_path).unwrap();
         SourceChanges::new([ChangeEvent::ContentChanged(file_path.clone())]).apply(&mut db);
-        assert_eq!(file.source(&db).as_str(), "disk template");
+        assert_eq!(
+            file.try_source(&db)
+                .expect("disk file should be readable")
+                .as_str(),
+            "changed disk template"
+        );
     }
 }

--- a/crates/djls-source/src/changes.rs
+++ b/crates/djls-source/src/changes.rs
@@ -74,15 +74,15 @@ fn apply_visible_path_change(
     file_set_membership: FileSetMembership,
 ) {
     File::sync_path(db, path);
-    let Ok(file) = path_to_file(db, path) else {
+    if path_to_file(db, path).is_err() {
         return;
-    };
+    }
 
-    db.bump_file_and_maybe_root_revision(
-        file,
-        path,
-        matches!(file_set_membership, FileSetMembership::Changed),
-    );
+    if matches!(file_set_membership, FileSetMembership::Changed)
+        && let Some(root) = db.files().root(db, path)
+    {
+        db.bump_file_root_revision(root);
+    }
 }
 
 fn apply_content_change(db: &mut dyn Db, path: &Utf8Path) {
@@ -91,7 +91,6 @@ fn apply_content_change(db: &mut dyn Db, path: &Utf8Path) {
     };
 
     file.sync(db);
-    db.bump_file_revision(file);
 }
 
 fn apply_deleted_path(db: &mut dyn Db, path: &Utf8Path) {

--- a/crates/djls-source/src/db.rs
+++ b/crates/djls-source/src/db.rs
@@ -47,12 +47,4 @@ pub trait Db: salsa::Database {
         let new_rev = current_rev + 1;
         root.set_revision(self).to(new_rev);
     }
-
-    /// Bump a tracked file and, when discovery changed, its containing source root.
-    fn bump_file_and_maybe_root_revision(&mut self, file: File, path: &Utf8Path, bump_root: bool) {
-        self.bump_file_revision(file);
-        if bump_root && let Some(root) = self.files().root(self, path) {
-            self.bump_file_root_revision(root);
-        }
-    }
 }

--- a/crates/djls-source/src/files.rs
+++ b/crates/djls-source/src/files.rs
@@ -88,32 +88,55 @@ pub struct FileRoot {
     pub revision: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("failed to read {path}: {kind:?}")]
+pub struct FileReadError {
+    path: Utf8PathBuf,
+    kind: std::io::ErrorKind,
+}
+
+impl FileReadError {
+    #[must_use]
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> std::io::ErrorKind {
+        self.kind
+    }
+}
+
 #[salsa::tracked]
 impl File {
     #[salsa::tracked]
-    pub fn source(self, db: &dyn Db) -> SourceText {
+    pub fn try_source(self, db: &dyn Db) -> Result<SourceText, FileReadError> {
         let _ = self.revision(db);
-        let path = self.path(db);
-        let source = db.read_file(path).unwrap_or_default();
-        SourceText::new(path, source)
+        db.files().source(db, self)
+    }
+
+    #[salsa::tracked]
+    pub(crate) fn source_or_empty(self, db: &dyn Db) -> SourceText {
+        self.try_source(db)
+            .unwrap_or_else(|_| SourceText::new(self.path(db), String::new()))
     }
 
     #[salsa::tracked(returns(ref))]
     pub fn line_index(self, db: &dyn Db) -> LineIndex {
-        let text = self.source(db);
+        let text = self.source_or_empty(db);
         LineIndex::from(text.as_str())
     }
 
     #[must_use]
     pub fn end_line_col(self, db: &dyn Db, encoding: PositionEncoding) -> LineCol {
-        let source = self.source(db);
+        let source = self.source_or_empty(db);
         let line_index = self.line_index(db);
         line_index.end_line_col(source.as_str(), encoding)
     }
 
-    pub fn sync(self, db: &mut dyn Db) {
+    pub(crate) fn sync(self, db: &mut dyn Db) {
         let path = self.path(db).clone();
-        Self::sync_path(db, &path);
+        sync_file(db, &path);
     }
 
     pub fn sync_path(db: &mut dyn Db, path: &Utf8Path) {
@@ -247,8 +270,13 @@ pub struct SourceFiles(Arc<SourceFilesInner>);
 
 #[derive(Default)]
 struct SourceFilesInner {
-    by_path: FxDashMap<Utf8PathBuf, File>,
+    by_path: FxDashMap<Utf8PathBuf, SourceFileEntry>,
     roots: RwLock<Vec<FileRoot>>,
+}
+
+struct SourceFileEntry {
+    file: File,
+    source: Result<SourceText, FileReadError>,
 }
 
 /// Classification used to assign durability to files under a root.
@@ -274,17 +302,54 @@ impl SourceFiles {
     #[must_use]
     fn get_or_create_file(&self, db: &dyn Db, path: &Utf8Path) -> File {
         let path = path.to_owned();
-        *self.0.by_path.entry(path.clone()).or_insert_with(|| {
-            File::builder(path.clone(), 0, file_status(db, &path))
-                .durability(self.durability_for(db, &path))
-                .path_durability(Durability::HIGH)
-                .new(db)
-        })
+        self.0
+            .by_path
+            .entry(path.clone())
+            .or_insert_with(|| SourceFileEntry {
+                file: File::builder(path.clone(), 0, file_status(db, &path))
+                    .durability(self.durability_for(db, &path))
+                    .path_durability(Durability::HIGH)
+                    .new(db),
+                source: read_source(db, &path),
+            })
+            .file
     }
 
     #[must_use]
     pub fn try_file(&self, path: &Utf8Path) -> Option<File> {
-        self.0.by_path.get(path).map(|entry| *entry.value())
+        self.0.by_path.get(path).map(|entry| entry.value().file)
+    }
+
+    /// Register an explicitly constructed file and synchronize its source outcome.
+    ///
+    /// Normal callers should use [`path_to_file`]. This supports fixture databases
+    /// that need distinct file identities for the same path across revisions.
+    pub fn register_file(&self, db: &dyn Db, file: File) {
+        let path = file.path(db).clone();
+        self.0.by_path.insert(
+            path.clone(),
+            SourceFileEntry {
+                file,
+                source: read_source(db, &path),
+            },
+        );
+    }
+
+    fn source(&self, db: &dyn Db, file: File) -> Result<SourceText, FileReadError> {
+        self.0
+            .by_path
+            .get(file.path(db))
+            .expect("interned file should have a synchronized source outcome")
+            .source
+            .clone()
+    }
+
+    fn set_source(&self, path: &Utf8Path, source: Result<SourceText, FileReadError>) {
+        self.0
+            .by_path
+            .get_mut(path)
+            .expect("interned file should have a synchronized source outcome")
+            .source = source;
     }
 
     #[must_use]
@@ -405,19 +470,34 @@ pub(crate) fn sync_known_paths(db: &mut dyn Db) {
     }
 }
 
+fn read_source(db: &dyn Db, path: &Utf8Path) -> Result<SourceText, FileReadError> {
+    db.read_file(path)
+        .map(|source| SourceText::new(path, source))
+        .map_err(|error| FileReadError {
+            path: path.to_owned(),
+            kind: error.kind(),
+        })
+}
+
 fn sync_file(db: &mut dyn Db, path: &Utf8Path) {
     let Some(file) = db.files().try_file(path) else {
         return;
     };
 
     let current_status = file.status(db);
+    let current_source = db.files().source(db, file);
     let next_status = file_status(db, path);
-    if current_status == next_status {
+    let next_source = read_source(db, path);
+
+    if current_status == next_status && current_source == next_source {
         return;
     }
 
-    file.set_status(db).to(next_status);
-    if matches!(current_status, FileStatus::Exists) != matches!(next_status, FileStatus::Exists) {
-        db.bump_file_revision(file);
+    if current_status != next_status {
+        file.set_status(db).to(next_status);
     }
+    if current_source != next_source {
+        db.files().set_source(path, next_source);
+    }
+    db.bump_file_revision(file);
 }

--- a/crates/djls-source/src/lib.rs
+++ b/crates/djls-source/src/lib.rs
@@ -17,6 +17,7 @@ pub use db::Db;
 pub use files::File;
 pub use files::FileError;
 pub use files::FileKind;
+pub use files::FileReadError;
 pub use files::FileRoot;
 pub use files::FileRootKind;
 pub use files::FileStatus;

--- a/crates/djls-source/tests/file_status.rs
+++ b/crates/djls-source/tests/file_status.rs
@@ -1,8 +1,10 @@
 use camino::Utf8Path;
+use djls_source::ChangeEvent;
 use djls_source::Db as _;
 use djls_source::File;
 use djls_source::FileError;
 use djls_source::FileStatus;
+use djls_source::SourceChanges;
 use djls_source::path_to_file;
 use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
@@ -100,7 +102,82 @@ fn path_to_file_existing_file_returns_file_with_source() {
 
     let file = path_to_file(&db, Utf8Path::new(path)).expect("file should exist");
 
-    assert_eq!(file.source(&db).as_str(), "print('hello')\n");
+    assert_eq!(
+        file.try_source(&db)
+            .expect("file should be readable")
+            .as_str(),
+        "print('hello')\n"
+    );
+}
+
+#[test]
+fn readable_empty_source_is_distinct_from_unreadable_source() {
+    let mut db = TestDatabase::new();
+    let path = Utf8Path::new("/project/empty.py");
+    db.add_file(path.as_str(), "");
+    let file = path_to_file(&db, path).expect("file should exist");
+
+    assert_eq!(
+        file.try_source(&db)
+            .expect("file should be readable")
+            .as_str(),
+        ""
+    );
+
+    db.remove_file(path.as_str());
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+    let error = file
+        .try_source(&db)
+        .expect_err("deleted file should be unreadable");
+    assert_eq!(error.path(), path);
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+
+    db.add_file(path.as_str(), "recreated");
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+    assert_eq!(
+        file.try_source(&db)
+            .expect("recreated file should be readable")
+            .as_str(),
+        "recreated"
+    );
+}
+
+#[test]
+fn rescan_refreshes_content_and_backdates_equal_outcomes() {
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    let path = Utf8Path::new("/project/app.py");
+    db.add_file(path.as_str(), "old");
+    let file = path_to_file(&db, path).expect("file should exist");
+    assert_eq!(file.try_source(&db).unwrap().as_str(), "old");
+
+    let old_revision = file.revision(&db);
+    db.add_file(path.as_str(), "new");
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+    assert_eq!(file.revision(&db), old_revision + 1);
+    assert_eq!(file.try_source(&db).unwrap().as_str(), "new");
+
+    let unchanged_revision = file.revision(&db);
+    let _ = event_log.take();
+    SourceChanges::new([ChangeEvent::Rescan]).apply(&mut db);
+    assert_eq!(file.revision(&db), unchanged_revision);
+    assert_eq!(file.try_source(&db).unwrap().as_str(), "new");
+    assert_eq!(execution_count(&db, &event_log.take(), "try_source"), 0);
+}
+
+#[test]
+fn content_change_synchronizes_source_with_one_revision_bump() {
+    let mut db = TestDatabase::new();
+    let path = Utf8Path::new("/project/app.py");
+    db.add_file(path.as_str(), "old");
+    let file = path_to_file(&db, path).expect("file should exist");
+    let old_revision = file.revision(&db);
+
+    db.add_file(path.as_str(), "new");
+    SourceChanges::new([ChangeEvent::ContentChanged(path.to_path_buf())]).apply(&mut db);
+
+    assert_eq!(file.revision(&db), old_revision + 1);
+    assert_eq!(file.try_source(&db).unwrap().as_str(), "new");
 }
 
 #[test]

--- a/crates/djls-templates/src/db.rs
+++ b/crates/djls-templates/src/db.rs
@@ -27,8 +27,8 @@
 //! ## Example
 //!
 //! ```ignore
-//! // Parse a template and get its AST
-//! let nodelist = parse_template(db, file);
+//! // Parse a readable template and get its AST
+//! let nodelist = parse_template(db, file).expect("template should be readable");
 //!
 //! // Retrieve accumulated errors
 //! let errors = parse_template::accumulated::<TemplateErrorAccumulator>(db, file);

--- a/crates/djls-templates/src/lib.rs
+++ b/crates/djls-templates/src/lib.rs
@@ -26,7 +26,7 @@
 //! // For LSP integration with Salsa (primary usage):
 //! use djls_templates::{parse_template, TemplateErrorAccumulator};
 //!
-//! let nodelist = parse_template(db, file);
+//! let nodelist = parse_template(db, file).expect("template should be readable");
 //! let errors = parse_template::accumulated::<TemplateErrorAccumulator>(db, file);
 //!
 //! // For direct parsing (testing/debugging):
@@ -52,6 +52,7 @@ pub use db::TemplateErrorAccumulator;
 use djls_source::Db;
 use djls_source::File;
 use djls_source::FileKind;
+use djls_source::FileReadError;
 pub use error::TemplateError;
 pub use filters::Filter;
 pub use nodelist::Node;
@@ -63,15 +64,42 @@ pub use tokens::TagDelimiter;
 pub use tokens::Token;
 pub use visitor::Visitor;
 
+#[derive(Clone, PartialEq, Eq, salsa::Update)]
+pub enum TemplateParseResult<'db> {
+    Parsed(NodeList<'db>),
+    NotTemplate,
+    Unreadable(FileReadError),
+}
+
+impl<'db> TemplateParseResult<'db> {
+    /// Return the parsed tree or panic with the supplied fixture context.
+    ///
+    /// This is intended for callers that have already established that the
+    /// file is a readable template, such as tests and benchmarks.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the file is not a template or could not be read.
+    #[track_caller]
+    #[must_use]
+    pub fn expect(self, message: &str) -> NodeList<'db> {
+        match self {
+            Self::Parsed(nodelist) => nodelist,
+            Self::NotTemplate => panic!("{message}: file is not a template"),
+            Self::Unreadable(error) => panic!("{message}: {error}"),
+        }
+    }
+}
+
 /// Lex a Django template file.
 #[salsa::tracked(returns(ref))]
-pub fn lex_template(db: &dyn Db, file: File) -> Vec<Token> {
-    let source = file.source(db);
+pub fn lex_template(db: &dyn Db, file: File) -> Result<Vec<Token>, FileReadError> {
+    let source = file.try_source(db)?;
     if *source.kind() != FileKind::Template {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    lex_template_impl(source.as_ref())
+    Ok(lex_template_impl(source.as_ref()))
 }
 
 /// Lex a template using the pure lexer.
@@ -89,10 +117,13 @@ pub fn lex_template_impl(source: &str) -> Vec<Token> {
 ///     parse_template::accumulated::<TemplateDiagnostic>(db, file);
 /// ```
 #[salsa::tracked]
-pub fn parse_template(db: &dyn Db, file: File) -> Option<NodeList<'_>> {
-    let source = file.source(db);
+pub fn parse_template(db: &dyn Db, file: File) -> TemplateParseResult<'_> {
+    let source = match file.try_source(db) {
+        Ok(source) => source,
+        Err(error) => return TemplateParseResult::Unreadable(error),
+    };
     if *source.kind() != FileKind::Template {
-        return None;
+        return TemplateParseResult::NotTemplate;
     }
 
     let (nodes, errors) = parse_template_impl(source.as_ref());
@@ -103,7 +134,7 @@ pub fn parse_template(db: &dyn Db, file: File) -> Option<NodeList<'_>> {
     }
 
     // Always return a NodeList (may contain Error nodes if there were parse errors)
-    Some(NodeList::new(db, nodes))
+    TemplateParseResult::Parsed(NodeList::new(db, nodes))
 }
 
 /// Parse a template using the pure parser (no database needed)

--- a/crates/djls-testing/src/db.rs
+++ b/crates/djls-testing/src/db.rs
@@ -172,10 +172,12 @@ impl TestDatabase {
             self.file_system().is_file(path),
             "fixture file should exist before creating tracked file: {path}"
         );
-        File::builder(path.to_owned(), revision, FileStatus::Exists)
+        let file = File::builder(path.to_owned(), revision, FileStatus::Exists)
             .durability(salsa::Durability::LOW)
             .path_durability(salsa::Durability::HIGH)
-            .new(self)
+            .new(self);
+        self.files.register_file(self, file);
+        file
     }
 }
 

--- a/crates/djls-testing/src/fixtures.rs
+++ b/crates/djls-testing/src/fixtures.rs
@@ -545,9 +545,8 @@ pub fn collect_errors_with_revision(
     db.add_file(path, source);
     let file = db.create_file_with_revision(Utf8Path::new(path), revision);
 
-    let Some(nodelist) = parse_template(db, file) else {
-        return Vec::new();
-    };
+    let nodelist =
+        parse_template(db, file).expect("validation fixture should be a readable template");
 
     djls_semantic::validate_nodelist(db, nodelist);
 
@@ -577,9 +576,8 @@ pub fn collect_argument_validation_errors_with_revision(
     db.add_file(path, source);
     let file = db.create_file_with_revision(Utf8Path::new(path), revision);
 
-    let Some(nodelist) = parse_template(db, file) else {
-        return Vec::new();
-    };
+    let nodelist =
+        parse_template(db, file).expect("validation fixture should be a readable template");
 
     djls_semantic::validate_nodelist(db, nodelist);
 
@@ -691,9 +689,8 @@ pub fn snapshot_validate_files<'a>(
 
     let file = db.create_file_with_revision(Utf8Path::new(primary_path), 0);
 
-    let Some(nodelist) = parse_template(&db, file) else {
-        return String::new();
-    };
+    let nodelist =
+        parse_template(&db, file).expect("validation fixture should be a readable template");
 
     djls_semantic::validate_nodelist(&db, nodelist);
 

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -183,16 +183,19 @@ impl Command for Check {
                 for path in files {
                     let db = db.clone();
                     let tx = tx.clone();
-                    scope.spawn(move |_| {
-                        let result = check_file_with_source(&db, &path);
-                        if result.check.has_diagnostics() {
-                            let _ = tx.send(result);
+                    scope.spawn(move |_| match check_file_with_source(&db, &path) {
+                        Ok(result) if result.check.has_diagnostics() => {
+                            let _ = tx.send(Ok(result));
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            let _ = tx.send(Err(error));
                         }
                     });
                 }
             });
 
-            rx.into_iter().collect()
+            rx.into_iter().collect::<Result<Vec<_>>>()?
         };
         raw_results.sort_by(|left, right| left.path.cmp(&right.path));
 
@@ -256,7 +259,7 @@ fn check_stdin(
     let mut db = DjangoDatabase::new(fs, settings, Some(project_root));
     db.apply_project_settings(settings.clone());
 
-    let result = check_file_with_source(&db, &stdin_path);
+    let result = check_file_with_source(&db, &stdin_path)?;
     if quiet {
         return if result.renderable_diagnostic_count(config) > 0 {
             Ok(Exit::error())
@@ -280,25 +283,25 @@ fn check_stdin(
 }
 
 /// Run validation and capture the source text for later rendering.
-fn check_file_with_source(db: &DjangoDatabase, path: &Utf8Path) -> FileCheckResult {
+fn check_file_with_source(db: &DjangoDatabase, path: &Utf8Path) -> Result<FileCheckResult> {
     let Ok(file) = path_to_file(db, path) else {
-        return FileCheckResult {
+        return Ok(FileCheckResult {
             path: path.to_owned(),
             source: SourceText::default(),
             check: CheckResult {
                 template_errors: Vec::new(),
                 validation_errors: Vec::new(),
             },
-        };
+        });
     };
-    let source = file.source(db);
+    let source = file.try_source(db)?;
     let check = check_file(db, file);
 
-    FileCheckResult {
+    Ok(FileCheckResult {
         path: path.to_owned(),
         source,
         check,
-    }
+    })
 }
 
 fn check_file(db: &dyn djls_semantic::Db, file: File) -> CheckResult {

--- a/tests/e2e/test_startup.py
+++ b/tests/e2e/test_startup.py
@@ -258,7 +258,6 @@ async def test_supported_client_receives_startup_progress_begin_report_end(
         "Discovering model modules",
         "Discovering template libraries",
         "Discovering template tag candidates",
-        "Applying project facts",
         "Building tag specs",
         "Building filter arity specs",
         "Building model graph",


### PR DESCRIPTION
## Summary
- replace infallible file source reads with synchronized typed read outcomes and explicit parser policies
- keep unreadable files distinct from readable empty files across Python, templates, IDE requests, CLI checks, and semantic analysis
- remove the untracked project import-loader path and preserve typed read failures
- stage reloads as settings → environment/root synchronization → rescan → fresh-clone Project Facts
- add source transition, unreadable template, overlay authority, and one-reload freshness regressions

## Verification
- `cargo test -q`
- `just clippy`
- `just fmt --check`
- `just lint`
- `just hawk`