### PR TITLE
fix: suppress hidden reverse accessors

### DIFF
--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -798,6 +798,7 @@ mod tests {
     use super::extract_models_impl;
     use super::*;
     use crate::models::graph::ModelId;
+    use crate::models::graph::RelatedName;
 
     fn extract_model_graph(source: &str, module_name: &str) -> ModelGraph {
         let db = TestDatabase::new();
@@ -1127,7 +1128,10 @@ class Order(models.Model):
         let rel = &model(&graph, "Order").relations[0];
         assert!(matches!(
             rel.relation_type,
-            RelationType::ForeignKey { ref related_name, .. } if related_name.as_deref() == Some("orders")
+            RelationType::ForeignKey {
+                related_name: Some(RelatedName::Named(ref name)),
+                ..
+            } if name == "orders"
         ));
         assert_eq!(
             rel.effective_related_name("Order", "shop.models"),

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -244,6 +244,16 @@ pub(crate) enum RelationTargetUnresolvedReason {
     },
 }
 
+/// The declared `related_name` for a relation field.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(untagged)]
+pub(crate) enum RelatedName {
+    /// An explicit accessor-name template, before placeholder substitution.
+    Named(String),
+    /// Django's trailing-`+` convention: no reverse accessor exists.
+    Suppressed,
+}
+
 /// The kind of relation a Django model field represents.
 ///
 /// Each variant carries its own data, so fields that don't apply to a given
@@ -254,15 +264,15 @@ pub(crate) enum RelationTargetUnresolvedReason {
 pub(crate) enum RelationType {
     ForeignKey {
         target: Spanned<RelationTarget>,
-        related_name: Option<String>,
+        related_name: Option<RelatedName>,
     },
     OneToOne {
         target: Spanned<RelationTarget>,
-        related_name: Option<String>,
+        related_name: Option<RelatedName>,
     },
     ManyToMany {
         target: Spanned<RelationTarget>,
-        related_name: Option<String>,
+        related_name: Option<RelatedName>,
     },
     GenericForeignKey {
         ct_field: FieldName,
@@ -285,6 +295,13 @@ impl RelationType {
         target: Spanned<RelationTarget>,
         related_name: Option<String>,
     ) -> Option<Self> {
+        let related_name = related_name.map(|name| {
+            if name.ends_with('+') {
+                RelatedName::Suppressed
+            } else {
+                RelatedName::Named(name)
+            }
+        });
         match name {
             "ForeignKey" => Some(Self::ForeignKey {
                 target,
@@ -395,14 +412,20 @@ impl Relation {
         let lower = source_model.to_lowercase();
         match &self.relation_type {
             RelationType::ForeignKey { related_name, .. }
-            | RelationType::ManyToMany { related_name, .. } => Some(match related_name {
-                Some(name) => substitute_related_name(name, &lower, module_name),
-                None => format!("{lower}_set"),
-            }),
-            RelationType::OneToOne { related_name, .. } => Some(match related_name {
-                Some(name) => substitute_related_name(name, &lower, module_name),
-                None => lower,
-            }),
+            | RelationType::ManyToMany { related_name, .. } => match related_name {
+                Some(RelatedName::Named(name)) => {
+                    Some(substitute_related_name(name, &lower, module_name))
+                }
+                Some(RelatedName::Suppressed) => None,
+                None => Some(format!("{lower}_set")),
+            },
+            RelationType::OneToOne { related_name, .. } => match related_name {
+                Some(RelatedName::Named(name)) => {
+                    Some(substitute_related_name(name, &lower, module_name))
+                }
+                Some(RelatedName::Suppressed) => None,
+                None => Some(lower),
+            },
             RelationType::GenericForeignKey { .. } => None,
         }
     }
@@ -416,17 +439,19 @@ impl Relation {
         match &self.relation_type {
             RelationType::ForeignKey { related_name, .. }
             | RelationType::ManyToMany { related_name, .. } => match related_name {
-                Some(name) => {
+                Some(RelatedName::Named(name)) => {
                     template_related_name_matches(name, source_model, module_name, field_name)
                 }
+                Some(RelatedName::Suppressed) => false,
                 None => field_name
                     .strip_suffix("_set")
                     .is_some_and(|prefix| source_model.to_lowercase() == prefix),
             },
             RelationType::OneToOne { related_name, .. } => match related_name {
-                Some(name) => {
+                Some(RelatedName::Named(name)) => {
                     template_related_name_matches(name, source_model, module_name, field_name)
                 }
+                Some(RelatedName::Suppressed) => false,
                 None => source_model.to_lowercase() == field_name,
             },
             RelationType::GenericForeignKey { .. } => false,
@@ -1082,7 +1107,7 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("orders".into()),
+                related_name: Some(RelatedName::Named("orders".into())),
             },
         ));
 
@@ -1194,7 +1219,7 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("orders".into()),
+                related_name: Some(RelatedName::Named("orders".into())),
             },
         ));
 
@@ -1252,6 +1277,79 @@ mod tests {
     }
 
     #[test]
+    fn suppressed_related_names_have_no_reverse_accessor() {
+        for declared_name in ["+", "order+", "%(class)s+"] {
+            let relation_type = RelationType::from_field_class(
+                "ForeignKey",
+                Spanned::new(
+                    RelationTarget::Bare {
+                        name: ModelName::new("User"),
+                        import_reference: None,
+                    },
+                    test_span(10),
+                ),
+                Some(declared_name.into()),
+            )
+            .expect("ForeignKey should produce a relation type");
+            assert!(matches!(
+                relation_type,
+                RelationType::ForeignKey {
+                    related_name: Some(RelatedName::Suppressed),
+                    ..
+                }
+            ));
+            let relation = relation("user", relation_type);
+
+            assert_eq!(
+                relation.effective_related_name("Order", "shop.models"),
+                None
+            );
+            for candidate in ["+", "order+", "foo+"] {
+                assert!(!relation.effective_related_name_matches(
+                    "Order",
+                    "shop.models",
+                    candidate
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn named_related_name_still_matches_after_substitution() {
+        let relation_type = RelationType::from_field_class(
+            "ForeignKey",
+            Spanned::new(
+                RelationTarget::Bare {
+                    name: ModelName::new("User"),
+                    import_reference: None,
+                },
+                test_span(10),
+            ),
+            Some("%(class)s_orders".into()),
+        )
+        .expect("ForeignKey should produce a relation type");
+        assert!(matches!(
+            relation_type,
+            RelationType::ForeignKey {
+                related_name: Some(RelatedName::Named(ref name)),
+                ..
+            } if name == "%(class)s_orders"
+        ));
+        let relation = relation("user", relation_type);
+
+        assert!(relation.effective_related_name_matches(
+            "SpecialOrder",
+            "shop.models",
+            "specialorder_orders"
+        ));
+        assert!(!relation.effective_related_name_matches(
+            "SpecialOrder",
+            "shop.models",
+            "specialorder_set"
+        ));
+    }
+
+    #[test]
     fn class_substitution_in_related_name() {
         let rel = relation(
             "user",
@@ -1263,7 +1361,7 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("%(class)s_orders".into()),
+                related_name: Some(RelatedName::Named("%(class)s_orders".into())),
             },
         );
         assert_eq!(
@@ -1284,7 +1382,9 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("attached_%(app_label)s_%(class)s_set".into()),
+                related_name: Some(RelatedName::Named(
+                    "attached_%(app_label)s_%(class)s_set".into(),
+                )),
             },
         );
         assert_eq!(
@@ -1305,7 +1405,7 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("%(app_label)s_%(class)s_set".into()),
+                related_name: Some(RelatedName::Named("%(app_label)s_%(class)s_set".into())),
             },
         );
         assert_eq!(
@@ -1328,7 +1428,7 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("%(app_label)s_%(class)s_set".into()),
+                related_name: Some(RelatedName::Named("%(app_label)s_%(class)s_set".into())),
             },
         );
         assert_eq!(
@@ -1350,7 +1450,7 @@ mod tests {
                     },
                     test_span(10),
                 ),
-                related_name: Some("%(app_label)s_set".into()),
+                related_name: Some(RelatedName::Named("%(app_label)s_set".into())),
             },
         );
         assert_eq!(

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -709,6 +709,72 @@ class Profile(models.Model):
 }
 
 #[test]
+fn trailing_plus_related_names_create_no_reverse_accessor() {
+    let source = r#"
+from django.db import models
+
+class User(models.Model):
+    pass
+
+class Order(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="orders")
+
+class HiddenOrder(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="+")
+
+class TemplatedHiddenOrder(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="%(class)s+")
+"#;
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/accounts/models.py", source)
+        .build(&db)
+        .expect("related-name suppression fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let user =
+        model_id(graph, "User", "accounts.models").expect("model fixture should contain User");
+
+    let order =
+        model_id(graph, "Order", "accounts.models").expect("model fixture should contain Order");
+    let hidden_order = model_id(graph, "HiddenOrder", "accounts.models")
+        .expect("model fixture should contain HiddenOrder");
+    let templated_hidden_order = model_id(graph, "TemplatedHiddenOrder", "accounts.models")
+        .expect("model fixture should contain TemplatedHiddenOrder");
+    let resolved = graph
+        .resolve_relation(user, "orders")
+        .expect("ordinary related_name should create a reverse accessor");
+    assert!(ptr::eq(
+        resolved,
+        graph
+            .get_by_id(order)
+            .expect("ordinary reverse relation target should resolve")
+    ));
+
+    for absent_accessor in [
+        "+",
+        "hiddenorder+",
+        "templatedhiddenorder+",
+        "hiddenorder_set",
+        "templatedhiddenorder_set",
+    ] {
+        assert_eq!(graph.resolve_relation(user, absent_accessor), None);
+    }
+
+    for source in [hidden_order, templated_hidden_order] {
+        let resolved = graph
+            .resolve_relation(source, "user")
+            .expect("suppression should not affect forward resolution");
+        assert!(ptr::eq(
+            resolved,
+            graph
+                .get_by_id(user)
+                .expect("suppressed relation target should resolve")
+        ));
+    }
+}
+
+#[test]
 fn self_relation_resolves_to_scope_model() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__checklists__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__checklists__models.py.snap
@@ -89,7 +89,7 @@ models:
           span:
             start: 7777
             length: 7
-        related_name: +
+        related_name: ~
       - field_name:
           value: eol_release
           span:
@@ -103,7 +103,7 @@ models:
           span:
             start: 7904
             length: 7
-        related_name: +
+        related_name: ~
     kind: concrete
   checklists.models.PreRelease:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__dashboard__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__dashboard__models.py.snap
@@ -41,7 +41,7 @@ models:
           span:
             start: 8342
             length: 11
-        related_name: +
+        related_name: ~
     kind: concrete
   dashboard.models.GitHubSearchCountMetric:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__common__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__common__models.py.snap
@@ -42,7 +42,7 @@ models:
           span:
             start: 91973
             length: 4
-        related_name: +
+        related_name: ~
     kind: concrete
   src.backend.InvenTree.common.models.EmailMessage:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__order__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__order__models.py.snap
@@ -38,7 +38,7 @@ models:
           span:
             start: 21897
             length: 4
-        related_name: +
+        related_name: ~
     kind: concrete
   src.backend.InvenTree.order.models.ReturnOrder:
     name:
@@ -98,7 +98,7 @@ models:
           span:
             start: 47047
             length: 4
-        related_name: +
+        related_name: ~
     kind: concrete
   src.backend.InvenTree.order.models.SalesOrderAllocation:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__legal__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__legal__models.py.snap
@@ -26,7 +26,7 @@ models:
           span:
             start: 1814
             length: 24
-        related_name: +
+        related_name: ~
       - field_name:
           value: last_modified_by
           span:
@@ -42,7 +42,7 @@ models:
           span:
             start: 2141
             length: 24
-        related_name: +
+        related_name: ~
     kind: concrete
   misago.legal.models.UserAgreement:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__notifications__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__misago__misago__notifications__models.py.snap
@@ -42,7 +42,7 @@ models:
           span:
             start: 598
             length: 24
-        related_name: +
+        related_name: ~
       - field_name:
           value: category
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__wireless__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__wireless__models.py.snap
@@ -88,7 +88,7 @@ models:
           span:
             start: 3744
             length: 16
-        related_name: +
+        related_name: ~
       - field_name:
           value: interface_b
           span:
@@ -103,7 +103,7 @@ models:
           span:
             start: 3915
             length: 16
-        related_name: +
+        related_name: ~
       - field_name:
           value: tenant
           span:
@@ -133,7 +133,7 @@ models:
           span:
             start: 4712
             length: 13
-        related_name: +
+        related_name: ~
       - field_name:
           value: _interface_b_device
           span:
@@ -148,5 +148,5 @@ models:
           span:
             start: 4887
             length: 13
-        related_name: +
+        related_name: ~
     kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__readthedocs.org__readthedocs__projects__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__readthedocs.org__readthedocs__projects__models.py.snap
@@ -205,7 +205,7 @@ models:
           span:
             start: 22772
             length: 14
-        related_name: +
+        related_name: ~
     kind: concrete
   readthedocs.projects.models.ProjectRelationship:
     name:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__admin__models.py.snap
@@ -49,7 +49,7 @@ models:
           span:
             start: 3129
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__search__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__search__models.py.snap
@@ -24,7 +24,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:
@@ -55,7 +55,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:
@@ -86,7 +86,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:
@@ -117,7 +117,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__admin__models.py.snap
@@ -49,7 +49,7 @@ models:
           span:
             start: 3129
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__search__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__search__models.py.snap
@@ -24,7 +24,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:
@@ -55,7 +55,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:
@@ -86,7 +86,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:
@@ -117,7 +117,7 @@ models:
           span:
             start: 1804
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__admin__models.py.snap
@@ -49,7 +49,7 @@ models:
           span:
             start: 3129
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__admin__models.py.snap
@@ -49,7 +49,7 @@ models:
           span:
             start: 3129
             length: 11
-        related_name: +
+        related_name: ~
       - field_name:
           value: content_object
           span:


### PR DESCRIPTION
## Summary

- model declared `related_name` values as named or reverse-accessor-suppressing facts
- make every trailing-`+` declaration produce no reverse accessor while preserving forward resolution
- retain ordinary/default names and review all 26 affected corpus relations

## Checks

- `cargo test -q -p djls-project models::graph::`
- `cargo test -q -p djls-project --test model_relations`
- `cargo test -q -p djls-project`
- `cargo test -q`
- corpus snapshot suite under nextest
- `just clippy`
- `just fmt --check`
- `just lint`
- `just hawk`