### PR TITLE
feat: evaluate os.path.abspath

### DIFF
--- a/crates/djls-project/src/python/evaluation/evaluator.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator.rs
@@ -169,6 +169,7 @@ impl PythonModuleEvaluator<'_> {
                             | PythonPathIntrinsic::PathlibPathType
                             | PythonPathIntrinsic::OsPathJoinFunction
                             | PythonPathIntrinsic::OsPathDirnameFunction
+                            | PythonPathIntrinsic::OsPathAbspathFunction
                     ) && !self
                         .state
                         .module_effects

--- a/crates/djls-project/src/python/evaluation/evaluator/expression.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/expression.rs
@@ -235,6 +235,7 @@ impl PythonModuleEvaluator<'_> {
             }
             PythonPathIntrinsic::OsPathJoinFunction
             | PythonPathIntrinsic::OsPathDirnameFunction
+            | PythonPathIntrinsic::OsPathAbspathFunction
                 if cfg!(windows) =>
             {
                 PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin)
@@ -262,6 +263,21 @@ impl PythonModuleEvaluator<'_> {
                     let path = string_path_from_value(value, origin);
                     project_bound_alternatives(&path, origin, |path| {
                         parent_string_path(path, origin)
+                    })
+                })
+            }
+            PythonPathIntrinsic::OsPathAbspathFunction => {
+                let Some(argument) = single_positional_argument(&call.arguments) else {
+                    return PythonBinding::unknown(
+                        &PythonUnknownCause::UnsupportedExpression,
+                        origin,
+                    );
+                };
+                let argument = self.evaluate_binding(argument);
+                project_bound_alternatives(&argument, origin, |value| {
+                    let path = string_path_from_value(value, origin);
+                    project_bound_alternatives(&path, origin, |path| {
+                        abspath_string_path(path, origin)
                     })
                 })
             }
@@ -589,6 +605,19 @@ fn parent_string_path(value: &PythonValue, origin: Origin) -> PythonBinding {
         PythonValue::string(os_path_dirname(path, cfg!(windows)), origin),
         origin,
     )
+}
+
+fn abspath_string_path(value: &PythonValue, origin: Origin) -> PythonBinding {
+    let PythonValueKind::Str(text) = &value.kind else {
+        return PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin);
+    };
+    let Some(path) = PythonPath::from_absolute_string(text) else {
+        return PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin);
+    };
+    let Some(PythonPath::Object(resolved)) = path.resolve() else {
+        return PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin);
+    };
+    PythonBinding::bound(PythonValue::string(resolved.to_string(), origin), origin)
 }
 
 fn os_path_dirname(path: &str, windows: bool) -> String {

--- a/crates/djls-project/src/python/path_eval.rs
+++ b/crates/djls-project/src/python/path_eval.rs
@@ -85,6 +85,7 @@ pub(crate) enum PythonPathIntrinsic {
     OsPathModule,
     OsPathJoinFunction,
     OsPathDirnameFunction,
+    OsPathAbspathFunction,
 }
 
 impl PythonPathIntrinsic {
@@ -123,6 +124,7 @@ impl PythonPathIntrinsic {
             (Some("os"), "path") => Some(Self::OsPathModule),
             (Some("os.path"), "join") => Some(Self::OsPathJoinFunction),
             (Some("os.path"), "dirname") => Some(Self::OsPathDirnameFunction),
+            (Some("os.path"), "abspath") => Some(Self::OsPathAbspathFunction),
             _ => None,
         }
     }
@@ -134,7 +136,8 @@ impl PythonPathIntrinsic {
             Self::OsModule
             | Self::OsPathModule
             | Self::OsPathJoinFunction
-            | Self::OsPathDirnameFunction => PythonPathNamespace::Os,
+            | Self::OsPathDirnameFunction
+            | Self::OsPathAbspathFunction => PythonPathNamespace::Os,
         }
     }
 
@@ -149,6 +152,7 @@ impl PythonPathIntrinsic {
             (Self::OsModule, "path") => Some(Self::OsPathModule),
             (Self::OsPathModule, "join") => Some(Self::OsPathJoinFunction),
             (Self::OsPathModule, "dirname") => Some(Self::OsPathDirnameFunction),
+            (Self::OsPathModule, "abspath") => Some(Self::OsPathAbspathFunction),
             _ => None,
         }
     }
@@ -163,6 +167,7 @@ impl PythonPathIntrinsic {
             Self::OsPathModule => 5,
             Self::OsPathJoinFunction => 6,
             Self::OsPathDirnameFunction => 7,
+            Self::OsPathAbspathFunction => 8,
         }
     }
 }

--- a/crates/djls-project/src/testing/python_evaluation.rs
+++ b/crates/djls-project/src/testing/python_evaluation.rs
@@ -103,6 +103,7 @@ pub enum PythonPathIntrinsicView {
     OsPathModule,
     OsPathJoinFunction,
     OsPathDirnameFunction,
+    OsPathAbspathFunction,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -414,6 +415,9 @@ fn path_intrinsic_view(intrinsic: crate::python::PythonPathIntrinsic) -> PythonP
         }
         crate::python::PythonPathIntrinsic::OsPathDirnameFunction => {
             PythonPathIntrinsicView::OsPathDirnameFunction
+        }
+        crate::python::PythonPathIntrinsic::OsPathAbspathFunction => {
+            PythonPathIntrinsicView::OsPathAbspathFunction
         }
     }
 }

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -413,6 +413,50 @@ fn python_evaluator_produces_unbound_for_a_path_without_assignment() {
 }
 
 #[test]
+fn os_path_abspath_follows_import_and_assignment_aliases() {
+    let db = TestDatabase::new();
+    db.add_file(
+        "/project/settings.py",
+        "import os as operating_system\nfrom os.path import abspath as path_abspath\nassigned_abspath = path_abspath\nROOT_ABS = operating_system.path.abspath(__file__)\nBASE_DIR = operating_system.path.dirname(operating_system.path.dirname(operating_system.path.abspath(__file__)))\nNORMALIZED_ABS = path_abspath('/project/one/../settings.py')\nASSIGNED_ABS = assigned_abspath(__file__)\nRELATIVE_ABS = path_abspath('relative')\nMISSING_ABS = path_abspath()\nKEYWORD_ABS = path_abspath(path=__file__)\n",
+    )
+    .expect("settings-extraction test file should be added");
+    let project = python_project(&db);
+    let settings = db
+        .file(Utf8Path::new("/project/settings.py"))
+        .expect("settings-extraction test file should exist");
+    let evaluation = python_module_evaluation(&db, project, settings)
+        .expect("Python file should map to a module");
+
+    let assert_kind = |name: &str, expected: PythonValueKindView| {
+        let binding = evaluation.binding(name).expect("binding should exist");
+        let bound =
+            only_bound(&binding.alternatives).expect("binding should have one bound alternative");
+        assert_eq!(bound.value.kind, expected, "unexpected value for {name}");
+    };
+    for name in ["path_abspath", "assigned_abspath"] {
+        assert_kind(
+            name,
+            PythonValueKindView::Path(PythonPathView::Intrinsic(
+                PythonPathIntrinsicView::OsPathAbspathFunction,
+            )),
+        );
+    }
+    for name in ["ROOT_ABS", "NORMALIZED_ABS", "ASSIGNED_ABS"] {
+        assert_kind(
+            name,
+            PythonValueKindView::Str("/project/settings.py".to_string()),
+        );
+    }
+    assert_kind("BASE_DIR", PythonValueKindView::Str("/".to_string()));
+    for name in ["RELATIVE_ABS", "MISSING_ABS", "KEYWORD_ABS"] {
+        let binding = evaluation.binding(name).expect("binding should exist");
+        let bound =
+            only_bound(&binding.alternatives).expect("binding should have one bound alternative");
+        assert!(matches!(bound.value.kind, PythonValueKindView::Unknown(_)));
+    }
+}
+
+#[test]
 fn python_path_intrinsics_follow_import_and_assignment_aliases() {
     let db = TestDatabase::new();
     db.add_file(


### PR DESCRIPTION
## Summary

- recognize `os.path.abspath` through direct imports, aliases, and module members
- normalize absolute inputs through the existing static path model
- keep relative inputs and invalid calls Unknown because the runtime working directory is unavailable

## Checks

- 141 focused evaluator tests
- 281 settings-extraction tests
- `cargo test -q`
- `just clippy`
- `just fmt --check`
- `just lint`
- `just hawk`