### PR TITLE
Honor Python boolean short-circuiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed Django relative template paths (`./`, `../`) in `{% extends %}` and `{% include %}` resolution, including inheritance chains, document links, goto definition, and find references.
 - Fixed false tag argument errors for manually parsed tags that strip trailing assignment clauses, such as `{% now ... as var %}` and `{% url ... as var %}`.
 - Fixed static Django settings analysis hanging on projects with many conditional module effects.
+- Fixed static Python evaluation to honor short-circuiting `and` and `or` operands.
 
 ## [6.0.3]
 

--- a/crates/djls-project/src/python/evaluation/evaluator.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator.rs
@@ -33,7 +33,8 @@ use super::PythonValueKind;
 use super::ReachableAllocationSites;
 use super::UniqueVec;
 use super::module_object::PathIntrinsicContamination;
-use super::name_analysis::expr_calls;
+use super::name_analysis::reachable_expr_calls;
+use super::truthiness::Truthiness;
 use crate::ast::ExprExt;
 use crate::ast::RangedExt;
 use crate::db::Db as ProjectDb;
@@ -114,8 +115,11 @@ impl PythonModuleEvaluator<'_> {
         Origin::new(self.module.file(), span)
     }
 
-    fn record_unsupported_call_effects(&mut self, expression: &ast::Expr) {
-        for call in expr_calls(expression) {
+    pub(super) fn record_unsupported_call_effects(&mut self, expression: &ast::Expr) {
+        let calls = reachable_expr_calls(expression, &|value| {
+            Truthiness::of_expr(value, &|name| self.state.known_truthiness(name))
+        });
+        for call in calls {
             let include_receiver = match self.unsupported_call_effect(&call) {
                 UnsupportedCallEffect::None => continue,
                 UnsupportedCallEffect::Arguments => false,
@@ -499,7 +503,7 @@ impl PythonEvaluationState {
     /// The definite truthiness of a name, if any: a uniformly boolean binding
     /// yields its constant value, and a uniformly module-valued binding is
     /// always truthy (Python module objects are never falsy).
-    fn known_truthiness(&self, name: &str) -> Option<bool> {
+    pub(super) fn known_truthiness(&self, name: &str) -> Option<bool> {
         if let Some(value) = self.bool_value(name) {
             return Some(value);
         }

--- a/crates/djls-project/src/python/evaluation/evaluator/expression.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/expression.rs
@@ -9,6 +9,7 @@ use super::PythonValueKind;
 use super::ast;
 use crate::python::PythonPath;
 use crate::python::PythonPathIntrinsic;
+use crate::python::evaluation::truthiness::Truthiness;
 
 impl PythonModuleEvaluator<'_> {
     pub(super) fn evaluate_binding(&self, expression: &ast::Expr) -> PythonBinding {
@@ -63,8 +64,8 @@ impl PythonModuleEvaluator<'_> {
             ast::Expr::Call(call) => self.evaluate_call_binding(call, origin),
             ast::Expr::Dict(dict) => self.evaluate_dict_binding(dict, origin),
             ast::Expr::Attribute(attribute) => self.evaluate_attribute_binding(attribute, origin),
-            ast::Expr::BoolOp(_)
-            | ast::Expr::Named(_)
+            ast::Expr::BoolOp(boolean) => self.evaluate_bool_op_binding(boolean, origin),
+            ast::Expr::Named(_)
             | ast::Expr::BinOp(_)
             | ast::Expr::UnaryOp(_)
             | ast::Expr::Lambda(_)
@@ -94,6 +95,31 @@ impl PythonModuleEvaluator<'_> {
                 PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin)
             }
         }
+    }
+
+    fn evaluate_bool_op_binding(&self, boolean: &ast::ExprBoolOp, origin: Origin) -> PythonBinding {
+        let Some((last, preceding)) = boolean.values.split_last() else {
+            return PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin);
+        };
+        for expression in preceding {
+            let truthiness =
+                Truthiness::of_expr(expression, &|name| self.state.known_truthiness(name));
+            match (boolean.op, truthiness) {
+                (ast::BoolOp::And, Truthiness::AlwaysFalse)
+                | (ast::BoolOp::Or, Truthiness::AlwaysTrue) => {
+                    return self.evaluate_binding(expression);
+                }
+                (ast::BoolOp::And, Truthiness::AlwaysTrue)
+                | (ast::BoolOp::Or, Truthiness::AlwaysFalse) => {}
+                (_, Truthiness::Ambiguous) => {
+                    return PythonBinding::unknown(
+                        &PythonUnknownCause::UnsupportedExpression,
+                        origin,
+                    );
+                }
+            }
+        }
+        self.evaluate_binding(last)
     }
 
     /// Read `receiver.member` through the receiver's nominal abstract value.

--- a/crates/djls-project/src/python/evaluation/evaluator/statement.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/statement.rs
@@ -42,13 +42,16 @@ impl PythonModuleEvaluator<'_> {
                 self.bind_for_target(&stmt_for.target);
                 self.degrade_loop_bodies(&[&stmt_for.body, &stmt_for.orelse], stmt_for.span());
             }
-            ast::Stmt::While(stmt_while) => match self.test_truthiness(&stmt_while.test) {
-                Truthiness::AlwaysFalse => self.evaluate_body(&stmt_while.orelse),
-                Truthiness::AlwaysTrue | Truthiness::Ambiguous => self.degrade_loop_bodies(
-                    &[&stmt_while.body, &stmt_while.orelse],
-                    stmt_while.span(),
-                ),
-            },
+            ast::Stmt::While(stmt_while) => {
+                self.record_unsupported_call_effects(&stmt_while.test);
+                match self.test_truthiness(&stmt_while.test) {
+                    Truthiness::AlwaysFalse => self.evaluate_body(&stmt_while.orelse),
+                    Truthiness::AlwaysTrue | Truthiness::Ambiguous => self.degrade_loop_bodies(
+                        &[&stmt_while.body, &stmt_while.orelse],
+                        stmt_while.span(),
+                    ),
+                }
+            }
             ast::Stmt::With(stmt_with) => {
                 for item in &stmt_with.items {
                     if let Some(optional_vars) = &item.optional_vars {
@@ -93,6 +96,7 @@ impl PythonModuleEvaluator<'_> {
         let arm_count = 1
             + clauses.len()
             + usize::from(clauses.last().is_none_or(|clause| clause.test.is_some()));
+        self.record_unsupported_call_effects(&stmt_if.test);
         match self.test_truthiness(&stmt_if.test) {
             Truthiness::AlwaysTrue => self.evaluate_body(&stmt_if.body),
             Truthiness::AlwaysFalse => {
@@ -103,6 +107,7 @@ impl PythonModuleEvaluator<'_> {
                         return;
                     };
 
+                    self.record_unsupported_call_effects(test);
                     match self.test_truthiness(test) {
                         Truthiness::AlwaysTrue => {
                             self.evaluate_body(&clause.body);
@@ -116,6 +121,7 @@ impl PythonModuleEvaluator<'_> {
                                 index + 1,
                                 arm_count,
                                 control_span,
+                                true,
                             );
                             return;
                         }
@@ -128,6 +134,7 @@ impl PythonModuleEvaluator<'_> {
                 1,
                 arm_count,
                 stmt_if.span(),
+                false,
             ),
         }
     }
@@ -139,6 +146,7 @@ impl PythonModuleEvaluator<'_> {
         first_clause_arm: usize,
         arm_count: usize,
         control_span: Span,
+        first_test_already_evaluated: bool,
     ) {
         let mut bodies = Vec::with_capacity(clauses.len() + 2);
         if let Some(body) = first_body {
@@ -154,6 +162,9 @@ impl PythonModuleEvaluator<'_> {
                 break;
             };
 
+            if offset != 0 || !first_test_already_evaluated {
+                self.record_unsupported_call_effects(test);
+            }
             match self.test_truthiness(test) {
                 Truthiness::AlwaysTrue => {
                     bodies.push((arm, clause.body.as_slice()));

--- a/crates/djls-project/src/python/evaluation/mutation.rs
+++ b/crates/djls-project/src/python/evaluation/mutation.rs
@@ -11,7 +11,8 @@ use super::ReachableAllocationSites;
 use super::StructuralOrd;
 use super::evaluator::PythonEvaluationState;
 use super::evaluator::PythonModuleEvaluator;
-use super::name_analysis::expr_read_names;
+use super::name_analysis::reachable_expr_read_names;
+use super::truthiness::Truthiness;
 use crate::ast::ExprExt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -379,8 +380,9 @@ impl PythonEvaluationState {
 impl PythonModuleEvaluator<'_> {
     pub(super) fn evaluate_expression_statement(&mut self, expression: &ast::Expr) {
         let ast::Expr::Call(call) = expression else {
+            self.record_unsupported_call_effects(expression);
             self.state.degrade_names(
-                expr_read_names(expression),
+                self.reachable_read_names(expression),
                 &PythonUnknownCause::UnsupportedExpression,
                 self.origin(expression),
             );
@@ -388,14 +390,14 @@ impl PythonModuleEvaluator<'_> {
         };
         let ast::Expr::Attribute(attribute) = call.func.as_ref() else {
             self.state.degrade_unsupported_mutation_names(
-                expr_read_names(expression),
+                self.reachable_read_names(expression),
                 self.origin(expression),
             );
             return;
         };
         let Some(target) = MutationTarget::from_expr(&attribute.value) else {
             self.state.degrade_unsupported_mutation_names(
-                expr_read_names(expression),
+                self.reachable_read_names(expression),
                 self.origin(expression),
             );
             return;
@@ -409,7 +411,7 @@ impl PythonModuleEvaluator<'_> {
                 receiver_aliases.push(target.binding.to_string());
             }
             self.state
-                .degrade_unsupported_mutation_names(expr_read_names(expression), origin);
+                .degrade_unsupported_mutation_names(self.reachable_read_names(expression), origin);
             self.state.invalidate_names(
                 receiver_aliases,
                 &PythonUnknownCause::UnsupportedMutation,
@@ -435,13 +437,19 @@ impl PythonModuleEvaluator<'_> {
                 stale_aliases.push(target.binding.to_string());
             }
             self.state
-                .degrade_unsupported_mutation_names(expr_read_names(expression), origin);
+                .degrade_unsupported_mutation_names(self.reachable_read_names(expression), origin);
             self.state.invalidate_names(
                 stale_aliases,
                 &PythonUnknownCause::UnsupportedMutation,
                 origin,
             );
         }
+    }
+
+    fn reachable_read_names(&self, expression: &ast::Expr) -> rustc_hash::FxHashSet<String> {
+        reachable_expr_read_names(expression, &|value| {
+            Truthiness::of_expr(value, &|name| self.state.known_truthiness(name))
+        })
     }
 
     fn try_apply_mutation_call(

--- a/crates/djls-project/src/python/evaluation/name_analysis.rs
+++ b/crates/djls-project/src/python/evaluation/name_analysis.rs
@@ -2,6 +2,7 @@ use ruff_python_ast as ast;
 use rustc_hash::FxHashSet;
 
 use crate::ast::ExprExt;
+use crate::python::evaluation::truthiness::Truthiness;
 
 pub(super) fn target_write_names(target: &ast::Expr) -> Vec<&str> {
     let mut names = Vec::new();
@@ -62,25 +63,41 @@ fn collect_target_write_names<'a>(target: &'a ast::Expr, names: &mut Vec<&'a str
 
 /// Collects names whose current bindings are read while evaluating an expression.
 pub(super) fn expr_read_names(expression: &ast::Expr) -> FxHashSet<String> {
-    ReadNameCollector::collect(expression, false).names
+    ReadNameCollector::collect(expression, false, None).names
 }
 
-pub(super) fn expr_calls(expression: &ast::Expr) -> Vec<ast::ExprCall> {
-    ReadNameCollector::collect(expression, true)
+pub(super) fn reachable_expr_read_names(
+    expression: &ast::Expr,
+    truthiness: &impl Fn(&ast::Expr) -> Truthiness,
+) -> FxHashSet<String> {
+    ReadNameCollector::collect(expression, false, Some(truthiness)).names
+}
+
+pub(super) fn reachable_expr_calls(
+    expression: &ast::Expr,
+    truthiness: &impl Fn(&ast::Expr) -> Truthiness,
+) -> Vec<ast::ExprCall> {
+    ReadNameCollector::collect(expression, true, Some(truthiness))
         .calls
         .unwrap_or_default()
 }
 
 #[derive(Default)]
-struct ReadNameCollector {
+struct ReadNameCollector<'a> {
     names: FxHashSet<String>,
     calls: Option<Vec<ast::ExprCall>>,
+    truthiness: Option<&'a dyn Fn(&ast::Expr) -> Truthiness>,
 }
 
-impl ReadNameCollector {
-    fn collect(expression: &ast::Expr, collect_calls: bool) -> Self {
+impl<'a> ReadNameCollector<'a> {
+    fn collect(
+        expression: &ast::Expr,
+        collect_calls: bool,
+        truthiness: Option<&'a dyn Fn(&ast::Expr) -> Truthiness>,
+    ) -> Self {
         let mut collector = Self {
             calls: collect_calls.then(Vec::new),
+            truthiness,
             ..Self::default()
         };
         collector.visit_expr(expression);
@@ -113,7 +130,7 @@ impl ReadNameCollector {
                 self.visit_expr(&binary.right);
             }
             ast::Expr::UnaryOp(unary) => self.visit_expr(&unary.operand),
-            ast::Expr::BoolOp(boolean) => self.visit_elements(&boolean.values),
+            ast::Expr::BoolOp(boolean) => self.visit_bool_op(boolean),
             ast::Expr::Compare(compare) => {
                 self.visit_expr(&compare.left);
                 self.visit_elements(&compare.comparators);
@@ -180,6 +197,22 @@ impl ReadNameCollector {
             | ast::Expr::NoneLiteral(_)
             | ast::Expr::EllipsisLiteral(_)
             | ast::Expr::IpyEscapeCommand(_) => {}
+        }
+    }
+
+    fn visit_bool_op(&mut self, boolean: &ast::ExprBoolOp) {
+        for value in &boolean.values {
+            self.visit_expr(value);
+            let Some(truthiness) = self.truthiness.map(|truthiness| truthiness(value)) else {
+                continue;
+            };
+            if matches!(
+                (boolean.op, truthiness),
+                (ast::BoolOp::And, Truthiness::AlwaysFalse)
+                    | (ast::BoolOp::Or, Truthiness::AlwaysTrue)
+            ) {
+                break;
+            }
         }
     }
 
@@ -303,8 +336,11 @@ mod tests {
     use ruff_python_ast as ast;
     use ruff_python_parser::parse_module;
 
+    use super::Truthiness;
     use super::expr_read_names;
     use super::pattern_bound_names;
+    use super::reachable_expr_calls;
+    use super::reachable_expr_read_names;
     use super::target_write_names;
 
     fn read_names(expression: &str) -> BTreeSet<String> {
@@ -401,6 +437,20 @@ mod tests {
                 .map(str::to_string)
                 .collect()
         );
+    }
+
+    #[test]
+    fn reachable_expression_collection_stops_at_decisive_boolean_operands() {
+        let module = parse_module("VALUE = False and unreachable(ARGUMENT)\n")
+            .expect("expression should parse")
+            .into_syntax();
+        let [ast::Stmt::Assign(assignment)] = module.body.as_slice() else {
+            panic!("expected one assignment");
+        };
+        let truthiness = |expression: &ast::Expr| Truthiness::of_expr(expression, &|_| None);
+
+        assert!(reachable_expr_read_names(&assignment.value, &truthiness).is_empty());
+        assert!(reachable_expr_calls(&assignment.value, &truthiness).is_empty());
     }
 
     #[test]

--- a/crates/djls-project/src/python/evaluation/touched_names.rs
+++ b/crates/djls-project/src/python/evaluation/touched_names.rs
@@ -9,6 +9,7 @@ use super::PythonSyntaxErrorImpact;
 use super::mutation::MutationTarget;
 use super::name_analysis::expr_read_names;
 use super::name_analysis::pattern_bound_names;
+use super::name_analysis::reachable_expr_read_names;
 use super::name_analysis::target_write_names;
 use super::truthiness::Truthiness;
 use crate::ast::ExprExt;
@@ -237,7 +238,7 @@ impl DefiniteWriteCollector {
         match statement {
             ast::Stmt::Assign(assign) => {
                 let value = self.exact_bool(&assign.value);
-                let dominates = self.taint.expression_is_independent(&assign.value);
+                let dominates = self.expression_is_independent(&assign.value);
                 for target in &assign.targets {
                     self.record_targets(target, value, dominates);
                 }
@@ -245,7 +246,7 @@ impl DefiniteWriteCollector {
             ast::Stmt::AnnAssign(assign) => {
                 if let Some(value) = assign.value.as_deref() {
                     let exact_bool = self.exact_bool(value);
-                    let dominates = self.taint.expression_is_independent(value);
+                    let dominates = self.expression_is_independent(value);
                     self.record_targets(&assign.target, exact_bool, dominates);
                 }
             }
@@ -420,6 +421,12 @@ impl DefiniteWriteCollector {
             self.known_name_truthiness.get(name).copied()
         })
     }
+
+    fn expression_is_independent(&self, value: &ast::Expr) -> bool {
+        reachable_expr_read_names(value, &|expression| self.known_truthiness(expression))
+            .iter()
+            .all(|name| !self.taint.name_is_tainted(name))
+    }
 }
 
 struct AssignmentTaint {
@@ -435,12 +442,6 @@ impl AssignmentTaint {
             namespace_open,
             clean_names: FxHashSet::default(),
         }
-    }
-
-    fn expression_is_independent(&self, value: &ast::Expr) -> bool {
-        expr_read_names(value)
-            .iter()
-            .all(|name| !self.name_is_tainted(name))
     }
 
     fn name_is_tainted(&self, name: &str) -> bool {

--- a/crates/djls-project/src/python/evaluation/truthiness.rs
+++ b/crates/djls-project/src/python/evaluation/truthiness.rs
@@ -23,8 +23,19 @@ impl Truthiness {
             ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not => {
                 Self::of_expr(&unary.operand, known_bool).negate()
             }
-            ast::Expr::BoolOp(_)
-            | ast::Expr::Named(_)
+            ast::Expr::BoolOp(boolean) => match boolean.op {
+                ast::BoolOp::And => boolean
+                    .values
+                    .iter()
+                    .map(|value| Self::of_expr(value, known_bool))
+                    .fold(Self::AlwaysTrue, Self::and),
+                ast::BoolOp::Or => boolean
+                    .values
+                    .iter()
+                    .map(|value| Self::of_expr(value, known_bool))
+                    .fold(Self::AlwaysFalse, Self::or),
+            },
+            ast::Expr::Named(_)
             | ast::Expr::BinOp(_)
             | ast::Expr::UnaryOp(_)
             | ast::Expr::Lambda(_)
@@ -71,6 +82,26 @@ impl Truthiness {
             Self::AlwaysTrue => Self::AlwaysFalse,
             Self::AlwaysFalse => Self::AlwaysTrue,
             Self::Ambiguous => Self::Ambiguous,
+        }
+    }
+
+    const fn and(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::AlwaysFalse, _) | (_, Self::AlwaysFalse) => Self::AlwaysFalse,
+            (Self::AlwaysTrue, Self::AlwaysTrue) => Self::AlwaysTrue,
+            (Self::AlwaysTrue | Self::Ambiguous, Self::AlwaysTrue | Self::Ambiguous) => {
+                Self::Ambiguous
+            }
+        }
+    }
+
+    const fn or(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::AlwaysTrue, _) | (_, Self::AlwaysTrue) => Self::AlwaysTrue,
+            (Self::AlwaysFalse, Self::AlwaysFalse) => Self::AlwaysFalse,
+            (Self::AlwaysFalse | Self::Ambiguous, Self::AlwaysFalse | Self::Ambiguous) => {
+                Self::Ambiguous
+            }
         }
     }
 }

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -7627,6 +7627,109 @@ fn only_deterministic_if_assignments_dominate_namespace_wide_syntax_impact() {
 }
 
 #[test]
+fn boolean_short_circuit_preserves_decisive_bound_values() {
+    for (assignment, expected) in [
+        ("SELECT = False\nSELECT = SELECT and UNKNOWN", "fallback"),
+        ("SELECT = True\nSELECT = SELECT or UNKNOWN", "selected"),
+    ] {
+        let source = format!(
+            "{assignment}\nif SELECT:\n    INSTALLED_APPS = ['selected']\nelse:\n    INSTALLED_APPS = ['fallback']\n"
+        );
+        let settings = extract(&source).expect("Django settings extraction should succeed");
+        let setting_cases = cases(&settings, "/installed_apps/cases")
+            .expect("settings JSON pointer should identify an array");
+
+        assert_eq!(setting_cases.len(), 1, "{assignment}");
+        assert_eq!(setting_cases[0]["known"]["apps"][0]["value"], expected);
+    }
+}
+
+#[test]
+fn short_circuit_returns_the_decisive_operand_without_boolean_coercion() {
+    let (_file, evaluation) = evaluate_module_with(
+        &[("/project/helper.py", "")],
+        "import helper\nVALUE = helper or UNKNOWN\n",
+    )
+    .expect("multi-file Python evaluation fixture should build");
+
+    assert!(matches!(
+        bound_module(&evaluation, "VALUE"),
+        Some(PythonModuleView::Source(module)) if module.as_str() == "helper"
+    ));
+}
+
+#[test]
+fn unreachable_boolean_calls_do_not_contaminate_path_values() {
+    for statement in [
+        "IGNORED = False and mutate(pathlib.Path)",
+        "False and mutate(pathlib.Path)",
+        "if False and mutate(pathlib.Path):\n    pass",
+    ] {
+        let source = format!(
+            "import pathlib\n{statement}\nBASE = pathlib.Path(__file__).parent\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [BASE / 'templates']}}]\n"
+        );
+        let settings = extract(&source).expect("Django settings extraction should succeed");
+        let setting_cases = cases(&settings, "/templates/cases")
+            .expect("settings JSON pointer should identify an array");
+
+        assert_eq!(setting_cases.len(), 1, "{statement}");
+        assert_eq!(
+            setting_cases[0]["known"]["backends"][0]["dirs"][0]["value"],
+            "/project/settings/config/templates",
+            "{statement}"
+        );
+    }
+}
+
+#[test]
+fn reachable_boolean_calls_persist_path_intrinsic_contamination() {
+    for statement in [
+        "True and mutate(pathlib.Path)",
+        "if mutate(pathlib.Path) and False:\n    pass",
+    ] {
+        let source = format!(
+            "import pathlib\n{statement}\nimport pathlib as fresh_pathlib\nBASE = fresh_pathlib.Path(__file__).parent\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [BASE / 'templates']}}]\n"
+        );
+        let settings = extract(&source).expect("Django settings extraction should succeed");
+        let setting_cases = cases(&settings, "/templates/cases")
+            .expect("settings JSON pointer should identify an array");
+
+        assert_eq!(setting_cases.len(), 1, "{statement}");
+        assert!(setting_cases[0].get("dynamic").is_some(), "{statement}");
+    }
+}
+
+#[test]
+fn short_circuit_assignments_clear_unreachable_syntax_taint() {
+    let settings = extract_project(
+        "if FLAG:\n    from clean import *\n    broken(]\nSELECT = False\nSELECT = SELECT and UNKNOWN\nif SELECT:\n    INSTALLED_APPS = ['wrong']\nelse:\n    INSTALLED_APPS = ['selected']\n",
+        &[("clean", "")],
+    )
+    .expect("settings extraction project should build")
+    .2;
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(setting_cases.len(), 1);
+    assert_eq!(setting_cases[0]["known"]["apps"][0]["value"], "selected");
+}
+
+#[test]
+fn boolean_control_flow_honors_decisive_operands() {
+    for (condition, expected) in [("FLAG and False", "fallback"), ("FLAG or True", "selected")] {
+        let source = format!(
+            "if {condition}:\n    INSTALLED_APPS = ['selected']\nelse:\n    INSTALLED_APPS = ['fallback']\n"
+        );
+        let settings = extract(&source).expect("Django settings extraction should succeed");
+        let setting_cases = cases(&settings, "/installed_apps/cases")
+            .expect("settings JSON pointer should identify an array");
+
+        assert_eq!(setting_cases.len(), 1, "{condition}");
+        assert_eq!(setting_cases[0]["known"]["apps"][0]["value"], expected);
+    }
+}
+
+#[test]
 fn unrelated_later_syntax_error_preserves_all_exact_settings() {
     let settings = extract("INSTALLED_APPS = ['blog']\nTEMPLATES = []\ndef broken(\n")
         .expect("Django settings extraction should succeed");


### PR DESCRIPTION
## Summary

- preserve the decisive operand for statically known `and` and `or` expressions
- prune unreachable reads, calls, syntax taint, and mutation effects
- retain reachable condition and expression-statement side effects
- add evaluator and Django settings regressions for value, branch, and contamination behavior

## Verification

- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`
- `cargo build -q`
- `just hawk`