### PR TITLE
fix: extract keyword relation targets

### DIFF
--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -452,6 +452,21 @@ fn is_abstract_assignment(stmt: &Stmt) -> bool {
     matches!(assign.value.as_ref(), Expr::BooleanLiteral(b) if b.value)
 }
 
+fn relation_target_expr(call: &ruff_python_ast::ExprCall) -> Option<&Expr> {
+    call.arguments.args.first().or_else(|| {
+        call.arguments
+            .keywords
+            .iter()
+            .find(|keyword| {
+                keyword
+                    .arg
+                    .as_ref()
+                    .is_some_and(|name| name.as_str() == "to")
+            })
+            .map(|keyword| &keyword.value)
+    })
+}
+
 fn extract_relation(stmt: &Stmt, file: File, aliases: &ModelImportState) -> Option<Relation> {
     let Stmt::Assign(assign) = stmt else {
         return None;
@@ -472,8 +487,8 @@ fn extract_relation(stmt: &Stmt, file: File, aliases: &ModelImportState) -> Opti
         call.func.name_target()?
     };
 
-    let first_arg = call.arguments.args.first()?;
-    let target = if let Expr::StringLiteral(string) = first_arg {
+    let target_expr = relation_target_expr(call)?;
+    let target = if let Expr::StringLiteral(string) = target_expr {
         let value = string.value.to_string();
         if value == "self" {
             RelationTarget::SelfRef
@@ -489,7 +504,7 @@ fn extract_relation(stmt: &Stmt, file: File, aliases: &ModelImportState) -> Opti
             }
         }
     } else {
-        let path = first_arg.path_segments()?;
+        let path = target_expr.path_segments()?;
         let (root, tail) = path.split_first()?;
         let import_reference = aliases.resolve_reference(root, tail);
         if path.len() == 1 {
@@ -508,7 +523,7 @@ fn extract_relation(stmt: &Stmt, file: File, aliases: &ModelImportState) -> Opti
 
     let relation_type = RelationType::from_field_class(
         field_class_name,
-        Spanned::new(target, first_arg.span()),
+        Spanned::new(target, target_expr.span()),
         related_name,
     )?;
 
@@ -1001,6 +1016,102 @@ class Order(models.Model):
             rel.relation_type,
             RelationType::ForeignKey { ref related_name, .. } if related_name.is_none()
         ));
+    }
+
+    #[test]
+    fn keyword_bare_relation_target_preserves_value_span() {
+        let source = r"
+from django.db import models
+
+class Order(models.Model):
+    user = models.ForeignKey(to=User, on_delete=models.CASCADE)
+";
+        let graph = extract_model_graph(source, "shop.models");
+        let relation = &model(&graph, "Order").relations[0];
+        let target_start = source
+            .find("to=User")
+            .expect("keyword relation target should occur in the fixture")
+            + "to=".len();
+
+        assert_eq!(bare_target_name(relation), Some("User"));
+        assert_eq!(
+            relation.target_span(),
+            Some(Span::saturating_from_parts_usize(
+                target_start,
+                "User".len()
+            ))
+        );
+    }
+
+    #[test]
+    fn keyword_qualified_relation_target() {
+        let source = r#"
+from django.db import models
+
+class Order(models.Model):
+    user = models.ForeignKey(to="accounts.User", on_delete=models.CASCADE)
+"#;
+        let graph = extract_model_graph(source, "shop.models");
+
+        assert!(matches!(
+            model(&graph, "Order").relations[0].target_model(),
+            Some(RelationTarget::Qualified { app_label, name })
+                if app_label == "accounts" && name.as_str() == "User"
+        ));
+    }
+
+    #[test]
+    fn keyword_self_relation_target() {
+        let source = r#"
+from django.db import models
+
+class Category(models.Model):
+    parent = models.ForeignKey(to="self", on_delete=models.CASCADE)
+"#;
+        let graph = extract_model_graph(source, "catalog.models");
+
+        assert!(matches!(
+            model(&graph, "Category").relations[0].target_model(),
+            Some(RelationTarget::SelfRef)
+        ));
+    }
+
+    #[test]
+    fn keyword_attribute_relation_target() {
+        let source = r"
+from django.db import models
+import accounts.models as account_models
+
+class Order(models.Model):
+    user = models.ForeignKey(to=account_models.User, on_delete=models.CASCADE)
+";
+        let graph = extract_model_graph(source, "shop.models");
+
+        assert!(matches!(
+            model(&graph, "Order").relations[0].target_model(),
+            Some(RelationTarget::Attribute { path, .. })
+                if path == &["account_models", "User"]
+        ));
+    }
+
+    #[test]
+    fn positional_relation_target_wins_over_keyword() {
+        let source = r"
+from django.db import models
+
+class Order(models.Model):
+    preferred = models.ForeignKey(Author, to=Editor, on_delete=models.CASCADE)
+    positional = models.ForeignKey(Editor, on_delete=models.CASCADE)
+    missing = models.ForeignKey(on_delete=models.CASCADE)
+";
+        let graph = extract_model_graph(source, "shop.models");
+        let order = model(&graph, "Order");
+
+        assert_eq!(order.relations.len(), 2);
+        assert_eq!(order.relations[0].field_name.value().as_str(), "preferred");
+        assert_eq!(bare_target_name(&order.relations[0]), Some("Author"));
+        assert_eq!(order.relations[1].field_name.value().as_str(), "positional");
+        assert_eq!(bare_target_name(&order.relations[1]), Some("Editor"));
     }
 
     #[test]

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -660,6 +660,55 @@ fn bare_relation_resolves_relative_to_scope_app() {
 }
 
 #[test]
+fn keyword_relation_target_resolves_through_project_graph() {
+    let source = r"
+from django.db import models
+
+class User(models.Model):
+    pass
+
+class Profile(models.Model):
+    user = models.ForeignKey(to=User, on_delete=models.CASCADE)
+";
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/accounts/models.py", source)
+        .build(&db)
+        .expect("keyword-relation project fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let profile = model_id(graph, "Profile", "accounts.models")
+        .expect("model fixture should contain Profile");
+    let user =
+        model_id(graph, "User", "accounts.models").expect("model fixture should contain User");
+    let resolved = graph
+        .resolve_relation(profile, "user")
+        .expect("keyword relation should resolve");
+    assert!(ptr::eq(
+        resolved,
+        graph
+            .get_by_id(user)
+            .expect("keyword relation target should resolve")
+    ));
+
+    let file = db
+        .file(Utf8Path::new("/project/accounts/models.py"))
+        .expect("keyword-relation model file should exist");
+    let locations = model_relation_locations(graph, "accounts.models", "Profile");
+    assert_relation_location(
+        relation_location(&locations, "user").expect("user relation location should exist"),
+        "user",
+        file,
+        expected_span_after(source, "class Profile", "user")
+            .expect("user field should occur in the Profile fixture"),
+        Some(
+            expected_span_after(source, "class Profile", "User")
+                .expect("User target should occur in the Profile fixture"),
+        ),
+    );
+}
+
+#[test]
 fn self_relation_resolves_to_scope_model() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__base__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__base__models.py.snap
@@ -193,7 +193,21 @@ models:
         start: 80322
         length: 4
     module_name: geonode.base.models
-    relations: []
+    relations:
+      - field_name:
+          value: placeholder
+          span:
+            start: 80416
+            length: 11
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: MenuPlaceholder
+          span:
+            start: 80451
+            length: 17
+        related_name: ~
     kind: concrete
   geonode.base.models.MenuItem:
     name:
@@ -202,7 +216,21 @@ models:
         start: 80790
         length: 8
     module_name: geonode.base.models
-    relations: []
+    relations:
+      - field_name:
+          value: menu
+          span:
+            start: 80888
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Menu
+          span:
+            start: 80916
+            length: 6
+        related_name: ~
     kind: concrete
   geonode.base.models.MenuPlaceholder:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__extras__models__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__extras__models__models.py.snap
@@ -12,6 +12,21 @@ models:
     module_name: netbox.extras.models.models
     relations:
       - field_name:
+          value: object_type
+          span:
+            start: 26672
+            length: 11
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: contenttypes
+            name: ContentType
+          span:
+            start: 26716
+            length: 26
+        related_name: ~
+      - field_name:
           value: object
           span:
             start: 26836
@@ -19,4 +34,20 @@ models:
         relation_type: GenericForeignKey
         ct_field: object_type
         fk_field: object_id
+      - field_name:
+          value: user
+          span:
+            start: 26935
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Attribute
+            path:
+              - settings
+              - AUTH_USER_MODEL
+          span:
+            start: 26972
+            length: 24
+        related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__wireless__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__wireless__models.py.snap
@@ -19,7 +19,52 @@ models:
         start: 2073
         length: 11
     module_name: netbox.wireless.models
-    relations: []
+    relations:
+      - field_name:
+          value: group
+          span:
+            start: 2353
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: wireless
+            name: WirelessLANGroup
+          span:
+            start: 2391
+            length: 27
+        related_name: wireless_lans
+      - field_name:
+          value: vlan
+          span:
+            start: 2732
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: ipam
+            name: VLAN
+          span:
+            start: 2769
+            length: 11
+        related_name: ~
+      - field_name:
+          value: tenant
+          span:
+            start: 2896
+            length: 6
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: tenancy
+            name: Tenant
+          span:
+            start: 2935
+            length: 16
+        related_name: wireless_lans
     kind: concrete
   netbox.wireless.models.WirelessLink:
     name:
@@ -28,5 +73,80 @@ models:
         start: 3544
         length: 12
     module_name: netbox.wireless.models
-    relations: []
+    relations:
+      - field_name:
+          value: interface_a
+          span:
+            start: 3700
+            length: 11
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: dcim
+            name: Interface
+          span:
+            start: 3744
+            length: 16
+        related_name: +
+      - field_name:
+          value: interface_b
+          span:
+            start: 3871
+            length: 11
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: dcim
+            name: Interface
+          span:
+            start: 3915
+            length: 16
+        related_name: +
+      - field_name:
+          value: tenant
+          span:
+            start: 4344
+            length: 6
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: tenancy
+            name: Tenant
+          span:
+            start: 4383
+            length: 16
+        related_name: wireless_links
+      - field_name:
+          value: _interface_a_device
+          span:
+            start: 4660
+            length: 19
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: dcim
+            name: Device
+          span:
+            start: 4712
+            length: 13
+        related_name: +
+      - field_name:
+          value: _interface_b_device
+          span:
+            start: 4835
+            length: 19
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: dcim
+            name: Device
+          span:
+            start: 4887
+            length: 13
+        related_name: +
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__pythonic-news__news__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__pythonic-news__news__models.py.snap
@@ -25,4 +25,18 @@ models:
             start: 3853
             length: 4
         related_name: ~
+      - field_name:
+          value: user
+          span:
+            start: 4011
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: CustomUser
+          span:
+            start: 4039
+            length: 10
+        related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__search__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__search__models.py.snap
@@ -134,5 +134,20 @@ models:
         start: 4811
         length: 19
     module_name: wagtail.search.models
-    relations: []
+    relations:
+      - field_name:
+          value: index_entry
+          span:
+            start: 4988
+            length: 11
+        relation_type: OneToOne
+        target:
+          value:
+            kind: Qualified
+            app_label: wagtailsearch
+            name: indexentry
+          span:
+            start: 5070
+            length: 26
+        related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__search__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__search__models.py.snap
@@ -134,5 +134,20 @@ models:
         start: 4811
         length: 19
     module_name: wagtail.search.models
-    relations: []
+    relations:
+      - field_name:
+          value: index_entry
+          span:
+            start: 4988
+            length: 11
+        relation_type: OneToOne
+        target:
+          value:
+            kind: Qualified
+            app_label: wagtailsearch
+            name: indexentry
+          span:
+            start: 5070
+            length: 26
+        related_name: ~
     kind: concrete


### PR DESCRIPTION
## Summary

- extract relation targets from Django’s `to=` keyword when no positional target is present
- keep positional-target precedence and attach spans to the selected value
- cover project-graph resolution and the six corpus fixtures that use this form

## Checks

- `cargo test -q -p djls-project models::extract::`
- `cargo test -q -p djls-project --test model_relations`
- `DJLS_RUN_CORPUS_TESTS=1 cargo test -p djls-project --test corpus corpus_models -- --nocapture`
- `cargo test -q -p djls-project`
- `cargo test -q`
- `just fmt --check`
- strict workspace Clippy
- `just lint`
- `just hawk`