### PR TITLE
Fix branch constraint growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed project reloads so an analysis task panic no longer prevents later reloads.
 - Fixed Django relative template paths (`./`, `../`) in `{% extends %}` and `{% include %}` resolution, including inheritance chains, document links, goto definition, and find references.
 - Fixed false tag argument errors for manually parsed tags that strip trailing assignment clauses, such as `{% now ... as var %}` and `{% url ... as var %}`.
+- Fixed static Django settings analysis hanging on projects with many conditional module effects.
 
 ## [6.0.3]
 

--- a/crates/djls-project/src/python/evaluation.rs
+++ b/crates/djls-project/src/python/evaluation.rs
@@ -26,6 +26,7 @@ pub(crate) use self::binding::PythonBinding;
 pub(crate) use self::binding::PythonBindingState;
 pub(crate) use self::binding::PythonBoundValue;
 pub(crate) use self::constraints::BranchConstraints;
+use self::constraints::BranchJoin;
 pub(crate) use self::mapping::MappingEntryEvidence;
 pub(crate) use self::mapping::MappingLogItem;
 pub(crate) use self::mapping::MappingOverride;

--- a/crates/djls-project/src/python/evaluation/binding.rs
+++ b/crates/djls-project/src/python/evaluation/binding.rs
@@ -4,6 +4,7 @@ use std::mem;
 use djls_source::Origin;
 
 use super::BranchConstraints;
+use super::BranchJoin;
 use super::MAX_EXACT_PYTHON_ALTERNATIVES;
 use super::OriginSet;
 use super::PythonUnknownCause;
@@ -182,9 +183,10 @@ impl PythonBinding {
         self
     }
 
-    pub(super) fn select_branch(&mut self, join: Origin, arm: usize) {
+    pub(super) fn select_branch(&mut self, join: impl Into<BranchJoin>, arm: usize) {
+        let join = join.into();
         for case in &mut self.cases {
-            case.constraints.select(join, arm);
+            case.constraints.select(join.clone(), arm);
         }
     }
 

--- a/crates/djls-project/src/python/evaluation/constraints.rs
+++ b/crates/djls-project/src/python/evaluation/constraints.rs
@@ -3,133 +3,344 @@ use std::cmp::Ordering;
 use djls_source::Origin;
 
 use super::StructuralOrd;
+use crate::python::PythonSourceModule;
 
+/// One finite control-flow join. The module identity and source origin name
+/// one execution coordinate; `arm_count` records its complete modeled domain.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct BranchConstraints {
-    // Disjunction of conjunctions. Each conjunction records one arm selected at a control-flow
-    // join. Origins identify joins without retaining AST nodes across query boundaries.
-    alternatives: Vec<Vec<(Origin, usize)>>,
+pub(super) struct BranchJoin {
+    module: PythonSourceModule,
+    origin: Origin,
+    arm_count: usize,
 }
 
-impl BranchConstraints {
-    pub(crate) fn unconstrained() -> Self {
+impl BranchJoin {
+    pub(super) fn new(module: PythonSourceModule, origin: Origin, arm_count: usize) -> Self {
+        assert!(arm_count > 0, "a branch join must have at least one arm");
         Self {
-            alternatives: vec![Vec::new()],
+            module,
+            origin,
+            arm_count,
         }
     }
 
-    pub(super) fn select(&mut self, join: Origin, arm: usize) {
-        for alternative in &mut self.alternatives {
-            alternative.retain(|(existing, _)| *existing != join);
-            alternative.push((join, arm));
-            alternative.sort_by(cmp_branch_choice);
-        }
-        self.normalize();
+    pub(super) fn origin(&self) -> Origin {
+        self.origin
     }
 
-    pub(crate) fn merge(&mut self, other: Self) {
-        self.alternatives.extend(other.alternatives);
-        self.normalize();
+    fn identity_cmp(&self, other: &Self) -> Ordering {
+        self.module
+            .structural_cmp(&other.module)
+            .then_with(|| self.origin.structural_cmp(&other.origin))
     }
 
-    fn normalize(&mut self) {
-        for choices in &mut self.alternatives {
-            choices.sort_by(cmp_branch_choice);
-        }
-        self.alternatives
-            .sort_by(|left, right| cmp_conjunction(left, right));
-        self.alternatives.dedup();
+    fn assert_same_domain(&self, other: &Self) {
+        assert_eq!(
+            self.arm_count, other.arm_count,
+            "one branch join coordinate cannot have two arm domains"
+        );
     }
 
-    pub(crate) fn is_impossible(&self) -> bool {
-        self.alternatives.is_empty()
-    }
+    #[cfg(test)]
+    fn for_test(origin: Origin, arm_count: usize) -> Self {
+        use camino::Utf8PathBuf;
 
-    pub(crate) fn intersection(&self, other: &Self) -> Self {
-        let mut alternatives = Vec::new();
-        for left in &self.alternatives {
-            for right in &other.alternatives {
-                let mut choices = left.clone();
-                let mut compatible = true;
-                for &(join, arm) in right {
-                    if let Some((_, existing_arm)) = choices
-                        .iter()
-                        .find(|(existing_join, _)| *existing_join == join)
-                    {
-                        if *existing_arm != arm {
-                            compatible = false;
-                            break;
-                        }
-                    } else {
-                        choices.push((join, arm));
-                    }
-                }
-                if compatible {
-                    choices.sort_by(cmp_branch_choice);
-                    alternatives.push(choices);
-                }
-            }
-        }
-        let mut constraints = Self { alternatives };
-        constraints.normalize();
-        constraints
-    }
+        use crate::python::PythonModuleName;
+        use crate::python::SearchPath;
 
-    pub(crate) fn compatible_with(&self, other: &Self) -> bool {
-        self.alternatives.iter().any(|left| {
-            other
-                .alternatives
-                .iter()
-                .any(|right| conjunctions_are_compatible(left, right))
-        })
+        Self::new(
+            PythonSourceModule::file_module(
+                PythonModuleName::parse("test").expect("static test module name is valid"),
+                Utf8PathBuf::from("/test.py"),
+                origin.file,
+                SearchPath::FirstParty(Utf8PathBuf::from("/")),
+            ),
+            origin,
+            arm_count,
+        )
     }
 }
 
-impl StructuralOrd for BranchConstraints {
+#[cfg(test)]
+impl From<Origin> for BranchJoin {
+    fn from(origin: Origin) -> Self {
+        Self::for_test(origin, 2)
+    }
+}
+
+impl StructuralOrd for BranchJoin {
     fn structural_cmp(&self, other: &Self) -> Ordering {
-        for (left, right) in self.alternatives.iter().zip(&other.alternatives) {
-            let ordering = cmp_conjunction(left, right);
-            if ordering != Ordering::Equal {
-                return ordering;
-            }
-        }
-        self.alternatives.len().cmp(&other.alternatives.len())
+        self.module
+            .structural_cmp(&other.module)
+            .then_with(|| self.origin.structural_cmp(&other.origin))
+            .then_with(|| self.arm_count.cmp(&other.arm_count))
     }
 }
 
-fn conjunctions_are_compatible(left: &[(Origin, usize)], right: &[(Origin, usize)]) -> bool {
-    let mut left_index = 0;
-    let mut right_index = 0;
-    while let (Some((left_join, left_arm)), Some((right_join, right_arm))) =
-        (left.get(left_index), right.get(right_index))
-    {
-        match left_join.structural_cmp(right_join) {
-            Ordering::Less => left_index += 1,
-            Ordering::Greater => right_index += 1,
-            Ordering::Equal if left_arm != right_arm => return false,
-            Ordering::Equal => {
-                left_index += 1;
-                right_index += 1;
-            }
+/// A canonical ordered multi-valued decision diagram over branch joins.
+///
+/// Branch nodes follow structural origin order along every path. A node whose
+/// arms all lead to the same child is reduced to that child, so exhaustive
+/// branch domains collapse without enumerating path conjunction products.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ConstraintNode {
+    Impossible,
+    Unconstrained,
+    Branch { join: BranchJoin, arms: Vec<Self> },
+}
+
+impl ConstraintNode {
+    fn selected(join: BranchJoin, arm: usize) -> Self {
+        assert!(
+            arm < join.arm_count,
+            "branch arm {arm} is outside a {}-arm join",
+            join.arm_count
+        );
+        let mut arms = vec![Self::Impossible; join.arm_count];
+        arms[arm] = Self::Unconstrained;
+        Self::branch(join, arms)
+    }
+
+    fn branch(join: BranchJoin, arms: Vec<Self>) -> Self {
+        assert_eq!(
+            arms.len(),
+            join.arm_count,
+            "branch node must cover every join arm"
+        );
+        if let Some(first) = arms.first()
+            && arms.iter().all(|arm| arm == first)
+        {
+            return first.clone();
+        }
+        Self::Branch { join, arms }
+    }
+
+    fn collect_joins(&self, joins: &mut Vec<BranchJoin>) {
+        let Self::Branch { join, arms } = self else {
+            return;
+        };
+        if let Some(existing) = joins
+            .iter()
+            .find(|existing| existing.identity_cmp(join) == Ordering::Equal)
+        {
+            existing.assert_same_domain(join);
+        } else {
+            joins.push(join.clone());
+        }
+        for arm in arms {
+            arm.collect_joins(joins);
         }
     }
-    true
+
+    fn assert_compatible_domains(&self, other: &Self) {
+        let mut joins = Vec::new();
+        self.collect_joins(&mut joins);
+        other.collect_joins(&mut joins);
+    }
+
+    fn union(&self, other: &Self) -> Self {
+        self.assert_compatible_domains(other);
+        self.union_canonical(other)
+    }
+
+    fn union_canonical(&self, other: &Self) -> Self {
+        if self == other {
+            return self.clone();
+        }
+        match (self, other) {
+            (Self::Unconstrained, _) | (_, Self::Unconstrained) => Self::Unconstrained,
+            (Self::Impossible, other) => other.clone(),
+            (this, Self::Impossible) => this.clone(),
+            (
+                Self::Branch {
+                    join: left_join,
+                    arms: left_arms,
+                },
+                Self::Branch {
+                    join: right_join,
+                    arms: right_arms,
+                },
+            ) => match left_join.identity_cmp(right_join) {
+                Ordering::Less => Self::branch(
+                    left_join.clone(),
+                    left_arms
+                        .iter()
+                        .map(|arm| arm.union_canonical(other))
+                        .collect(),
+                ),
+                Ordering::Greater => Self::branch(
+                    right_join.clone(),
+                    right_arms
+                        .iter()
+                        .map(|arm| self.union_canonical(arm))
+                        .collect(),
+                ),
+                Ordering::Equal => {
+                    left_join.assert_same_domain(right_join);
+                    Self::branch(
+                        left_join.clone(),
+                        left_arms
+                            .iter()
+                            .zip(right_arms)
+                            .map(|(left, right)| left.union_canonical(right))
+                            .collect(),
+                    )
+                }
+            },
+        }
+    }
+
+    fn intersection(&self, other: &Self) -> Self {
+        self.assert_compatible_domains(other);
+        self.intersection_canonical(other)
+    }
+
+    fn intersection_canonical(&self, other: &Self) -> Self {
+        if self == other {
+            return self.clone();
+        }
+        match (self, other) {
+            (Self::Impossible, _) | (_, Self::Impossible) => Self::Impossible,
+            (Self::Unconstrained, other) => other.clone(),
+            (this, Self::Unconstrained) => this.clone(),
+            (
+                Self::Branch {
+                    join: left_join,
+                    arms: left_arms,
+                },
+                Self::Branch {
+                    join: right_join,
+                    arms: right_arms,
+                },
+            ) => match left_join.identity_cmp(right_join) {
+                Ordering::Less => Self::branch(
+                    left_join.clone(),
+                    left_arms
+                        .iter()
+                        .map(|arm| arm.intersection_canonical(other))
+                        .collect(),
+                ),
+                Ordering::Greater => Self::branch(
+                    right_join.clone(),
+                    right_arms
+                        .iter()
+                        .map(|arm| self.intersection_canonical(arm))
+                        .collect(),
+                ),
+                Ordering::Equal => {
+                    left_join.assert_same_domain(right_join);
+                    Self::branch(
+                        left_join.clone(),
+                        left_arms
+                            .iter()
+                            .zip(right_arms)
+                            .map(|(left, right)| left.intersection_canonical(right))
+                            .collect(),
+                    )
+                }
+            },
+        }
+    }
+
+    /// Existentially remove one join so selecting it again replaces its prior
+    /// arm, matching assignment at a repeated control-flow coordinate.
+    fn forget(&self, forgotten: &BranchJoin) -> Self {
+        match self {
+            Self::Impossible | Self::Unconstrained => self.clone(),
+            Self::Branch { join, arms } => match join.identity_cmp(forgotten) {
+                Ordering::Less => Self::branch(
+                    join.clone(),
+                    arms.iter().map(|arm| arm.forget(forgotten)).collect(),
+                ),
+                Ordering::Greater => self.clone(),
+                Ordering::Equal => {
+                    join.assert_same_domain(forgotten);
+                    arms.iter()
+                        .fold(Self::Impossible, |result, arm| result.union_canonical(arm))
+                }
+            },
+        }
+    }
 }
 
-fn cmp_branch_choice(left: &(Origin, usize), right: &(Origin, usize)) -> Ordering {
-    left.0
-        .structural_cmp(&right.0)
-        .then_with(|| left.1.cmp(&right.1))
+impl StructuralOrd for ConstraintNode {
+    fn structural_cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Impossible, Self::Impossible) | (Self::Unconstrained, Self::Unconstrained) => {
+                Ordering::Equal
+            }
+            (Self::Impossible, _) | (Self::Unconstrained, Self::Branch { .. }) => Ordering::Less,
+            (_, Self::Impossible) | (Self::Branch { .. }, Self::Unconstrained) => Ordering::Greater,
+            (
+                Self::Branch {
+                    join: left_join,
+                    arms: left_arms,
+                },
+                Self::Branch {
+                    join: right_join,
+                    arms: right_arms,
+                },
+            ) => left_join
+                .structural_cmp(right_join)
+                .then_with(|| structural_cmp_nodes(left_arms, right_arms)),
+        }
+    }
 }
 
-fn cmp_conjunction(left: &[(Origin, usize)], right: &[(Origin, usize)]) -> Ordering {
-    for (left, right) in left.iter().zip(right) {
-        let ordering = cmp_branch_choice(left, right);
+fn structural_cmp_nodes(left: &[ConstraintNode], right: &[ConstraintNode]) -> Ordering {
+    for (left, right) in left.iter().rev().zip(right.iter().rev()) {
+        let ordering = left.structural_cmp(right);
         if ordering != Ordering::Equal {
             return ordering;
         }
     }
     left.len().cmp(&right.len())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BranchConstraints {
+    root: Box<ConstraintNode>,
+}
+
+impl BranchConstraints {
+    pub(crate) fn unconstrained() -> Self {
+        Self {
+            root: Box::new(ConstraintNode::Unconstrained),
+        }
+    }
+
+    pub(super) fn select(&mut self, join: impl Into<BranchJoin>, arm: usize) {
+        let join = join.into();
+        *self.root = self
+            .root
+            .forget(&join)
+            .intersection(&ConstraintNode::selected(join, arm));
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        let Self { root } = other;
+        *self.root = self.root.union(&root);
+    }
+
+    pub(crate) fn is_impossible(&self) -> bool {
+        *self.root == ConstraintNode::Impossible
+    }
+
+    pub(crate) fn intersection(&self, other: &Self) -> Self {
+        Self {
+            root: Box::new(self.root.intersection(&other.root)),
+        }
+    }
+
+    pub(crate) fn compatible_with(&self, other: &Self) -> bool {
+        !self.intersection(other).is_impossible()
+    }
+}
+
+impl StructuralOrd for BranchConstraints {
+    fn structural_cmp(&self, other: &Self) -> Ordering {
+        self.root.structural_cmp(&other.root)
+    }
 }
 
 #[cfg(test)]
@@ -142,7 +353,10 @@ mod tests {
     use salsa::plumbing::FromId as _;
 
     use super::BranchConstraints;
+    use super::BranchJoin;
+    use super::ConstraintNode;
     use super::Origin;
+    use super::PythonSourceModule;
     use super::StructuralOrd;
 
     fn origin(file_index: u32, start: u32) -> Origin {
@@ -152,55 +366,154 @@ mod tests {
         Origin::new(file, Span::new(start, 1))
     }
 
-    fn selected(join: Origin, arm: usize) -> BranchConstraints {
+    #[derive(Clone, Copy)]
+    struct TestJoin {
+        origin: Origin,
+        arm_count: usize,
+    }
+
+    fn join(origin: Origin, arm_count: usize) -> TestJoin {
+        TestJoin { origin, arm_count }
+    }
+
+    impl From<TestJoin> for BranchJoin {
+        fn from(join: TestJoin) -> Self {
+            Self::for_test(join.origin, join.arm_count)
+        }
+    }
+
+    fn selected(join: TestJoin, arm: usize) -> BranchConstraints {
         let mut constraints = BranchConstraints::unconstrained();
-        constraints.select(join, arm);
+        constraints.select(BranchJoin::for_test(join.origin, join.arm_count), arm);
         constraints
     }
 
+    fn impossible() -> BranchConstraints {
+        BranchConstraints {
+            root: Box::new(ConstraintNode::Impossible),
+        }
+    }
+
     #[test]
-    fn typed_provenance_order_selection_replaces_arm_and_canonicalizes_choices() {
-        let numerically_first = origin(15, 2);
-        let numerically_later = origin(16, 1);
-        let mut constraints = selected(numerically_later, 0);
-        constraints.select(numerically_first, 1);
-        constraints.select(numerically_later, 1);
+    fn selection_replaces_an_existing_arm() {
+        let branch = join(origin(15, 1), 2);
+        let mut constraints = selected(branch, 0);
+        constraints.select(branch, 1);
+
+        assert_eq!(constraints, selected(branch, 1));
+    }
+
+    #[test]
+    fn structural_order_follows_branch_arm_order() {
+        let branch = join(origin(15, 1), 3);
 
         assert_eq!(
-            constraints.alternatives,
-            vec![vec![(numerically_first, 1), (numerically_later, 1)]]
+            selected(branch, 0).structural_cmp(&selected(branch, 1)),
+            Ordering::Less
+        );
+        assert_eq!(
+            selected(branch, 1).structural_cmp(&selected(branch, 2)),
+            Ordering::Less
         );
     }
 
     #[test]
-    fn typed_provenance_order_branch_arms_are_distinct_and_total() {
-        let join = origin(15, 1);
-        let first_arm = selected(join, 0);
-        let second_arm = selected(join, 1);
+    fn all_join_arms_reduce_to_the_shared_residual() {
+        let branch = join(origin(15, 1), 2);
+        let residual = join(origin(16, 1), 2);
+        let mut first_arm = selected(branch, 0).intersection(&selected(residual, 1));
+        let second_arm = selected(branch, 1).intersection(&selected(residual, 1));
+        first_arm.merge(second_arm);
 
-        assert_ne!(first_arm, second_arm);
-        assert_eq!(first_arm.structural_cmp(&second_arm), Ordering::Less);
-        assert_eq!(second_arm.structural_cmp(&first_arm), Ordering::Greater);
-
-        let mut alternatives = second_arm.clone();
-        alternatives.merge(first_arm.clone());
-        assert_eq!(
-            alternatives.alternatives,
-            vec![vec![(join, 0)], vec![(join, 1)]]
-        );
-        assert_ne!(alternatives.structural_cmp(&first_arm), Ordering::Equal);
+        assert_eq!(first_arm, selected(residual, 1));
     }
 
     #[test]
-    fn typed_provenance_order_unequal_constraints_never_compare_equal() {
-        let first = origin(15, 1);
-        let second = origin(16, 1);
+    fn large_complete_join_reduces_to_unconstrained() {
+        let branch = join(origin(15, 1), 23);
+        let mut constraints = impossible();
+        for arm in 0..23 {
+            constraints.merge(selected(branch, arm));
+        }
+
+        assert_eq!(constraints, BranchConstraints::unconstrained());
+    }
+
+    #[test]
+    fn one_arm_domain_is_unconstrained() {
+        let branch = join(origin(15, 1), 1);
+        assert_eq!(selected(branch, 0), BranchConstraints::unconstrained());
+    }
+
+    #[test]
+    fn incomplete_or_different_residual_groups_do_not_reduce() {
+        let branch = join(origin(15, 1), 3);
+        let first_residual = join(origin(16, 1), 2);
+        let second_residual = join(origin(17, 1), 2);
+        let mut incomplete = selected(branch, 0);
+        incomplete.merge(selected(branch, 1));
+        assert_ne!(incomplete, BranchConstraints::unconstrained());
+
+        let mut different = selected(branch, 0).intersection(&selected(first_residual, 0));
+        different.merge(selected(branch, 1).intersection(&selected(second_residual, 0)));
+        assert_ne!(different, BranchConstraints::unconstrained());
+    }
+
+    #[test]
+    fn nested_complete_domains_reduce_without_path_products() {
+        let joins = [
+            join(origin(15, 1), 23),
+            join(origin(16, 1), 2),
+            join(origin(17, 1), 4),
+            join(origin(18, 1), 2),
+        ];
+        let mut constraints = impossible();
+        for first in 0..23 {
+            for second in 0..2 {
+                for third in 0..4 {
+                    for fourth in 0..2 {
+                        let mut alternative = BranchConstraints::unconstrained();
+                        for (join, arm) in joins.into_iter().zip([first, second, third, fourth]) {
+                            alternative = alternative.intersection(&selected(join, arm));
+                        }
+                        constraints.merge(alternative);
+                    }
+                }
+            }
+        }
+
+        assert_eq!(constraints, BranchConstraints::unconstrained());
+    }
+
+    #[test]
+    fn normalization_is_independent_of_merge_grouping() {
+        let first = join(origin(15, 1), 2);
+        let second = join(origin(16, 1), 2);
+        let a = selected(first, 0).intersection(&selected(second, 0));
+        let b = selected(first, 1).intersection(&selected(second, 0));
+        let c = selected(first, 0).intersection(&selected(second, 1));
+
+        let mut left_grouped = a.clone();
+        left_grouped.merge(b.clone());
+        left_grouped.merge(c.clone());
+
+        let mut right_grouped = b;
+        right_grouped.merge(c);
+        let mut right_grouped_result = a;
+        right_grouped_result.merge(right_grouped);
+
+        assert_eq!(left_grouped, right_grouped_result);
+    }
+
+    #[test]
+    fn structural_order_unequal_constraints_never_compare_equal() {
+        let first = join(origin(15, 1), 2);
+        let second = join(origin(16, 1), 2);
         let first_arm = selected(first, 0);
         let second_arm = selected(first, 1);
         let impossible = first_arm.intersection(&second_arm);
         let unconstrained = BranchConstraints::unconstrained();
-        let mut conjunction = first_arm.clone();
-        conjunction.select(second, 0);
+        let conjunction = first_arm.intersection(&selected(second, 0));
         let mut disjunction = first_arm.clone();
         disjunction.merge(selected(second, 0));
         let constraints = [
@@ -224,52 +537,39 @@ mod tests {
     }
 
     #[test]
-    fn typed_provenance_order_conjunction_and_disjunction_are_order_independent() {
-        let first = origin(15, 1);
-        let second = origin(16, 1);
+    fn merge_and_intersection_obey_algebraic_laws() {
+        let first = selected(join(origin(0, 1), 2), 0);
+        let second = selected(join(origin(0, 2), 2), 1);
+        let third = selected(join(origin(0, 3), 3), 2);
 
-        let mut forward_conjunction = selected(first, 0);
-        forward_conjunction.select(second, 1);
-        let mut reversed_conjunction = selected(second, 1);
-        reversed_conjunction.select(first, 0);
-        assert_eq!(forward_conjunction, reversed_conjunction);
+        let mut left_grouped = first.clone();
+        left_grouped.merge(second.clone());
+        left_grouped.merge(third.clone());
+        let mut right_grouped = second.clone();
+        right_grouped.merge(third.clone());
+        let mut right_result = first.clone();
+        right_result.merge(right_grouped);
+        assert_eq!(left_grouped, right_result, "union must be associative");
+
+        let left_intersection = first.intersection(&second).intersection(&third);
+        let right_intersection = first.intersection(&second.intersection(&third));
         assert_eq!(
-            forward_conjunction.structural_cmp(&reversed_conjunction),
-            Ordering::Equal
+            left_intersection, right_intersection,
+            "intersection must be associative"
         );
+        assert_eq!(first.intersection(&second), second.intersection(&first));
 
-        let first_alternative = selected(first, 0);
-        let second_alternative = selected(second, 1);
-        let mut forward_disjunction = first_alternative.clone();
-        forward_disjunction.merge(second_alternative.clone());
-        let mut reversed_disjunction = second_alternative;
-        reversed_disjunction.merge(first_alternative);
-        assert_eq!(forward_disjunction, reversed_disjunction);
-        assert_eq!(
-            forward_disjunction.structural_cmp(&reversed_disjunction),
-            Ordering::Equal
-        );
-    }
-
-    #[test]
-    fn merge_and_intersection_are_deterministic() {
-        let left = selected(origin(0, 1), 0);
-        let right = selected(origin(0, 2), 1);
-
-        let mut left_then_right = left.clone();
-        left_then_right.merge(right.clone());
-        let mut right_then_left = right.clone();
-        right_then_left.merge(left.clone());
-        assert_eq!(left_then_right, right_then_left);
-        assert_eq!(left.intersection(&right), right.intersection(&left));
+        let mut idempotent = first.clone();
+        idempotent.merge(first.clone());
+        assert_eq!(idempotent, first);
     }
 
     #[test]
     fn conflicts_are_impossible_and_compatible_constraints_intersect() {
-        let join = origin(0, 1);
-        let left = selected(join, 0);
-        let conflicting = selected(join, 1);
-        let independent = selected(origin(0, 2), 0);
+        let branch = join(origin(0, 1), 2);
+        let left = selected(branch, 0);
+        let conflicting = selected(branch, 1);
+        let independent = selected(join(origin(0, 2), 2), 0);
 
         assert!(left.intersection(&conflicting).is_impossible());
         assert!(!left.compatible_with(&conflicting));
@@ -278,22 +578,64 @@ mod tests {
     }
 
     #[test]
-    fn compatibility_handles_unconstrained_impossible_and_disjunctive_paths() {
-        let join = origin(0, 1);
-        let first_arm = selected(join, 0);
-        let second_arm = selected(join, 1);
-        let impossible = first_arm.intersection(&second_arm);
-        let unconstrained = BranchConstraints::unconstrained();
-        let mut either_arm = first_arm.clone();
-        either_arm.merge(second_arm.clone());
+    #[should_panic(expected = "one branch join coordinate cannot have two arm domains")]
+    fn one_join_coordinate_cannot_have_two_domains() {
+        let two_arms = join(origin(0, 1), 2);
+        let three_arms = join(origin(0, 1), 3);
+        let _ = selected(two_arms, 0).intersection(&selected(three_arms, 0));
+    }
 
-        assert!(unconstrained.compatible_with(&first_arm));
-        assert!(first_arm.compatible_with(&unconstrained));
-        assert!(!impossible.compatible_with(&first_arm));
-        assert!(!first_arm.compatible_with(&impossible));
-        assert!(first_arm.compatible_with(&first_arm));
-        assert!(!first_arm.compatible_with(&second_arm));
-        assert!(either_arm.compatible_with(&second_arm));
-        assert!(second_arm.compatible_with(&either_arm));
+    #[test]
+    #[should_panic(expected = "one branch join coordinate cannot have two arm domains")]
+    fn domain_mismatch_is_rejected_under_disjoint_outer_arms() {
+        let outer = join(origin(0, 1), 2);
+        let two_arms = join(origin(0, 2), 2);
+        let three_arms = join(origin(0, 2), 3);
+        let mut left = selected(outer, 0).intersection(&selected(two_arms, 0));
+        let right = selected(outer, 1).intersection(&selected(three_arms, 0));
+
+        left.merge(right);
+    }
+
+    #[test]
+    fn module_identity_separates_equal_source_origins() {
+        use camino::Utf8PathBuf;
+
+        use crate::python::PythonModuleName;
+        use crate::python::SearchPath;
+
+        let source_origin = origin(0, 1);
+        let module = |root: &str| {
+            PythonSourceModule::file_module(
+                PythonModuleName::parse("shared").expect("static test module name is valid"),
+                Utf8PathBuf::from("/shared.py"),
+                source_origin.file,
+                SearchPath::FirstParty(Utf8PathBuf::from(root)),
+            )
+        };
+        let first = BranchJoin::new(module("/first"), source_origin, 2);
+        let second = BranchJoin::new(module("/second"), source_origin, 2);
+        let constrained = |join: BranchJoin, arm| {
+            let mut constraints = BranchConstraints::unconstrained();
+            constraints.select(join, arm);
+            constraints
+        };
+
+        let cross_execution =
+            constrained(first.clone(), 0).intersection(&constrained(second.clone(), 1));
+        assert!(!cross_execution.is_impossible());
+
+        let mut replaced = cross_execution;
+        replaced.select(first.clone(), 1);
+        assert_eq!(
+            replaced,
+            constrained(first, 1).intersection(&constrained(second, 1))
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "outside a 2-arm join")]
+    fn selection_rejects_an_out_of_domain_arm() {
+        let _ = selected(join(origin(0, 1), 2), 2);
     }
 }

--- a/crates/djls-project/src/python/evaluation/evaluator.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator.rs
@@ -11,6 +11,7 @@ use djls_source::Span;
 use ruff_python_ast as ast;
 
 use super::BranchConstraints;
+use super::BranchJoin;
 use super::ChildImportFallback;
 use super::PythonBinding;
 use super::PythonBindingState;
@@ -91,11 +92,18 @@ impl PythonModuleEvaluator<'_> {
     }
 
     fn join_forks(&mut self, forks: Vec<Self>, origin: Origin) {
+        let arm_count = forks.len();
+        self.join_indexed_forks(forks.into_iter().enumerate().collect(), origin, arm_count);
+    }
+
+    fn join_indexed_forks(&mut self, forks: Vec<(usize, Self)>, origin: Origin, arm_count: usize) {
         let branches = forks
             .into_iter()
-            .map(|evaluator| evaluator.state)
+            .map(|(arm, evaluator)| (arm, evaluator.state))
             .collect::<Vec<_>>();
-        self.state = PythonEvaluationState::join_branches(self.state.clone(), &branches, origin);
+        let join = BranchJoin::new(self.module.clone(), origin, arm_count);
+        self.state =
+            PythonEvaluationState::join_indexed_branches(self.state.clone(), &branches, &join);
     }
 
     pub(super) fn origin<T: RangedExt>(&self, ranged: &T) -> Origin {
@@ -637,19 +645,24 @@ impl PythonEvaluationState {
         self
     }
 
-    fn join_branches(mut base: Self, branches: &[Self], origin: Origin) -> Self {
+    fn join_indexed_branches(
+        mut base: Self,
+        branches: &[(usize, Self)],
+        join: &BranchJoin,
+    ) -> Self {
+        let origin = join.origin();
         let names = branches
             .iter()
-            .flat_map(|branch| branch.changed_names_from(&base))
+            .flat_map(|(_, branch)| branch.changed_names_from(&base))
             .collect::<BTreeSet<_>>();
         for name in names {
             let mut joined: Option<PythonBinding> = None;
-            for (arm, branch) in branches.iter().enumerate() {
+            for (arm, branch) in branches {
                 let mut candidate = branch
                     .binding(&name)
                     .cloned()
                     .unwrap_or_else(PythonBinding::unbound);
-                candidate.select_branch(origin, arm);
+                candidate.select_branch(join.to_owned(), *arm);
                 joined = Some(match joined {
                     Some(current) => current.join(candidate, origin),
                     None => candidate,
@@ -662,10 +675,10 @@ impl PythonEvaluationState {
         base.namespace_causes.clear();
         base.mutations.clear();
         base.import_trace = PythonImportTrace::default();
-        for (arm, branch) in branches.iter().enumerate() {
+        for (arm, branch) in branches {
             base.namespace_causes
                 .extend(branch.namespace_causes.iter().cloned().map(|mut cause| {
-                    cause.select_branch(origin, arm);
+                    cause.select_branch(join.to_owned(), *arm);
                     cause
                 }));
             base.mutations.extend(branch.mutations.iter().cloned());
@@ -673,10 +686,17 @@ impl PythonEvaluationState {
         }
         let branch_effects = branches
             .iter()
-            .map(|branch| branch.module_effects.clone())
+            .map(|(arm, branch)| (*arm, branch.module_effects.clone()))
             .collect::<Vec<_>>();
-        base.module_effects = PythonModuleEffects::join_branches(&branch_effects, origin);
+        base.module_effects = PythonModuleEffects::join_indexed_branches(&branch_effects, join);
         base
+    }
+
+    #[cfg(test)]
+    fn join_branches(base: Self, branches: &[Self], origin: Origin) -> Self {
+        let indexed = branches.iter().cloned().enumerate().collect::<Vec<_>>();
+        let join = origin.into();
+        Self::join_indexed_branches(base, &indexed, &join)
     }
 
     fn changed_names_from(&self, base: &Self) -> BTreeSet<String> {

--- a/crates/djls-project/src/python/evaluation/evaluator/statement.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/statement.rs
@@ -89,10 +89,13 @@ impl PythonModuleEvaluator<'_> {
     }
 
     fn walk_if(&mut self, stmt_if: &ast::StmtIf) {
+        let clauses = &stmt_if.elif_else_clauses;
+        let arm_count = 1
+            + clauses.len()
+            + usize::from(clauses.last().is_none_or(|clause| clause.test.is_some()));
         match self.test_truthiness(&stmt_if.test) {
             Truthiness::AlwaysTrue => self.evaluate_body(&stmt_if.body),
             Truthiness::AlwaysFalse => {
-                let clauses = &stmt_if.elif_else_clauses;
                 let control_span = stmt_if.span();
                 for (index, clause) in clauses.iter().enumerate() {
                     let Some(test) = &clause.test else {
@@ -107,15 +110,23 @@ impl PythonModuleEvaluator<'_> {
                         }
                         Truthiness::AlwaysFalse => {}
                         Truthiness::Ambiguous => {
-                            self.join_reachable_if_bodies(None, &clauses[index..], control_span);
+                            self.join_reachable_if_bodies(
+                                None,
+                                &clauses[index..],
+                                index + 1,
+                                arm_count,
+                                control_span,
+                            );
                             return;
                         }
                     }
                 }
             }
             Truthiness::Ambiguous => self.join_reachable_if_bodies(
-                Some(&stmt_if.body),
-                &stmt_if.elif_else_clauses,
+                Some((0, &stmt_if.body)),
+                clauses,
+                1,
+                arm_count,
                 stmt_if.span(),
             ),
         }
@@ -123,8 +134,10 @@ impl PythonModuleEvaluator<'_> {
 
     fn join_reachable_if_bodies(
         &mut self,
-        first_body: Option<&[ast::Stmt]>,
+        first_body: Option<(usize, &[ast::Stmt])>,
         clauses: &[ast::ElifElseClause],
+        first_clause_arm: usize,
+        arm_count: usize,
         control_span: Span,
     ) {
         let mut bodies = Vec::with_capacity(clauses.len() + 2);
@@ -133,34 +146,35 @@ impl PythonModuleEvaluator<'_> {
         }
 
         let mut has_fallthrough = true;
-        for clause in clauses {
+        for (offset, clause) in clauses.iter().enumerate() {
+            let arm = first_clause_arm + offset;
             let Some(test) = &clause.test else {
-                bodies.push(clause.body.as_slice());
+                bodies.push((arm, clause.body.as_slice()));
                 has_fallthrough = false;
                 break;
             };
 
             match self.test_truthiness(test) {
                 Truthiness::AlwaysTrue => {
-                    bodies.push(clause.body.as_slice());
+                    bodies.push((arm, clause.body.as_slice()));
                     has_fallthrough = false;
                     break;
                 }
                 Truthiness::AlwaysFalse => {}
-                Truthiness::Ambiguous => bodies.push(clause.body.as_slice()),
+                Truthiness::Ambiguous => bodies.push((arm, clause.body.as_slice())),
             }
         }
         if has_fallthrough {
-            bodies.push(&[]);
+            bodies.push((arm_count - 1, &[]));
         }
 
         let mut branches = Vec::with_capacity(bodies.len());
-        for body in bodies {
+        for (arm, body) in bodies {
             let mut branch = self.fork();
             branch.evaluate_body(body);
-            branches.push(branch);
+            branches.push((arm, branch));
         }
-        self.join_forks(branches, self.origin_at(control_span));
+        self.join_indexed_forks(branches, self.origin_at(control_span), arm_count);
     }
 
     fn walk_try(&mut self, stmt_try: &ast::StmtTry) {

--- a/crates/djls-project/src/python/evaluation/module_object.rs
+++ b/crates/djls-project/src/python/evaluation/module_object.rs
@@ -10,6 +10,7 @@ use std::cmp::Ordering;
 use djls_source::Origin;
 
 use super::BranchConstraints;
+use super::BranchJoin;
 use super::PythonBinding;
 use super::PythonBindingState;
 use super::PythonNamespaceCause;
@@ -409,9 +410,10 @@ impl PythonModuleEffects {
     /// Branch join: contribute `Unbound` for a branch that did not attach a
     /// coordinate, then normalize with `PythonBinding::join`. Each open cause is
     /// retained under its branch constraints.
-    pub(crate) fn join_branches(branches: &[Self], origin: Origin) -> Self {
+    pub(super) fn join_indexed_branches(branches: &[(usize, Self)], join: &BranchJoin) -> Self {
+        let origin = join.origin();
         let mut keys: Vec<(PythonModule, String)> = Vec::new();
-        for branch in branches {
+        for (_, branch) in branches {
             for child in &branch.children {
                 let key = (child.object.clone(), child.attribute.clone());
                 if !keys.contains(&key) {
@@ -423,12 +425,12 @@ impl PythonModuleEffects {
         let mut joined = Self::default();
         for (object, attribute) in keys {
             let mut binding: Option<PythonBinding> = None;
-            for (arm, branch) in branches.iter().enumerate() {
+            for (arm, branch) in branches {
                 let mut candidate = branch
                     .read_child(&object, &attribute)
                     .cloned()
                     .unwrap_or_else(PythonBinding::unbound);
-                candidate.select_branch(origin, arm);
+                candidate.select_branch(join.to_owned(), *arm);
                 binding = Some(match binding {
                     Some(current) => current.join(candidate, origin),
                     None => candidate,
@@ -443,10 +445,10 @@ impl PythonModuleEffects {
             }
         }
 
-        for (arm, branch) in branches.iter().enumerate() {
+        for (arm, branch) in branches {
             for entry in &branch.causes {
                 let mut cause = entry.cause.clone();
-                cause.select_branch(origin, arm);
+                cause.select_branch(join.to_owned(), *arm);
                 joined.causes.push(ModuleEffectCause {
                     object: entry.object.clone(),
                     cause,
@@ -459,6 +461,13 @@ impl PythonModuleEffects {
 
         joined.normalize();
         joined
+    }
+
+    #[cfg(test)]
+    fn join_branches(branches: &[Self], origin: Origin) -> Self {
+        let indexed = branches.iter().cloned().enumerate().collect::<Vec<_>>();
+        let join = origin.into();
+        Self::join_indexed_branches(&indexed, &join)
     }
 
     /// Zero-iteration loop degradation: the baseline (`self`) path is included,
@@ -556,16 +565,20 @@ impl PythonModuleEffects {
     fn normalize(&mut self) {
         self.children.sort_by(ModuleChildCoordinate::structural_cmp);
 
-        // Open causes preserve first-seen order with exact full-value dedup: no
-        // structural sort and no cause-kind coalescing, so distinct origins or
-        // constraints stay as distinct open causes.
-        let mut deduped: Vec<ModuleEffectCause> = Vec::new();
+        // Open causes preserve first-seen order. Identical object-scoped
+        // unknowns merge their path constraints so complete branch domains can
+        // collapse, while distinct origins remain separate evidence.
+        let mut normalized: Vec<ModuleEffectCause> = Vec::new();
         for entry in std::mem::take(&mut self.causes) {
-            if !deduped.contains(&entry) {
-                deduped.push(entry);
+            if let Some(existing) = normalized.iter_mut().find(|existing| {
+                existing.object == entry.object && existing.cause.unknown == entry.cause.unknown
+            }) {
+                existing.cause.constraints.merge(entry.cause.constraints);
+            } else {
+                normalized.push(entry);
             }
         }
-        self.causes = deduped;
+        self.causes = normalized;
     }
 }
 
@@ -798,6 +811,21 @@ mod tests {
             .read_child(&parent, "child")
             .expect("coordinate present");
         assert_eq!(binding.alternatives().len(), 2);
+    }
+
+    #[test]
+    fn branch_join_collapses_identical_causes_across_complete_domain() {
+        let object = source("pkg", 1);
+        let mut left = PythonModuleEffects::default();
+        left.open_cause(object.clone(), cause(1));
+        let mut right = PythonModuleEffects::default();
+        right.open_cause(object.clone(), cause(1));
+
+        let joined = PythonModuleEffects::join_branches(&[left, right], origin(10));
+        let causes: Vec<_> = joined.causes_for(&object).collect();
+
+        assert_eq!(causes.len(), 1);
+        assert_eq!(causes[0].constraints, BranchConstraints::unconstrained());
     }
 
     #[test]

--- a/crates/djls-project/src/python/evaluation/result.rs
+++ b/crates/djls-project/src/python/evaluation/result.rs
@@ -9,6 +9,7 @@ use djls_source::Origin;
 use rustc_hash::FxHashSet;
 
 use super::BranchConstraints;
+use super::BranchJoin;
 use super::PythonBinding;
 use super::PythonModuleEffects;
 use super::PythonMutation;
@@ -74,7 +75,7 @@ impl PythonNamespaceCause {
         }
     }
 
-    pub(super) fn select_branch(&mut self, join: Origin, arm: usize) {
+    pub(super) fn select_branch(&mut self, join: impl Into<BranchJoin>, arm: usize) {
         self.constraints.select(join, arm);
     }
 }

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -6430,6 +6430,52 @@ fn relative_import_cycle_uses_module_identities_in_overlapping_roots() {
 }
 
 #[test]
+fn branch_constraints_distinguish_overlapping_root_module_identities() {
+    let db = TestDatabase::new();
+    db.add_file(
+        "/project/settings.py",
+        "from lib.pkg.branch import VALUE as ROOT_VALUE\nfrom pkg.branch import VALUE as NESTED_VALUE\nPAIR = (ROOT_VALUE, NESTED_VALUE)\n",
+    )
+    .expect("settings-extraction test file should be added");
+    db.add_file(
+        "/project/lib/pkg/branch.py",
+        "if FLAG:\n    VALUE = 'left'\nelse:\n    VALUE = 'right'\n",
+    )
+    .expect("settings-extraction test file should be added");
+    let project = python_project_with_paths(&db, &[Utf8PathBuf::from("/project/lib")]);
+    let settings = db
+        .file(Utf8Path::new("/project/settings.py"))
+        .expect("settings-extraction test file should exist");
+
+    let evaluation = python_module_evaluation(&db, project, settings)
+        .expect("Python file should map to a module");
+    let pairs = evaluation
+        .binding("PAIR")
+        .expect("PAIR binding should exist")
+        .alternatives
+        .iter()
+        .filter_map(|alternative| {
+            let PythonBindingAlternativeView::Bound(bound) = alternative else {
+                return None;
+            };
+            string_list_items(&bound.value)
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        pairs,
+        [
+            vec!["str:left".to_string(), "str:left".to_string()],
+            vec!["str:left".to_string(), "str:right".to_string()],
+            vec!["str:right".to_string(), "str:left".to_string()],
+            vec!["str:right".to_string(), "str:right".to_string()],
+        ]
+        .into_iter()
+        .collect()
+    );
+}
+
+#[test]
 fn typed_module_order_disjoint_import_cycles_are_root_order_independent() {
     let cycle_edges = |settings_source| {
         let db = TestDatabase::new();
@@ -7676,6 +7722,30 @@ fn ambiguous_installed_apps_insert_and_remove_are_dynamic() {
             assert!(!cases[0].to_string().contains("known"), "{source}");
         }
     }
+}
+
+#[test]
+fn handler_if_uses_stable_arms_across_try_prefixes() {
+    let source = "try:\n    B = True\n    MARKER = 1\nexcept Exception:\n    if A:\n        VALUE = 'a'\n    elif B:\n        VALUE = 'b'\n    else:\n        VALUE = 'c'\n";
+    let (_file, evaluation) =
+        evaluate_module(source).expect("Python evaluation fixture should build");
+    let values = evaluation
+        .binding("VALUE")
+        .expect("handler binding should exist")
+        .alternatives
+        .iter()
+        .filter_map(|alternative| {
+            let PythonBindingAlternativeView::Bound(bound) = alternative else {
+                return None;
+            };
+            let PythonValueKindView::Str(value) = &bound.value.kind else {
+                return None;
+            };
+            Some(value.as_str())
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(values, ["a", "b", "c"].into_iter().collect());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace branch-path DNF products with a canonical ordered multi-valued decision diagram
- key joins by module execution and stable syntax arm domains
- coalesce equal module-effect causes while preserving branch correlation
- add regressions for algebraic laws, overlapping roots, try-prefix evaluation, and source order

ArchiveBox settings evaluation now completes in about 0.33 seconds instead of exceeding 40 minutes.

## Verification

- `cargo test -q`
- `just test`
- `just clippy`
- `just fmt`
- `just lint`
- `cargo build -q`
- `just hawk`