### PR TITLE
Evaluate nested dictionary assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed false tag argument errors for manually parsed tags that strip trailing assignment clauses, such as `{% now ... as var %}` and `{% url ... as var %}`.
 - Fixed static Django settings analysis hanging on projects with many conditional module effects.
 - Fixed static Python evaluation to honor short-circuiting `and` and `or` operands.
+- Fixed static settings analysis to preserve known template backend fields after nested dictionary assignments.
 
 ## [6.0.3]
 

--- a/crates/djls-project/src/python/evaluation/binding.rs
+++ b/crates/djls-project/src/python/evaluation/binding.rs
@@ -130,7 +130,8 @@ impl PythonBinding {
                 }
                 PythonBindingState::Unbound => None,
             })
-            .sum()
+            .max()
+            .unwrap_or(0)
     }
 
     pub(super) fn single_bound(&self) -> Option<&PythonBoundValue> {
@@ -157,6 +158,23 @@ impl PythonBinding {
             return None;
         };
         Some(bound)
+    }
+
+    pub(super) fn try_mutate_all_bound(
+        &mut self,
+        mut mutate: impl FnMut(&mut PythonValue) -> bool,
+    ) -> bool {
+        let mut candidate = self.clone();
+        for state in candidate.alternatives_mut() {
+            let PythonBindingState::Bound(bound) = state else {
+                return false;
+            };
+            if !mutate(&mut bound.value) {
+                return false;
+            }
+        }
+        *self = candidate;
+        true
     }
 
     pub(super) fn rebase_cycle_unknowns(&mut self, origin: Origin) {

--- a/crates/djls-project/src/python/evaluation/evaluator/statement.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/statement.rs
@@ -30,7 +30,7 @@ impl PythonModuleEvaluator<'_> {
                 if let Some(value) = &assign.value {
                     self.record_unsupported_call_effects(value);
                     let evaluated = self.evaluate_binding(value);
-                    self.assign_target(&assign.target, value, evaluated);
+                    self.assign_target(&assign.target, value, evaluated, self.origin(assign));
                 }
             }
             ast::Stmt::AugAssign(assign) => self.walk_aug_assign(assign),
@@ -258,8 +258,9 @@ impl PythonModuleEvaluator<'_> {
             }
             return;
         }
+        let assignment_origin = self.origin(assign);
         for target in &assign.targets {
-            self.assign_target(target, &assign.value, value.clone());
+            self.assign_target(target, &assign.value, value.clone(), assignment_origin);
         }
     }
 
@@ -312,7 +313,15 @@ impl PythonModuleEvaluator<'_> {
                 let mut stale_aliases = self
                     .state
                     .stale_alias_names_after_mutation(name, &PythonMutationPath::default());
-                let extended = list.extend_from(right, origin);
+                let embedded_sites = right.iterated_reachable_allocation_sites();
+                let recursive = self
+                    .state
+                    .sites_reach_mutation_target(&target, &embedded_sites);
+                let extended = if recursive {
+                    None
+                } else {
+                    list.extend_from(right, origin)
+                };
                 if extended.is_some() {
                     left.record_origin(origin);
                     // A successful in-place list `+=` updates the binding
@@ -406,18 +415,39 @@ impl PythonModuleEvaluator<'_> {
             .degrade_loop_effects(evaluated_bodies, self.origin_at(control_span));
     }
 
-    fn assign_target(&mut self, target: &ast::Expr, expression: &ast::Expr, value: PythonBinding) {
+    fn assign_target(
+        &mut self,
+        target: &ast::Expr,
+        expression: &ast::Expr,
+        value: PythonBinding,
+        assignment_origin: Origin,
+    ) {
+        let origin = self.origin(expression);
         if let Some(name) = target.name_target() {
-            let origin = self.origin(expression);
             if let Some(source_name) = expression.name_target() {
                 self.state
                     .assign_from_name(name, source_name, value, origin);
             } else {
                 self.state.assign_binding(name, value, origin);
             }
-        } else {
-            self.bind_unknown_targets(target, &PythonUnknownCause::UnsupportedExpression);
+            return;
         }
+
+        if let ast::Expr::Subscript(subscript) = target
+            && let Some(key) = subscript.slice.string_literal()
+            && let Some(receiver) = MutationTarget::from_expr(&subscript.value)
+        {
+            self.state.assign_string_key(
+                &receiver,
+                key,
+                self.origin(subscript.slice.as_ref()),
+                &value,
+                assignment_origin,
+            );
+            return;
+        }
+
+        self.bind_unknown_targets(target, &PythonUnknownCause::UnsupportedExpression);
     }
 
     fn bind_unknown_targets(&mut self, target: &ast::Expr, cause: &PythonUnknownCause) {

--- a/crates/djls-project/src/python/evaluation/mapping.rs
+++ b/crates/djls-project/src/python/evaluation/mapping.rs
@@ -11,7 +11,6 @@ use super::PythonValueKind;
 use super::ReachableAllocationSites;
 use super::StructuralOrd;
 use super::allocation::AllocationSites;
-use crate::python::PythonPath;
 
 /// A concrete Python `dict` value stored as an ordered write/unpack log rather
 /// than a flattened map: unknown unpacks and later exact entries affect lookup
@@ -115,16 +114,15 @@ impl PythonDict {
                         selected = Some(&mut entry.value);
                         break;
                     }
+                    PythonValueKind::Unknown(_) => return false,
                     PythonValueKind::Str(_)
-                    | PythonValueKind::Path(PythonPath::Intrinsic(_))
-                    | PythonValueKind::UnsupportedLiteral => {}
-                    PythonValueKind::Unknown(_)
                     | PythonValueKind::Bool(_)
-                    | PythonValueKind::Path(PythonPath::Object(_))
+                    | PythonValueKind::Path(_)
+                    | PythonValueKind::UnsupportedLiteral
                     | PythonValueKind::List(_)
                     | PythonValueKind::Tuple(_)
                     | PythonValueKind::Module(_)
-                    | PythonValueKind::Dict(_) => return false,
+                    | PythonValueKind::Dict(_) => {}
                 },
                 DictItem::UnknownUnpack(_) => return false,
             }
@@ -297,8 +295,8 @@ impl<'a> PythonMapping<'a> {
 
     /// The values that a write to `wanted` might target, conservatively: the
     /// latest exact string-key value (after which no earlier write can be the
-    /// target) plus every earlier value whose non-string key could equal
-    /// `wanted` at runtime. Yielded latest-write first, matching traversal.
+    /// target) plus every earlier value whose unknown key could equal `wanted`
+    /// at runtime. Yielded latest-write first, matching traversal.
     pub(crate) fn possible_string_values(self, wanted: &str) -> Vec<&'a PythonValue> {
         let mut values = Vec::new();
         for item in self.dict.items.iter().rev() {
@@ -310,16 +308,15 @@ impl<'a> PythonMapping<'a> {
                     values.push(&entry.value);
                     return values;
                 }
+                PythonValueKind::Unknown(_) => values.push(&entry.value),
                 PythonValueKind::Str(_)
-                | PythonValueKind::Path(PythonPath::Intrinsic(_))
-                | PythonValueKind::UnsupportedLiteral => {}
-                PythonValueKind::Unknown(_)
                 | PythonValueKind::Bool(_)
-                | PythonValueKind::Path(PythonPath::Object(_))
+                | PythonValueKind::Path(_)
+                | PythonValueKind::UnsupportedLiteral
                 | PythonValueKind::List(_)
                 | PythonValueKind::Tuple(_)
                 | PythonValueKind::Module(_)
-                | PythonValueKind::Dict(_) => values.push(&entry.value),
+                | PythonValueKind::Dict(_) => {}
             }
         }
         values
@@ -691,10 +688,11 @@ mod tests {
     }
 
     #[test]
-    fn path_intrinsic_keys_do_not_block_exact_string_key_mutation() {
+    fn known_non_string_keys_do_not_block_exact_string_key_mutation() {
         let mut dict = dict_with(vec![
             (str_value("target", 1), str_value("before", 2)),
             (path_intrinsic(3), str_value("intrinsic", 4)),
+            (PythonValue::bool(true, origin(5)), str_value("boolean", 6)),
         ]);
 
         let possible = dict.mapping().possible_string_values("target");

--- a/crates/djls-project/src/python/evaluation/mutation.rs
+++ b/crates/djls-project/src/python/evaluation/mutation.rs
@@ -3,6 +3,8 @@ use std::cmp::Ordering;
 use djls_source::Origin;
 use ruff_python_ast as ast;
 
+use super::PythonBinding;
+use super::PythonBindingState;
 use super::PythonSequenceItem;
 use super::PythonUnknownCause;
 use super::PythonValue;
@@ -105,6 +107,11 @@ enum EvaluatedMutation<'a> {
         value: &'a PythonValue,
     },
     Remove(&'a str),
+    SetKey {
+        key: &'a str,
+        key_origin: Origin,
+        value: &'a PythonValue,
+    },
 }
 
 impl StructuralOrd for PythonMutationPath {
@@ -266,16 +273,49 @@ impl PythonMutationPath {
 }
 
 impl EvaluatedMutation<'_> {
-    fn apply(&self, value: &mut PythonValue, origin: Origin) -> bool {
-        let PythonValueKind::List(list) = &mut value.kind else {
-            return false;
-        };
+    fn embedded_sites(&self) -> Option<ReachableAllocationSites> {
         match self {
-            Self::Append(argument) => list.append_value((*argument).clone()),
+            Self::Append(value) | Self::Insert { value, .. } | Self::SetKey { value, .. } => {
+                Some(value.reachable_allocation_sites())
+            }
+            Self::Extend(value) => Some(value.iterated_reachable_allocation_sites()),
+            Self::Remove(_) => None,
+        }
+    }
+
+    fn apply(&self, value: &mut PythonValue, origin: Origin) -> bool {
+        match self {
+            Self::SetKey {
+                key,
+                key_origin,
+                value: assigned,
+            } => {
+                let PythonValueKind::Dict(dictionary) = &mut value.kind else {
+                    return false;
+                };
+                dictionary.append_entry(
+                    PythonValue::string((*key).to_string(), *key_origin),
+                    (*assigned).clone(),
+                );
+                true
+            }
+            Self::Append(argument) => {
+                let PythonValueKind::List(list) = &mut value.kind else {
+                    return false;
+                };
+                list.append_value((*argument).clone());
+                true
+            }
             Self::Extend(extension) => {
-                return list.extend_from(extension, origin).is_some();
+                let PythonValueKind::List(list) = &mut value.kind else {
+                    return false;
+                };
+                list.extend_from(extension, origin).is_some()
             }
             Self::Insert { index, value: item } => {
+                let PythonValueKind::List(list) = &mut value.kind else {
+                    return false;
+                };
                 if !list.is_authoritative() {
                     return false;
                 }
@@ -291,15 +331,15 @@ impl EvaluatedMutation<'_> {
                     }
                 };
                 list.insert_value(index, (*item).clone());
+                true
             }
             Self::Remove(needle) => {
-                if !list.is_authoritative() {
+                let PythonValueKind::List(list) = &mut value.kind else {
                     return false;
-                }
-                return list.remove_str(needle);
+                };
+                list.is_authoritative() && list.remove_str(needle)
             }
         }
-        true
     }
 }
 
@@ -329,6 +369,44 @@ impl<'a> MutationTarget<'a> {
 }
 
 impl PythonEvaluationState {
+    pub(super) fn assign_string_key(
+        &mut self,
+        target: &MutationTarget<'_>,
+        key: &str,
+        key_origin: Origin,
+        value: &PythonBinding,
+        origin: Origin,
+    ) {
+        let mut stale_aliases = self.stale_alias_names_after_mutation(target.binding, &target.path);
+        let applied = value.single_bound().is_some_and(|assigned| {
+            self.try_apply_mutation(
+                target,
+                &EvaluatedMutation::SetKey {
+                    key,
+                    key_origin,
+                    value: &assigned.value,
+                },
+                origin,
+            )
+        });
+        if applied {
+            self.invalidate_names(
+                stale_aliases,
+                &PythonUnknownCause::UnsupportedExpression,
+                origin,
+            );
+        } else {
+            if !stale_aliases.iter().any(|name| name == target.binding) {
+                stale_aliases.push(target.binding.to_string());
+            }
+            self.degrade_names(
+                stale_aliases,
+                &PythonUnknownCause::UnsupportedMutation,
+                origin,
+            );
+        }
+    }
+
     pub(super) fn apply_augmented_add(
         &mut self,
         target: MutationTarget<'_>,
@@ -359,21 +437,44 @@ impl PythonEvaluationState {
         self.mutations.insert(fact);
     }
 
+    pub(super) fn sites_reach_mutation_target(
+        &self,
+        target: &MutationTarget<'_>,
+        sites: &ReachableAllocationSites,
+    ) -> bool {
+        let receiver_sites = self
+            .bindings
+            .get(target.binding)
+            .map(|binding| {
+                let mut sites = ReachableAllocationSites::default();
+                for alternative in binding.alternatives() {
+                    let PythonBindingState::Bound(bound) = alternative else {
+                        continue;
+                    };
+                    sites.absorb(target.path.possible_target_allocation_sites(&bound.value));
+                }
+                sites
+            })
+            .unwrap_or_default();
+        receiver_sites.intersects(sites)
+    }
+
     fn try_apply_mutation(
         &mut self,
         target: &MutationTarget<'_>,
         mutation: &EvaluatedMutation<'_>,
         origin: Origin,
     ) -> bool {
+        if mutation
+            .embedded_sites()
+            .is_some_and(|sites| self.sites_reach_mutation_target(target, &sites))
+        {
+            return false;
+        }
         let Some(binding) = self.bindings.get_mut(target.binding) else {
             return false;
         };
-        let Some(bound) = binding.single_bound_mut() else {
-            return false;
-        };
-        target
-            .path
-            .try_apply_exact(&mut bound.value, mutation, origin)
+        binding.try_mutate_all_bound(|value| target.path.try_apply_exact(value, mutation, origin))
     }
 }
 

--- a/crates/djls-project/src/python/evaluation/value.rs
+++ b/crates/djls-project/src/python/evaluation/value.rs
@@ -8,6 +8,7 @@ use djls_source::FileReadError;
 use djls_source::Origin;
 
 use super::BranchConstraints;
+use super::MappingLogItem;
 use super::OriginSet;
 use super::PythonDict;
 use super::PythonList;
@@ -424,6 +425,40 @@ impl PythonValue {
     pub(super) fn reachable_allocation_sites(&self) -> ReachableAllocationSites {
         let mut sites = ReachableAllocationSites::default();
         self.collect_reachable_sites(&mut sites);
+        sites
+    }
+
+    pub(super) fn iterated_reachable_allocation_sites(&self) -> ReachableAllocationSites {
+        let mut sites = ReachableAllocationSites::default();
+        match &self.kind {
+            PythonValueKind::List(list) => {
+                for item in list.semantic_items() {
+                    if let PythonSequenceItem::Value(value) = item {
+                        value.collect_reachable_sites(&mut sites);
+                    }
+                }
+            }
+            PythonValueKind::Tuple(tuple) => {
+                for item in tuple.semantic_items() {
+                    if let PythonSequenceItem::Value(value) = item {
+                        value.collect_reachable_sites(&mut sites);
+                    }
+                }
+            }
+            PythonValueKind::Dict(dict) => {
+                for item in dict.mapping().projection() {
+                    if let MappingLogItem::Entry { key, .. } = item {
+                        key.collect_reachable_sites(&mut sites);
+                    }
+                }
+            }
+            PythonValueKind::Module(_)
+            | PythonValueKind::Unknown(_)
+            | PythonValueKind::Str(_)
+            | PythonValueKind::Bool(_)
+            | PythonValueKind::Path(_)
+            | PythonValueKind::UnsupportedLiteral => {}
+        }
         sites
     }
 

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -9148,6 +9148,113 @@ TEMPLATES[0]['DIRS'].remove('/removed')",
 }
 
 #[test]
+fn imported_template_nested_mutation_preserves_known_backend_fields() {
+    let settings = extract_project(
+        "from base import *\nif FLAG:\n    TEMPLATES[0]['OPTIONS']['loaders'] = ('loader',)\nTEMPLATES[0]['DIRS'].insert(0, dynamic_path())\n",
+        &[(
+            "base",
+            "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/base'], 'OPTIONS': {'context_processors': ['app.context.processor']}}]\n",
+        )],
+    )
+    .expect("settings extraction project should build")
+    .2;
+    let template_case = &cases(&settings, "/templates/cases")
+        .expect("settings JSON pointer should identify an array")[0];
+    let backend = &template_case["dynamic"]["evidence"][0]["backend"];
+
+    assert_eq!(
+        backend["backend"]["known"]["value"], "django.template.backends.django.DjangoTemplates",
+        "{settings:#}"
+    );
+    assert_eq!(
+        backend["context_processors"]["known"][0]["value"],
+        "app.context.processor"
+    );
+    assert!(backend["dirs"].to_string().contains("dynamic_expression"));
+    assert!(backend["dirs"].to_string().contains("/base"));
+}
+
+#[test]
+fn nested_dictionary_assignment_invalidates_stale_aliases_only() {
+    let source = "OPTIONS = {}\nALIAS = OPTIONS\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'OPTIONS': OPTIONS}]\nTEMPLATES[0]['OPTIONS']['loaders'] = ('loader',)\n";
+    let (_file, evaluation) =
+        evaluate_module(source).expect("Python module evaluation fixture should build");
+    assert!(has_unknown_alternative(&evaluation, "OPTIONS"));
+    assert!(has_unknown_alternative(&evaluation, "ALIAS"));
+
+    let settings = extract(source).expect("Django settings extraction should succeed");
+    let template_case = &cases(&settings, "/templates/cases")
+        .expect("settings JSON pointer should identify an array")[0];
+    assert_eq!(
+        template_case["known"]["backends"][0]["backend"]["value"],
+        "django.template.backends.django.DjangoTemplates"
+    );
+}
+
+#[test]
+fn rejected_nested_dictionary_assignment_invalidates_possible_aliases() {
+    for source in [
+        "OPTIONS = {}\nALIAS = OPTIONS\nWRAPPER = {'OPTIONS': OPTIONS, **UNKNOWN}\nWRAPPER['OPTIONS']['loaders'] = ('loader',)\n",
+        "OPTIONS = {}\nALIAS = OPTIONS\nif FLAG:\n    LOADERS = []\nelse:\n    LOADERS = ['cached']\nOPTIONS['loaders'] = LOADERS\n",
+        "LEFT = {}\nRIGHT = {}\nALIAS = LEFT\nif FLAG:\n    ROOT = LEFT\nelse:\n    ROOT = RIGHT\nROOT['loaders'] = []\n",
+    ] {
+        let (_file, evaluation) =
+            evaluate_module(source).expect("Python module evaluation fixture should build");
+
+        assert!(has_unknown_alternative(&evaluation, "ALIAS"), "{source}");
+    }
+}
+
+#[test]
+fn recursive_mutations_degrade_unrepresentable_values() {
+    for (source, names) in [
+        ("ROOT = {}\nROOT['self'] = ROOT\n", &["ROOT"][..]),
+        (
+            "CHILD = {}\nROOT = {'child': CHILD}\nROOT['child']['parent'] = ROOT\n",
+            &["CHILD", "ROOT"],
+        ),
+        (
+            "ROOT = {'child': []}\nROOT['child'].append(ROOT)\n",
+            &["ROOT"],
+        ),
+        (
+            "ROOT = {'child': []}\nROOT['child'].insert(0, ROOT)\n",
+            &["ROOT"],
+        ),
+        (
+            "ROOT = {'child': []}\nROOT['child'].extend([ROOT])\n",
+            &["ROOT"],
+        ),
+        ("ROOT = []\nROOT += [ROOT]\n", &["ROOT"]),
+    ] {
+        let (_file, evaluation) =
+            evaluate_module(source).expect("Python module evaluation fixture should build");
+
+        for name in names {
+            assert!(
+                has_unknown_alternative(&evaluation, name),
+                "{source}: {name}"
+            );
+        }
+    }
+}
+
+#[test]
+fn self_extension_duplicates_elements_without_creating_recursion() {
+    for operation in ["VALUES.extend(VALUES)", "VALUES += VALUES"] {
+        let source = format!("VALUES = ['app']\n{operation}\nINSTALLED_APPS = VALUES\n");
+        let settings = extract(&source).expect("Django settings extraction should succeed");
+        let apps = cases(&settings, "/installed_apps/cases")
+            .expect("settings JSON pointer should identify an array")[0]["known"]["apps"]
+            .as_array()
+            .expect("expected JSON field should be an array");
+
+        assert_eq!(apps.len(), 2, "{operation}: {settings:#}");
+        assert!(apps.iter().all(|app| app["value"] == "app"));
+    }
+}
+
+#[test]
 fn nested_template_dirs_mutation_updates_all_correlated_equal_lists() {
     let settings = extract(
         "if FLAG:\n    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/a']}]\nelse:\n    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/a']}]\nTEMPLATES[0]['DIRS'].append('/b')",


### PR DESCRIPTION
## Summary

- apply exact string-key assignments through nested mutable paths
- preserve known settings fields while invalidating stale aliases
- degrade ambiguous and recursive mutations instead of retaining false exact values
- keep valid list self-extension precise
- add cross-module settings, alias, ambiguity, and cycle regressions

## Verification

- `cargo test -q`
- `cargo test -q -p djls-project --test settings_extraction`
- `just clippy`
- `just fmt --check`
- `just lint`
- `cargo build -q`
- `just hawk`