### PR TITLE
Snapshot Django settings from the project corpus

### DIFF
--- a/crates/djls-project/tests/corpus_settings.rs
+++ b/crates/djls-project/tests/corpus_settings.rs
@@ -1,0 +1,267 @@
+//! Corpus-backed snapshots for Django settings extraction.
+//!
+//! The corpus must be synced before running this suite:
+//!
+//! ```bash
+//! just corpus sync
+//! cargo test -p djls-project --test corpus_settings
+//! ```
+
+#[cfg(not(windows))]
+use std::collections::BTreeSet;
+#[cfg(not(windows))]
+use std::io;
+
+use camino::Utf8Path;
+#[cfg(not(windows))]
+use djls_project::Interpreter;
+#[cfg(not(windows))]
+use djls_project::Project;
+#[cfg(not(windows))]
+use djls_project::PythonModuleName;
+#[cfg(not(windows))]
+use djls_project::SearchPaths;
+#[cfg(not(windows))]
+use djls_project::testing::django_settings;
+#[cfg(not(windows))]
+use djls_project::testing::settings_module_file;
+#[cfg(not(windows))]
+use djls_source::Db as _;
+use djls_testing::Corpus;
+#[cfg(not(windows))]
+use djls_testing::OsTestDatabase;
+use serde_json::Value;
+
+#[cfg(not(windows))]
+fn snapshot_dir() -> insta::internals::SettingsBindDropGuard {
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/snapshots/settings"
+    ));
+    settings.bind_to_scope()
+}
+
+fn redact_repo_root(value: &mut Value, repo_root: &Utf8Path) {
+    match value {
+        Value::String(text) => {
+            let normalized_text = text.replace('\\', "/");
+            let normalized_repo_root = repo_root.as_str().replace('\\', "/");
+            if let Ok(relative) =
+                Utf8Path::new(&normalized_text).strip_prefix(Utf8Path::new(&normalized_repo_root))
+            {
+                *text = if relative.as_str().is_empty() {
+                    "${REPO}".to_string()
+                } else {
+                    format!("${{REPO}}/{relative}")
+                };
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_repo_root(value, repo_root);
+            }
+        }
+        Value::Object(values) => {
+            for value in values.values_mut() {
+                redact_repo_root(value, repo_root);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+#[cfg(not(windows))]
+fn installed_app_cases(settings: &Value) -> Result<(Vec<BTreeSet<&str>>, usize), io::Error> {
+    let cases = settings
+        .pointer("/installed_apps/cases")
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("settings should contain installed-app cases"))?;
+    let mut known = Vec::new();
+    let mut dynamic_count = 0;
+
+    for case in cases {
+        if let Some(apps) = case.pointer("/known/apps").and_then(Value::as_array) {
+            known.push(
+                apps.iter()
+                    .map(|app| {
+                        app.get("value").and_then(Value::as_str).ok_or_else(|| {
+                            io::Error::other("known installed app should be a string")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?,
+            );
+        } else if case.get("dynamic").is_some() {
+            dynamic_count += 1;
+        } else {
+            return Err(io::Error::other(
+                "installed-app case should be known or dynamic",
+            ));
+        }
+    }
+
+    Ok((known, dynamic_count))
+}
+
+#[cfg(not(windows))]
+fn check_predicate_correlations(repo_name: &str, settings: &Value) -> Result<(), io::Error> {
+    match repo_name {
+        "archivebox" => {
+            let (cases, dynamic_count) = installed_app_cases(settings)?;
+            if cases.len() != 2 || dynamic_count != 0 {
+                return Err(io::Error::other(format!(
+                    "ArchiveBox should have two exact app cases and no dynamic case, found {} exact and {dynamic_count} dynamic",
+                    cases.len()
+                )));
+            }
+            if cases
+                .iter()
+                .any(|apps| apps.contains("django_autotyping") != apps.contains("requests_tracker"))
+            {
+                return Err(io::Error::other(
+                    "ArchiveBox debug-controlled apps must occur together",
+                ));
+            }
+            if !cases.iter().any(|apps| apps.contains("django_autotyping"))
+                || !cases.iter().any(|apps| !apps.contains("django_autotyping"))
+            {
+                return Err(io::Error::other(
+                    "ArchiveBox should retain both debug predicate outcomes",
+                ));
+            }
+        }
+        "inventree" => {
+            let (cases, dynamic_count) = installed_app_cases(settings)?;
+            if cases.len() != 12 || dynamic_count != 1 {
+                return Err(io::Error::other(format!(
+                    "InvenTree should have twelve exact app cases and one dynamic case, found {} exact and {dynamic_count} dynamic",
+                    cases.len()
+                )));
+            }
+            if cases
+                .iter()
+                .any(|apps| apps.contains("silk") && !apps.contains("sslserver"))
+            {
+                return Err(io::Error::other(
+                    "InvenTree silk cases must also contain sslserver",
+                ));
+            }
+            if !cases.iter().any(|apps| apps.contains("silk"))
+                || !cases.iter().any(|apps| !apps.contains("silk"))
+            {
+                return Err(io::Error::other(
+                    "InvenTree should retain both silk predicate outcomes",
+                ));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[test]
+fn corpus_is_synced() -> Result<(), Box<dyn std::error::Error>> {
+    Corpus::require()?;
+    Ok(())
+}
+
+// The production evaluator deliberately leaves `os.path` calls unknown on
+// Windows. These snapshots encode POSIX settings semantics; path redaction is
+// tested on every platform below.
+#[cfg(not(windows))]
+#[test]
+fn settings_extraction_snapshots() -> Result<(), Box<dyn std::error::Error>> {
+    let corpus = Corpus::require()?;
+    let declarations = corpus.repo_settings_projects()?;
+    if declarations.is_empty() {
+        return Err(io::Error::other(
+            "corpus manifest should declare at least one Django settings module",
+        )
+        .into());
+    }
+    let _guard = snapshot_dir();
+    let mut snapshot_names = BTreeSet::new();
+
+    for corpus_project in declarations {
+        let repo_name = &corpus_project.repo_name;
+        let checkout_root = &corpus_project.checkout_root;
+        let project_root = &corpus_project.project_root;
+
+        for settings_module in corpus_project.django_settings_modules {
+            let mut db = OsTestDatabase::new();
+            let interpreter = Interpreter::VenvPath(corpus.root().join("hermetic-no-venv"));
+            let pythonpath = Vec::new();
+            let search_paths = SearchPaths::from_project_settings(
+                db.file_system(),
+                project_root.as_path(),
+                &interpreter,
+                &pythonpath,
+            );
+            search_paths.register_roots(&db);
+            let project = Project::new(
+                &db,
+                project_root.clone(),
+                search_paths,
+                interpreter,
+                Some(PythonModuleName::parse(&settings_module)?),
+                pythonpath,
+                Vec::new(),
+                djls_conf::Settings::default().tagspecs().clone(),
+            );
+            db.set_project(project);
+
+            settings_module_file(&db, project).ok_or_else(|| {
+                io::Error::other(format!(
+                    "settings module `{settings_module}` for corpus repo `{repo_name}` did not resolve"
+                ))
+            })?;
+            let mut settings = serde_json::to_value(django_settings(&db, project))?;
+            check_predicate_correlations(repo_name, &settings)?;
+            redact_repo_root(&mut settings, checkout_root);
+
+            let snapshot_name = format!("{repo_name}__{}", settings_module.replace('.', "__"));
+            if !snapshot_names.insert(snapshot_name.clone()) {
+                return Err(io::Error::other(format!(
+                    "corpus settings modules produce duplicate snapshot name `{snapshot_name}`"
+                ))
+                .into());
+            }
+            insta::assert_yaml_snapshot!(snapshot_name, settings);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn repo_root_redaction_rewrites_nested_string_values() {
+    let mut value = serde_json::json!({
+        "path": "/corpus/repo/templates",
+        "nested": ["/corpus/repo", "unchanged"],
+        "prefix_collision": "/corpus/repository/templates",
+    });
+
+    redact_repo_root(&mut value, Utf8Path::new("/corpus/repo"));
+
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "path": "${REPO}/templates",
+            "nested": ["${REPO}", "unchanged"],
+            "prefix_collision": "/corpus/repository/templates",
+        })
+    );
+
+    let mut windows_value = serde_json::json!({
+        "path": r"C:\corpus\repo\templates",
+        "prefix_collision": r"C:\corpus\repository\templates",
+    });
+    redact_repo_root(&mut windows_value, Utf8Path::new(r"C:\corpus\repo"));
+    assert_eq!(
+        windows_value,
+        serde_json::json!({
+            "path": "${REPO}/templates",
+            "prefix_collision": r"C:\corpus\repository\templates",
+        })
+    );
+}

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__archivebox__archivebox__core__settings.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__archivebox__archivebox__core__settings.snap
@@ -1,0 +1,230 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 8
+                start: 1637
+            value: daphne
+          - spans:
+              - length: 21
+                start: 1677
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1704
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1739
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 1770
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1801
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 1835
+            value: django.contrib.admin
+          - spans:
+              - length: 17
+                start: 1894
+            value: signal_webhooks
+          - spans:
+              - length: 23
+                start: 2037
+            value: django_object_actions
+          - spans:
+              - length: 20
+                start: 2447
+            value: archivebox.machine
+          - spans:
+              - length: 20
+                start: 2578
+            value: archivebox.workers
+          - spans:
+              - length: 21
+                start: 2697
+            value: archivebox.personas
+          - spans:
+              - length: 17
+                start: 2766
+            value: archivebox.core
+          - spans:
+              - length: 19
+                start: 2870
+            value: archivebox.crawls
+          - spans:
+              - length: 16
+                start: 2970
+            value: archivebox.api
+          - spans:
+              - length: 18
+                start: 3256
+            value: admin_data_views
+          - spans:
+              - length: 19
+                start: 3367
+            value: django_extensions
+          - spans:
+              - length: 19
+                start: 21699
+            value: django_autotyping
+          - spans:
+              - length: 18
+                start: 22263
+            value: requests_tracker
+    - known:
+        apps:
+          - spans:
+              - length: 8
+                start: 1637
+            value: daphne
+          - spans:
+              - length: 21
+                start: 1677
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1704
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1739
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 1770
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1801
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 1835
+            value: django.contrib.admin
+          - spans:
+              - length: 17
+                start: 1894
+            value: signal_webhooks
+          - spans:
+              - length: 23
+                start: 2037
+            value: django_object_actions
+          - spans:
+              - length: 20
+                start: 2447
+            value: archivebox.machine
+          - spans:
+              - length: 20
+                start: 2578
+            value: archivebox.workers
+          - spans:
+              - length: 21
+                start: 2697
+            value: archivebox.personas
+          - spans:
+              - length: 17
+                start: 2766
+            value: archivebox.core
+          - spans:
+              - length: 19
+                start: 2870
+            value: archivebox.crawls
+          - spans:
+              - length: 16
+                start: 2970
+            value: archivebox.api
+          - spans:
+              - length: 18
+                start: 3256
+            value: admin_data_views
+          - spans:
+              - length: 19
+                start: 3367
+            value: django_extensions
+templates:
+  cases:
+    - dynamic:
+        evidence:
+          - backend:
+              app_dirs:
+                issues: []
+                known:
+                  spans:
+                    - length: 4
+                      start: 8537
+                  value: true
+              backend:
+                issues: []
+                known:
+                  spans:
+                    - length: 49
+                      start: 8435
+                  value: django.template.backends.django.DjangoTemplates
+              builtins:
+                issues: []
+                known: []
+              context_processors:
+                issues: []
+                known:
+                  - spans:
+                      - length: 42
+                        start: 8616
+                    value: django.template.context_processors.debug
+                  - spans:
+                      - length: 44
+                        start: 8676
+                    value: django.template.context_processors.request
+                  - spans:
+                      - length: 45
+                        start: 8738
+                    value: django.contrib.auth.context_processors.auth
+                  - spans:
+                      - length: 53
+                        start: 8801
+                    value: django.contrib.messages.context_processors.messages
+              dirs:
+                evidence:
+                  - issue:
+                      kind: unknown_unpack
+                      spans:
+                        - length: 78
+                          start: 7964
+                  - issue:
+                      kind: unknown_element
+                      spans:
+                        - length: 46
+                          start: 8249
+                  - issue:
+                      kind: unknown_element
+                      spans:
+                        - length: 47
+                          start: 8301
+                  - issue:
+                      kind: unknown_element
+                      spans:
+                        - length: 37
+                          start: 8354
+              libraries:
+                issues: []
+                known: []
+              options:
+                issues: []
+                known: ~
+    - dynamic:
+        evidence:
+          - issue:
+              kind: unsupported_mutation
+              spans:
+                - length: 90
+                  start: 22427

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__django-allauth__tests__projects__account_only__settings.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__django-allauth__tests__projects__account_only__settings.snap
@@ -1,0 +1,86 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 21
+                start: 1551
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1578
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1613
+            value: django.contrib.sessions
+          - spans:
+              - length: 22
+                start: 1644
+            value: django.contrib.sites
+          - spans:
+              - length: 25
+                start: 1672
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1703
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 1737
+            value: django.contrib.admin
+          - spans:
+              - length: 25
+                start: 1765
+            value: django.contrib.humanize
+          - spans:
+              - length: 9
+                start: 1796
+            value: allauth
+          - spans:
+              - length: 17
+                start: 1811
+            value: allauth.account
+templates:
+  cases:
+    - known:
+        backends:
+          - app_dirs:
+              spans:
+                - length: 4
+                  start: 657
+              value: true
+            backend:
+              spans:
+                - length: 49
+                  start: 531
+              value: django.template.backends.django.DjangoTemplates
+            builtins: []
+            context_processors:
+              - spans:
+                  - length: 42
+                    start: 736
+                value: django.template.context_processors.debug
+              - spans:
+                  - length: 44
+                    start: 796
+                value: django.template.context_processors.request
+              - spans:
+                  - length: 45
+                    start: 858
+                value: django.contrib.auth.context_processors.auth
+              - spans:
+                  - length: 53
+                    start: 921
+                value: django.contrib.messages.context_processors.messages
+            dirs:
+              - spans:
+                  - length: 35
+                    start: 599
+                value: "${REPO}/tests/projects/account_only/templates"
+            libraries: []

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__healthchecks__hc__settings.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__healthchecks__hc__settings.snap
@@ -1,0 +1,240 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 13
+                start: 2458
+            value: hc.accounts
+          - spans:
+              - length: 22
+                start: 2477
+            value: django.contrib.admin
+          - spans:
+              - length: 21
+                start: 2505
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 2532
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 2567
+            value: django.contrib.humanize
+          - spans:
+              - length: 25
+                start: 2598
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 2629
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 2660
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 12
+                start: 2694
+            value: compressor
+          - spans:
+              - length: 8
+                start: 2712
+            value: hc.api
+          - spans:
+              - length: 10
+                start: 2726
+            value: hc.front
+          - spans:
+              - length: 9
+                start: 2742
+            value: hc.logs
+          - spans:
+              - length: 13
+                start: 2757
+            value: hc.payments
+          - spans:
+              - length: 25
+                start: 2776
+            value: hc.integrations.apprise
+          - spans:
+              - length: 22
+                start: 2807
+            value: hc.integrations.call
+          - spans:
+              - length: 25
+                start: 2835
+            value: hc.integrations.discord
+          - spans:
+              - length: 23
+                start: 2866
+            value: hc.integrations.email
+          - spans:
+              - length: 24
+                start: 2895
+            value: hc.integrations.github
+          - spans:
+              - length: 28
+                start: 2925
+            value: hc.integrations.googlechat
+          - spans:
+              - length: 24
+                start: 2959
+            value: hc.integrations.gotify
+          - spans:
+              - length: 23
+                start: 2989
+            value: hc.integrations.group
+          - spans:
+              - length: 24
+                start: 3018
+            value: hc.integrations.matrix
+          - spans:
+              - length: 28
+                start: 3048
+            value: hc.integrations.mattermost
+          - spans:
+              - length: 26
+                start: 3082
+            value: hc.integrations.msteamsw
+          - spans:
+              - length: 22
+                start: 3114
+            value: hc.integrations.ntfy
+          - spans:
+              - length: 26
+                start: 3142
+            value: hc.integrations.opsgenie
+          - spans:
+              - length: 27
+                start: 3174
+            value: hc.integrations.pagertree
+          - spans:
+              - length: 20
+                start: 3207
+            value: hc.integrations.pd
+          - spans:
+              - length: 20
+                start: 3233
+            value: hc.integrations.po
+          - spans:
+              - length: 28
+                start: 3259
+            value: hc.integrations.prometheus
+          - spans:
+              - length: 28
+                start: 3293
+            value: hc.integrations.pushbullet
+          - spans:
+              - length: 28
+                start: 3327
+            value: hc.integrations.rocketchat
+          - spans:
+              - length: 23
+                start: 3361
+            value: hc.integrations.shell
+          - spans:
+              - length: 24
+                start: 3390
+            value: hc.integrations.signal
+          - spans:
+              - length: 23
+                start: 3420
+            value: hc.integrations.slack
+          - spans:
+              - length: 21
+                start: 3449
+            value: hc.integrations.sms
+          - spans:
+              - length: 23
+                start: 3476
+            value: hc.integrations.spike
+          - spans:
+              - length: 26
+                start: 3505
+            value: hc.integrations.telegram
+          - spans:
+              - length: 24
+                start: 3537
+            value: hc.integrations.trello
+          - spans:
+              - length: 27
+                start: 3567
+            value: hc.integrations.victorops
+          - spans:
+              - length: 25
+                start: 3600
+            value: hc.integrations.webhook
+          - spans:
+              - length: 26
+                start: 3631
+            value: hc.integrations.whatsapp
+          - spans:
+              - length: 23
+                start: 3663
+            value: hc.integrations.zulip
+    - dynamic:
+        evidence:
+          - issue:
+              kind: dynamic_expression
+              spans:
+                - length: 29
+                  start: 13789
+templates:
+  cases:
+    - known:
+        backends:
+          - app_dirs:
+              spans:
+                - length: 4
+                  start: 4813
+              value: true
+            backend:
+              spans:
+                - length: 49
+                  start: 4700
+              value: django.template.backends.django.DjangoTemplates
+            builtins: []
+            context_processors:
+              - spans:
+                  - length: 42
+                    start: 4892
+                value: django.template.context_processors.debug
+              - spans:
+                  - length: 44
+                    start: 4952
+                value: django.template.context_processors.request
+              - spans:
+                  - length: 45
+                    start: 5014
+                value: django.contrib.auth.context_processors.auth
+              - spans:
+                  - length: 53
+                    start: 5077
+                value: django.contrib.messages.context_processors.messages
+              - spans:
+                  - length: 38
+                    start: 5148
+                value: hc.front.context_processors.branding
+              - spans:
+                  - length: 41
+                    start: 5204
+                value: hc.payments.context_processors.payments
+            dirs:
+              - spans:
+                  - length: 22
+                    start: 4768
+                value: "${REPO}/templates"
+            libraries: []
+    - dynamic:
+        evidence:
+          - issue:
+              kind: dynamic_expression
+              spans:
+                - length: 29
+                  start: 13789

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__inventree__InvenTree__settings.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__inventree__InvenTree__settings.snap
@@ -1,0 +1,2784 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 6
+                start: 13999
+            value: silk
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+          - spans:
+              - length: 26
+                start: 22750
+            value: rest_framework_simplejwt
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 10600
+            value: django.contrib.sites
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 6
+                start: 13999
+            value: silk
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+          - spans:
+              - length: 26
+                start: 22750
+            value: rest_framework_simplejwt
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 6
+                start: 13999
+            value: silk
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 10600
+            value: django.contrib.sites
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 6
+                start: 13999
+            value: silk
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+          - spans:
+              - length: 26
+                start: 22750
+            value: rest_framework_simplejwt
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 10600
+            value: django.contrib.sites
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+          - spans:
+              - length: 26
+                start: 22750
+            value: rest_framework_simplejwt
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 10600
+            value: django.contrib.sites
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 11
+                start: 20273
+            value: sslserver
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 26
+                start: 22750
+            value: rest_framework_simplejwt
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 10600
+            value: django.contrib.sites
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+          - spans:
+              - length: 26
+                start: 22750
+            value: rest_framework_simplejwt
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+    - known:
+        apps:
+          - spans:
+              - length: 22
+                start: 9694
+            value: django.contrib.admin
+          - spans:
+              - length: 26
+                start: 9722
+            value: django.contrib.admindocs
+          - spans:
+              - length: 24
+                start: 9775
+            value: build.apps.BuildConfig
+          - spans:
+              - length: 26
+                start: 9805
+            value: common.apps.CommonConfig
+          - spans:
+              - length: 29
+                start: 9837
+            value: plugin.apps.PluginAppConfig
+          - spans:
+              - length: 28
+                start: 9958
+            value: company.apps.CompanyConfig
+          - spans:
+              - length: 24
+                start: 9992
+            value: order.apps.OrderConfig
+          - spans:
+              - length: 22
+                start: 10022
+            value: part.apps.PartConfig
+          - spans:
+              - length: 26
+                start: 10050
+            value: report.apps.ReportConfig
+          - spans:
+              - length: 24
+                start: 10082
+            value: stock.apps.StockConfig
+          - spans:
+              - length: 24
+                start: 10112
+            value: users.apps.UsersConfig
+          - spans:
+              - length: 28
+                start: 10142
+            value: machine.apps.MachineConfig
+          - spans:
+              - length: 39
+                start: 10176
+            value: data_exporter.apps.DataExporterConfig
+          - spans:
+              - length: 30
+                start: 10221
+            value: importer.apps.ImporterConfig
+          - spans:
+              - length: 5
+                start: 10257
+            value: web
+          - spans:
+              - length: 9
+                start: 10268
+            value: generic
+          - spans:
+              - length: 32
+                start: 10283
+            value: InvenTree.apps.InvenTreeConfig
+          - spans:
+              - length: 21
+                start: 10374
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 10401
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 10436
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 10467
+            value: django.contrib.humanize
+          - spans:
+              - length: 31
+                start: 10498
+            value: whitenoise.runserver_nostatic
+          - spans:
+              - length: 25
+                start: 10535
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 10566
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 22
+                start: 10600
+            value: django.contrib.sites
+          - spans:
+              - length: 18
+                start: 10646
+            value: maintenance_mode
+          - spans:
+              - length: 16
+                start: 10695
+            value: django_filters
+          - spans:
+              - length: 16
+                start: 10750
+            value: rest_framework
+          - spans:
+              - length: 13
+                start: 10803
+            value: corsheaders
+          - spans:
+              - length: 35
+                start: 10863
+            value: django_cleanup.apps.CleanupConfig
+          - spans:
+              - length: 6
+                start: 10949
+            value: mptt
+          - spans:
+              - length: 13
+                start: 10997
+            value: markdownify
+          - spans:
+              - length: 9
+                start: 11047
+            value: djmoney
+          - spans:
+              - length: 26
+                start: 11090
+            value: djmoney.contrib.exchange
+          - spans:
+              - length: 14
+                start: 11153
+            value: error_report
+          - spans:
+              - length: 10
+                start: 11215
+            value: django_q
+          - spans:
+              - length: 10
+                start: 11231
+            value: dbbackup
+          - spans:
+              - length: 8
+                start: 11276
+            value: taggit
+          - spans:
+              - length: 7
+                start: 11301
+            value: flags
+          - spans:
+              - length: 18
+                start: 11341
+            value: django_structlog
+          - spans:
+              - length: 9
+                start: 11387
+            value: allauth
+          - spans:
+              - length: 17
+                start: 11422
+            value: allauth.account
+          - spans:
+              - length: 18
+                start: 11474
+            value: allauth.headless
+          - spans:
+              - length: 23
+                start: 11515
+            value: allauth.socialaccount
+          - spans:
+              - length: 13
+                start: 11570
+            value: allauth.mfa
+          - spans:
+              - length: 22
+                start: 11612
+            value: allauth.usersessions
+          - spans:
+              - length: 12
+                start: 11655
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 11713
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 11766
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 17
+                start: 11819
+            value: oauth2_provider
+          - spans:
+              - length: 17
+                start: 11876
+            value: drf_spectacular
+          - spans:
+              - length: 13
+                start: 11920
+            value: django_ical
+          - spans:
+              - length: 16
+                start: 11966
+            value: django_mailbox
+          - spans:
+              - length: 9
+                start: 12008
+            value: anymail
+          - spans:
+              - length: 10
+                start: 12063
+            value: storages
+    - dynamic:
+        evidence:
+          - issue:
+              kind: dynamic_expression
+              spans:
+                - length: 283
+                  start: 46353
+templates:
+  cases:
+    - dynamic:
+        evidence:
+          - backend:
+              app_dirs:
+                issues: []
+                known: ~
+              backend:
+                issues: []
+                known:
+                  spans:
+                    - length: 49
+                      start: 20389
+                  value: django.template.backends.django.DjangoTemplates
+              builtins:
+                issues: []
+                known: []
+              context_processors:
+                issues: []
+                known:
+                  - spans:
+                      - length: 42
+                        start: 20594
+                    value: django.template.context_processors.debug
+                  - spans:
+                      - length: 44
+                        start: 20654
+                    value: django.template.context_processors.request
+                  - spans:
+                      - length: 41
+                        start: 20716
+                    value: django.template.context_processors.i18n
+                  - spans:
+                      - length: 45
+                        start: 20775
+                    value: django.contrib.auth.context_processors.auth
+                  - spans:
+                      - length: 53
+                        start: 20838
+                    value: django.contrib.messages.context_processors.messages
+              dirs:
+                evidence:
+                  - issue:
+                      kind: unknown_element
+                      spans:
+                        - length: 30
+                          start: 20457
+                  - issue:
+                      kind: unknown_element
+                      spans:
+                        - length: 29
+                          start: 20489
+              libraries:
+                issues: []
+                known: []
+              options:
+                issues: []
+                known: ~

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__netbox__netbox__settings.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__netbox__netbox__settings.snap
@@ -1,0 +1,368 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 21
+                start: 19619
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 19646
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 19681
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 19712
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 19743
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 25
+                start: 19777
+            value: django.contrib.humanize
+          - spans:
+              - length: 14
+                start: 19808
+            value: django.forms
+          - spans:
+              - length: 13
+                start: 19828
+            value: corsheaders
+          - spans:
+              - length: 16
+                start: 19868
+            value: django_filters
+          - spans:
+              - length: 13
+                start: 19890
+            value: django_htmx
+          - spans:
+              - length: 16
+                start: 19909
+            value: django_tables2
+          - spans:
+              - length: 19
+                start: 19931
+            value: django_prometheus
+          - spans:
+              - length: 19
+                start: 19956
+            value: strawberry_django
+          - spans:
+              - length: 6
+                start: 19981
+            value: mptt
+          - spans:
+              - length: 16
+                start: 19993
+            value: rest_framework
+          - spans:
+              - length: 15
+                start: 20015
+            value: social_django
+          - spans:
+              - length: 16
+                start: 20036
+            value: sorl.thumbnail
+          - spans:
+              - length: 8
+                start: 20058
+            value: taggit
+          - spans:
+              - length: 16
+                start: 20072
+            value: timezone_field
+          - spans:
+              - length: 6
+                start: 20094
+            value: core
+          - spans:
+              - length: 9
+                start: 20106
+            value: account
+          - spans:
+              - length: 10
+                start: 20121
+            value: circuits
+          - spans:
+              - length: 6
+                start: 20137
+            value: dcim
+          - spans:
+              - length: 6
+                start: 20149
+            value: ipam
+          - spans:
+              - length: 8
+                start: 20161
+            value: extras
+          - spans:
+              - length: 9
+                start: 20175
+            value: tenancy
+          - spans:
+              - length: 7
+                start: 20190
+            value: users
+          - spans:
+              - length: 11
+                start: 20203
+            value: utilities
+          - spans:
+              - length: 16
+                start: 20220
+            value: virtualization
+          - spans:
+              - length: 5
+                start: 20242
+            value: vpn
+          - spans:
+              - length: 10
+                start: 20253
+            value: wireless
+          - spans:
+              - length: 11
+                start: 20269
+            value: django_rq
+          - spans:
+              - length: 17
+                start: 20352
+            value: drf_spectacular
+          - spans:
+              - length: 25
+                start: 20375
+            value: drf_spectacular_sidecar
+    - known:
+        apps:
+          - spans:
+              - length: 21
+                start: 19619
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 19646
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 19681
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 19712
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 19743
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 25
+                start: 19777
+            value: django.contrib.humanize
+          - spans:
+              - length: 14
+                start: 19808
+            value: django.forms
+          - spans:
+              - length: 13
+                start: 19828
+            value: corsheaders
+          - spans:
+              - length: 15
+                start: 19847
+            value: debug_toolbar
+          - spans:
+              - length: 16
+                start: 19868
+            value: django_filters
+          - spans:
+              - length: 13
+                start: 19890
+            value: django_htmx
+          - spans:
+              - length: 16
+                start: 19909
+            value: django_tables2
+          - spans:
+              - length: 19
+                start: 19931
+            value: django_prometheus
+          - spans:
+              - length: 19
+                start: 19956
+            value: strawberry_django
+          - spans:
+              - length: 6
+                start: 19981
+            value: mptt
+          - spans:
+              - length: 16
+                start: 19993
+            value: rest_framework
+          - spans:
+              - length: 15
+                start: 20015
+            value: social_django
+          - spans:
+              - length: 16
+                start: 20036
+            value: sorl.thumbnail
+          - spans:
+              - length: 8
+                start: 20058
+            value: taggit
+          - spans:
+              - length: 16
+                start: 20072
+            value: timezone_field
+          - spans:
+              - length: 6
+                start: 20094
+            value: core
+          - spans:
+              - length: 9
+                start: 20106
+            value: account
+          - spans:
+              - length: 10
+                start: 20121
+            value: circuits
+          - spans:
+              - length: 6
+                start: 20137
+            value: dcim
+          - spans:
+              - length: 6
+                start: 20149
+            value: ipam
+          - spans:
+              - length: 8
+                start: 20161
+            value: extras
+          - spans:
+              - length: 9
+                start: 20175
+            value: tenancy
+          - spans:
+              - length: 7
+                start: 20190
+            value: users
+          - spans:
+              - length: 11
+                start: 20203
+            value: utilities
+          - spans:
+              - length: 16
+                start: 20220
+            value: virtualization
+          - spans:
+              - length: 5
+                start: 20242
+            value: vpn
+          - spans:
+              - length: 10
+                start: 20253
+            value: wireless
+          - spans:
+              - length: 11
+                start: 20269
+            value: django_rq
+          - spans:
+              - length: 17
+                start: 20352
+            value: drf_spectacular
+          - spans:
+              - length: 25
+                start: 20375
+            value: drf_spectacular_sidecar
+    - dynamic:
+        evidence:
+          - issue:
+              kind: dynamic_expression
+              spans:
+                - length: 3461
+                  start: 32047
+                - length: 29
+                  start: 36405
+templates:
+  cases:
+    - known:
+        backends:
+          - app_dirs:
+              spans:
+                - length: 4
+                  start: 21821
+              value: true
+            backend:
+              spans:
+                - length: 49
+                  start: 21717
+              value: django.template.backends.django.DjangoTemplates
+            builtins:
+              - spans:
+                  - length: 41
+                    start: 21890
+                value: utilities.templatetags.builtins.filters
+              - spans:
+                  - length: 38
+                    start: 21949
+                value: utilities.templatetags.builtins.tags
+            context_processors:
+              - spans:
+                  - length: 42
+                    start: 22056
+                value: django.template.context_processors.debug
+              - spans:
+                  - length: 44
+                    start: 22116
+                value: django.template.context_processors.request
+              - spans:
+                  - length: 42
+                    start: 22178
+                value: django.template.context_processors.media
+              - spans:
+                  - length: 45
+                    start: 22238
+                value: django.contrib.auth.context_processors.auth
+              - spans:
+                  - length: 53
+                    start: 22301
+                value: django.contrib.messages.context_processors.messages
+              - spans:
+                  - length: 36
+                    start: 22372
+                value: netbox.context_processors.settings
+              - spans:
+                  - length: 34
+                    start: 22426
+                value: netbox.context_processors.config
+              - spans:
+                  - length: 36
+                    start: 22478
+                value: netbox.context_processors.registry
+              - spans:
+                  - length: 39
+                    start: 22532
+                value: netbox.context_processors.preferences
+            dirs:
+              - spans:
+                  - length: 23
+                    start: 21654
+                value: "${REPO}/netbox/templates"
+            libraries: []
+    - dynamic:
+        evidence:
+          - issue:
+              kind: dynamic_expression
+              spans:
+                - length: 29
+                  start: 36405

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__pretix__pretix__settings.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__pretix__pretix__settings.snap
@@ -1,0 +1,815 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 21
+                start: 1425
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1452
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1487
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 1518
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1549
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 25
+                start: 1583
+            value: django.contrib.humanize
+          - spans:
+              - length: 13
+                start: 1614
+            value: pretix.base
+          - spans:
+              - length: 16
+                start: 1633
+            value: pretix.control
+          - spans:
+              - length: 16
+                start: 1655
+            value: pretix.presale
+          - spans:
+              - length: 20
+                start: 1677
+            value: pretix.multidomain
+          - spans:
+              - length: 12
+                start: 1703
+            value: pretix.api
+          - spans:
+              - length: 16
+                start: 1721
+            value: pretix.helpers
+          - spans:
+              - length: 16
+                start: 1743
+            value: rest_framework
+          - spans:
+              - length: 17
+                start: 1765
+            value: djangoformsetjs
+          - spans:
+              - length: 12
+                start: 1788
+            value: compressor
+          - spans:
+              - length: 12
+                start: 1806
+            value: bootstrap3
+          - spans:
+              - length: 29
+                start: 1824
+            value: pretix.plugins.banktransfer
+          - spans:
+              - length: 23
+                start: 1859
+            value: pretix.plugins.stripe
+          - spans:
+              - length: 23
+                start: 1888
+            value: pretix.plugins.paypal
+          - spans:
+              - length: 24
+                start: 1917
+            value: pretix.plugins.paypal2
+          - spans:
+              - length: 32
+                start: 1947
+            value: pretix.plugins.ticketoutputpdf
+          - spans:
+              - length: 25
+                start: 1985
+            value: pretix.plugins.sendmail
+          - spans:
+              - length: 27
+                start: 2016
+            value: pretix.plugins.statistics
+          - spans:
+              - length: 24
+                start: 2049
+            value: pretix.plugins.reports
+          - spans:
+              - length: 29
+                start: 2079
+            value: pretix.plugins.checkinlists
+          - spans:
+              - length: 28
+                start: 2114
+            value: pretix.plugins.pretixdroid
+          - spans:
+              - length: 23
+                start: 2148
+            value: pretix.plugins.badges
+          - spans:
+              - length: 30
+                start: 2177
+            value: pretix.plugins.manualpayment
+          - spans:
+              - length: 26
+                start: 2213
+            value: pretix.plugins.returnurl
+          - spans:
+              - length: 28
+                start: 2245
+            value: pretix.plugins.autocheckin
+          - spans:
+              - length: 27
+                start: 2279
+            value: pretix.plugins.webcheckin
+          - spans:
+              - length: 18
+                start: 2312
+            value: django_countries
+          - spans:
+              - length: 17
+                start: 2336
+            value: oauth2_provider
+          - spans:
+              - length: 19
+                start: 2359
+            value: phonenumber_field
+          - spans:
+              - length: 12
+                start: 2384
+            value: statici18n
+          - spans:
+              - length: 14
+                start: 2402
+            value: django.forms
+          - spans:
+              - length: 16
+                start: 18772
+            value: django_filters
+          - spans:
+              - length: 15
+                start: 18794
+            value: django_markup
+          - spans:
+              - length: 12
+                start: 18815
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 18833
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 18868
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 8
+                start: 18905
+            value: hijack
+          - spans:
+              - length: 13
+                start: 18919
+            value: localflavor
+          - spans:
+              - length: 19
+                start: 19144
+            value: django_extensions
+    - known:
+        apps:
+          - spans:
+              - length: 21
+                start: 1425
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1452
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1487
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 1518
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1549
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 25
+                start: 1583
+            value: django.contrib.humanize
+          - spans:
+              - length: 13
+                start: 1614
+            value: pretix.base
+          - spans:
+              - length: 16
+                start: 1633
+            value: pretix.control
+          - spans:
+              - length: 16
+                start: 1655
+            value: pretix.presale
+          - spans:
+              - length: 20
+                start: 1677
+            value: pretix.multidomain
+          - spans:
+              - length: 12
+                start: 1703
+            value: pretix.api
+          - spans:
+              - length: 16
+                start: 1721
+            value: pretix.helpers
+          - spans:
+              - length: 16
+                start: 1743
+            value: rest_framework
+          - spans:
+              - length: 17
+                start: 1765
+            value: djangoformsetjs
+          - spans:
+              - length: 12
+                start: 1788
+            value: compressor
+          - spans:
+              - length: 12
+                start: 1806
+            value: bootstrap3
+          - spans:
+              - length: 29
+                start: 1824
+            value: pretix.plugins.banktransfer
+          - spans:
+              - length: 23
+                start: 1859
+            value: pretix.plugins.stripe
+          - spans:
+              - length: 23
+                start: 1888
+            value: pretix.plugins.paypal
+          - spans:
+              - length: 24
+                start: 1917
+            value: pretix.plugins.paypal2
+          - spans:
+              - length: 32
+                start: 1947
+            value: pretix.plugins.ticketoutputpdf
+          - spans:
+              - length: 25
+                start: 1985
+            value: pretix.plugins.sendmail
+          - spans:
+              - length: 27
+                start: 2016
+            value: pretix.plugins.statistics
+          - spans:
+              - length: 24
+                start: 2049
+            value: pretix.plugins.reports
+          - spans:
+              - length: 29
+                start: 2079
+            value: pretix.plugins.checkinlists
+          - spans:
+              - length: 28
+                start: 2114
+            value: pretix.plugins.pretixdroid
+          - spans:
+              - length: 23
+                start: 2148
+            value: pretix.plugins.badges
+          - spans:
+              - length: 30
+                start: 2177
+            value: pretix.plugins.manualpayment
+          - spans:
+              - length: 26
+                start: 2213
+            value: pretix.plugins.returnurl
+          - spans:
+              - length: 28
+                start: 2245
+            value: pretix.plugins.autocheckin
+          - spans:
+              - length: 27
+                start: 2279
+            value: pretix.plugins.webcheckin
+          - spans:
+              - length: 18
+                start: 2312
+            value: django_countries
+          - spans:
+              - length: 17
+                start: 2336
+            value: oauth2_provider
+          - spans:
+              - length: 19
+                start: 2359
+            value: phonenumber_field
+          - spans:
+              - length: 12
+                start: 2384
+            value: statici18n
+          - spans:
+              - length: 14
+                start: 2402
+            value: django.forms
+          - spans:
+              - length: 16
+                start: 18772
+            value: django_filters
+          - spans:
+              - length: 15
+                start: 18794
+            value: django_markup
+          - spans:
+              - length: 12
+                start: 18815
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 18833
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 18868
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 8
+                start: 18905
+            value: hijack
+          - spans:
+              - length: 13
+                start: 18919
+            value: localflavor
+    - known:
+        apps:
+          - spans:
+              - length: 25
+                start: 19048
+            value: django.contrib.postgres
+          - spans:
+              - length: 21
+                start: 1425
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1452
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1487
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 1518
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1549
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 25
+                start: 1583
+            value: django.contrib.humanize
+          - spans:
+              - length: 13
+                start: 1614
+            value: pretix.base
+          - spans:
+              - length: 16
+                start: 1633
+            value: pretix.control
+          - spans:
+              - length: 16
+                start: 1655
+            value: pretix.presale
+          - spans:
+              - length: 20
+                start: 1677
+            value: pretix.multidomain
+          - spans:
+              - length: 12
+                start: 1703
+            value: pretix.api
+          - spans:
+              - length: 16
+                start: 1721
+            value: pretix.helpers
+          - spans:
+              - length: 16
+                start: 1743
+            value: rest_framework
+          - spans:
+              - length: 17
+                start: 1765
+            value: djangoformsetjs
+          - spans:
+              - length: 12
+                start: 1788
+            value: compressor
+          - spans:
+              - length: 12
+                start: 1806
+            value: bootstrap3
+          - spans:
+              - length: 29
+                start: 1824
+            value: pretix.plugins.banktransfer
+          - spans:
+              - length: 23
+                start: 1859
+            value: pretix.plugins.stripe
+          - spans:
+              - length: 23
+                start: 1888
+            value: pretix.plugins.paypal
+          - spans:
+              - length: 24
+                start: 1917
+            value: pretix.plugins.paypal2
+          - spans:
+              - length: 32
+                start: 1947
+            value: pretix.plugins.ticketoutputpdf
+          - spans:
+              - length: 25
+                start: 1985
+            value: pretix.plugins.sendmail
+          - spans:
+              - length: 27
+                start: 2016
+            value: pretix.plugins.statistics
+          - spans:
+              - length: 24
+                start: 2049
+            value: pretix.plugins.reports
+          - spans:
+              - length: 29
+                start: 2079
+            value: pretix.plugins.checkinlists
+          - spans:
+              - length: 28
+                start: 2114
+            value: pretix.plugins.pretixdroid
+          - spans:
+              - length: 23
+                start: 2148
+            value: pretix.plugins.badges
+          - spans:
+              - length: 30
+                start: 2177
+            value: pretix.plugins.manualpayment
+          - spans:
+              - length: 26
+                start: 2213
+            value: pretix.plugins.returnurl
+          - spans:
+              - length: 28
+                start: 2245
+            value: pretix.plugins.autocheckin
+          - spans:
+              - length: 27
+                start: 2279
+            value: pretix.plugins.webcheckin
+          - spans:
+              - length: 18
+                start: 2312
+            value: django_countries
+          - spans:
+              - length: 17
+                start: 2336
+            value: oauth2_provider
+          - spans:
+              - length: 19
+                start: 2359
+            value: phonenumber_field
+          - spans:
+              - length: 12
+                start: 2384
+            value: statici18n
+          - spans:
+              - length: 14
+                start: 2402
+            value: django.forms
+          - spans:
+              - length: 16
+                start: 18772
+            value: django_filters
+          - spans:
+              - length: 15
+                start: 18794
+            value: django_markup
+          - spans:
+              - length: 12
+                start: 18815
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 18833
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 18868
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 8
+                start: 18905
+            value: hijack
+          - spans:
+              - length: 13
+                start: 18919
+            value: localflavor
+          - spans:
+              - length: 19
+                start: 19144
+            value: django_extensions
+    - known:
+        apps:
+          - spans:
+              - length: 25
+                start: 19048
+            value: django.contrib.postgres
+          - spans:
+              - length: 21
+                start: 1425
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 1452
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 1487
+            value: django.contrib.sessions
+          - spans:
+              - length: 25
+                start: 1518
+            value: django.contrib.messages
+          - spans:
+              - length: 28
+                start: 1549
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 25
+                start: 1583
+            value: django.contrib.humanize
+          - spans:
+              - length: 13
+                start: 1614
+            value: pretix.base
+          - spans:
+              - length: 16
+                start: 1633
+            value: pretix.control
+          - spans:
+              - length: 16
+                start: 1655
+            value: pretix.presale
+          - spans:
+              - length: 20
+                start: 1677
+            value: pretix.multidomain
+          - spans:
+              - length: 12
+                start: 1703
+            value: pretix.api
+          - spans:
+              - length: 16
+                start: 1721
+            value: pretix.helpers
+          - spans:
+              - length: 16
+                start: 1743
+            value: rest_framework
+          - spans:
+              - length: 17
+                start: 1765
+            value: djangoformsetjs
+          - spans:
+              - length: 12
+                start: 1788
+            value: compressor
+          - spans:
+              - length: 12
+                start: 1806
+            value: bootstrap3
+          - spans:
+              - length: 29
+                start: 1824
+            value: pretix.plugins.banktransfer
+          - spans:
+              - length: 23
+                start: 1859
+            value: pretix.plugins.stripe
+          - spans:
+              - length: 23
+                start: 1888
+            value: pretix.plugins.paypal
+          - spans:
+              - length: 24
+                start: 1917
+            value: pretix.plugins.paypal2
+          - spans:
+              - length: 32
+                start: 1947
+            value: pretix.plugins.ticketoutputpdf
+          - spans:
+              - length: 25
+                start: 1985
+            value: pretix.plugins.sendmail
+          - spans:
+              - length: 27
+                start: 2016
+            value: pretix.plugins.statistics
+          - spans:
+              - length: 24
+                start: 2049
+            value: pretix.plugins.reports
+          - spans:
+              - length: 29
+                start: 2079
+            value: pretix.plugins.checkinlists
+          - spans:
+              - length: 28
+                start: 2114
+            value: pretix.plugins.pretixdroid
+          - spans:
+              - length: 23
+                start: 2148
+            value: pretix.plugins.badges
+          - spans:
+              - length: 30
+                start: 2177
+            value: pretix.plugins.manualpayment
+          - spans:
+              - length: 26
+                start: 2213
+            value: pretix.plugins.returnurl
+          - spans:
+              - length: 28
+                start: 2245
+            value: pretix.plugins.autocheckin
+          - spans:
+              - length: 27
+                start: 2279
+            value: pretix.plugins.webcheckin
+          - spans:
+              - length: 18
+                start: 2312
+            value: django_countries
+          - spans:
+              - length: 17
+                start: 2336
+            value: oauth2_provider
+          - spans:
+              - length: 19
+                start: 2359
+            value: phonenumber_field
+          - spans:
+              - length: 12
+                start: 2384
+            value: statici18n
+          - spans:
+              - length: 14
+                start: 2402
+            value: django.forms
+          - spans:
+              - length: 16
+                start: 18772
+            value: django_filters
+          - spans:
+              - length: 15
+                start: 18794
+            value: django_markup
+          - spans:
+              - length: 12
+                start: 18815
+            value: django_otp
+          - spans:
+              - length: 29
+                start: 18833
+            value: django_otp.plugins.otp_totp
+          - spans:
+              - length: 31
+                start: 18868
+            value: django_otp.plugins.otp_static
+          - spans:
+              - length: 8
+                start: 18905
+            value: hijack
+          - spans:
+              - length: 13
+                start: 18919
+            value: localflavor
+    - dynamic:
+        evidence:
+          - issue:
+              kind: dynamic_expression
+              spans:
+                - length: 219
+                  start: 19208
+    - dynamic:
+        evidence:
+          - issue:
+              kind: unsupported_mutation
+              spans:
+                - length: 62
+                  start: 21606
+templates:
+  cases:
+    - dynamic:
+        evidence:
+          - backend:
+              app_dirs:
+                issues: []
+                known: ~
+              backend:
+                issues: []
+                known:
+                  spans:
+                    - length: 49
+                      start: 5318
+                  value: django.template.backends.django.DjangoTemplates
+              builtins:
+                issues: []
+                known: []
+              context_processors:
+                issues: []
+                known:
+                  - spans:
+                      - length: 45
+                        start: 5520
+                    value: django.contrib.auth.context_processors.auth
+                  - spans:
+                      - length: 42
+                        start: 5583
+                    value: django.template.context_processors.debug
+                  - spans:
+                      - length: 41
+                        start: 5643
+                    value: django.template.context_processors.i18n
+                  - spans:
+                      - length: 42
+                        start: 5702
+                    value: django.template.context_processors.media
+                  - spans:
+                      - length: 44
+                        start: 5762
+                    value: django.template.context_processors.request
+                  - spans:
+                      - length: 43
+                        start: 5824
+                    value: django.template.context_processors.static
+                  - spans:
+                      - length: 39
+                        start: 5885
+                    value: django.template.context_processors.tz
+                  - spans:
+                      - length: 53
+                        start: 5942
+                    value: django.contrib.messages.context_processors.messages
+                  - spans:
+                      - length: 38
+                        start: 6013
+                    value: pretix.base.context.contextprocessor
+                  - spans:
+                      - length: 41
+                        start: 6069
+                    value: pretix.control.context.contextprocessor
+                  - spans:
+                      - length: 41
+                        start: 6128
+                    value: pretix.presale.context.contextprocessor
+              dirs:
+                evidence:
+                  - issue:
+                      kind: dynamic_expression
+                      spans:
+                        - length: 35
+                          start: 23820
+                  - known:
+                      spans:
+                        - length: 35
+                          start: 5399
+                      value: "${REPO}/src/templates"
+              libraries:
+                issues: []
+                known: []
+              options:
+                issues: []
+                known: ~

--- a/crates/djls-project/tests/snapshots/settings/corpus_settings__sentry__sentry__conf__server.snap
+++ b/crates/djls-project/tests/snapshots/settings/corpus_settings__sentry__sentry__conf__server.snap
@@ -1,0 +1,298 @@
+---
+source: crates/djls-project/tests/corpus_settings.rs
+expression: settings
+---
+installed_apps:
+  cases:
+    - known:
+        apps:
+          - spans:
+              - length: 21
+                start: 14582
+            value: django.contrib.auth
+          - spans:
+              - length: 29
+                start: 14609
+            value: django.contrib.contenttypes
+          - spans:
+              - length: 25
+                start: 14644
+            value: django.contrib.humanize
+          - spans:
+              - length: 25
+                start: 14675
+            value: django.contrib.messages
+          - spans:
+              - length: 25
+                start: 14706
+            value: django.contrib.postgres
+          - spans:
+              - length: 25
+                start: 14737
+            value: django.contrib.sessions
+          - spans:
+              - length: 22
+                start: 14768
+            value: django.contrib.sites
+          - spans:
+              - length: 17
+                start: 14796
+            value: drf_spectacular
+          - spans:
+              - length: 14
+                start: 14819
+            value: crispy_forms
+          - spans:
+              - length: 16
+                start: 14839
+            value: rest_framework
+          - spans:
+              - length: 8
+                start: 14861
+            value: sentry
+          - spans:
+              - length: 18
+                start: 14875
+            value: sentry.autopilot
+          - spans:
+              - length: 18
+                start: 14899
+            value: sentry.analytics
+          - spans:
+              - length: 16
+                start: 14923
+            value: sentry.auth_v2
+          - spans:
+              - length: 30
+                start: 14945
+            value: sentry.incidents.apps.Config
+          - spans:
+              - length: 18
+                start: 14981
+            value: sentry.deletions
+          - spans:
+              - length: 17
+                start: 15005
+            value: sentry.discover
+          - spans:
+              - length: 25
+                start: 15028
+            value: sentry.analytics.events
+          - spans:
+              - length: 27
+                start: 15059
+            value: sentry.services.nodestore
+          - spans:
+              - length: 14
+                start: 15092
+            value: sentry.users
+          - spans:
+              - length: 20
+                start: 15112
+            value: sentry.sentry_apps
+          - spans:
+              - length: 21
+                start: 15138
+            value: sentry.integrations
+          - spans:
+              - length: 22
+                start: 15165
+            value: sentry.notifications
+          - spans:
+              - length: 14
+                start: 15193
+            value: sentry.flags
+          - spans:
+              - length: 17
+                start: 15213
+            value: sentry.monitors
+          - spans:
+              - length: 15
+                start: 15236
+            value: sentry.uptime
+          - spans:
+              - length: 16
+                start: 15257
+            value: sentry.tempest
+          - spans:
+              - length: 16
+                start: 15279
+            value: sentry.replays
+          - spans:
+              - length: 23
+                start: 15301
+            value: sentry.release_health
+          - spans:
+              - length: 15
+                start: 15330
+            value: sentry.search
+          - spans:
+              - length: 23
+                start: 15351
+            value: sentry.sentry_metrics
+          - spans:
+              - length: 52
+                start: 15380
+            value: sentry.sentry_metrics.indexer.postgres.apps.Config
+          - spans:
+              - length: 14
+                start: 15438
+            value: sentry.snuba
+          - spans:
+              - length: 30
+                start: 15458
+            value: sentry.lang.java.apps.Config
+          - spans:
+              - length: 36
+                start: 15494
+            value: sentry.lang.javascript.apps.Config
+          - spans:
+              - length: 30
+                start: 15536
+            value: sentry.lang.dart.apps.Config
+          - spans:
+              - length: 51
+                start: 15572
+            value: sentry.plugins.sentry_interface_types.apps.Config
+          - spans:
+              - length: 40
+                start: 15629
+            value: sentry.plugins.sentry_urls.apps.Config
+          - spans:
+              - length: 46
+                start: 15675
+            value: sentry.plugins.sentry_useragents.apps.Config
+          - spans:
+              - length: 44
+                start: 15727
+            value: sentry.plugins.sentry_webhooks.apps.Config
+          - spans:
+              - length: 13
+                start: 15777
+            value: social_auth
+          - spans:
+              - length: 6
+                start: 15796
+            value: sudo
+          - spans:
+              - length: 20
+                start: 15808
+            value: sentry.eventstream
+          - spans:
+              - length: 42
+                start: 15834
+            value: sentry.auth.providers.google.apps.Config
+          - spans:
+              - length: 39
+                start: 15882
+            value: sentry.auth.providers.fly.apps.Config
+          - spans:
+              - length: 28
+                start: 15927
+            value: django.contrib.staticfiles
+          - spans:
+              - length: 27
+                start: 15961
+            value: sentry.issues.apps.Config
+          - spans:
+              - length: 17
+                start: 15994
+            value: sentry.feedback
+          - spans:
+              - length: 20
+                start: 16017
+            value: sentry.hybridcloud
+          - spans:
+              - length: 19
+                start: 16043
+            value: sentry.relocation
+          - spans:
+              - length: 41
+                start: 16068
+            value: sentry.remote_subscriptions.apps.Config
+          - spans:
+              - length: 21
+                start: 16115
+            value: sentry.data_secrecy
+          - spans:
+              - length: 24
+                start: 16142
+            value: sentry.workflow_engine
+          - spans:
+              - length: 16
+                start: 16172
+            value: sentry.explore
+          - spans:
+              - length: 17
+                start: 16194
+            value: sentry.insights
+          - spans:
+              - length: 16
+                start: 16217
+            value: sentry.preprod
+          - spans:
+              - length: 17
+                start: 16239
+            value: sentry.releases
+          - spans:
+              - length: 16
+                start: 16262
+            value: sentry.prevent
+          - spans:
+              - length: 13
+                start: 16284
+            value: sentry.seer
+templates:
+  cases:
+    - dynamic:
+        evidence:
+          - backend:
+              app_dirs:
+                issues: []
+                known:
+                  spans:
+                    - length: 4
+                      start: 13964
+                  value: true
+              backend:
+                issues: []
+                known:
+                  spans:
+                    - length: 49
+                      start: 13834
+                  value: django.template.backends.django.DjangoTemplates
+              builtins:
+                issues: []
+                known: []
+              context_processors:
+                issues: []
+                known:
+                  - spans:
+                      - length: 45
+                        start: 14043
+                    value: django.contrib.auth.context_processors.auth
+                  - spans:
+                      - length: 53
+                        start: 14106
+                    value: django.contrib.messages.context_processors.messages
+                  - spans:
+                      - length: 41
+                        start: 14177
+                    value: django.template.context_processors.csrf
+                  - spans:
+                      - length: 44
+                        start: 14236
+                    value: django.template.context_processors.request
+              dirs:
+                evidence:
+                  - issue:
+                      kind: unknown_element
+                      spans:
+                        - length: 39
+                          start: 13902
+              libraries:
+                issues: []
+                known: []
+              options:
+                issues: []
+                known: ~

--- a/crates/djls-testing/README.md
+++ b/crates/djls-testing/README.md
@@ -4,7 +4,7 @@ Corpus of real-world Django projects for grounding tests in reality.
 
 This crate syncs pinned versions of Django, popular third-party libraries, and open-source Django projects as git archives, then provides helpers to enumerate and locate files within them.
 
-Django project fact tests use minimal `django_settings_module` / `django_settings_modules` selectors in `manifest.toml`. The manifest identifies which corpus entries or local fixtures should be analyzed; expected apps, template directories, template tag modules, confidence, and reasons stay in tests or snapshots so the manifest does not become hand-written project-model data. The GH-401 multi-site monorepo shape lives under `fixtures/django-projects/` because the public corpus does not currently contain that exact real-world layout.
+Django project fact tests use minimal `django_settings_module` / `django_settings_modules` selectors in `manifest.toml`. Repos whose Django project lives below the checkout root also declare a relative `project_root`. These fields describe how to build the test project; expected apps, template directories, template tag modules, confidence, and reasons stay in tests or snapshots so the manifest does not become hand-written project-model data. The GH-401 multi-site monorepo shape lives under `fixtures/django-projects/` because the public corpus does not currently contain that exact real-world layout.
 
 ## Commands
 

--- a/crates/djls-testing/manifest.toml
+++ b/crates/djls-testing/manifest.toml
@@ -214,6 +214,7 @@ ref = "1.3.12"
 name = "inventree"
 url = "https://github.com/inventree/InvenTree.git"
 ref = "master"
+project_root = "src/backend/InvenTree"
 django_settings_module = "InvenTree.settings"
 
 [[repo]]
@@ -230,6 +231,7 @@ ref = "main"
 name = "netbox"
 url = "https://github.com/netbox-community/netbox.git"
 ref = "main"
+project_root = "netbox"
 django_settings_module = "netbox.settings"
 
 [[repo]]

--- a/crates/djls-testing/src/corpus.rs
+++ b/crates/djls-testing/src/corpus.rs
@@ -49,6 +49,7 @@ pub use sync::sync_corpus;
 
 const CORPUS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/.corpus");
 const LOCKFILE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/manifest.lock");
+const MANIFEST_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/manifest.toml");
 
 /// A validated corpus root directory.
 ///
@@ -56,7 +57,26 @@ const LOCKFILE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/manifest.lock"
 /// directory exists. Once constructed, the root path is trusted for
 /// the lifetime of the value.
 pub struct Corpus {
-    _private: (),
+    lockfile: lock::Lockfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorpusSettingsProject {
+    pub repo_name: String,
+    pub checkout_root: Utf8PathBuf,
+    pub project_root: Utf8PathBuf,
+    pub django_settings_modules: Vec<String>,
+}
+
+fn lock_entry_matches_declaration(
+    locked_repo: &lock::LockedRepo,
+    declaration: &manifest::RepoSettingsProject<'_>,
+) -> bool {
+    locked_repo.name == declaration.repo_name
+        && locked_repo.url == declaration.repo_url
+        && declaration
+            .repo_ref
+            .is_none_or(|repo_ref| locked_repo.tag == repo_ref)
 }
 
 impl Corpus {
@@ -71,11 +91,11 @@ impl Corpus {
         if !Self::is_available() {
             anyhow::bail!("Corpus not synced. Run: cargo run -p djls-testing --bin corpus -- sync");
         }
-        let corpus = Self { _private: () };
         let lockfile = lock::Lockfile::load(Utf8Path::new(LOCKFILE_PATH)).map_err(|error| {
             anyhow::anyhow!("Corpus lockfile missing or invalid. Run: just corpus lock: {error}")
         })?;
-        sync::validate_synced_corpus(&lockfile, corpus.root())?;
+        let corpus = Self { lockfile };
+        sync::validate_synced_corpus(&corpus.lockfile, corpus.root())?;
         Ok(corpus)
     }
 
@@ -83,6 +103,65 @@ impl Corpus {
     #[must_use]
     pub fn root(&self) -> &Utf8Path {
         Utf8Path::new(CORPUS_DIR)
+    }
+
+    pub fn repo_settings_projects(&self) -> anyhow::Result<Vec<CorpusSettingsProject>> {
+        let manifest = Manifest::load(Utf8Path::new(MANIFEST_PATH))?;
+        manifest
+            .repo_settings_projects()
+            .into_iter()
+            .map(|declaration| {
+                let mut lock_matches = self
+                    .lockfile
+                    .repos
+                    .iter()
+                    .filter(|repo| repo.name == declaration.repo_name);
+                let locked_repo = lock_matches.next().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "corpus repo `{}` has settings metadata but no lock entry; run `just corpus lock`",
+                        declaration.repo_name
+                    )
+                })?;
+                anyhow::ensure!(
+                    lock_matches.next().is_none(),
+                    "corpus repo `{}` has duplicate lock entries; run `just corpus lock`",
+                    declaration.repo_name
+                );
+                anyhow::ensure!(
+                    lock_entry_matches_declaration(locked_repo, &declaration),
+                    "corpus repo `{}` identity differs between manifest.toml and manifest.lock; run `just corpus lock`",
+                    declaration.repo_name
+                );
+
+                let checkout_root = self
+                    .root()
+                    .join("repos")
+                    .join(declaration.repo_name);
+                let project_root = declaration.relative_root.map_or_else(
+                    || checkout_root.clone(),
+                    |relative_root| checkout_root.join(relative_root),
+                );
+                if !project_root.as_std_path().is_dir() {
+                    anyhow::bail!(
+                        "corpus repo `{}` project root `{}` does not exist",
+                        declaration.repo_name,
+                        declaration
+                            .relative_root
+                            .map_or(".", Utf8Path::as_str)
+                    );
+                }
+                Ok(CorpusSettingsProject {
+                    repo_name: declaration.repo_name.to_string(),
+                    checkout_root,
+                    project_root,
+                    django_settings_modules: declaration
+                        .django_settings_modules
+                        .into_iter()
+                        .map(str::to_string)
+                        .collect(),
+                })
+            })
+            .collect()
     }
 
     /// Derive the corpus entry directory for a path under the corpus root.
@@ -386,4 +465,103 @@ pub fn module_name_from_file(file: &Utf8Path) -> String {
         .map(|s| s.strip_suffix(".py").unwrap_or(s))
         .collect::<Vec<_>>()
         .join(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Corpus;
+    use super::lock_entry_matches_declaration;
+    use crate::corpus::lock::LockedRepo;
+    use crate::corpus::manifest::RepoSettingsProject;
+
+    #[test]
+    fn lock_entry_must_match_the_declared_repo_ref() {
+        let locked_repo = LockedRepo {
+            name: "example".to_string(),
+            url: "https://example.com/repo.git".to_string(),
+            tag: "main".to_string(),
+            git_ref: "0123456789abcdef".to_string(),
+        };
+        let matching = RepoSettingsProject {
+            repo_name: "example",
+            repo_url: "https://example.com/repo.git",
+            repo_ref: Some("main"),
+            relative_root: None,
+            django_settings_modules: vec!["project.settings"],
+        };
+        let stale = RepoSettingsProject {
+            repo_ref: Some("release"),
+            ..matching.clone()
+        };
+
+        assert!(lock_entry_matches_declaration(&locked_repo, &matching));
+        assert!(!lock_entry_matches_declaration(&locked_repo, &stale));
+    }
+
+    #[test]
+    fn corpus_exposes_real_repo_settings_projects() {
+        let corpus = Corpus::require().expect("synced corpus should be available");
+        let projects = corpus
+            .repo_settings_projects()
+            .expect("default corpus manifest should load")
+            .into_iter()
+            .map(|project| {
+                let relative_root = if project.project_root == project.checkout_root {
+                    ".".to_string()
+                } else {
+                    project
+                        .project_root
+                        .strip_prefix(&project.checkout_root)
+                        .expect("project root should stay within its checkout")
+                        .to_string()
+                };
+                (
+                    project.repo_name,
+                    relative_root,
+                    project.django_settings_modules,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            projects,
+            vec![
+                (
+                    "archivebox".to_string(),
+                    ".".to_string(),
+                    vec!["archivebox.core.settings".to_string()],
+                ),
+                (
+                    "django-allauth".to_string(),
+                    ".".to_string(),
+                    vec!["tests.projects.account_only.settings".to_string()],
+                ),
+                (
+                    "healthchecks".to_string(),
+                    ".".to_string(),
+                    vec!["hc.settings".to_string()],
+                ),
+                (
+                    "inventree".to_string(),
+                    "src/backend/InvenTree".to_string(),
+                    vec!["InvenTree.settings".to_string()],
+                ),
+                (
+                    "netbox".to_string(),
+                    "netbox".to_string(),
+                    vec!["netbox.settings".to_string()],
+                ),
+                (
+                    "pretix".to_string(),
+                    ".".to_string(),
+                    vec!["pretix.settings".to_string()],
+                ),
+                (
+                    "sentry".to_string(),
+                    ".".to_string(),
+                    vec!["sentry.conf.server".to_string()],
+                ),
+            ]
+        );
+    }
 }

--- a/crates/djls-testing/src/corpus/manifest.rs
+++ b/crates/djls-testing/src/corpus/manifest.rs
@@ -1,4 +1,5 @@
 use anyhow::ensure;
+use camino::Utf8Component;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use serde::Deserialize;
@@ -29,6 +30,17 @@ pub(crate) struct Repo {
     django_settings_module: Option<String>,
     #[serde(default)]
     django_settings_modules: Vec<String>,
+    #[serde(default)]
+    project_root: Option<Utf8PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RepoSettingsProject<'a> {
+    pub(crate) repo_name: &'a str,
+    pub(crate) repo_url: &'a str,
+    pub(crate) repo_ref: Option<&'a str>,
+    pub(crate) relative_root: Option<&'a Utf8Path>,
+    pub(crate) django_settings_modules: Vec<&'a str>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,6 +67,23 @@ impl Manifest {
         base_dir.join(&self.corpus.root_dir)
     }
 
+    #[must_use]
+    pub(crate) fn repo_settings_projects(&self) -> Vec<RepoSettingsProject<'_>> {
+        self.repos
+            .iter()
+            .filter_map(|repo| {
+                let django_settings_modules: Vec<_> = repo.django_settings_modules().collect();
+                (!django_settings_modules.is_empty()).then_some(RepoSettingsProject {
+                    repo_name: repo.name.as_str(),
+                    repo_url: repo.url.as_str(),
+                    repo_ref: repo.git_ref.as_deref(),
+                    relative_root: repo.project_root.as_deref(),
+                    django_settings_modules,
+                })
+            })
+            .collect()
+    }
+
     fn validate(&self, manifest_dir: &Utf8Path) -> anyhow::Result<()> {
         for repo in &self.repos {
             repo.validate()?;
@@ -75,6 +104,28 @@ impl Repo {
     }
 
     fn validate(&self) -> anyhow::Result<()> {
+        let mut name_components = Utf8Path::new(&self.name).components();
+        ensure!(
+            !self.name.contains(['/', '\\'])
+                && matches!(name_components.next(), Some(Utf8Component::Normal(_)))
+                && name_components.next().is_none(),
+            "repo name `{}` must be one path-safe component",
+            self.name
+        );
+        if let Some(project_root) = &self.project_root {
+            ensure!(
+                !project_root.as_str().is_empty()
+                    && !project_root.is_absolute()
+                    && !project_root.as_str().contains(['\\', ':'])
+                    && project_root
+                        .as_str()
+                        .split('/')
+                        .all(|segment| !segment.is_empty() && !matches!(segment, "." | "..")),
+                "repo `{}` project root `{project_root}` must be a canonical path within its checkout",
+                self.name
+            );
+        }
+
         for module in self.django_settings_modules() {
             ensure!(
                 !module.trim().is_empty(),
@@ -172,6 +223,85 @@ mod tests {
                 .as_slice(),
             ["site1.settings.dev", "site2.settings.dev"]
         );
+    }
+
+    #[test]
+    fn manifest_exposes_real_repo_settings_projects() {
+        let manifest = load_default_manifest();
+        let projects = manifest
+            .repo_settings_projects()
+            .into_iter()
+            .map(|project| {
+                (
+                    project.repo_name,
+                    project.relative_root.map_or(".", Utf8Path::as_str),
+                    project.django_settings_modules,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            projects,
+            vec![
+                ("archivebox", ".", vec!["archivebox.core.settings"]),
+                (
+                    "django-allauth",
+                    ".",
+                    vec!["tests.projects.account_only.settings"]
+                ),
+                ("healthchecks", ".", vec!["hc.settings"]),
+                (
+                    "inventree",
+                    "src/backend/InvenTree",
+                    vec!["InvenTree.settings"]
+                ),
+                ("netbox", "netbox", vec!["netbox.settings"]),
+                ("pretix", ".", vec!["pretix.settings"]),
+                ("sentry", ".", vec!["sentry.conf.server"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn repo_project_root_must_stay_within_the_checkout() {
+        for root in [
+            "",
+            "/absolute",
+            "..",
+            "nested/../outside",
+            "./nested",
+            "nested/.",
+            "C:outside",
+            "C:\\outside",
+            "nested\\root",
+        ] {
+            let repo = Repo {
+                name: "example".to_string(),
+                url: "https://example.com/repo.git".to_string(),
+                git_ref: None,
+                django_settings_module: Some("project.settings".to_string()),
+                django_settings_modules: Vec::new(),
+                project_root: Some(Utf8PathBuf::from(root)),
+            };
+
+            assert!(repo.validate().is_err(), "`{root}` should be rejected");
+        }
+    }
+
+    #[test]
+    fn repo_name_must_be_one_path_safe_component() {
+        for name in ["", ".", "..", "nested/repo", "nested\\repo"] {
+            let repo = Repo {
+                name: name.to_string(),
+                url: "https://example.com/repo.git".to_string(),
+                git_ref: None,
+                django_settings_module: Some("project.settings".to_string()),
+                django_settings_modules: Vec::new(),
+                project_root: None,
+            };
+
+            assert!(repo.validate().is_err(), "`{name}` should be rejected");
+        }
     }
 
     #[test]

--- a/crates/djls-testing/src/lib.rs
+++ b/crates/djls-testing/src/lib.rs
@@ -6,6 +6,7 @@ mod mdtest;
 mod vendor;
 
 pub use corpus::Corpus;
+pub use corpus::CorpusSettingsProject;
 pub use corpus::LockFilter;
 pub use corpus::Lockfile;
 pub use corpus::Manifest;


### PR DESCRIPTION
## Summary

- expose validated corpus settings projects without exposing manifest internals
- support declared nested project roots for InvenTree and NetBox while tying each checkout to its lock entry and sync marker
- snapshot production DjangoSettings output for seven real projects
- redact checkout paths recursively with portable separator handling
- assert the ArchiveBox and InvenTree predicate case shapes that found evaluator regressions

The semantic snapshots run on non-Windows hosts because the production evaluator deliberately leaves Windows os.path operations unknown. Corpus synchronization and path-redaction checks still run on every platform.

## Verification

- just corpus sync
- cargo test -q -p djls-testing manifest
- cargo test -q -p djls-testing corpus
- cargo test -q -p djls-project --test corpus_settings
- cargo test -q
- just test
- just clippy
- just fmt --check
- just lint
- cargo build -q
- just hawk
- semantic review of all seven snapshots
- independent API, safety, and state-invariant reviews