### PR TITLE
Use truthiness values for predicate arms

### DIFF
--- a/crates/djls-project/src/python/evaluation/evaluator.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator.rs
@@ -215,9 +215,14 @@ impl PythonModuleEvaluator<'_> {
             return;
         }
         let join = BranchJoin::predicate(self.module.clone(), identity);
-        let falsy_constraints =
-            constraints.intersection(&BranchConstraints::required(join.clone(), 0));
-        let truthy_constraints = constraints.intersection(&BranchConstraints::required(join, 1));
+        let falsy_constraints = constraints.intersection(&BranchConstraints::required(
+            join.clone(),
+            Truthiness::Falsy.branch_arm(),
+        ));
+        let truthy_constraints = constraints.intersection(&BranchConstraints::required(
+            join,
+            Truthiness::Truthy.branch_arm(),
+        ));
         merge_truth_guard(falsy, falsy_constraints);
         merge_truth_guard(truthy, truthy_constraints);
     }
@@ -635,9 +640,9 @@ impl PythonEvaluationState {
     /// The definite truthiness of a name, if any: a uniformly boolean binding
     /// yields its constant value, and a uniformly module-valued binding is
     /// always truthy (Python module objects are never falsy).
-    pub(super) fn known_truthiness(&self, name: &str) -> Option<bool> {
+    pub(super) fn known_truthiness(&self, name: &str) -> Option<Truthiness> {
         if let Some(value) = self.bool_value(name) {
-            return Some(value);
+            return Some(Truthiness::from_bool(value));
         }
         let binding = self.binding(name)?;
         let is_module = |state: &PythonBindingState| {
@@ -646,7 +651,7 @@ impl PythonEvaluationState {
         };
         let mut alternatives = binding.alternatives();
         let first = alternatives.next()?;
-        (is_module(first) && alternatives.all(is_module)).then_some(true)
+        (is_module(first) && alternatives.all(is_module)).then_some(Truthiness::Truthy)
     }
 
     fn degrade_all_bindings(
@@ -970,6 +975,7 @@ mod tests {
     use super::PythonUnknown;
     use super::PythonUnknownCause;
     use super::PythonValue;
+    use super::Truthiness;
     use crate::python::PythonModule;
     use crate::python::PythonModuleName;
     use crate::python::PythonNamespacePackage;
@@ -1023,7 +1029,7 @@ mod tests {
         );
         assert_eq!(
             state.known_truthiness("MOD"),
-            Some(true),
+            Some(Truthiness::Truthy),
             "a uniformly module-valued binding is always truthy",
         );
 
@@ -1046,7 +1052,7 @@ mod tests {
             "FLAG".to_string(),
             PythonBinding::bound(PythonValue::bool(true, origin(1)), origin(1)),
         );
-        assert_eq!(state.known_truthiness("FLAG"), Some(true));
+        assert_eq!(state.known_truthiness("FLAG"), Some(Truthiness::Truthy));
     }
 
     #[test]

--- a/crates/djls-project/src/python/evaluation/evaluator/statement.rs
+++ b/crates/djls-project/src/python/evaluation/evaluator/statement.rs
@@ -45,8 +45,8 @@ impl<'db> PythonModuleEvaluator<'db> {
             ast::Stmt::While(stmt_while) => {
                 self.record_unsupported_call_effects(&stmt_while.test);
                 match self.test_truthiness(&stmt_while.test) {
-                    Truthiness::AlwaysFalse => self.evaluate_body(&stmt_while.orelse),
-                    Truthiness::AlwaysTrue | Truthiness::Ambiguous => self.degrade_loop_bodies(
+                    Some(Truthiness::Falsy) => self.evaluate_body(&stmt_while.orelse),
+                    Some(Truthiness::Truthy) | None => self.degrade_loop_bodies(
                         &[&stmt_while.body, &stmt_while.orelse],
                         stmt_while.span(),
                     ),
@@ -458,7 +458,7 @@ impl<'db> PythonModuleEvaluator<'db> {
         }
     }
 
-    fn test_truthiness(&self, expression: &ast::Expr) -> Truthiness {
+    fn test_truthiness(&self, expression: &ast::Expr) -> Option<Truthiness> {
         Truthiness::of_expr(expression, &|name| self.state.known_truthiness(name))
     }
 }

--- a/crates/djls-project/src/python/evaluation/name_analysis.rs
+++ b/crates/djls-project/src/python/evaluation/name_analysis.rs
@@ -68,32 +68,34 @@ pub(super) fn expr_read_names(expression: &ast::Expr) -> FxHashSet<String> {
 
 pub(super) fn reachable_expr_read_names(
     expression: &ast::Expr,
-    truthiness: &impl Fn(&ast::Expr) -> Truthiness,
+    truthiness: &impl Fn(&ast::Expr) -> Option<Truthiness>,
 ) -> FxHashSet<String> {
     ReadNameCollector::collect(expression, false, Some(truthiness)).names
 }
 
 pub(super) fn reachable_expr_calls(
     expression: &ast::Expr,
-    truthiness: &impl Fn(&ast::Expr) -> Truthiness,
+    truthiness: &impl Fn(&ast::Expr) -> Option<Truthiness>,
 ) -> Vec<ast::ExprCall> {
     ReadNameCollector::collect(expression, true, Some(truthiness))
         .calls
         .unwrap_or_default()
 }
 
+type TruthinessCallback<'a> = dyn Fn(&ast::Expr) -> Option<Truthiness> + 'a;
+
 #[derive(Default)]
 struct ReadNameCollector<'a> {
     names: FxHashSet<String>,
     calls: Option<Vec<ast::ExprCall>>,
-    truthiness: Option<&'a dyn Fn(&ast::Expr) -> Truthiness>,
+    truthiness: Option<&'a TruthinessCallback<'a>>,
 }
 
 impl<'a> ReadNameCollector<'a> {
     fn collect(
         expression: &ast::Expr,
         collect_calls: bool,
-        truthiness: Option<&'a dyn Fn(&ast::Expr) -> Truthiness>,
+        truthiness: Option<&'a TruthinessCallback<'a>>,
     ) -> Self {
         let mut collector = Self {
             calls: collect_calls.then(Vec::new),
@@ -208,8 +210,8 @@ impl<'a> ReadNameCollector<'a> {
             };
             if matches!(
                 (boolean.op, truthiness),
-                (ast::BoolOp::And, Truthiness::AlwaysFalse)
-                    | (ast::BoolOp::Or, Truthiness::AlwaysTrue)
+                (ast::BoolOp::And, Some(Truthiness::Falsy))
+                    | (ast::BoolOp::Or, Some(Truthiness::Truthy))
             ) {
                 break;
             }

--- a/crates/djls-project/src/python/evaluation/touched_names.rs
+++ b/crates/djls-project/src/python/evaluation/touched_names.rs
@@ -210,7 +210,7 @@ pub(super) fn collect_syntax_impacts(
 struct DefiniteWriteCollector {
     taint: AssignmentTaint,
     names: FxHashSet<String>,
-    known_name_truthiness: FxHashMap<String, bool>,
+    known_name_truthiness: FxHashMap<String, Truthiness>,
 }
 
 impl DefiniteWriteCollector {
@@ -237,7 +237,7 @@ impl DefiniteWriteCollector {
     fn visit_stmt(&mut self, statement: &ast::Stmt) {
         match statement {
             ast::Stmt::Assign(assign) => {
-                let value = self.exact_bool(&assign.value);
+                let value = self.known_truthiness(&assign.value);
                 let dominates = self.expression_is_independent(&assign.value);
                 for target in &assign.targets {
                     self.record_targets(target, value, dominates);
@@ -245,9 +245,9 @@ impl DefiniteWriteCollector {
             }
             ast::Stmt::AnnAssign(assign) => {
                 if let Some(value) = assign.value.as_deref() {
-                    let exact_bool = self.exact_bool(value);
+                    let truthiness = self.known_truthiness(value);
                     let dominates = self.expression_is_independent(value);
-                    self.record_targets(&assign.target, exact_bool, dominates);
+                    self.record_targets(&assign.target, truthiness, dominates);
                 }
             }
             ast::Stmt::Import(import) => {
@@ -299,7 +299,7 @@ impl DefiniteWriteCollector {
         }
     }
 
-    fn record_targets(&mut self, target: &ast::Expr, value: Option<bool>, dominates: bool) {
+    fn record_targets(&mut self, target: &ast::Expr, value: Option<Truthiness>, dominates: bool) {
         let exact_name = target.name_target();
         self.record_binding_targets(target, exact_name, value, dominates);
     }
@@ -308,7 +308,7 @@ impl DefiniteWriteCollector {
         &mut self,
         target: &ast::Expr,
         exact_name: Option<&str>,
-        value: Option<bool>,
+        value: Option<Truthiness>,
         dominates: bool,
     ) {
         if let Some(name) = target.name_target() {
@@ -363,7 +363,7 @@ impl DefiniteWriteCollector {
         }
     }
 
-    fn record_name(&mut self, name: &str, value: Option<bool>, dominates: bool) {
+    fn record_name(&mut self, name: &str, value: Option<Truthiness>, dominates: bool) {
         self.taint.record_write(name, dominates);
         if dominates {
             self.names.insert(name.to_string());
@@ -390,33 +390,25 @@ impl DefiniteWriteCollector {
 
     fn deterministic_if_body<'a>(&self, statement: &'a ast::StmtIf) -> Option<&'a [ast::Stmt]> {
         match self.known_truthiness(&statement.test) {
-            Truthiness::AlwaysTrue => Some(&statement.body),
-            Truthiness::AlwaysFalse => {
+            Some(Truthiness::Truthy) => Some(&statement.body),
+            Some(Truthiness::Falsy) => {
                 for clause in &statement.elif_else_clauses {
                     let Some(test) = &clause.test else {
                         return Some(&clause.body);
                     };
                     match self.known_truthiness(test) {
-                        Truthiness::AlwaysTrue => return Some(&clause.body),
-                        Truthiness::AlwaysFalse => {}
-                        Truthiness::Ambiguous => return None,
+                        Some(Truthiness::Truthy) => return Some(&clause.body),
+                        Some(Truthiness::Falsy) => {}
+                        None => return None,
                     }
                 }
                 Some(&[])
             }
-            Truthiness::Ambiguous => None,
+            None => None,
         }
     }
 
-    fn exact_bool(&self, expression: &ast::Expr) -> Option<bool> {
-        match self.known_truthiness(expression) {
-            Truthiness::AlwaysTrue => Some(true),
-            Truthiness::AlwaysFalse => Some(false),
-            Truthiness::Ambiguous => None,
-        }
-    }
-
-    fn known_truthiness(&self, expression: &ast::Expr) -> Truthiness {
+    fn known_truthiness(&self, expression: &ast::Expr) -> Option<Truthiness> {
         Truthiness::of_expr(expression, &|name| {
             self.known_name_truthiness.get(name).copied()
         })

--- a/crates/djls-project/src/python/evaluation/truthiness.rs
+++ b/crates/djls-project/src/python/evaluation/truthiness.rs
@@ -2,38 +2,44 @@ use ruff_python_ast as ast;
 
 use crate::ast::ExprExt;
 
+/// A statically known result of Python truth testing.
+///
+/// `None` represents an expression whose truthiness cannot be decided.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Truthiness {
-    AlwaysTrue,
-    AlwaysFalse,
-    Ambiguous,
+    Falsy,
+    Truthy,
 }
 
 impl Truthiness {
     pub(super) fn of_expr(
         expression: &ast::Expr,
-        known_bool: &impl Fn(&str) -> Option<bool>,
-    ) -> Self {
+        known_truthiness: &impl Fn(&str) -> Option<Self>,
+    ) -> Option<Self> {
         if let Some(name) = expression.name_target() {
-            return known_bool(name).map_or(Self::Ambiguous, Self::from_bool);
+            return known_truthiness(name);
         }
 
         match expression {
-            ast::Expr::BooleanLiteral(literal) => Self::from_bool(literal.value),
+            ast::Expr::BooleanLiteral(literal) => Some(Self::from_bool(literal.value)),
             ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not => {
-                Self::of_expr(&unary.operand, known_bool).negate()
+                Self::of_expr(&unary.operand, known_truthiness).map(Self::negate)
             }
             ast::Expr::BoolOp(boolean) => match boolean.op {
-                ast::BoolOp::And => boolean
-                    .values
-                    .iter()
-                    .map(|value| Self::of_expr(value, known_bool))
-                    .fold(Self::AlwaysTrue, Self::and),
-                ast::BoolOp::Or => boolean
-                    .values
-                    .iter()
-                    .map(|value| Self::of_expr(value, known_bool))
-                    .fold(Self::AlwaysFalse, Self::or),
+                ast::BoolOp::And => {
+                    let mut result = Some(Self::Truthy);
+                    for value in &boolean.values {
+                        result = Self::and(result, Self::of_expr(value, known_truthiness));
+                    }
+                    result
+                }
+                ast::BoolOp::Or => {
+                    let mut result = Some(Self::Falsy);
+                    for value in &boolean.values {
+                        result = Self::or(result, Self::of_expr(value, known_truthiness));
+                    }
+                    result
+                }
             },
             ast::Expr::Named(_)
             | ast::Expr::BinOp(_)
@@ -65,43 +71,98 @@ impl Truthiness {
             | ast::Expr::List(_)
             | ast::Expr::Tuple(_)
             | ast::Expr::Slice(_)
-            | ast::Expr::IpyEscapeCommand(_) => Self::Ambiguous,
+            | ast::Expr::IpyEscapeCommand(_) => None,
         }
     }
 
-    const fn from_bool(value: bool) -> Self {
-        if value {
-            Self::AlwaysTrue
-        } else {
-            Self::AlwaysFalse
+    pub(super) const fn from_bool(value: bool) -> Self {
+        if value { Self::Truthy } else { Self::Falsy }
+    }
+
+    pub(super) const fn branch_arm(self) -> usize {
+        match self {
+            Self::Falsy => 0,
+            Self::Truthy => 1,
         }
     }
 
     const fn negate(self) -> Self {
         match self {
-            Self::AlwaysTrue => Self::AlwaysFalse,
-            Self::AlwaysFalse => Self::AlwaysTrue,
-            Self::Ambiguous => Self::Ambiguous,
+            Self::Falsy => Self::Truthy,
+            Self::Truthy => Self::Falsy,
         }
     }
 
-    const fn and(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::AlwaysFalse, _) | (_, Self::AlwaysFalse) => Self::AlwaysFalse,
-            (Self::AlwaysTrue, Self::AlwaysTrue) => Self::AlwaysTrue,
-            (Self::AlwaysTrue | Self::Ambiguous, Self::AlwaysTrue | Self::Ambiguous) => {
-                Self::Ambiguous
-            }
+    const fn and(left: Option<Self>, right: Option<Self>) -> Option<Self> {
+        match (left, right) {
+            (Some(Self::Falsy), _) | (_, Some(Self::Falsy)) => Some(Self::Falsy),
+            (Some(Self::Truthy), Some(Self::Truthy)) => Some(Self::Truthy),
+            (Some(Self::Truthy) | None, Some(Self::Truthy) | None) => None,
         }
     }
 
-    const fn or(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::AlwaysTrue, _) | (_, Self::AlwaysTrue) => Self::AlwaysTrue,
-            (Self::AlwaysFalse, Self::AlwaysFalse) => Self::AlwaysFalse,
-            (Self::AlwaysFalse | Self::Ambiguous, Self::AlwaysFalse | Self::Ambiguous) => {
-                Self::Ambiguous
-            }
+    const fn or(left: Option<Self>, right: Option<Self>) -> Option<Self> {
+        match (left, right) {
+            (Some(Self::Truthy), _) | (_, Some(Self::Truthy)) => Some(Self::Truthy),
+            (Some(Self::Falsy), Some(Self::Falsy)) => Some(Self::Falsy),
+            (Some(Self::Falsy) | None, Some(Self::Falsy) | None) => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast as ast;
+    use ruff_python_parser::parse_module;
+
+    use super::Truthiness;
+
+    fn classify_with(
+        expression: &str,
+        known_truthiness: &impl Fn(&str) -> Option<Truthiness>,
+    ) -> Option<Truthiness> {
+        let source = format!("VALUE = {expression}\n");
+        let module = parse_module(&source)
+            .expect("expression should parse")
+            .into_syntax();
+        let [ast::Stmt::Assign(assignment)] = module.body.as_slice() else {
+            panic!("expected one assignment");
+        };
+        Truthiness::of_expr(&assignment.value, known_truthiness)
+    }
+
+    fn classify(expression: &str) -> Option<Truthiness> {
+        classify_with(expression, &|_| None)
+    }
+
+    #[test]
+    fn classifies_boolean_literals_names_and_negation() {
+        assert_eq!(classify("False"), Some(Truthiness::Falsy));
+        assert_eq!(classify("True"), Some(Truthiness::Truthy));
+        assert_eq!(classify("unknown"), None);
+        assert_eq!(
+            classify_with("known", &|name| {
+                (name == "known").then_some(Truthiness::Truthy)
+            }),
+            Some(Truthiness::Truthy),
+        );
+        assert_eq!(classify("not False"), Some(Truthiness::Truthy));
+        assert_eq!(classify("not unknown"), None);
+    }
+
+    #[test]
+    fn boolean_operators_preserve_decisive_values_amid_ambiguity() {
+        assert_eq!(classify("unknown and False"), Some(Truthiness::Falsy));
+        assert_eq!(classify("False and unknown"), Some(Truthiness::Falsy));
+        assert_eq!(classify("unknown and True"), None);
+        assert_eq!(classify("unknown or True"), Some(Truthiness::Truthy));
+        assert_eq!(classify("True or unknown"), Some(Truthiness::Truthy));
+        assert_eq!(classify("unknown or False"), None);
+    }
+
+    #[test]
+    fn exact_truthiness_maps_to_predicate_arms() {
+        assert_eq!(Truthiness::Falsy.branch_arm(), 0);
+        assert_eq!(Truthiness::Truthy.branch_arm(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- represent exact Python truth results as Truthiness::Falsy or Truthiness::Truthy
- represent undecidable truth tests as Option::None instead of a third enum state
- derive predicate decision arms from Truthiness rather than raw numeric arm values
- keep TruthPartition as the pair of feasible constraint sets

## Verification

- cargo test -q
- just test
- just clippy
- just fmt
- just lint
- cargo build -q
- just hawk
- independent simplicity and state-model reviews