### PR TITLE
Fix Python predicate correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed false tag argument errors for manually parsed tags that strip trailing assignment clauses, such as `{% now ... as var %}` and `{% url ... as var %}`.
 - Fixed static Django settings analysis hanging on projects with many conditional module effects.
 - Fixed static Python evaluation to honor short-circuiting `and` and `or` operands.
+- Fixed static settings analysis to exclude impossible combinations from repeated and derived configuration predicates.
 - Fixed static settings analysis to preserve known template backend fields after nested dictionary assignments.
 
 ## [6.0.3]

--- a/crates/djls-project/src/python/evaluation.rs
+++ b/crates/djls-project/src/python/evaluation.rs
@@ -27,6 +27,7 @@ pub(crate) use self::binding::PythonBindingState;
 pub(crate) use self::binding::PythonBoundValue;
 pub(crate) use self::constraints::BranchConstraints;
 use self::constraints::BranchJoin;
+use self::constraints::PredicateIdentity;
 pub(crate) use self::mapping::MappingEntryEvidence;
 pub(crate) use self::mapping::MappingLogItem;
 pub(crate) use self::mapping::MappingOverride;

--- a/crates/djls-project/src/python/evaluation/binding.rs
+++ b/crates/djls-project/src/python/evaluation/binding.rs
@@ -7,17 +7,20 @@ use super::BranchConstraints;
 use super::BranchJoin;
 use super::MAX_EXACT_PYTHON_ALTERNATIVES;
 use super::OriginSet;
+use super::PredicateIdentity;
 use super::PythonUnknownCause;
 use super::PythonValue;
 use super::PythonValueKind;
 use super::ReachableAllocationSites;
 use super::StructuralOrd;
 use crate::python::PythonModule;
+use crate::python::PythonSourceModule;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BindingCase {
     state: PythonBindingState,
     constraints: BranchConstraints,
+    predicate_identity: Option<PredicateIdentity>,
 }
 
 /// Feasible bound and unbound states for one Python name.
@@ -37,6 +40,7 @@ impl PythonBinding {
                 binding_origins: [binding_origin].into_iter().collect(),
             }),
             constraints: BranchConstraints::unconstrained(),
+            predicate_identity: None,
         })
     }
 
@@ -49,7 +53,9 @@ impl PythonBinding {
     }
 
     pub(super) fn unknown(cause: &PythonUnknownCause, origin: Origin) -> Self {
-        Self::bound(PythonValue::unknown(cause.clone(), Some(origin)), origin)
+        let mut binding = Self::bound(PythonValue::unknown(cause.clone(), Some(origin)), origin);
+        binding.cases[0].predicate_identity = Some(PredicateIdentity::new(origin));
+        binding
     }
 
     pub(super) fn constrained_unknown(
@@ -57,17 +63,14 @@ impl PythonBinding {
         origin: Origin,
         constraints: &BranchConstraints,
     ) -> Option<Self> {
-        Self::constrained_bound(
-            PythonValue::unknown(cause.clone(), Some(origin)),
-            origin,
-            constraints,
-        )
+        Self::unknown(cause, origin).intersect_constraints(constraints)
     }
 
     pub(super) fn unbound() -> Self {
         Self::from_case(BindingCase {
             state: PythonBindingState::Unbound,
             constraints: BranchConstraints::unconstrained(),
+            predicate_identity: None,
         })
     }
 
@@ -78,6 +81,7 @@ impl PythonBinding {
                 binding_origins: OriginSet::default(),
             }),
             constraints: BranchConstraints::unconstrained(),
+            predicate_identity: None,
         })
     }
 
@@ -97,6 +101,87 @@ impl PythonBinding {
         self.cases
             .iter()
             .map(|case| (&case.state, &case.constraints))
+    }
+
+    pub(super) fn alternatives_with_predicates(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &PythonBindingState,
+            &BranchConstraints,
+            Option<&PredicateIdentity>,
+        ),
+    > {
+        self.cases.iter().map(|case| {
+            (
+                &case.state,
+                &case.constraints,
+                case.predicate_identity.as_ref(),
+            )
+        })
+    }
+
+    pub(super) fn discriminate_predicates(
+        &mut self,
+        name: &str,
+        origin: Origin,
+        module: Option<&PythonSourceModule>,
+    ) {
+        for case in &mut self.cases {
+            let needs_identity = matches!(
+                &case.state,
+                PythonBindingState::Bound(bound)
+                    if matches!(
+                        &bound.value.kind,
+                        PythonValueKind::UnsupportedLiteral | PythonValueKind::Unknown(_)
+                    )
+            );
+            if needs_identity {
+                let identity = case
+                    .predicate_identity
+                    .get_or_insert_with(|| PredicateIdentity::new(origin));
+                identity.discriminate(name, module);
+            }
+        }
+    }
+
+    pub(super) fn force_predicate_identity(
+        &mut self,
+        name: &str,
+        origin: Origin,
+        module: Option<&PythonSourceModule>,
+    ) {
+        for case in &mut self.cases {
+            let needs_identity = matches!(
+                &case.state,
+                PythonBindingState::Bound(bound)
+                    if matches!(
+                        &bound.value.kind,
+                        PythonValueKind::UnsupportedLiteral | PythonValueKind::Unknown(_)
+                    )
+            );
+            if needs_identity {
+                let mut identity = PredicateIdentity::new(origin);
+                identity.discriminate(name, module);
+                case.predicate_identity = Some(identity);
+            }
+        }
+        self.normalize(None);
+    }
+
+    pub(super) fn replace_predicate_identities(
+        &mut self,
+        name: &str,
+        origin: Origin,
+        module: Option<&PythonSourceModule>,
+    ) {
+        for case in &mut self.cases {
+            if case.predicate_identity.is_some() {
+                let mut identity = PredicateIdentity::new(origin);
+                identity.discriminate(name, module);
+                case.predicate_identity = Some(identity);
+            }
+        }
     }
 
     fn alternatives_mut(&mut self) -> impl Iterator<Item = &mut PythonBindingState> {
@@ -134,6 +219,7 @@ impl PythonBinding {
             .unwrap_or(0)
     }
 
+    #[cfg(test)]
     pub(super) fn single_bound(&self) -> Option<&PythonBoundValue> {
         let [
             BindingCase {
@@ -145,6 +231,22 @@ impl PythonBinding {
             return None;
         };
         Some(bound)
+    }
+
+    pub(super) fn merged_semantic_value(&self) -> Option<PythonValue> {
+        let mut values = self.alternatives().map(|state| {
+            let PythonBindingState::Bound(bound) = state else {
+                return None;
+            };
+            Some(bound.value.clone())
+        });
+        let mut merged = values.next()??;
+        for incoming in values {
+            if !merged.merge_semantically_equal(incoming?, None) {
+                return None;
+            }
+        }
+        Some(merged)
     }
 
     pub(super) fn single_bound_mut(&mut self) -> Option<&mut PythonBoundValue> {
@@ -498,7 +600,8 @@ impl PythonBinding {
                         .value
                         .constrain_value_evidence(&incoming_case.constraints);
                     if let Some(existing_case) = normalized.iter_mut().find(|candidate| {
-                        matches!(&candidate.state, PythonBindingState::Bound(bound) if bound.value.same_semantic_value(&incoming.value))
+                        candidate.predicate_identity == incoming_case.predicate_identity
+                            && matches!(&candidate.state, PythonBindingState::Bound(bound) if bound.value.same_semantic_value(&incoming.value))
                     }) {
                         match &mut existing_case.state {
                             PythonBindingState::Bound(existing) => {
@@ -535,6 +638,7 @@ impl BindingCase {
             // The remainder represents alternatives discarded from potentially different
             // arms, so leaving it unconstrained is conservative and preserves the cap.
             constraints: BranchConstraints::unconstrained(),
+            predicate_identity: None,
         }
     }
 
@@ -551,10 +655,19 @@ impl BindingCase {
 
 impl StructuralOrd for BindingCase {
     /// Unbound precedes Bound so cap retention remains stable. Bound cases then
-    /// compare complete value evidence, binding provenance, and constraints.
+    /// compare complete value evidence, predicate identity, binding provenance,
+    /// and constraints.
     fn structural_cmp(&self, other: &Self) -> Ordering {
         self.state
             .structural_cmp(&other.state)
+            .then_with(
+                || match (&self.predicate_identity, &other.predicate_identity) {
+                    (None, None) => Ordering::Equal,
+                    (None, Some(_)) => Ordering::Less,
+                    (Some(_), None) => Ordering::Greater,
+                    (Some(left), Some(right)) => left.structural_cmp(right),
+                },
+            )
             .then_with(|| self.constraints.structural_cmp(&other.constraints))
     }
 }
@@ -749,6 +862,26 @@ mod tests {
     }
 
     #[test]
+    fn constrained_unknowns_retain_predicate_identity() {
+        let constraints = BranchConstraints::unconstrained();
+        let mut first = PythonBinding::constrained_unknown(
+            &PythonUnknownCause::UnsupportedExpression,
+            origin(0, 1),
+            &constraints,
+        )
+        .expect("selected constraints should be feasible");
+        let mut second = first.clone();
+        first.discriminate_predicates("FIRST", origin(0, 1), None);
+        second.discriminate_predicates("SECOND", origin(0, 1), None);
+
+        assert!(first.cases[0].predicate_identity.is_some());
+        assert_ne!(
+            first.cases[0].predicate_identity,
+            second.cases[0].predicate_identity
+        );
+    }
+
+    #[test]
     fn infeasible_unbound_replacement_stays_conservatively_unbound() {
         let join = origin(0, 100);
         let mut imported_constraints = BranchConstraints::unconstrained();
@@ -757,6 +890,7 @@ mod tests {
             cases: vec![BindingCase {
                 state: PythonBindingState::Unbound,
                 constraints: imported_constraints.clone(),
+                predicate_identity: None,
             }],
         };
         let mut prior_constraints = BranchConstraints::unconstrained();
@@ -904,6 +1038,7 @@ mod tests {
                 binding_origins: [origin(0, 10)].into_iter().collect(),
             }),
             constraints: first_constraints,
+            predicate_identity: None,
         };
         let second = BindingCase {
             state: PythonBindingState::Bound(PythonBoundValue {
@@ -911,10 +1046,12 @@ mod tests {
                 binding_origins: [origin(0, 20)].into_iter().collect(),
             }),
             constraints: second_constraints,
+            predicate_identity: None,
         };
         let unbound = BindingCase {
             state: PythonBindingState::Unbound,
             constraints: BranchConstraints::unconstrained(),
+            predicate_identity: None,
         };
         assert_eq!(unbound.structural_cmp(&first), Ordering::Less);
         assert_ne!(first, second);

--- a/crates/djls-project/src/python/evaluation/constraints.rs
+++ b/crates/djls-project/src/python/evaluation/constraints.rs
@@ -5,13 +5,77 @@ use djls_source::Origin;
 use super::StructuralOrd;
 use crate::python::PythonSourceModule;
 
-/// One finite control-flow join. The module identity and source origin name
-/// one execution coordinate; `arm_count` records its complete modeled domain.
+// Four correlated predicates cover common settings aliases and binary boolean
+// expressions without rebuilding the path explosion this domain replaced.
+// Overflow existentially forgets later predicates: it may add false-positive
+// worlds, but it never removes a feasible runtime world.
+const MAX_TRACKED_PREDICATES: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum BranchJoinKind {
+    Control,
+    BindingChoice,
+    Predicate,
+}
+
+/// One stable symbolic truth input in the module-level abstract interpreter.
+///
+/// Unknown values keep one truth decision until a modeled rebind or mutation
+/// replaces it. Stateful user-defined `__bool__` methods lie outside this
+/// evaluator's static settings subset and remain covered by unsupported-call
+/// and mutation evidence rather than repeated truth transitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PredicateIdentity {
+    module: Option<PythonSourceModule>,
+    origin: Origin,
+    discriminator: Option<String>,
+}
+
+impl PredicateIdentity {
+    pub(super) fn new(origin: Origin) -> Self {
+        Self {
+            module: None,
+            origin,
+            discriminator: None,
+        }
+    }
+
+    pub(super) fn discriminate(&mut self, name: &str, module: Option<&PythonSourceModule>) {
+        if self.module.is_none() {
+            self.module = module.cloned();
+        }
+        if self.discriminator.is_none() {
+            self.discriminator = Some(name.to_string());
+        }
+    }
+
+    pub(super) fn origin(&self) -> Origin {
+        self.origin
+    }
+}
+
+impl StructuralOrd for PredicateIdentity {
+    fn structural_cmp(&self, other: &Self) -> Ordering {
+        match (&self.module, &other.module) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(left), Some(right)) => left.structural_cmp(right),
+        }
+        .then_with(|| self.origin.structural_cmp(&other.origin))
+        .then_with(|| self.discriminator.cmp(&other.discriminator))
+    }
+}
+
+/// One finite decision join. The module identity, source origin, and kind name
+/// one coordinate; `arm_count` records its complete modeled domain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct BranchJoin {
     module: PythonSourceModule,
     origin: Origin,
     arm_count: usize,
+    kind: BranchJoinKind,
+    predicate_discriminator: Option<String>,
 }
 
 impl BranchJoin {
@@ -21,6 +85,28 @@ impl BranchJoin {
             module,
             origin,
             arm_count,
+            kind: BranchJoinKind::Control,
+            predicate_discriminator: None,
+        }
+    }
+
+    pub(super) fn binding_choice(module: PythonSourceModule, origin: Origin, name: &str) -> Self {
+        Self {
+            module,
+            origin,
+            arm_count: 2,
+            kind: BranchJoinKind::BindingChoice,
+            predicate_discriminator: Some(name.to_string()),
+        }
+    }
+
+    pub(super) fn predicate(module: PythonSourceModule, identity: &PredicateIdentity) -> Self {
+        Self {
+            module: identity.module.clone().unwrap_or(module),
+            origin: identity.origin,
+            arm_count: 2,
+            kind: BranchJoinKind::Predicate,
+            predicate_discriminator: identity.discriminator.clone(),
         }
     }
 
@@ -29,9 +115,14 @@ impl BranchJoin {
     }
 
     fn identity_cmp(&self, other: &Self) -> Ordering {
-        self.module
-            .structural_cmp(&other.module)
+        self.kind
+            .cmp(&other.kind)
+            .then_with(|| self.module.structural_cmp(&other.module))
             .then_with(|| self.origin.structural_cmp(&other.origin))
+            .then_with(|| {
+                self.predicate_discriminator
+                    .cmp(&other.predicate_discriminator)
+            })
     }
 
     fn assert_same_domain(&self, other: &Self) {
@@ -39,6 +130,13 @@ impl BranchJoin {
             self.arm_count, other.arm_count,
             "one branch join coordinate cannot have two arm domains"
         );
+    }
+
+    #[cfg(test)]
+    fn predicate_for_test(origin: Origin) -> Self {
+        let mut join = Self::for_test(origin, 2);
+        join.kind = BranchJoinKind::Predicate;
+        join
     }
 
     #[cfg(test)]
@@ -70,9 +168,7 @@ impl From<Origin> for BranchJoin {
 
 impl StructuralOrd for BranchJoin {
     fn structural_cmp(&self, other: &Self) -> Ordering {
-        self.module
-            .structural_cmp(&other.module)
-            .then_with(|| self.origin.structural_cmp(&other.origin))
+        self.identity_cmp(other)
             .then_with(|| self.arm_count.cmp(&other.arm_count))
     }
 }
@@ -138,9 +234,23 @@ impl ConstraintNode {
         other.collect_joins(&mut joins);
     }
 
+    fn widen_predicates(self) -> Self {
+        let mut joins = Vec::new();
+        self.collect_joins(&mut joins);
+        let mut predicates = joins
+            .into_iter()
+            .filter(|join| join.kind == BranchJoinKind::Predicate)
+            .collect::<Vec<_>>();
+        predicates.sort_by(BranchJoin::structural_cmp);
+        predicates
+            .iter()
+            .skip(MAX_TRACKED_PREDICATES)
+            .fold(self, |constraints, join| constraints.forget(join))
+    }
+
     fn union(&self, other: &Self) -> Self {
         self.assert_compatible_domains(other);
-        self.union_canonical(other)
+        self.union_canonical(other).widen_predicates()
     }
 
     fn union_canonical(&self, other: &Self) -> Self {
@@ -192,7 +302,7 @@ impl ConstraintNode {
 
     fn intersection(&self, other: &Self) -> Self {
         self.assert_compatible_domains(other);
-        self.intersection_canonical(other)
+        self.intersection_canonical(other).widen_predicates()
     }
 
     fn intersection_canonical(&self, other: &Self) -> Self {
@@ -317,6 +427,21 @@ impl BranchConstraints {
             .intersection(&ConstraintNode::selected(join, arm));
     }
 
+    /// Require one arm without forgetting an earlier requirement for the same
+    /// coordinate. Repeated predicate assumptions must conflict rather than
+    /// replace one another as repeated control-flow executions do.
+    pub(super) fn required(join: BranchJoin, arm: usize) -> Self {
+        Self {
+            root: Box::new(ConstraintNode::selected(join, arm)),
+        }
+    }
+
+    pub(super) fn impossible() -> Self {
+        Self {
+            root: Box::new(ConstraintNode::Impossible),
+        }
+    }
+
     pub(crate) fn merge(&mut self, other: Self) {
         let Self { root } = other;
         *self.root = self.root.union(&root);
@@ -355,6 +480,7 @@ mod tests {
     use super::BranchConstraints;
     use super::BranchJoin;
     use super::ConstraintNode;
+    use super::MAX_TRACKED_PREDICATES;
     use super::Origin;
     use super::PythonSourceModule;
     use super::StructuralOrd;
@@ -392,6 +518,52 @@ mod tests {
         BranchConstraints {
             root: Box::new(ConstraintNode::Impossible),
         }
+    }
+
+    #[test]
+    fn control_and_predicate_joins_at_one_origin_do_not_collide() {
+        let shared_origin = origin(0, 1);
+        let control = BranchJoin::for_test(shared_origin, 3);
+        let predicate = BranchJoin::predicate_for_test(shared_origin);
+        let constraints = BranchConstraints::required(control, 2)
+            .intersection(&BranchConstraints::required(predicate, 1));
+
+        assert!(!constraints.is_impossible());
+    }
+
+    #[test]
+    fn predicate_overflow_forgets_later_decisions() {
+        let joins = (1_u32..)
+            .take(MAX_TRACKED_PREDICATES + 1)
+            .map(|start| BranchJoin::predicate_for_test(origin(0, start)))
+            .collect::<Vec<_>>();
+        let constraints =
+            joins
+                .iter()
+                .fold(BranchConstraints::unconstrained(), |constraints, join| {
+                    constraints.intersection(&BranchConstraints::required(join.clone(), 1))
+                });
+
+        assert!(
+            !constraints.compatible_with(&BranchConstraints::required(joins[0].clone(), 0)),
+            "the earliest tracked predicate should remain required"
+        );
+        assert!(
+            constraints.compatible_with(&BranchConstraints::required(
+                joins[MAX_TRACKED_PREDICATES].clone(),
+                0,
+            )),
+            "overflow should conservatively forget the latest predicate"
+        );
+    }
+
+    #[test]
+    fn required_arms_for_one_join_conflict() {
+        let coordinate = BranchJoin::for_test(origin(0, 1), 2);
+        let falsy = BranchConstraints::required(coordinate.clone(), 0);
+        let truthy = BranchConstraints::required(coordinate, 1);
+
+        assert!(falsy.intersection(&truthy).is_impossible());
     }
 
     #[test]

--- a/crates/djls-project/src/python/evaluation/evaluator.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator.rs
@@ -13,6 +13,7 @@ use ruff_python_ast as ast;
 use super::BranchConstraints;
 use super::BranchJoin;
 use super::ChildImportFallback;
+use super::PredicateIdentity;
 use super::PythonBinding;
 use super::PythonBindingState;
 use super::PythonImportOutcome;
@@ -44,6 +45,17 @@ use crate::python::PythonPathIntrinsic;
 use crate::python::PythonSourceModule;
 use crate::python::PythonSyntaxError;
 
+fn merge_truth_guard(target: &mut Option<BranchConstraints>, incoming: BranchConstraints) {
+    if incoming.is_impossible() {
+        return;
+    }
+    if let Some(existing) = target {
+        existing.merge(incoming);
+    } else {
+        *target = Some(incoming);
+    }
+}
+
 pub(super) fn evaluate_body(
     db: &dyn ProjectDb,
     project: Project,
@@ -56,12 +68,14 @@ pub(super) fn evaluate_body(
     let state = PythonEvaluationState::with_path_intrinsic_contamination(
         module.file(),
         path_intrinsic_contamination,
+        Some(module.clone()),
     );
     let mut evaluator = PythonModuleEvaluator {
         db,
         project,
         module,
         state,
+        active_constraints: BranchConstraints::unconstrained(),
     };
     evaluator.evaluate_body(body);
     evaluator.state.finish(syntax_errors, syntax_impacts)
@@ -73,6 +87,12 @@ pub(super) struct PythonModuleEvaluator<'db> {
     project: Project,
     module: PythonSourceModule,
     pub(super) state: PythonEvaluationState,
+    pub(super) active_constraints: BranchConstraints,
+}
+
+struct TruthPartition {
+    truthy: BranchConstraints,
+    falsy: BranchConstraints,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -89,6 +109,7 @@ impl PythonModuleEvaluator<'_> {
             project: self.project,
             module: self.module.clone(),
             state: self.state.clone(),
+            active_constraints: self.active_constraints.clone(),
         }
     }
 
@@ -107,12 +128,98 @@ impl PythonModuleEvaluator<'_> {
             PythonEvaluationState::join_indexed_branches(self.state.clone(), &branches, &join);
     }
 
+    fn join_guarded_forks(&mut self, forks: Vec<(usize, Self)>, origin: Origin, arm_count: usize) {
+        let branches = forks
+            .into_iter()
+            .map(|(arm, evaluator)| (arm, evaluator.active_constraints, evaluator.state))
+            .collect::<Vec<_>>();
+        let join = BranchJoin::new(self.module.clone(), origin, arm_count);
+        self.state =
+            PythonEvaluationState::join_guarded_branches(self.state.clone(), &branches, &join);
+    }
+
     pub(super) fn origin<T: RangedExt>(&self, ranged: &T) -> Origin {
         Origin::new(self.module.file(), ranged.span())
     }
 
     fn origin_at(&self, span: Span) -> Origin {
         Origin::new(self.module.file(), span)
+    }
+
+    fn truth_partition(
+        &self,
+        binding: &PythonBinding,
+        fallback_origin: Origin,
+        track_fallback: bool,
+    ) -> TruthPartition {
+        let mut truthy = None;
+        let mut falsy = None;
+
+        for (state, case_constraints, predicate_identity) in binding.alternatives_with_predicates()
+        {
+            let case_constraints = case_constraints.intersection(&self.active_constraints);
+            if case_constraints.is_impossible() {
+                continue;
+            }
+            match state {
+                PythonBindingState::Bound(bound) => match &bound.value.kind {
+                    PythonValueKind::Bool(true) | PythonValueKind::Module(_) => {
+                        merge_truth_guard(&mut truthy, case_constraints);
+                    }
+                    PythonValueKind::Bool(false) => {
+                        merge_truth_guard(&mut falsy, case_constraints);
+                    }
+                    PythonValueKind::Str(_)
+                    | PythonValueKind::Path(_)
+                    | PythonValueKind::UnsupportedLiteral
+                    | PythonValueKind::List(_)
+                    | PythonValueKind::Tuple(_)
+                    | PythonValueKind::Dict(_)
+                    | PythonValueKind::Unknown(_) => {
+                        if let Some(identity) = predicate_identity
+                            && (track_fallback || identity.origin() != fallback_origin)
+                        {
+                            self.add_ambiguous_truth_identity(
+                                &mut truthy,
+                                &mut falsy,
+                                &case_constraints,
+                                identity,
+                            );
+                        } else {
+                            merge_truth_guard(&mut truthy, case_constraints.clone());
+                            merge_truth_guard(&mut falsy, case_constraints);
+                        }
+                    }
+                },
+                PythonBindingState::Unbound => {
+                    merge_truth_guard(&mut truthy, case_constraints.clone());
+                    merge_truth_guard(&mut falsy, case_constraints);
+                }
+            }
+        }
+
+        TruthPartition {
+            truthy: truthy.unwrap_or_else(BranchConstraints::impossible),
+            falsy: falsy.unwrap_or_else(BranchConstraints::impossible),
+        }
+    }
+
+    fn add_ambiguous_truth_identity(
+        &self,
+        truthy: &mut Option<BranchConstraints>,
+        falsy: &mut Option<BranchConstraints>,
+        constraints: &BranchConstraints,
+        identity: &PredicateIdentity,
+    ) {
+        if constraints.is_impossible() {
+            return;
+        }
+        let join = BranchJoin::predicate(self.module.clone(), identity);
+        let falsy_constraints =
+            constraints.intersection(&BranchConstraints::required(join.clone(), 0));
+        let truthy_constraints = constraints.intersection(&BranchConstraints::required(join, 1));
+        merge_truth_guard(falsy, falsy_constraints);
+        merge_truth_guard(truthy, truthy_constraints);
     }
 
     pub(super) fn record_unsupported_call_effects(&mut self, expression: &ast::Expr) {
@@ -211,17 +318,19 @@ pub(super) struct PythonEvaluationState {
     /// `PythonModuleFacts` equality; only the complete internal result carries
     /// it out through `evaluate_python_module`.
     module_effects: PythonModuleEffects,
+    pub(super) predicate_module: Option<PythonSourceModule>,
 }
 
 impl PythonEvaluationState {
     #[cfg(test)]
     fn new(file: File) -> Self {
-        Self::with_path_intrinsic_contamination(file, PathIntrinsicContamination::default())
+        Self::with_path_intrinsic_contamination(file, PathIntrinsicContamination::default(), None)
     }
 
     fn with_path_intrinsic_contamination(
         file: File,
         path_intrinsic_contamination: PathIntrinsicContamination,
+        predicate_module: Option<PythonSourceModule>,
     ) -> Self {
         Self {
             bindings: BTreeMap::new(),
@@ -231,6 +340,7 @@ impl PythonEvaluationState {
             module_effects: PythonModuleEffects::with_path_intrinsic_contamination(
                 path_intrinsic_contamination,
             ),
+            predicate_module,
         }
     }
 
@@ -320,13 +430,21 @@ impl PythonEvaluationState {
     ///
     /// If the binding no longer has one bound value, retain that loss of
     /// precision as an unknown instead of treating it as an evaluator invariant.
-    fn update_bound_value(&mut self, name: &str, value: PythonValue, origin: Origin) {
-        if let Some(bound) = self
-            .bindings
-            .get_mut(name)
-            .and_then(PythonBinding::single_bound_mut)
-        {
-            bound.value = value;
+    fn update_bound_value(
+        &mut self,
+        name: &str,
+        value: PythonValue,
+        origin: Origin,
+        active_constraints: &BranchConstraints,
+    ) {
+        let updated = self.bindings.get(name).cloned().and_then(|binding| {
+            let mut binding = binding.intersect_constraints(active_constraints)?;
+            binding.single_bound_mut()?.value = value;
+            binding.replace_predicate_identities(name, origin, self.predicate_module.as_ref());
+            Some(binding)
+        });
+        if let Some(binding) = updated {
+            self.bindings.insert(name.to_string(), binding);
         } else {
             self.assign_value(
                 name,
@@ -336,8 +454,9 @@ impl PythonEvaluationState {
         }
     }
 
-    fn assign_binding(&mut self, name: &str, binding: PythonBinding, origin: Origin) {
+    fn assign_binding(&mut self, name: &str, mut binding: PythonBinding, origin: Origin) {
         self.mutations.retain(|mutation| mutation.binding != name);
+        binding.discriminate_predicates(name, origin, self.predicate_module.as_ref());
         self.bindings
             .insert(name.to_string(), binding.rebase_binding_origin(origin));
     }
@@ -346,9 +465,10 @@ impl PythonEvaluationState {
         &mut self,
         name: &str,
         source: &str,
-        binding: PythonBinding,
+        mut binding: PythonBinding,
         origin: Origin,
     ) {
+        binding.discriminate_predicates(name, origin, self.predicate_module.as_ref());
         self.bindings
             .insert(name.to_string(), binding.rebase_binding_origin(origin));
         let copied = self
@@ -454,9 +574,14 @@ impl PythonEvaluationState {
         &self,
         name: &str,
         path: &PythonMutationPath,
+        active_constraints: &BranchConstraints,
     ) -> Vec<String> {
         let mut wanted = ReachableAllocationSites::default();
-        let Some(binding) = self.binding(name) else {
+        let Some(binding) = self
+            .binding(name)
+            .cloned()
+            .and_then(|binding| binding.intersect_constraints(active_constraints))
+        else {
             return Vec::new();
         };
         for state in binding.alternatives() {
@@ -471,16 +596,23 @@ impl PythonEvaluationState {
         self.bindings
             .iter()
             .filter(|(candidate_name, candidate)| {
-                let occurrences = candidate.allocation_site_occurrences(&wanted);
+                let occurrences = (*candidate)
+                    .clone()
+                    .intersect_constraints(active_constraints)
+                    .map_or(0, |candidate| {
+                        candidate.allocation_site_occurrences(&wanted)
+                    });
                 occurrences > usize::from(candidate_name.as_str() == name)
             })
             .map(|(name, _binding)| name.clone())
             .collect()
     }
 
-    fn value_for_name(&self, name: &str) -> Option<PythonValue> {
-        let binding = self.binding(name)?;
-        Some(binding.single_bound()?.value.clone())
+    fn value_for_name(&self, name: &str, constraints: &BranchConstraints) -> Option<PythonValue> {
+        self.binding(name)?
+            .clone()
+            .intersect_constraints(constraints)?
+            .merged_semantic_value()
     }
 
     fn bool_value(&self, name: &str) -> Option<bool> {
@@ -526,8 +658,19 @@ impl PythonEvaluationState {
         let Some(unknown) = PythonBinding::constrained_unknown(cause, origin, constraints) else {
             return;
         };
-        for binding in self.bindings.values_mut() {
-            *binding = binding.clone().join(unknown.clone(), origin);
+        for (name, binding) in &mut self.bindings {
+            let mut degraded = unknown.clone();
+            degraded.discriminate_predicates(name, origin, self.predicate_module.as_ref());
+            if let Some(module) = &self.predicate_module {
+                let choice = BranchJoin::binding_choice(module.clone(), origin, name);
+                let mut prior = binding.clone();
+                prior.select_branch(choice.clone(), 0);
+                degraded.select_branch(choice, 1);
+                *binding = prior.join(degraded, origin);
+            } else {
+                *binding = binding.clone().join(degraded, origin);
+            }
+            binding.force_predicate_identity(name, origin, self.predicate_module.as_ref());
         }
     }
 
@@ -610,7 +753,8 @@ impl PythonEvaluationState {
             }
         }
         for name in names {
-            let unknown = PythonBinding::unknown(cause, origin);
+            let mut unknown = PythonBinding::unknown(cause, origin);
+            unknown.discriminate_predicates(&name, origin, self.predicate_module.as_ref());
             let binding = match self.bindings.remove(&name) {
                 Some(binding) => binding.join(unknown, origin),
                 None => unknown,
@@ -633,6 +777,7 @@ impl PythonEvaluationState {
                 mutations,
                 import_trace,
                 module_effects,
+                predicate_module: _,
             } = body;
             self.namespace_causes.extend(namespace_causes);
             self.mutations.extend(mutations);
@@ -693,6 +838,62 @@ impl PythonEvaluationState {
             .map(|(arm, branch)| (*arm, branch.module_effects.clone()))
             .collect::<Vec<_>>();
         base.module_effects = PythonModuleEffects::join_indexed_branches(&branch_effects, join);
+        base
+    }
+
+    fn join_guarded_branches(
+        mut base: Self,
+        branches: &[(usize, BranchConstraints, Self)],
+        join: &BranchJoin,
+    ) -> Self {
+        let origin = join.origin();
+        let names = branches
+            .iter()
+            .flat_map(|(_, _, branch)| branch.changed_names_from(&base))
+            .collect::<BTreeSet<_>>();
+        for name in names {
+            let mut joined: Option<PythonBinding> = None;
+            for (arm, constraints, branch) in branches {
+                let mut candidate = branch
+                    .binding(&name)
+                    .cloned()
+                    .unwrap_or_else(PythonBinding::unbound);
+                candidate.select_branch(join.to_owned(), *arm);
+                let candidate = candidate.intersect_constraints(constraints);
+                let Some(candidate) = candidate else {
+                    continue;
+                };
+                joined = Some(match joined {
+                    Some(current) => current.join(candidate, origin),
+                    None => candidate,
+                });
+            }
+            if let Some(binding) = joined {
+                base.bindings.insert(name, binding);
+            }
+        }
+
+        base.namespace_causes.clear();
+        base.mutations.clear();
+        base.import_trace = PythonImportTrace::default();
+        for (arm, constraints, branch) in branches {
+            base.namespace_causes
+                .extend(branch.namespace_causes.iter().filter_map(|cause| {
+                    let mut cause = cause.clone();
+                    cause.select_branch(join.to_owned(), *arm);
+                    cause.constraints = cause.constraints.intersection(constraints);
+                    (!cause.constraints.is_impossible()).then_some(cause)
+                }));
+            base.mutations.extend(branch.mutations.iter().cloned());
+            base.import_trace.absorb(&branch.import_trace);
+        }
+        let branch_effects = branches
+            .iter()
+            .map(|(arm, constraints, branch)| {
+                (*arm, constraints.clone(), branch.module_effects.clone())
+            })
+            .collect::<Vec<_>>();
+        base.module_effects = PythonModuleEffects::join_guarded_branches(&branch_effects, join);
         base
     }
 
@@ -933,14 +1134,14 @@ mod tests {
     fn loop_effect_degradation_aggregates_effects_and_degrades_changed_names() {
         let base = state_with_binding();
         let loop_origin = origin(6);
+        let mut loop_unknown =
+            PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, loop_origin);
+        loop_unknown.discriminate_predicates("VALUE", loop_origin, None);
         let expected_binding = base
             .binding("VALUE")
             .expect("the fixture binding should exist")
             .clone()
-            .join(
-                PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, loop_origin),
-                loop_origin,
-            );
+            .join(loop_unknown, loop_origin);
         let mut first_mutation = mutation(PythonMutationOperation::Extend, 2);
         first_mutation.binding = "OTHER".to_string();
         let mut later_mutation = mutation(PythonMutationOperation::Append, 3);

--- a/crates/djls-project/src/python/evaluation/evaluator/expression.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/expression.rs
@@ -9,7 +9,6 @@ use super::PythonValueKind;
 use super::ast;
 use crate::python::PythonPath;
 use crate::python::PythonPathIntrinsic;
-use crate::python::evaluation::truthiness::Truthiness;
 
 impl PythonModuleEvaluator<'_> {
     pub(super) fn evaluate_binding(&self, expression: &ast::Expr) -> PythonBinding {
@@ -65,6 +64,9 @@ impl PythonModuleEvaluator<'_> {
             ast::Expr::Dict(dict) => self.evaluate_dict_binding(dict, origin),
             ast::Expr::Attribute(attribute) => self.evaluate_attribute_binding(attribute, origin),
             ast::Expr::BoolOp(boolean) => self.evaluate_bool_op_binding(boolean, origin),
+            ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not => {
+                self.evaluate_not_binding(unary, origin)
+            }
             ast::Expr::Named(_)
             | ast::Expr::BinOp(_)
             | ast::Expr::UnaryOp(_)
@@ -98,28 +100,66 @@ impl PythonModuleEvaluator<'_> {
     }
 
     fn evaluate_bool_op_binding(&self, boolean: &ast::ExprBoolOp, origin: Origin) -> PythonBinding {
-        let Some((last, preceding)) = boolean.values.split_last() else {
-            return PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin);
-        };
-        for expression in preceding {
-            let truthiness =
-                Truthiness::of_expr(expression, &|name| self.state.known_truthiness(name));
-            match (boolean.op, truthiness) {
-                (ast::BoolOp::And, Truthiness::AlwaysFalse)
-                | (ast::BoolOp::Or, Truthiness::AlwaysTrue) => {
-                    return self.evaluate_binding(expression);
-                }
-                (ast::BoolOp::And, Truthiness::AlwaysTrue)
-                | (ast::BoolOp::Or, Truthiness::AlwaysFalse) => {}
-                (_, Truthiness::Ambiguous) => {
-                    return PythonBinding::unknown(
-                        &PythonUnknownCause::UnsupportedExpression,
-                        origin,
-                    );
-                }
+        let mut continuation = self.active_constraints.clone();
+        let mut result: Option<PythonBinding> = None;
+
+        for (index, expression) in boolean.values.iter().enumerate() {
+            let Some(binding) = self
+                .evaluate_binding(expression)
+                .intersect_constraints(&continuation)
+            else {
+                break;
+            };
+            if index + 1 == boolean.values.len() {
+                result = Some(match result {
+                    Some(current) => current.join(binding, origin),
+                    None => binding,
+                });
+                break;
+            }
+
+            let partition = self.truth_partition(&binding, self.origin(expression), true);
+            let (returned, next) = match boolean.op {
+                ast::BoolOp::And => (partition.falsy, partition.truthy),
+                ast::BoolOp::Or => (partition.truthy, partition.falsy),
+            };
+            if let Some(decisive) = binding.intersect_constraints(&returned) {
+                result = Some(match result {
+                    Some(current) => current.join(decisive, origin),
+                    None => decisive,
+                });
+            }
+            continuation = next;
+            if continuation.is_impossible() {
+                break;
             }
         }
-        self.evaluate_binding(last)
+
+        result.unwrap_or_else(|| {
+            PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin)
+        })
+    }
+
+    fn evaluate_not_binding(&self, unary: &ast::ExprUnaryOp, origin: Origin) -> PythonBinding {
+        let operand = self.evaluate_binding(&unary.operand);
+        let partition = self.truth_partition(&operand, self.origin(unary.operand.as_ref()), true);
+        let falsy = PythonBinding::constrained_bound(
+            PythonValue::bool(false, origin),
+            origin,
+            &partition.truthy,
+        );
+        let truthy = PythonBinding::constrained_bound(
+            PythonValue::bool(true, origin),
+            origin,
+            &partition.falsy,
+        );
+        match (falsy, truthy) {
+            (Some(falsy), Some(truthy)) => falsy.join(truthy, origin),
+            (Some(binding), None) | (None, Some(binding)) => binding,
+            (None, None) => {
+                PythonBinding::unknown(&PythonUnknownCause::UnsupportedExpression, origin)
+            }
+        }
     }
 
     /// Read `receiver.member` through the receiver's nominal abstract value.
@@ -352,11 +392,11 @@ impl PythonModuleEvaluator<'_> {
     ) -> PythonValue {
         let origin = self.origin(expression);
         self.evaluate_binding(expression)
-            .single_bound()
-            .map_or_else(
-                || PythonValue::unknown(PythonUnknownCause::UnsupportedExpression, Some(origin)),
-                |bound| bound.value.clone(),
-            )
+            .intersect_constraints(&self.active_constraints)
+            .and_then(|binding| binding.merged_semantic_value())
+            .unwrap_or_else(|| {
+                PythonValue::unknown(PythonUnknownCause::UnsupportedExpression, Some(origin))
+            })
     }
 
     fn evaluate_sequence_binding(

--- a/crates/djls-project/src/python/evaluation/evaluator/imports.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/imports.rs
@@ -695,9 +695,10 @@ impl PythonModuleEvaluator<'_> {
         }
 
         let selected = paths.exact.is_some() || paths.absent.is_some() || paths.dynamic.is_some();
-        if let Some(binding) = joined
+        if let Some(mut binding) = joined
             && (selected || caller_had_name)
         {
+            binding.discriminate_predicates(name, origin, self.state.predicate_module.as_ref());
             self.state.bindings.insert(name.to_string(), binding);
         }
 

--- a/crates/djls-project/src/python/evaluation/evaluator/statement.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/statement.rs
@@ -16,7 +16,7 @@ use super::PythonModuleEvaluator;
 use crate::ast::ExprExt;
 use crate::ast::RangedExt;
 
-impl PythonModuleEvaluator<'_> {
+impl<'db> PythonModuleEvaluator<'db> {
     pub(super) fn evaluate_body(&mut self, body: &[ast::Stmt]) {
         for stmt in body {
             self.walk_stmt(stmt);
@@ -96,96 +96,60 @@ impl PythonModuleEvaluator<'_> {
         let arm_count = 1
             + clauses.len()
             + usize::from(clauses.last().is_none_or(|clause| clause.test.is_some()));
-        self.record_unsupported_call_effects(&stmt_if.test);
-        match self.test_truthiness(&stmt_if.test) {
-            Truthiness::AlwaysTrue => self.evaluate_body(&stmt_if.body),
-            Truthiness::AlwaysFalse => {
-                let control_span = stmt_if.span();
-                for (index, clause) in clauses.iter().enumerate() {
-                    let Some(test) = &clause.test else {
-                        self.evaluate_body(&clause.body);
-                        return;
-                    };
+        let mut remaining = self.active_constraints.clone();
+        let mut branches = Vec::with_capacity(arm_count);
 
-                    self.record_unsupported_call_effects(test);
-                    match self.test_truthiness(test) {
-                        Truthiness::AlwaysTrue => {
-                            self.evaluate_body(&clause.body);
-                            return;
-                        }
-                        Truthiness::AlwaysFalse => {}
-                        Truthiness::Ambiguous => {
-                            self.join_reachable_if_bodies(
-                                None,
-                                &clauses[index..],
-                                index + 1,
-                                arm_count,
-                                control_span,
-                                true,
-                            );
-                            return;
-                        }
-                    }
-                }
+        self.add_guarded_if_body(
+            0,
+            &stmt_if.test,
+            &stmt_if.body,
+            &mut remaining,
+            &mut branches,
+        );
+        for (index, clause) in clauses.iter().enumerate() {
+            if remaining.is_impossible() {
+                break;
             }
-            Truthiness::Ambiguous => self.join_reachable_if_bodies(
-                Some((0, &stmt_if.body)),
-                clauses,
-                1,
-                arm_count,
-                stmt_if.span(),
-                false,
-            ),
+            let arm = index + 1;
+            if let Some(test) = &clause.test {
+                self.add_guarded_if_body(arm, test, &clause.body, &mut remaining, &mut branches);
+            } else {
+                let mut branch = self.fork();
+                branch.active_constraints = remaining.clone();
+                branch.evaluate_body(&clause.body);
+                branches.push((arm, branch));
+                remaining = super::BranchConstraints::impossible();
+                break;
+            }
         }
+
+        if !remaining.is_impossible() {
+            let mut fallthrough = self.fork();
+            fallthrough.active_constraints = remaining;
+            branches.push((arm_count - 1, fallthrough));
+        }
+        self.join_guarded_forks(branches, self.origin(stmt_if), arm_count);
     }
 
-    fn join_reachable_if_bodies(
+    fn add_guarded_if_body(
         &mut self,
-        first_body: Option<(usize, &[ast::Stmt])>,
-        clauses: &[ast::ElifElseClause],
-        first_clause_arm: usize,
-        arm_count: usize,
-        control_span: Span,
-        first_test_already_evaluated: bool,
+        arm: usize,
+        test: &ast::Expr,
+        body: &[ast::Stmt],
+        remaining: &mut super::BranchConstraints,
+        branches: &mut Vec<(usize, PythonModuleEvaluator<'db>)>,
     ) {
-        let mut bodies = Vec::with_capacity(clauses.len() + 2);
-        if let Some(body) = first_body {
-            bodies.push(body);
-        }
-
-        let mut has_fallthrough = true;
-        for (offset, clause) in clauses.iter().enumerate() {
-            let arm = first_clause_arm + offset;
-            let Some(test) = &clause.test else {
-                bodies.push((arm, clause.body.as_slice()));
-                has_fallthrough = false;
-                break;
-            };
-
-            if offset != 0 || !first_test_already_evaluated {
-                self.record_unsupported_call_effects(test);
-            }
-            match self.test_truthiness(test) {
-                Truthiness::AlwaysTrue => {
-                    bodies.push((arm, clause.body.as_slice()));
-                    has_fallthrough = false;
-                    break;
-                }
-                Truthiness::AlwaysFalse => {}
-                Truthiness::Ambiguous => bodies.push((arm, clause.body.as_slice())),
-            }
-        }
-        if has_fallthrough {
-            bodies.push((arm_count - 1, &[]));
-        }
-
-        let mut branches = Vec::with_capacity(bodies.len());
-        for (arm, body) in bodies {
+        self.record_unsupported_call_effects(test);
+        let binding = self.evaluate_binding(test);
+        let partition = self.truth_partition(&binding, self.origin(test), false);
+        let body_constraints = remaining.intersection(&partition.truthy);
+        if !body_constraints.is_impossible() {
             let mut branch = self.fork();
+            branch.active_constraints = body_constraints;
             branch.evaluate_body(body);
             branches.push((arm, branch));
         }
-        self.join_indexed_forks(branches, self.origin_at(control_span), arm_count);
+        *remaining = remaining.intersection(&partition.falsy);
     }
 
     fn walk_try(&mut self, stmt_try: &ast::StmtTry) {
@@ -243,7 +207,7 @@ impl PythonModuleEvaluator<'_> {
 
     fn walk_assign(&mut self, assign: &ast::StmtAssign) {
         self.record_unsupported_call_effects(&assign.value);
-        let value = self.evaluate_binding(&assign.value);
+        let mut value = self.evaluate_binding(&assign.value);
         let aliases_mutable_value =
             assign.targets.len() > 1 && !value.reachable_allocation_sites().is_empty();
         if aliases_mutable_value {
@@ -259,6 +223,19 @@ impl PythonModuleEvaluator<'_> {
             return;
         }
         let assignment_origin = self.origin(assign);
+        if assign.targets.len() > 1
+            && assign
+                .targets
+                .iter()
+                .all(|target| target.name_target().is_some())
+            && let Some(shared_name) = assign.targets[0].name_target()
+        {
+            value.discriminate_predicates(
+                shared_name,
+                self.origin(assign.value.as_ref()),
+                Some(&self.module),
+            );
+        }
         for target in &assign.targets {
             self.assign_target(target, &assign.value, value.clone(), assignment_origin);
         }
@@ -269,7 +246,9 @@ impl PythonModuleEvaluator<'_> {
         if assign.op == ast::Operator::Add
             && let Some(target) = MutationTarget::from_expr(&assign.target)
             && assign.target.name_target().is_some()
-            && let Some(left) = self.state.value_for_name(target.binding)
+            && let Some(left) = self
+                .state
+                .value_for_name(target.binding, &self.active_constraints)
         {
             let right = self.evaluate_value(&assign.value);
             self.apply_name_augmented_add(target, left, &right, origin);
@@ -280,7 +259,8 @@ impl PythonModuleEvaluator<'_> {
             && let Some(target) = MutationTarget::from_expr(&assign.target)
         {
             let extension = self.evaluate_value(&assign.value);
-            self.state.apply_augmented_add(target, &extension, origin);
+            self.state
+                .apply_augmented_add(target, &extension, origin, &self.active_constraints);
             return;
         }
 
@@ -310,13 +290,17 @@ impl PythonModuleEvaluator<'_> {
         let mut left = left;
         match &mut left.kind {
             PythonValueKind::List(list) => {
-                let mut stale_aliases = self
-                    .state
-                    .stale_alias_names_after_mutation(name, &PythonMutationPath::default());
+                let mut stale_aliases = self.state.stale_alias_names_after_mutation(
+                    name,
+                    &PythonMutationPath::default(),
+                    &self.active_constraints,
+                );
                 let embedded_sites = right.iterated_reachable_allocation_sites();
-                let recursive = self
-                    .state
-                    .sites_reach_mutation_target(&target, &embedded_sites);
+                let recursive = self.state.sites_reach_mutation_target(
+                    &target,
+                    &embedded_sites,
+                    &self.active_constraints,
+                );
                 let extended = if recursive {
                     None
                 } else {
@@ -327,7 +311,8 @@ impl PythonModuleEvaluator<'_> {
                     // A successful in-place list `+=` updates the binding
                     // without clearing prior mutation facts; the `Extend` fact
                     // below then accumulates onto them.
-                    self.state.update_bound_value(name, left, origin);
+                    self.state
+                        .update_bound_value(name, left, origin, &self.active_constraints);
                     self.state.invalidate_names(
                         stale_aliases,
                         &PythonUnknownCause::UnsupportedExpression,
@@ -367,9 +352,11 @@ impl PythonModuleEvaluator<'_> {
             | PythonValueKind::Bool(_)
             | PythonValueKind::Module(_)
             | PythonValueKind::Unknown(_) => {
-                let stale_aliases = self
-                    .state
-                    .stale_alias_names_after_mutation(name, &PythonMutationPath::default());
+                let stale_aliases = self.state.stale_alias_names_after_mutation(
+                    name,
+                    &PythonMutationPath::default(),
+                    &self.active_constraints,
+                );
                 self.state.assign_value(
                     name,
                     PythonValue::unknown(PythonUnknownCause::UnsupportedExpression, Some(origin)),
@@ -443,6 +430,7 @@ impl PythonModuleEvaluator<'_> {
                 self.origin(subscript.slice.as_ref()),
                 &value,
                 assignment_origin,
+                &self.active_constraints,
             );
             return;
         }

--- a/crates/djls-project/src/python/evaluation/module_object.rs
+++ b/crates/djls-project/src/python/evaluation/module_object.rs
@@ -463,6 +463,69 @@ impl PythonModuleEffects {
         joined
     }
 
+    pub(super) fn join_guarded_branches(
+        branches: &[(usize, BranchConstraints, Self)],
+        join: &BranchJoin,
+    ) -> Self {
+        let origin = join.origin();
+        let mut keys: Vec<(PythonModule, String)> = Vec::new();
+        for (_, _, branch) in branches {
+            for child in &branch.children {
+                let key = (child.object.clone(), child.attribute.clone());
+                if !keys.contains(&key) {
+                    keys.push(key);
+                }
+            }
+        }
+
+        let mut joined = Self::default();
+        for (object, attribute) in keys {
+            let mut binding: Option<PythonBinding> = None;
+            for (arm, constraints, branch) in branches {
+                let mut candidate = branch
+                    .read_child(&object, &attribute)
+                    .cloned()
+                    .unwrap_or_else(PythonBinding::unbound);
+                candidate.select_branch(join.to_owned(), *arm);
+                let candidate = candidate.intersect_constraints(constraints);
+                let Some(candidate) = candidate else {
+                    continue;
+                };
+                binding = Some(match binding {
+                    Some(current) => current.join(candidate, origin),
+                    None => candidate,
+                });
+            }
+            if let Some(binding) = binding {
+                joined.children.push(ModuleChildCoordinate {
+                    object,
+                    attribute,
+                    binding,
+                });
+            }
+        }
+
+        for (arm, constraints, branch) in branches {
+            for entry in &branch.causes {
+                let mut cause = entry.cause.clone();
+                cause.select_branch(join.to_owned(), *arm);
+                cause.constraints = cause.constraints.intersection(constraints);
+                if !cause.constraints.is_impossible() {
+                    joined.causes.push(ModuleEffectCause {
+                        object: entry.object.clone(),
+                        cause,
+                    });
+                }
+            }
+            joined.absorb_path_intrinsic_contamination(
+                branch.path_intrinsic_contamination.0.iter().copied(),
+            );
+        }
+
+        joined.normalize();
+        joined
+    }
+
     #[cfg(test)]
     fn join_branches(branches: &[Self], origin: Origin) -> Self {
         let indexed = branches.iter().cloned().enumerate().collect::<Vec<_>>();

--- a/crates/djls-project/src/python/evaluation/mutation.rs
+++ b/crates/djls-project/src/python/evaluation/mutation.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use djls_source::Origin;
 use ruff_python_ast as ast;
 
+use super::BranchConstraints;
 use super::PythonBinding;
 use super::PythonBindingState;
 use super::PythonSequenceItem;
@@ -376,17 +377,24 @@ impl PythonEvaluationState {
         key_origin: Origin,
         value: &PythonBinding,
         origin: Origin,
+        active_constraints: &BranchConstraints,
     ) {
-        let mut stale_aliases = self.stale_alias_names_after_mutation(target.binding, &target.path);
-        let applied = value.single_bound().is_some_and(|assigned| {
+        let mut stale_aliases =
+            self.stale_alias_names_after_mutation(target.binding, &target.path, active_constraints);
+        let assigned = value
+            .clone()
+            .intersect_constraints(active_constraints)
+            .and_then(|binding| binding.merged_semantic_value());
+        let applied = assigned.as_ref().is_some_and(|assigned| {
             self.try_apply_mutation(
                 target,
                 &EvaluatedMutation::SetKey {
                     key,
                     key_origin,
-                    value: &assigned.value,
+                    value: assigned,
                 },
                 origin,
+                active_constraints,
             )
         });
         if applied {
@@ -412,11 +420,17 @@ impl PythonEvaluationState {
         target: MutationTarget<'_>,
         extension: &PythonValue,
         origin: Origin,
+        active_constraints: &BranchConstraints,
     ) {
         let binding = target.binding.to_string();
-        let mut stale_aliases = self.stale_alias_names_after_mutation(target.binding, &target.path);
-        let supported =
-            self.try_apply_mutation(&target, &EvaluatedMutation::Extend(extension), origin);
+        let mut stale_aliases =
+            self.stale_alias_names_after_mutation(target.binding, &target.path, active_constraints);
+        let supported = self.try_apply_mutation(
+            &target,
+            &EvaluatedMutation::Extend(extension),
+            origin,
+            active_constraints,
+        );
         let fact = target.into_fact(PythonMutationOperation::Extend, origin);
         if supported {
             self.invalidate_names(
@@ -441,10 +455,12 @@ impl PythonEvaluationState {
         &self,
         target: &MutationTarget<'_>,
         sites: &ReachableAllocationSites,
+        active_constraints: &BranchConstraints,
     ) -> bool {
         let receiver_sites = self
             .bindings
             .get(target.binding)
+            .and_then(|binding| binding.clone().intersect_constraints(active_constraints))
             .map(|binding| {
                 let mut sites = ReachableAllocationSites::default();
                 for alternative in binding.alternatives() {
@@ -464,17 +480,30 @@ impl PythonEvaluationState {
         target: &MutationTarget<'_>,
         mutation: &EvaluatedMutation<'_>,
         origin: Origin,
+        active_constraints: &BranchConstraints,
     ) -> bool {
-        if mutation
-            .embedded_sites()
-            .is_some_and(|sites| self.sites_reach_mutation_target(target, &sites))
-        {
+        if mutation.embedded_sites().is_some_and(|sites| {
+            self.sites_reach_mutation_target(target, &sites, active_constraints)
+        }) {
             return false;
         }
         let Some(binding) = self.bindings.get_mut(target.binding) else {
             return false;
         };
-        binding.try_mutate_all_bound(|value| target.path.try_apply_exact(value, mutation, origin))
+        let Some(feasible) = binding.clone().intersect_constraints(active_constraints) else {
+            return false;
+        };
+        *binding = feasible;
+        let applied = binding
+            .try_mutate_all_bound(|value| target.path.try_apply_exact(value, mutation, origin));
+        if applied {
+            binding.replace_predicate_identities(
+                target.binding,
+                origin,
+                self.predicate_module.as_ref(),
+            );
+        }
+        applied
     }
 }
 
@@ -505,9 +534,11 @@ impl PythonModuleEvaluator<'_> {
         };
         let origin = self.origin(call);
         let Some(operation) = PythonMutationOperation::from_method(attribute.attr.as_str()) else {
-            let mut receiver_aliases = self
-                .state
-                .stale_alias_names_after_mutation(target.binding, &target.path);
+            let mut receiver_aliases = self.state.stale_alias_names_after_mutation(
+                target.binding,
+                &target.path,
+                &self.active_constraints,
+            );
             if !receiver_aliases.iter().any(|name| name == target.binding) {
                 receiver_aliases.push(target.binding.to_string());
             }
@@ -520,9 +551,11 @@ impl PythonModuleEvaluator<'_> {
             );
             return;
         };
-        let mut stale_aliases = self
-            .state
-            .stale_alias_names_after_mutation(target.binding, &target.path);
+        let mut stale_aliases = self.state.stale_alias_names_after_mutation(
+            target.binding,
+            &target.path,
+            &self.active_constraints,
+        );
         let supported = self.try_apply_mutation_call(call, &target, operation, origin);
         if supported {
             self.state.invalidate_names(
@@ -606,7 +639,8 @@ impl PythonModuleEvaluator<'_> {
                 _,
             ) => return false,
         };
-        self.state.try_apply_mutation(target, &mutation, origin)
+        self.state
+            .try_apply_mutation(target, &mutation, origin, &self.active_constraints)
     }
 }
 

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -89,6 +89,22 @@ fn cases<'a>(settings: &'a Value, pointer: &str) -> Result<&'a [Value], io::Erro
         .ok_or_else(|| io::Error::other(format!("settings JSON at `{pointer}` is not an array")))
 }
 
+fn installed_app_alternatives(setting_cases: &[Value]) -> Option<BTreeSet<String>> {
+    setting_cases
+        .iter()
+        .map(|case| {
+            Some(
+                case.get("known")?
+                    .get("apps")?
+                    .as_array()?
+                    .iter()
+                    .map(|app| app.get("value")?.as_str())
+                    .collect::<Option<Vec<_>>>()?
+                    .join(","),
+            )
+        })
+        .collect()
+}
 fn binding_unknown_origin(source: &str, name: &str) -> Result<Origin, Box<dyn std::error::Error>> {
     let (db, project, _) = extract_project(source, &[])?;
     let file = settings_module_file(&db, project).ok_or_else(|| {
@@ -6476,6 +6492,46 @@ fn branch_constraints_distinguish_overlapping_root_module_identities() {
 }
 
 #[test]
+fn predicates_distinguish_overlapping_root_module_executions() {
+    let db = TestDatabase::new();
+    db.add_file(
+        "/project/settings.py",
+        "from lib.pkg.branch import FLAG as ROOT_FLAG\nfrom pkg.branch import FLAG as NESTED_FLAG\nINSTALLED_APPS = []\nif ROOT_FLAG:\n    INSTALLED_APPS.append('root')\nif NESTED_FLAG:\n    INSTALLED_APPS.append('nested')\n",
+    )
+    .expect("settings-extraction test file should be added");
+    db.add_file("/project/lib/pkg/branch.py", "FLAG = get_flag()\n")
+        .expect("settings-extraction test file should be added");
+    let project = python_project_with_paths(&db, &[Utf8PathBuf::from("/project/lib")]);
+    let settings = db
+        .file(Utf8Path::new("/project/settings.py"))
+        .expect("settings-extraction test file should exist");
+    let evaluation = python_module_evaluation(&db, project, settings)
+        .expect("Python file should map to a module");
+    let alternatives = evaluation
+        .binding("INSTALLED_APPS")
+        .expect("INSTALLED_APPS binding should exist")
+        .alternatives
+        .iter()
+        .filter_map(|alternative| {
+            let PythonBindingAlternativeView::Bound(bound) = alternative else {
+                return None;
+            };
+            string_list_items(&bound.value)
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        alternatives,
+        BTreeSet::from([
+            vec![],
+            vec!["str:nested".to_string()],
+            vec!["str:root".to_string()],
+            vec!["str:root".to_string(), "str:nested".to_string()],
+        ])
+    );
+}
+
+#[test]
 fn typed_module_order_disjoint_import_cycles_are_root_order_independent() {
     let cycle_edges = |settings_source| {
         let db = TestDatabase::new();
@@ -7727,6 +7783,276 @@ fn boolean_control_flow_honors_decisive_operands() {
         assert_eq!(setting_cases.len(), 1, "{condition}");
         assert_eq!(setting_cases[0]["known"]["apps"][0]["value"], expected);
     }
+}
+
+#[test]
+fn repeated_predicates_reuse_one_truth_decision() {
+    let settings = extract(
+        "FLAG = get_flag()\nINSTALLED_APPS = []\nif FLAG:\n    INSTALLED_APPS.append('first')\nif FLAG:\n    INSTALLED_APPS.append('second')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([String::new(), "first,second".to_string(),]))
+    );
+}
+
+#[test]
+fn boolean_alias_preserves_the_source_predicate() {
+    let settings = extract(
+        "DEBUG = get_debug()\nINSTALLED_APPS = []\nif DEBUG:\n    INSTALLED_APPS.append('django_autotyping')\nTRACKER = True and DEBUG\nif TRACKER:\n    INSTALLED_APPS.append('requests_tracker')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "django_autotyping,requests_tracker".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn derived_and_truth_implies_its_left_operand() {
+    let settings = extract(
+        "DEBUG = get_debug()\nSILK = DEBUG and get_silk()\nINSTALLED_APPS = []\nif SILK:\n    INSTALLED_APPS.append('silk')\nif DEBUG:\n    INSTALLED_APPS.append('sslserver')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "silk,sslserver".to_string(),
+            "sslserver".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn derived_or_truth_does_not_imply_its_left_operand() {
+    let settings = extract(
+        "LEFT = get_left()\nRIGHT = get_right()\nENABLED = LEFT or RIGHT\nINSTALLED_APPS = []\nif ENABLED:\n    INSTALLED_APPS.append('enabled')\nif LEFT:\n    INSTALLED_APPS.append('left')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "enabled".to_string(),
+            "enabled,left".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn independent_predicates_keep_their_cross_product() {
+    let settings = extract(
+        "FIRST = get_first()\nSECOND = get_second()\nINSTALLED_APPS = []\nif FIRST:\n    INSTALLED_APPS.append('first')\nif SECOND:\n    INSTALLED_APPS.append('second')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "first".to_string(),
+            "first,second".to_string(),
+            "second".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn unknowns_from_one_destructuring_target_stay_independent() {
+    let settings = extract(
+        "LEFT, RIGHT = get_pair()\nINSTALLED_APPS = []\nif LEFT:\n    INSTALLED_APPS.append('left')\nif RIGHT:\n    INSTALLED_APPS.append('right')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "left".to_string(),
+            "left,right".to_string(),
+            "right".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn aliases_preserve_a_predicate_identity() {
+    let settings = extract(
+        "SOURCE = get_flag()\nALIAS = SOURCE\nINSTALLED_APPS = []\nif SOURCE:\n    INSTALLED_APPS.append('source')\nif ALIAS:\n    INSTALLED_APPS.append('alias')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([String::new(), "source,alias".to_string(),]))
+    );
+}
+
+#[test]
+fn chained_assignment_targets_share_one_predicate_identity() {
+    let settings = extract(
+        "LEFT = RIGHT = get_flag()\nINSTALLED_APPS = []\nif LEFT:\n    INSTALLED_APPS.append('left')\nif RIGHT:\n    INSTALLED_APPS.append('right')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([String::new(), "left,right".to_string(),]))
+    );
+}
+
+#[test]
+fn repeated_unsupported_literal_tests_share_one_predicate_identity() {
+    let settings = extract(
+        "FLAG = 1\nINSTALLED_APPS = []\nif FLAG:\n    INSTALLED_APPS.append('first')\nif FLAG:\n    INSTALLED_APPS.append('second')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([String::new(), "first,second".to_string(),]))
+    );
+}
+
+#[test]
+fn imported_predicates_keep_source_module_correlations() {
+    let settings = extract_project(
+        "from flags import FLAG, APPS\nif FLAG:\n    INSTALLED_APPS = APPS + ['checked']\nelse:\n    INSTALLED_APPS = APPS\n",
+        &[(
+            "flags",
+            "FLAG = get_flag()\nif FLAG:\n    APPS = ['enabled']\nelse:\n    APPS = []\n",
+        )],
+    )
+    .expect("settings extraction project should build")
+    .2;
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "enabled,checked".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn guarded_mutations_ignore_infeasible_receiver_and_argument_cases() {
+    let settings = extract(
+        "FLAG = get_flag()\nif FLAG:\n    VALUES = []\n    ITEM = 'a'\nelse:\n    VALUES = True\n    ITEM = 'b'\nif FLAG:\n    VALUES.append(ITEM)\nINSTALLED_APPS = VALUES\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert!(
+        setting_cases.iter().any(|case| {
+            case.pointer("/known/apps/0/value").and_then(Value::as_str) == Some("a")
+        })
+    );
+}
+
+#[test]
+fn mixed_known_and_unknown_binding_cases_keep_stable_reads() {
+    let settings = extract(
+        "if CHOOSE:\n    FLAG = False\nelse:\n    FLAG = get_flag()\nINSTALLED_APPS = []\nif FLAG:\n    INSTALLED_APPS.append('first')\nif FLAG:\n    INSTALLED_APPS.append('second')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let known = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array")
+        .iter()
+        .filter_map(|case| case.pointer("/known/apps").and_then(Value::as_array))
+        .map(|apps| {
+            apps.iter()
+                .filter_map(|app| app.get("value").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        known,
+        BTreeSet::from([String::new(), "first,second".to_string()])
+    );
+}
+
+#[test]
+fn guarded_mutations_ignore_aliases_from_infeasible_cases() {
+    let settings = extract(
+        "FLAG = get_flag()\nINSTALLED_APPS = ['base']\nif FLAG:\n    TARGET = [[]]\nelse:\n    TARGET = [INSTALLED_APPS]\nif FLAG:\n    TARGET[0].append('x')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(setting_cases.len(), 1, "{settings:#}");
+    assert_eq!(setting_cases[0]["known"]["apps"][0]["value"], "base");
+}
+
+#[test]
+fn rebinding_replaces_a_predicate_identity() {
+    let settings = extract(
+        "FLAG = get_first()\nINSTALLED_APPS = []\nif FLAG:\n    INSTALLED_APPS.append('first')\nFLAG = get_second()\nif FLAG:\n    INSTALLED_APPS.append('second')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            String::new(),
+            "first".to_string(),
+            "first,second".to_string(),
+            "second".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn negated_and_positive_reads_are_mutually_exclusive() {
+    let settings = extract(
+        "FLAG = get_flag()\nINSTALLED_APPS = []\nif not FLAG:\n    INSTALLED_APPS.append('negative')\nif FLAG:\n    INSTALLED_APPS.append('positive')\n",
+    )
+    .expect("Django settings extraction should succeed");
+    let setting_cases = cases(&settings, "/installed_apps/cases")
+        .expect("settings JSON pointer should identify an array");
+
+    assert_eq!(
+        installed_app_alternatives(setting_cases),
+        Some(BTreeSet::from([
+            "negative".to_string(),
+            "positive".to_string(),
+        ]))
+    );
 }
 
 #[test]
@@ -9998,30 +10324,37 @@ fn unknown_library_key_weakens_prior_alias_and_later_exact_key_is_authoritative(
 }
 
 #[test]
-fn canonical_unknown_origins_merge_top_level_branch_spans() {
+fn branch_unknowns_retain_distinct_predicates_and_all_spans() {
     let source = "if FLAG:\n    VALUE = first()\nelse:\n    VALUE = second()\n";
     let (_, evaluation) =
         evaluate_module(source).expect("Python module evaluation fixture should build");
-    let bound = bound_value(&evaluation, "VALUE").expect("VALUE should have one bound alternative");
-    let unknown = match &bound.value.kind {
-        PythonValueKindView::Unknown(unknown) => Some(unknown),
-        PythonValueKindView::Str(_)
-        | PythonValueKindView::Bool(_)
-        | PythonValueKindView::Path(_)
-        | PythonValueKindView::UnsupportedLiteral
-        | PythonValueKindView::List(_)
-        | PythonValueKindView::Tuple(_)
-        | PythonValueKindView::Dict(_)
-        | PythonValueKindView::Module(_) => None,
-    }
-    .expect("equal unknown branches should produce one unknown");
+    let binding = evaluation
+        .binding("VALUE")
+        .expect("VALUE should have branch alternatives");
+    let unknowns = binding
+        .alternatives
+        .iter()
+        .filter_map(|alternative| {
+            let PythonBindingAlternativeView::Bound(bound) = alternative else {
+                return None;
+            };
+            let PythonValueKindView::Unknown(unknown) = &bound.value.kind else {
+                return None;
+            };
+            Some(unknown)
+        })
+        .collect::<Vec<_>>();
 
-    assert_eq!(unknown.cause, PythonUnknownCauseView::UnsupportedExpression);
-    assert_eq!(
-        unknown
-            .origins
+    assert_eq!(unknowns.len(), 2);
+    assert!(
+        unknowns
             .iter()
-            .map(|origin| origin.span)
+            .all(|unknown| unknown.cause == PythonUnknownCauseView::UnsupportedExpression)
+    );
+    assert_eq!(
+        unknowns
+            .iter()
+            .flat_map(|unknown| unknown.origins.iter().map(|origin| origin.span))
             .collect::<Vec<_>>(),
         [
             expected_span(source, "first()").expect("test source should contain expected text"),


### PR DESCRIPTION
## Summary

- keep repeated tests of one static settings predicate on the same feasible path
- preserve Python and/or/not operand semantics while carrying derived truth constraints
- bound predicate decisions with conservative widening and keep branch mutation effects path-feasible
- distinguish predicate identities across rebinding, imports, destructuring, and overlapping module roots

This removes impossible ArchiveBox and InvenTree settings combinations found while building the real-project settings corpus snapshots.

## Verification

- cargo test -q
- just test
- just clippy
- just fmt --check
- just lint
- cargo build -q
- just hawk
- independent evaluator and state-model reviews