### PR TITLE
Refactor Django model inheritance around typed base outcomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,11 @@ Prefer explicit tests over helper proliferation. Use helpers only for substantia
 
 Keep db/Salsa-backed tests in `crates/*/tests/`. Inline `src/` `#[cfg(test)]` modules should be pure unit tests with explicit data, not `djls_testing::TestDatabase`, even when possible.
 
+## Benchmarks
+A benchmark name is a stable comparison contract. Never rename, remove, or reshape a benchmark to hide a regression.
+
+When a change slows a benchmark, first check for an accidental regression in the code, inputs, setup, and measured path. Profile the hot path and fix real performance bugs. Some features require more work and may remain slower after that review; keep measuring the operation honestly and record why the cost changed. Rename a benchmark only when it truly measures a different operation, explain that change, and preserve the old comparison when it still represents a useful path.
+
 ## Generated Content
 - Do not edit text inside cog-generated blocks by hand. Update the source of truth, then run `just cog` to regenerate the block.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - **Internal**: Updated realistic template benchmarks to use project-backed source extraction, canonical builtin roles, and snapshot-backed workload contracts.
 - **Internal**: Moved corpus tooling and shared test fixtures into `djls-testing`.
 - **Internal**: Reworked Python settings evaluation around module identities, typed import outcomes, invariant-preserving collections, and correlated list alternatives.
+- **Internal**: Reworked Django model inheritance around typed base outcomes, C3 ordering, and declaration-owned relation bindings.
 
 ### Removed
 

--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -97,13 +97,13 @@ struct ModelExtractionInput {
 
 fn fixture_extraction_input(prefix: &str) -> Result<ModelExtractionInput, ModelSetupError> {
     let fixtures = model_fixtures()?;
-    let module = parse_module("bench.models")?;
     let mut db = Db::new();
     let mut files = Vec::with_capacity(fixtures.len());
     for (index, fixture) in fixtures.iter().enumerate() {
         let path = Utf8PathBuf::from(format!("/bench/models/{prefix}/{index}.py"));
         let file = register_model_source(&mut db, path, &fixture.source)?;
-        files.push((file, module.clone()));
+        let module = parse_module(&format!("bench.models.fixture_{index}"))?;
+        files.push((file, module));
     }
     Ok(ModelExtractionInput { db, files })
 }
@@ -130,31 +130,32 @@ fn extract(bencher: Bencher) {
         });
 }
 
-// Merge: extract graphs then merge them (the hot path in compute_model_graph)
+// Project assembly: reuse cached per-file extraction and rebuild inheritance.
 
 #[divan::bench]
-fn merge(bencher: Bencher) {
-    let input = require(
-        "prepare model merge benchmark input",
-        fixture_extraction_input("merge"),
-    );
-    let graphs: Vec<_> = input
-        .files
-        .into_iter()
-        .map(|(file, module)| extract_model_graph(&input.db, file, module).clone())
-        .collect();
-
-    bencher.bench_local(move || {
-        let mut merged_models = 0;
-        for _ in 0..REPEATED_INNER_ITERS {
-            let mut merged = ModelGraph::new();
-            for graph in &graphs {
-                merged.merge(graph.clone());
+fn assemble(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            require(
+                "prepare model assembly benchmark input",
+                fixture_extraction_input("assemble"),
+            )
+        })
+        .bench_local_values(|input| {
+            let project =
+                Project::initial(&input.db, Utf8Path::new("/bench"), &Settings::default());
+            let mut assembled_models = 0;
+            for _ in 0..REPEATED_INNER_ITERS {
+                let graph = resolve_model_graph_from_modules(
+                    &input.db,
+                    project,
+                    input.files.iter().cloned(),
+                );
+                assembled_models += graph.len();
+                divan::black_box(graph);
             }
-            merged_models += merged.len();
-        }
-        divan::black_box(merged_models);
-    });
+            divan::black_box(assembled_models);
+        });
 }
 
 // Resolution: forward and field-based relation lookups on a populated graph
@@ -379,12 +380,10 @@ fn bench_corpus(
             )
         })
         .bench_local_values(|input| {
-            let mut merged = ModelGraph::new();
-            for (file, module_name) in input.files {
-                let graph = extract_model_graph(&input.db, file, module_name);
-                merged.merge(graph.clone());
-            }
-            divan::black_box(merged);
+            let project =
+                Project::initial(&input.db, Utf8Path::new("/bench"), &Settings::default());
+            let graph = resolve_model_graph_from_modules(&input.db, project, input.files);
+            divan::black_box(graph);
         });
 }
 

--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -374,12 +374,14 @@ fn bench_corpus(
         });
 }
 
+// Typed inheritance resolves the corpus as one project; these are assembly
+// workloads rather than the former per-file extraction-and-merge workloads.
 #[divan::bench]
-fn corpus_django(bencher: Bencher) {
+fn corpus_django_project_assembly(bencher: Bencher) {
     bench_corpus(bencher, load_django_models(), "Django");
 }
 
 #[divan::bench]
-fn corpus_all(bencher: Bencher) {
+fn corpus_all_project_assembly(bencher: Bencher) {
     bench_corpus(bencher, load_all_corpus_models(), "full");
 }

--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -229,22 +229,9 @@ fn resolve_relations(bencher: Bencher) {
         "find Group in auth model graph",
         model_id(graph, "Group", "django.contrib.auth.models"),
     );
-    let user = require(
-        "find User in auth model graph",
-        model_id(graph, "User", "django.contrib.auth.models"),
-    );
-
     let lookup_queries = [("auth", "Permission"), ("auth", "Group"), ("auth", "User")];
-    let forward_queries = [
-        (permission, "content_type"),
-        (group, "permissions"),
-        (user, "groups"),
-    ];
-    let relation_queries = [
-        (group, "user_set"),
-        (permission, "group_set"),
-        (permission, "user_set"),
-    ];
+    let forward_queries = [(permission, "content_type"), (group, "permissions")];
+    let relation_queries = [(permission, "group_set")];
 
     for &(model, field) in &forward_queries {
         require_some(

--- a/crates/djls-bench/benches/models.rs
+++ b/crates/djls-bench/benches/models.rs
@@ -92,6 +92,7 @@ fn register_model_source(
 
 struct ModelExtractionInput {
     db: Db,
+    project: Project,
     files: Vec<(File, PythonModuleName)>,
 }
 
@@ -105,7 +106,8 @@ fn fixture_extraction_input(prefix: &str) -> Result<ModelExtractionInput, ModelS
         let module = parse_module(&format!("bench.models.fixture_{index}"))?;
         files.push((file, module));
     }
-    Ok(ModelExtractionInput { db, files })
+    let project = Project::initial(&db, Utf8Path::new("/bench"), &Settings::default());
+    Ok(ModelExtractionInput { db, project, files })
 }
 
 // Batch extraction: all fixtures in one iteration
@@ -142,13 +144,11 @@ fn assemble(bencher: Bencher) {
             )
         })
         .bench_local_values(|input| {
-            let project =
-                Project::initial(&input.db, Utf8Path::new("/bench"), &Settings::default());
             let mut assembled_models = 0;
             for _ in 0..REPEATED_INNER_ITERS {
                 let graph = resolve_model_graph_from_modules(
                     &input.db,
-                    project,
+                    input.project,
                     input.files.iter().cloned(),
                 );
                 assembled_models += graph.len();
@@ -175,6 +175,11 @@ fn build_auth_graph() -> Result<ModelGraph, ModelSetupError> {
         Utf8PathBuf::from("/bench/django/contrib/auth/models.py"),
         &auth.source,
     )?;
+    let base_user_file = register_model_source(
+        &mut db,
+        Utf8PathBuf::from("/bench/django/contrib/auth/base_user.py"),
+        "from django.db import models\n\nclass BaseUserManager:\n    pass\n\nclass AbstractBaseUser(models.Model):\n    class Meta:\n        abstract = True\n",
+    )?;
     let content_type_file = register_model_source(
         &mut db,
         Utf8PathBuf::from("/bench/django/contrib/contenttypes/models.py"),
@@ -186,6 +191,10 @@ fn build_auth_graph() -> Result<ModelGraph, ModelSetupError> {
         project,
         [
             (auth_file, parse_module("django.contrib.auth.models")?),
+            (
+                base_user_file,
+                parse_module("django.contrib.auth.base_user")?,
+            ),
             (
                 content_type_file,
                 parse_module("django.contrib.contenttypes.models")?,
@@ -229,9 +238,22 @@ fn resolve_relations(bencher: Bencher) {
         "find Group in auth model graph",
         model_id(graph, "Group", "django.contrib.auth.models"),
     );
+    let user = require(
+        "find User in auth model graph",
+        model_id(graph, "User", "django.contrib.auth.models"),
+    );
+
     let lookup_queries = [("auth", "Permission"), ("auth", "Group"), ("auth", "User")];
-    let forward_queries = [(permission, "content_type"), (group, "permissions")];
-    let relation_queries = [(permission, "group_set")];
+    let forward_queries = [
+        (permission, "content_type"),
+        (group, "permissions"),
+        (user, "groups"),
+    ];
+    let relation_queries = [
+        (group, "user_set"),
+        (permission, "group_set"),
+        (permission, "user_set"),
+    ];
 
     for &(model, field) in &forward_queries {
         require_some(
@@ -344,7 +366,8 @@ fn corpus_extraction_input(corpus: &CorpusModels) -> Result<ModelExtractionInput
         let file = register_model_source(&mut db, path, source)?;
         files.push((file, module_name.clone()));
     }
-    Ok(ModelExtractionInput { db, files })
+    let project = Project::initial(&db, Utf8Path::new("/bench"), &Settings::default());
+    Ok(ModelExtractionInput { db, project, files })
 }
 
 fn bench_corpus(
@@ -367,21 +390,17 @@ fn bench_corpus(
             )
         })
         .bench_local_values(|input| {
-            let project =
-                Project::initial(&input.db, Utf8Path::new("/bench"), &Settings::default());
-            let graph = resolve_model_graph_from_modules(&input.db, project, input.files);
+            let graph = resolve_model_graph_from_modules(&input.db, input.project, input.files);
             divan::black_box(graph);
         });
 }
 
-// Typed inheritance resolves the corpus as one project; these are assembly
-// workloads rather than the former per-file extraction-and-merge workloads.
 #[divan::bench]
-fn corpus_django_project_assembly(bencher: Bencher) {
+fn corpus_django(bencher: Bencher) {
     bench_corpus(bencher, load_django_models(), "Django");
 }
 
 #[divan::bench]
-fn corpus_all_project_assembly(bencher: Bencher) {
+fn corpus_all(bencher: Bencher) {
     bench_corpus(bencher, load_all_corpus_models(), "full");
 }

--- a/crates/djls-bench/src/db.rs
+++ b/crates/djls-bench/src/db.rs
@@ -29,6 +29,7 @@ use salsa::Storage;
 #[derive(Clone)]
 struct SourceMapFileSystem {
     sources: Arc<FxDashMap<Utf8PathBuf, String>>,
+    directories: Arc<FxDashMap<Utf8PathBuf, ()>>,
 }
 
 impl FileSystem for SourceMapFileSystem {
@@ -51,10 +52,7 @@ impl FileSystem for SourceMapFileSystem {
     }
 
     fn is_dir(&self, path: &Utf8Path) -> bool {
-        self.sources
-            .iter()
-            .any(|entry| entry.key().starts_with(path))
-            && !self.is_file(path)
+        self.directories.contains_key(path) && !self.is_file(path)
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {
@@ -146,6 +144,7 @@ impl Db {
         Self {
             fs: SourceMapFileSystem {
                 sources: Arc::new(FxDashMap::default()),
+                directories: Arc::new(FxDashMap::default()),
             },
             files: SourceFiles::default(),
             projectless_tag_specs: Arc::new(TagSpecs::default()),
@@ -172,7 +171,11 @@ impl Db {
         path: impl Into<Utf8PathBuf>,
         contents: impl Into<String>,
     ) {
-        self.fs.sources.insert(path.into(), contents.into());
+        let path = path.into();
+        for ancestor in path.ancestors().skip(1) {
+            self.fs.directories.insert(ancestor.to_path_buf(), ());
+        }
+        self.fs.sources.insert(path, contents.into());
     }
 
     pub(crate) fn set_project(&mut self, project: Project) {
@@ -292,6 +295,17 @@ mod tests {
             error.to_string(),
             "benchmark source /missing.html is not registered"
         );
+    }
+
+    #[test]
+    fn source_map_indexes_parent_directories() {
+        let db = Db::new();
+        db.add_fixture_source("/root/a/nested.py", "");
+
+        assert!(db.file_system().is_dir(Utf8Path::new("/root")));
+        assert!(db.file_system().is_dir(Utf8Path::new("/root/a")));
+        assert!(!db.file_system().is_dir(Utf8Path::new("/root/a/nested.py")));
+        assert!(!db.file_system().is_dir(Utf8Path::new("/root/missing")));
     }
 
     #[test]

--- a/crates/djls-project/src/models.rs
+++ b/crates/djls-project/src/models.rs
@@ -4,15 +4,22 @@ mod graph;
 mod imports;
 mod resolve;
 
+use std::collections::BTreeMap;
+
 pub use discovery::model_modules;
 use djls_source::File;
+pub(crate) use graph::AncestryOutcome;
+pub(crate) use graph::BaseOutcome;
+pub(crate) use graph::BaseUnresolvedReason;
+pub(crate) use graph::InheritanceError;
 pub use graph::ModelGraph;
 pub use graph::ModelId;
+pub(crate) use resolve::resolve_local_model_graph;
 
 use crate::db::Db;
 use crate::models::extract::ModelExtraction;
 use crate::models::extract::extract_models_impl;
-use crate::models::resolve::resolve_deferred_models;
+use crate::models::resolve::resolve_model_inheritance;
 use crate::project::Project;
 use crate::python::PythonModuleName;
 use crate::python::RecoveredPythonModule;
@@ -21,8 +28,8 @@ use crate::python::import::ModuleKind;
 /// Compute a merged `ModelGraph` from discovered model sources.
 #[salsa::tracked(returns(ref))]
 pub fn compute_model_graph(db: &dyn Db, project: Project) -> ModelGraph {
-    // `ModelGraph::merge` is last-wins. Iterate search paths in reverse so
-    // earlier Python search paths keep normal import precedence.
+    // Module selection is last-wins. Iterate search paths in reverse so the
+    // earlier Python search path supplies the final file for each module.
     resolve_model_graph_from_modules(
         db,
         project,
@@ -38,18 +45,22 @@ pub fn resolve_model_graph_from_modules(
     project: Project,
     modules: impl IntoIterator<Item = (File, PythonModuleName)>,
 ) -> ModelGraph {
-    let mut graph = ModelGraph::new();
-    let mut deferred = Vec::new();
-
+    let mut selected_modules = BTreeMap::new();
     for (file, module_name) in modules {
-        let extraction = extract_models(db, file, module_name);
-        if !extraction.graph.is_empty() {
-            graph.merge(extraction.graph.clone());
-        }
-        deferred.extend(extraction.deferred.iter().cloned());
+        selected_modules.insert(module_name, file);
     }
 
-    resolve_deferred_models(db, project, &mut graph, deferred);
+    let mut candidates = Vec::new();
+    for (module_name, file) in selected_modules {
+        candidates.extend(
+            extract_models(db, file, module_name)
+                .candidates
+                .iter()
+                .cloned(),
+        );
+    }
+
+    let mut graph = resolve_model_inheritance(db, project, candidates);
     graph.resolve_relation_targets(db, project);
     #[cfg(debug_assertions)]
     graph.debug_assert_no_file_local_placeholders();

--- a/crates/djls-project/src/models.rs
+++ b/crates/djls-project/src/models.rs
@@ -11,13 +11,14 @@ use djls_source::File;
 pub(crate) use graph::AncestryOutcome;
 pub(crate) use graph::BaseOutcome;
 pub(crate) use graph::BaseUnresolvedReason;
-pub(crate) use graph::InheritanceError;
+pub(crate) use graph::ClassId;
+pub(crate) use graph::InvalidAncestryReason;
 pub use graph::ModelGraph;
 pub use graph::ModelId;
 pub(crate) use resolve::resolve_local_model_graph;
 
 use crate::db::Db;
-use crate::models::extract::ModelExtraction;
+use crate::models::extract::ExtractedClasses;
 use crate::models::extract::extract_models_impl;
 use crate::models::resolve::resolve_model_inheritance;
 use crate::project::Project;
@@ -50,24 +51,24 @@ pub fn resolve_model_graph_from_modules(
         selected_modules.insert(module_name, file);
     }
 
-    let mut candidates = Vec::new();
+    let mut classes = Vec::new();
     for (module_name, file) in selected_modules {
-        candidates.extend(
+        classes.extend(
             extract_models(db, file, module_name)
-                .candidates
+                .as_slice()
                 .iter()
                 .cloned(),
         );
     }
 
-    let mut graph = resolve_model_inheritance(db, project, candidates);
+    let mut graph = resolve_model_inheritance(db, project, classes);
     graph.resolve_relation_targets(db, project);
     #[cfg(debug_assertions)]
     graph.debug_assert_no_file_local_placeholders();
     graph
 }
 
-/// Extract models from one Python file, cached by Salsa.
+/// Extract model-relevant Python classes from one file, cached by Salsa.
 ///
 /// This is a separate query from `compute_model_graph` so project-wide graph
 /// recomputation can reuse unchanged per-file data.
@@ -78,9 +79,9 @@ pub fn extract_models(
     db: &dyn djls_source::Db,
     file: File,
     module_name: PythonModuleName,
-) -> ModelExtraction {
+) -> ExtractedClasses {
     let Ok(Some(module)) = RecoveredPythonModule::from_file(db, file) else {
-        return ModelExtraction::default();
+        return ExtractedClasses::default();
     };
 
     let module_kind = if file.path(db).file_name() == Some("__init__.py") {

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use djls_source::File;
@@ -8,6 +9,7 @@ use ruff_python_ast::StmtClassDef;
 
 use crate::ast::ExprExt;
 use crate::ast::RangedExt;
+use crate::models::graph::ClassName;
 use crate::models::graph::FieldName;
 use crate::models::graph::ModelDef;
 use crate::models::graph::ModelKind;
@@ -23,38 +25,73 @@ use crate::python::import::FromImportSyntax;
 use crate::python::import::ModuleKind;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct ModelExtraction {
-    pub(super) candidates: Vec<ModelCandidate>,
+pub(crate) struct ExtractedClasses(Vec<ExtractedClass>);
+
+impl ExtractedClasses {
+    pub(super) fn as_slice(&self) -> &[ExtractedClass] {
+        &self.0
+    }
 }
 
-/// A class declaration with every statically recognized base expression.
-///
-/// Recognition happens after all project modules have been scanned. Keeping
-/// these source facts immutable prevents an early parent from hiding a later or
-/// unresolved base.
+/// A Python class declaration and the source facts extracted from its body.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct ModelCandidate {
-    pub(super) model: ModelDef,
-    pub(super) bases: Vec<Spanned<CandidateBaseRef>>,
+pub(super) struct ExtractedClass {
+    pub(super) file: File,
+    pub(super) name: Spanned<ClassName>,
+    pub(super) module_name: PythonModuleName,
+    relations: Vec<Relation>,
+    pub(super) declared_model_kind: ModelKind,
+    pub(super) bases: Vec<Spanned<ExtractedBaseRef>>,
+    pub(super) local_bindings: BTreeMap<FieldName, LocalBinding>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum CandidateBaseRef {
+pub(super) enum LocalBinding {
+    Relation(usize),
+    Other,
+}
+
+/// A base expression as understood from imports at its source occurrence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum ExtractedBaseRef {
     DjangoModelRoot,
     Qualified(PythonModuleName),
-    SameModule(ModelName),
+    SameModule(ClassName),
     UnsupportedExpression,
-    Unresolved {
-        path: Vec<String>,
-        reason: CandidateBaseReferenceError,
-    },
+    MissingBinding { path: Vec<String> },
+    ShadowedBinding { path: Vec<String> },
+    InvalidTarget { target: String },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum CandidateBaseReferenceError {
-    MissingBinding,
-    ShadowedBinding,
-    InvalidTarget { target: String },
+impl ExtractedClass {
+    fn push_local_relation(&mut self, relation: Relation) {
+        let name = relation.field_name.value().clone();
+        let relation_index = self.relations.len();
+        self.relations.push(relation);
+        self.local_bindings
+            .insert(name, LocalBinding::Relation(relation_index));
+    }
+
+    fn bind_local_other(&mut self, name: FieldName) {
+        self.local_bindings.insert(name, LocalBinding::Other);
+    }
+
+    pub(super) fn has_local_relation_binding(&self) -> bool {
+        self.local_bindings
+            .values()
+            .any(|binding| matches!(binding, LocalBinding::Relation(_)))
+    }
+
+    pub(super) fn into_admitted_model(self) -> (ModelDef, BTreeMap<FieldName, LocalBinding>) {
+        let definition = ModelDef {
+            file: self.file,
+            name: Spanned::new(ModelName::new(self.name.value().as_str()), self.name.span()),
+            module_name: self.module_name,
+            relations: self.relations,
+            kind: self.declared_model_kind,
+        };
+        (definition, self.local_bindings)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -66,10 +103,10 @@ struct ModelExtractionContext<'a> {
 
 enum ModelExtractionTarget<'out> {
     Module {
-        candidates: &'out mut Vec<ModelCandidate>,
+        classes: &'out mut Vec<ExtractedClass>,
     },
     Class {
-        model: &'out mut ModelDef,
+        extracted_class: &'out mut ExtractedClass,
     },
 }
 
@@ -85,17 +122,28 @@ fn scan_class(
     target: &mut ModelExtractionTarget<'_>,
     context: ModelExtractionContext<'_>,
 ) {
-    let ModelExtractionTarget::Module { candidates } = target else {
+    let ModelExtractionTarget::Module { classes } = target else {
         return;
     };
-    let mut model = ModelDef::new(
-        class.name.to_string(),
-        context.module_name.clone(),
-        context.file,
-        class.name.span(),
-    );
+    let bases = class
+        .arguments
+        .iter()
+        .flat_map(|arguments| &arguments.args)
+        .map(|arg| Spanned::new(ExtractedBaseRef::from_expr(arg, aliases), arg.span()))
+        .collect();
+    let mut extracted_class = ExtractedClass {
+        file: context.file,
+        name: Spanned::new(ClassName::new(class.name.to_string()), class.name.span()),
+        module_name: context.module_name.clone(),
+        relations: Vec::new(),
+        declared_model_kind: ModelKind::Concrete,
+        bases,
+        local_bindings: BTreeMap::new(),
+    };
     let mut class_state = aliases.clone();
-    let mut class_target = ModelExtractionTarget::Class { model: &mut model };
+    let mut class_target = ModelExtractionTarget::Class {
+        extracted_class: &mut extracted_class,
+    };
     scan_statements(
         &class.body,
         &mut class_state,
@@ -103,22 +151,15 @@ fn scan_class(
         context,
         true,
     );
-
-    let bases = class
-        .arguments
-        .iter()
-        .flat_map(|arguments| &arguments.args)
-        .map(|arg| Spanned::new(CandidateBaseRef::from_expr(arg, aliases), arg.span()))
-        .collect();
-    candidates.push(ModelCandidate { model, bases });
+    classes.push(extracted_class);
 }
 
-/// Scan Model-relevant occurrences in source order.
+/// Scan model-relevant occurrences in source order.
 ///
-/// Module scans collect model classes. Class scans collect relation and `Meta`
-/// facts. Compound bodies share this transition engine but receive independent
-/// alias clones, so contained facts see their branch's exact source order while
-/// no branch-local alias leaks into the following statement.
+/// Module scans collect Python classes. Class scans collect Django relation and
+/// `Meta` evidence. Compound bodies share this transition engine but receive
+/// independent alias clones, so contained facts see their branch's exact source
+/// order while no branch-local alias leaks into the following statement.
 fn scan_statements(
     stmts: &[Stmt],
     state: &mut ModelImportState,
@@ -127,11 +168,11 @@ fn scan_statements(
     record_local_bindings: bool,
 ) {
     for stmt in stmts {
-        if record_local_bindings && let ModelExtractionTarget::Class { model } = target {
+        if record_local_bindings && let ModelExtractionTarget::Class { extracted_class } = target {
             let mut names = BTreeSet::new();
             collect_touched_roots(stmt, &mut names);
             for name in names {
-                model.bind_local_other(FieldName::new(name));
+                extracted_class.bind_local_other(FieldName::new(name));
             }
         }
 
@@ -153,16 +194,28 @@ fn scan_statements(
                     scan_class(class, state, target, context);
                     state.bind_local_class(class.name.as_str());
                 }
-                ModelExtractionTarget::Class { model } => {
-                    process_class_body(stmt, context.file, model, state, record_local_bindings);
+                ModelExtractionTarget::Class { extracted_class } => {
+                    process_class_body(
+                        stmt,
+                        context.file,
+                        extracted_class,
+                        state,
+                        record_local_bindings,
+                    );
                     state.invalidate_root(class.name.as_str());
                 }
             }
             continue;
         }
 
-        if let ModelExtractionTarget::Class { model } = target {
-            process_class_body(stmt, context.file, model, state, record_local_bindings);
+        if let ModelExtractionTarget::Class { extracted_class } = target {
+            process_class_body(
+                stmt,
+                context.file,
+                extracted_class,
+                state,
+                record_local_bindings,
+            );
         }
         scan_compound(stmt, state, target, context);
 
@@ -242,8 +295,8 @@ pub(super) fn extract_models_impl(
     module_name: &PythonModuleName,
     file: File,
     module_kind: ModuleKind,
-) -> ModelExtraction {
-    let mut candidates = Vec::new();
+) -> ExtractedClasses {
+    let mut classes = Vec::new();
     let mut state = ModelImportState::default();
     let context = ModelExtractionContext {
         module_name,
@@ -251,14 +304,14 @@ pub(super) fn extract_models_impl(
         module_kind,
     };
     let mut target = ModelExtractionTarget::Module {
-        candidates: &mut candidates,
+        classes: &mut classes,
     };
     scan_statements(stmts, &mut state, &mut target, context, false);
 
-    ModelExtraction { candidates }
+    ExtractedClasses(classes)
 }
 
-impl CandidateBaseRef {
+impl ExtractedBaseRef {
     fn from_expr(expr: &Expr, aliases: &ModelImportState) -> Self {
         let Some(path) = expr.path_segments() else {
             return Self::UnsupportedExpression;
@@ -277,22 +330,13 @@ impl CandidateBaseRef {
             }
             Ok(path) => Self::Qualified(path),
             Err(ModelImportPathResolutionError::MissingBinding) if path.len() == 1 => {
-                Self::SameModule(ModelName::new(path[0].clone()))
+                Self::SameModule(ClassName::new(path[0].clone()))
             }
-            Err(error) => Self::Unresolved {
-                path,
-                reason: match error {
-                    ModelImportPathResolutionError::MissingBinding => {
-                        CandidateBaseReferenceError::MissingBinding
-                    }
-                    ModelImportPathResolutionError::ShadowedBinding => {
-                        CandidateBaseReferenceError::ShadowedBinding
-                    }
-                    ModelImportPathResolutionError::InvalidTarget { target, .. } => {
-                        CandidateBaseReferenceError::InvalidTarget { target }
-                    }
-                },
-            },
+            Err(ModelImportPathResolutionError::MissingBinding) => Self::MissingBinding { path },
+            Err(ModelImportPathResolutionError::ShadowedBinding) => Self::ShadowedBinding { path },
+            Err(ModelImportPathResolutionError::InvalidTarget { target, .. }) => {
+                Self::InvalidTarget { target }
+            }
         }
     }
 }
@@ -300,7 +344,7 @@ impl CandidateBaseRef {
 fn process_class_body(
     stmt: &Stmt,
     file: File,
-    model: &mut ModelDef,
+    extracted_class: &mut ExtractedClass,
     aliases: &ModelImportState,
     record_local_binding: bool,
 ) {
@@ -311,10 +355,10 @@ fn process_class_body(
         // A class statement rebinds `Meta` when it finishes. Start each
         // top-level declaration from Django's concrete default so an earlier
         // `Meta.abstract` value cannot survive a later replacement class.
-        model.kind = ModelKind::Concrete;
+        extracted_class.declared_model_kind = ModelKind::Concrete;
         for meta_stmt in &meta.body {
             if let Some(is_abstract) = static_abstract_assignment(meta_stmt) {
-                model.kind = if is_abstract {
+                extracted_class.declared_model_kind = if is_abstract {
                     ModelKind::Abstract
                 } else {
                     ModelKind::Concrete
@@ -328,7 +372,7 @@ fn process_class_body(
     let Some(relation) = relation else {
         return;
     };
-    model.push_local_relation(relation);
+    extracted_class.push_local_relation(relation);
 }
 
 fn static_abstract_assignment(stmt: &Stmt) -> Option<bool> {
@@ -690,12 +734,13 @@ mod tests {
 
     use super::extract_models_impl;
     use super::*;
+    use crate::models::graph::ModelDef;
     use crate::models::graph::ModelGraph;
     use crate::models::graph::ModelId;
     use crate::models::graph::RelatedName;
     use crate::models::resolve::resolve_local_model_graph;
 
-    fn extract_model_facts(source: &str, module_name: &str) -> ModelExtraction {
+    fn extract_model_facts(source: &str, module_name: &str) -> ExtractedClasses {
         let db = TestDatabase::new();
         db.add_file("/test.py", source)
             .expect("model extraction fixture should be added to the test database");
@@ -705,7 +750,7 @@ mod tests {
         let module_name =
             PythonModuleName::parse(module_name).expect("test Python module name should be valid");
         let Ok(parsed) = ruff_python_parser::parse_module(source) else {
-            return ModelExtraction::default();
+            return ExtractedClasses::default();
         };
         let module = parsed.into_syntax();
         extract_models_impl(&module.body, &module_name, file, ModuleKind::Module)
@@ -715,12 +760,12 @@ mod tests {
         resolve_local_model_graph(&extract_model_facts(source, module_name))
     }
 
-    fn candidate<'a>(extraction: &'a ModelExtraction, name: &str) -> &'a ModelCandidate {
+    fn extracted_class<'a>(extraction: &'a ExtractedClasses, name: &str) -> &'a ExtractedClass {
         extraction
-            .candidates
+            .as_slice()
             .iter()
-            .find(|candidate| candidate.model.name.value().as_str() == name)
-            .expect("model candidate should exist")
+            .find(|class| class.name.value().as_str() == name)
+            .expect("extracted class should exist")
     }
 
     fn model<'a>(graph: &'a ModelGraph, name: &'a str) -> &'a ModelDef {
@@ -765,9 +810,16 @@ mod tests {
     }
 
     #[test]
-    fn plain_class_ignored() {
-        let graph = extract_model_graph("class Foo:\n    pass\n", "test");
-        assert!(graph.is_empty());
+    fn plain_class_is_extracted_but_not_admitted() {
+        let source = "class Foo:\n    pass\n";
+        let extraction = extract_model_facts(source, "test");
+        let class = extracted_class(&extraction, "Foo");
+
+        assert_eq!(class.module_name.as_str(), "test");
+        assert_eq!(class.name.span(), Span::new(6, 3));
+        assert!(class.relations.is_empty());
+        assert_eq!(class.declared_model_kind, ModelKind::Concrete);
+        assert!(extract_model_graph(source, "test").is_empty());
     }
 
     #[test]
@@ -876,7 +928,7 @@ class Location(GeoModel):
     }
 
     #[test]
-    fn unrelated_alias_is_retained_as_a_qualified_candidate() {
+    fn unrelated_alias_is_retained_as_a_qualified_base() {
         let source = r"
 import foo
 
@@ -884,18 +936,18 @@ class NotAModel(foo.Model):
     pass
 ";
         let extraction = extract_model_facts(source, "app.models");
-        let candidate = candidate(&extraction, "NotAModel");
+        let class = extracted_class(&extraction, "NotAModel");
         assert!(matches!(
-            candidate.bases.as_slice(),
+            class.bases.as_slice(),
             [base] if matches!(
                 base.value(),
-                CandidateBaseRef::Qualified(path) if path.as_str() == "foo.Model"
+                ExtractedBaseRef::Qualified(path) if path.as_str() == "foo.Model"
             )
         ));
     }
 
     #[test]
-    fn imported_non_django_base_is_retained_as_a_qualified_candidate() {
+    fn imported_non_django_base_is_retained_as_a_qualified_base() {
         let source = r"
 from pydantic import BaseModel
 
@@ -903,12 +955,12 @@ class NotDjango(BaseModel):
     pass
 ";
         let extraction = extract_model_facts(source, "app.models");
-        let candidate = candidate(&extraction, "NotDjango");
+        let class = extracted_class(&extraction, "NotDjango");
         assert!(matches!(
-            candidate.bases.as_slice(),
+            class.bases.as_slice(),
             [base] if matches!(
                 base.value(),
-                CandidateBaseRef::Qualified(path) if path.as_str() == "pydantic.BaseModel"
+                ExtractedBaseRef::Qualified(path) if path.as_str() == "pydantic.BaseModel"
             )
         ));
     }
@@ -1155,17 +1207,14 @@ class ConcreteOrder(BaseOrder):
     seller = models.ForeignKey(Seller, on_delete=models.CASCADE)
 ";
         let extraction = extract_model_facts(source, "shop.models");
-        let concrete = candidate(&extraction, "ConcreteOrder");
+        let concrete = extracted_class(&extraction, "ConcreteOrder");
 
-        assert_eq!(concrete.model.kind, ModelKind::Concrete);
-        assert_eq!(concrete.model.relations.len(), 1);
-        assert_eq!(
-            bare_target_name(&concrete.model.relations[0]),
-            Some("Seller")
-        );
+        assert_eq!(concrete.declared_model_kind, ModelKind::Concrete);
+        assert_eq!(concrete.relations.len(), 1);
+        assert_eq!(bare_target_name(&concrete.relations[0]), Some("Seller"));
         assert!(matches!(
             concrete.bases.as_slice(),
-            [base] if matches!(base.value(), CandidateBaseRef::SameModule(name) if name.as_str() == "BaseOrder")
+            [base] if matches!(base.value(), ExtractedBaseRef::SameModule(name) if name.as_str() == "BaseOrder")
         ));
     }
 
@@ -1187,14 +1236,14 @@ class SpecialOrder(BaseOrder):
     pass
 "#;
         let extraction = extract_model_facts(source, "shop.models");
-        let base = candidate(&extraction, "BaseOrder");
-        let special = candidate(&extraction, "SpecialOrder");
+        let base = extracted_class(&extraction, "BaseOrder");
+        let special = extracted_class(&extraction, "SpecialOrder");
 
-        assert_eq!(base.model.relations.len(), 1);
-        assert!(special.model.relations.is_empty());
+        assert_eq!(base.relations.len(), 1);
+        assert!(special.relations.is_empty());
         assert!(matches!(
             special.bases.as_slice(),
-            [parent] if matches!(parent.value(), CandidateBaseRef::SameModule(name) if name.as_str() == "BaseOrder")
+            [parent] if matches!(parent.value(), ExtractedBaseRef::SameModule(name) if name.as_str() == "BaseOrder")
         ));
     }
 
@@ -1328,17 +1377,17 @@ class Document(TimestampMixin, AuditMixin):
     pass
 ";
         let extraction = extract_model_facts(source, "app.models");
-        let document = candidate(&extraction, "Document");
+        let document = extracted_class(&extraction, "Document");
 
-        assert!(document.model.relations.is_empty());
+        assert!(document.relations.is_empty());
         assert_eq!(document.bases.len(), 2);
         assert!(matches!(
             document.bases[0].value(),
-            CandidateBaseRef::SameModule(name) if name.as_str() == "TimestampMixin"
+            ExtractedBaseRef::SameModule(name) if name.as_str() == "TimestampMixin"
         ));
         assert!(matches!(
             document.bases[1].value(),
-            CandidateBaseRef::SameModule(name) if name.as_str() == "AuditMixin"
+            ExtractedBaseRef::SameModule(name) if name.as_str() == "AuditMixin"
         ));
     }
 
@@ -1357,17 +1406,11 @@ class Restaurant(Place):
     owner = models.ForeignKey(User, on_delete=models.CASCADE)
 ";
         let extraction = extract_model_facts(source, "app.models");
-        let restaurant = candidate(&extraction, "Restaurant");
+        let restaurant = extracted_class(&extraction, "Restaurant");
 
-        assert_eq!(restaurant.model.relations.len(), 1);
-        assert_eq!(
-            restaurant.model.relations[0].field_name.value().as_str(),
-            "owner"
-        );
-        assert_eq!(
-            bare_target_name(&restaurant.model.relations[0]),
-            Some("User")
-        );
+        assert_eq!(restaurant.relations.len(), 1);
+        assert_eq!(restaurant.relations[0].field_name.value().as_str(), "owner");
+        assert_eq!(bare_target_name(&restaurant.relations[0]), Some("User"));
     }
 
     #[test]
@@ -1388,13 +1431,13 @@ class ConcreteOrder(some_module.BaseOrder):
     pass
 ";
         let extraction = extract_model_facts(source, "shop.models");
-        let concrete = candidate(&extraction, "ConcreteOrder");
+        let concrete = extracted_class(&extraction, "ConcreteOrder");
 
         assert!(matches!(
             concrete.bases.as_slice(),
             [base] if matches!(
                 base.value(),
-                CandidateBaseRef::Unresolved { path, .. }
+                ExtractedBaseRef::MissingBinding { path }
                     if path == &["some_module".to_string(), "BaseOrder".to_string()]
             )
         ));
@@ -1422,13 +1465,13 @@ class Concrete(MiddleMixin):
     pass
 ";
         let extraction = extract_model_facts(source, "app.models");
-        let middle = candidate(&extraction, "MiddleMixin");
-        let concrete = candidate(&extraction, "Concrete");
+        let middle = extracted_class(&extraction, "MiddleMixin");
+        let concrete = extracted_class(&extraction, "Concrete");
 
-        assert_eq!(middle.model.kind, ModelKind::Abstract);
-        assert!(middle.model.relations.is_empty());
-        assert_eq!(concrete.model.kind, ModelKind::Concrete);
-        assert!(concrete.model.relations.is_empty());
+        assert_eq!(middle.declared_model_kind, ModelKind::Abstract);
+        assert!(middle.relations.is_empty());
+        assert_eq!(concrete.declared_model_kind, ModelKind::Concrete);
+        assert!(concrete.relations.is_empty());
     }
 
     #[test]
@@ -1546,15 +1589,15 @@ class TaggedItem(GenericMixin):
     pass
 "#;
         let extraction = extract_model_facts(source, "tagging.models");
-        let mixin = candidate(&extraction, "GenericMixin");
-        let tagged = candidate(&extraction, "TaggedItem");
+        let mixin = extracted_class(&extraction, "GenericMixin");
+        let tagged = extracted_class(&extraction, "TaggedItem");
 
-        assert_eq!(mixin.model.relations.len(), 1);
+        assert_eq!(mixin.relations.len(), 1);
         assert!(matches!(
-            mixin.model.relations[0].relation_type,
+            mixin.relations[0].relation_type,
             RelationType::GenericForeignKey { .. }
         ));
-        assert!(tagged.model.relations.is_empty());
+        assert!(tagged.relations.is_empty());
     }
 
     #[test]

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -1,7 +1,4 @@
-use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::collections::VecDeque;
-use std::mem::take;
 
 use djls_source::File;
 use djls_source::Spanned;
@@ -13,7 +10,6 @@ use crate::ast::ExprExt;
 use crate::ast::RangedExt;
 use crate::models::graph::FieldName;
 use crate::models::graph::ModelDef;
-use crate::models::graph::ModelGraph;
 use crate::models::graph::ModelKind;
 use crate::models::graph::ModelName;
 use crate::models::graph::Relation;
@@ -28,37 +24,37 @@ use crate::python::import::ModuleKind;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ModelExtraction {
-    pub(super) graph: ModelGraph,
-    pub(super) deferred: Vec<DeferredModel>,
+    pub(super) candidates: Vec<ModelCandidate>,
 }
 
-impl ModelExtraction {
-    #[must_use]
-    pub(crate) fn graph(&self) -> &ModelGraph {
-        &self.graph
-    }
-}
-
+/// A class declaration with every statically recognized base expression.
+///
+/// Recognition happens after all project modules have been scanned. Keeping
+/// these source facts immutable prevents an early parent from hiding a later or
+/// unresolved base.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct DeferredModel {
+pub(super) struct ModelCandidate {
     pub(super) model: ModelDef,
-    pub(super) bases: Vec<DeferredBaseRef>,
+    pub(super) bases: Vec<Spanned<CandidateBaseRef>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum DeferredBaseRef {
+pub(super) enum CandidateBaseRef {
+    DjangoModelRoot,
     Qualified(PythonModuleName),
     SameModule(ModelName),
+    UnsupportedExpression,
+    Unresolved {
+        path: Vec<String>,
+        reason: CandidateBaseReferenceError,
+    },
 }
 
-/// A class whose bases are not yet known to be Django models.
-///
-/// Its body and bases are lowered at the source occurrence. Deferred resolution
-/// therefore never consults a later alias table or re-evaluates source syntax.
-#[derive(Clone)]
-struct DeferredCandidate {
-    model: ModelDef,
-    bases: Vec<DeferredBaseRef>,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum CandidateBaseReferenceError {
+    MissingBinding,
+    ShadowedBinding,
+    InvalidTarget { target: String },
 }
 
 #[derive(Clone, Copy)]
@@ -70,8 +66,7 @@ struct ModelExtractionContext<'a> {
 
 enum ModelExtractionTarget<'out> {
     Module {
-        graph: &'out mut ModelGraph,
-        deferred: &'out mut Vec<DeferredCandidate>,
+        candidates: &'out mut Vec<ModelCandidate>,
     },
     Class {
         model: &'out mut ModelDef,
@@ -90,13 +85,9 @@ fn scan_class(
     target: &mut ModelExtractionTarget<'_>,
     context: ModelExtractionContext<'_>,
 ) {
-    let ModelExtractionTarget::Module { graph, deferred } = target else {
+    let ModelExtractionTarget::Module { candidates } = target else {
         return;
     };
-    let Some(args) = class.arguments.as_ref() else {
-        return;
-    };
-
     let mut model = ModelDef::new(
         class.name.to_string(),
         context.module_name.clone(),
@@ -105,21 +96,21 @@ fn scan_class(
     );
     let mut class_state = aliases.clone();
     let mut class_target = ModelExtractionTarget::Class { model: &mut model };
-    scan_statements(&class.body, &mut class_state, &mut class_target, context);
+    scan_statements(
+        &class.body,
+        &mut class_state,
+        &mut class_target,
+        context,
+        true,
+    );
 
-    if is_django_model(args.args.iter(), aliases) {
-        graph.add_model(model);
-        return;
-    }
-
-    let bases: Vec<_> = args
-        .args
+    let bases = class
+        .arguments
         .iter()
-        .filter_map(|arg| DeferredBaseRef::from_expr(arg, aliases))
+        .flat_map(|arguments| &arguments.args)
+        .map(|arg| Spanned::new(CandidateBaseRef::from_expr(arg, aliases), arg.span()))
         .collect();
-    if !bases.is_empty() {
-        deferred.push(DeferredCandidate { model, bases });
-    }
+    candidates.push(ModelCandidate { model, bases });
 }
 
 /// Scan Model-relevant occurrences in source order.
@@ -133,8 +124,17 @@ fn scan_statements(
     state: &mut ModelImportState,
     target: &mut ModelExtractionTarget<'_>,
     context: ModelExtractionContext<'_>,
+    record_local_bindings: bool,
 ) {
     for stmt in stmts {
+        if record_local_bindings && let ModelExtractionTarget::Class { model } = target {
+            let mut names = BTreeSet::new();
+            collect_touched_roots(stmt, &mut names);
+            for name in names {
+                model.bind_local_other(FieldName::new(name));
+            }
+        }
+
         if let Stmt::Import(import) = stmt {
             state.apply_direct_import(&DirectImportClause::lower(import));
             continue;
@@ -154,7 +154,7 @@ fn scan_statements(
                     state.bind_local_class(class.name.as_str());
                 }
                 ModelExtractionTarget::Class { model } => {
-                    process_class_body(stmt, context.file, model, state);
+                    process_class_body(stmt, context.file, model, state, record_local_bindings);
                     state.invalidate_root(class.name.as_str());
                 }
             }
@@ -162,7 +162,7 @@ fn scan_statements(
         }
 
         if let ModelExtractionTarget::Class { model } = target {
-            process_class_body(stmt, context.file, model, state);
+            process_class_body(stmt, context.file, model, state, record_local_bindings);
         }
         scan_compound(stmt, state, target, context);
 
@@ -181,7 +181,7 @@ fn scan_compound(
     let mut scan = |body: &[Stmt], invalidated: &BTreeSet<String>| {
         let mut state = entry.clone();
         invalidate_names(&mut state, invalidated);
-        scan_statements(body, &mut state, target, context);
+        scan_statements(body, &mut state, target, context, false);
     };
     let none = BTreeSet::new();
 
@@ -237,73 +237,13 @@ fn scan_compound(
     }
 }
 
-fn resolve_children(
-    graph: &mut ModelGraph,
-    children: &[DeferredCandidate],
-) -> Vec<DeferredCandidate> {
-    let mut remaining = children.to_vec();
-
-    // Fixed-point loop: each iteration may resolve new models, which in turn
-    // unblock children that inherit from them. Converges when no progress is
-    // made.
-    loop {
-        let before = remaining.len();
-        let mut unresolved = Vec::new();
-        let abstract_data: Vec<(ModelName, Vec<Relation>)> = graph
-            .models()
-            .filter(|model| model.kind == ModelKind::Abstract)
-            .map(|model| (model.name.value().clone(), model.relations.clone()))
-            .collect();
-        let known_names: Vec<ModelName> = graph
-            .models()
-            .map(|model| model.name.value().clone())
-            .collect();
-
-        for candidate in &remaining {
-            let has_model_parent = candidate.bases.iter().any(|base| {
-                let DeferredBaseRef::SameModule(name) = base else {
-                    return false;
-                };
-                known_names.iter().any(|known| known == name)
-            });
-            if !has_model_parent {
-                unresolved.push(candidate.clone());
-                continue;
-            }
-
-            let mut model = candidate.model.clone();
-            let own_relations = take(&mut model.relations);
-            for base in &candidate.bases {
-                let DeferredBaseRef::SameModule(parent_name) = base else {
-                    continue;
-                };
-                if let Some((_, relations)) =
-                    abstract_data.iter().find(|(name, _)| name == parent_name)
-                {
-                    model.relations.extend(relations.iter().cloned());
-                }
-            }
-            model.relations.extend(own_relations);
-            graph.add_model(model);
-        }
-
-        remaining = unresolved;
-        if remaining.len() == before {
-            break;
-        }
-    }
-
-    remaining
-}
-
 pub(super) fn extract_models_impl(
     stmts: &[Stmt],
     module_name: &PythonModuleName,
     file: File,
     module_kind: ModuleKind,
 ) -> ModelExtraction {
-    let mut graph = ModelGraph::new();
-    let mut deferred = Vec::new();
+    let mut candidates = Vec::new();
     let mut state = ModelImportState::default();
     let context = ModelExtractionContext {
         module_name,
@@ -311,145 +251,98 @@ pub(super) fn extract_models_impl(
         module_kind,
     };
     let mut target = ModelExtractionTarget::Module {
-        graph: &mut graph,
-        deferred: &mut deferred,
+        candidates: &mut candidates,
     };
-    scan_statements(stmts, &mut state, &mut target, context);
+    scan_statements(stmts, &mut state, &mut target, context, false);
 
-    let deferred = viable_deferred_candidates(resolve_children(&mut graph, &deferred))
-        .into_iter()
-        .map(DeferredModel::from_candidate)
-        .collect();
-    ModelExtraction { graph, deferred }
+    ModelExtraction { candidates }
 }
 
-fn viable_deferred_candidates(candidates: Vec<DeferredCandidate>) -> Vec<DeferredCandidate> {
-    let mut viable_names = BTreeSet::new();
-    let mut queue = VecDeque::new();
-    let mut children_by_base: BTreeMap<ModelName, Vec<usize>> = BTreeMap::new();
-
-    // Same-module models can only come from this file, so a deferred child that
-    // reaches no qualified base through the same-file deferred graph can never
-    // resolve during the project pass. Build the reverse same-file inheritance
-    // graph once, then mark viability from qualified-base roots in one walk.
-    for (index, candidate) in candidates.iter().enumerate() {
-        let candidate_name = candidate.model.name.value().clone();
-        if candidate
-            .bases
-            .iter()
-            .any(|base| matches!(base, DeferredBaseRef::Qualified(_)))
-            && viable_names.insert(candidate_name.clone())
-        {
-            queue.push_back(candidate_name);
-        }
-
-        for base in &candidate.bases {
-            if let DeferredBaseRef::SameModule(name) = base {
-                children_by_base
-                    .entry(name.clone())
-                    .or_default()
-                    .push(index);
-            }
-        }
-    }
-
-    while let Some(base_name) = queue.pop_front() {
-        let Some(children) = children_by_base.get(&base_name) else {
-            continue;
+impl CandidateBaseRef {
+    fn from_expr(expr: &Expr, aliases: &ModelImportState) -> Self {
+        let Some(path) = expr.path_segments() else {
+            return Self::UnsupportedExpression;
         };
-
-        for &index in children {
-            let candidate_name = candidates[index].model.name.value().clone();
-            if viable_names.insert(candidate_name.clone()) {
-                queue.push_back(candidate_name);
-            }
-        }
-    }
-
-    candidates
-        .into_iter()
-        .filter(|candidate| viable_names.contains(candidate.model.name.value()))
-        .collect()
-}
-
-impl DeferredModel {
-    fn from_candidate(candidate: DeferredCandidate) -> Self {
-        Self {
-            model: candidate.model,
-            bases: candidate.bases,
-        }
-    }
-}
-
-impl DeferredBaseRef {
-    fn from_expr(expr: &Expr, aliases: &ModelImportState) -> Option<Self> {
-        let path = expr.path_segments()?;
-        let (root, tail) = path.split_first()?;
+        let Some((root, tail)) = path.split_first() else {
+            return Self::UnsupportedExpression;
+        };
         match aliases.resolve_qualified_path(root, tail) {
-            Ok(path) => Some(Self::Qualified(path)),
-            Err(ModelImportPathResolutionError::MissingBinding) if path.len() == 1 => {
-                Some(Self::SameModule(ModelName::new(path[0].clone())))
+            Ok(path)
+                if matches!(
+                    path.as_str(),
+                    "django.db.models.Model" | "django.contrib.gis.db.models.Model"
+                ) =>
+            {
+                Self::DjangoModelRoot
             }
-            Err(
-                ModelImportPathResolutionError::MissingBinding
-                | ModelImportPathResolutionError::ShadowedBinding
-                | ModelImportPathResolutionError::InvalidTarget { .. },
-            ) => None,
+            Ok(path) => Self::Qualified(path),
+            Err(ModelImportPathResolutionError::MissingBinding) if path.len() == 1 => {
+                Self::SameModule(ModelName::new(path[0].clone()))
+            }
+            Err(error) => Self::Unresolved {
+                path,
+                reason: match error {
+                    ModelImportPathResolutionError::MissingBinding => {
+                        CandidateBaseReferenceError::MissingBinding
+                    }
+                    ModelImportPathResolutionError::ShadowedBinding => {
+                        CandidateBaseReferenceError::ShadowedBinding
+                    }
+                    ModelImportPathResolutionError::InvalidTarget { target, .. } => {
+                        CandidateBaseReferenceError::InvalidTarget { target }
+                    }
+                },
+            },
         }
     }
 }
 
-fn is_django_model<'a>(bases: impl Iterator<Item = &'a Expr>, aliases: &ModelImportState) -> bool {
-    bases
-        .filter_map(ExprExt::path_segments)
-        .filter_map(|path| {
-            let (root, tail) = path.split_first()?;
-            aliases.resolve_qualified_path(root, tail).ok()
-        })
-        .any(|path| {
-            matches!(
-                path.as_str(),
-                "django.db.models.Model" | "django.contrib.gis.db.models.Model"
-            )
-        })
-}
-
-fn process_class_body(stmt: &Stmt, file: File, model: &mut ModelDef, aliases: &ModelImportState) {
-    // Check for Meta.abstract
-    if let Stmt::ClassDef(meta) = stmt
+fn process_class_body(
+    stmt: &Stmt,
+    file: File,
+    model: &mut ModelDef,
+    aliases: &ModelImportState,
+    record_local_binding: bool,
+) {
+    if record_local_binding
+        && let Stmt::ClassDef(meta) = stmt
         && meta.name.as_str() == "Meta"
     {
+        // A class statement rebinds `Meta` when it finishes. Start each
+        // top-level declaration from Django's concrete default so an earlier
+        // `Meta.abstract` value cannot survive a later replacement class.
+        model.kind = ModelKind::Concrete;
         for meta_stmt in &meta.body {
-            if is_abstract_assignment(meta_stmt) {
-                model.kind = ModelKind::Abstract;
-                return;
+            if let Some(is_abstract) = static_abstract_assignment(meta_stmt) {
+                model.kind = if is_abstract {
+                    ModelKind::Abstract
+                } else {
+                    ModelKind::Concrete
+                };
             }
         }
     }
 
-    // Extract relation fields (FK, O2O, M2M)
-    if let Some(relation) = extract_relation(stmt, file, aliases) {
-        model.relations.push(relation);
+    let relation =
+        extract_relation(stmt, file, aliases).or_else(|| extract_generic_foreign_key(stmt, file));
+    let Some(relation) = relation else {
         return;
-    }
-
-    // Extract GenericForeignKey fields
-    if let Some(gfk) = extract_generic_foreign_key(stmt, file) {
-        model.relations.push(gfk);
-    }
+    };
+    model.push_local_relation(relation);
 }
 
-fn is_abstract_assignment(stmt: &Stmt) -> bool {
+fn static_abstract_assignment(stmt: &Stmt) -> Option<bool> {
     let Stmt::Assign(assign) = stmt else {
-        return false;
+        return None;
     };
-    let Some(target) = assign.targets.first() else {
-        return false;
-    };
+    let target = assign.targets.first()?;
     if target.name_target() != Some("abstract") {
-        return false;
+        return None;
     }
-    matches!(assign.value.as_ref(), Expr::BooleanLiteral(b) if b.value)
+    let Expr::BooleanLiteral(value) = assign.value.as_ref() else {
+        return None;
+    };
+    Some(value.value)
 }
 
 fn relation_target_expr(call: &ruff_python_ast::ExprCall) -> Option<&Expr> {
@@ -797,10 +690,12 @@ mod tests {
 
     use super::extract_models_impl;
     use super::*;
+    use crate::models::graph::ModelGraph;
     use crate::models::graph::ModelId;
     use crate::models::graph::RelatedName;
+    use crate::models::resolve::resolve_local_model_graph;
 
-    fn extract_model_graph(source: &str, module_name: &str) -> ModelGraph {
+    fn extract_model_facts(source: &str, module_name: &str) -> ModelExtraction {
         let db = TestDatabase::new();
         db.add_file("/test.py", source)
             .expect("model extraction fixture should be added to the test database");
@@ -810,10 +705,22 @@ mod tests {
         let module_name =
             PythonModuleName::parse(module_name).expect("test Python module name should be valid");
         let Ok(parsed) = ruff_python_parser::parse_module(source) else {
-            return ModelGraph::default();
+            return ModelExtraction::default();
         };
         let module = parsed.into_syntax();
-        extract_models_impl(&module.body, &module_name, file, ModuleKind::Module).graph
+        extract_models_impl(&module.body, &module_name, file, ModuleKind::Module)
+    }
+
+    fn extract_model_graph(source: &str, module_name: &str) -> ModelGraph {
+        resolve_local_model_graph(&extract_model_facts(source, module_name))
+    }
+
+    fn candidate<'a>(extraction: &'a ModelExtraction, name: &str) -> &'a ModelCandidate {
+        extraction
+            .candidates
+            .iter()
+            .find(|candidate| candidate.model.name.value().as_str() == name)
+            .expect("model candidate should exist")
     }
 
     fn model<'a>(graph: &'a ModelGraph, name: &'a str) -> &'a ModelDef {
@@ -969,29 +876,41 @@ class Location(GeoModel):
     }
 
     #[test]
-    fn unrelated_alias_not_matched() {
-        // foo.Model should NOT be detected as a Django model
+    fn unrelated_alias_is_retained_as_a_qualified_candidate() {
         let source = r"
 import foo
 
 class NotAModel(foo.Model):
     pass
 ";
-        let graph = extract_model_graph(source, "app.models");
-        assert!(graph.is_empty());
+        let extraction = extract_model_facts(source, "app.models");
+        let candidate = candidate(&extraction, "NotAModel");
+        assert!(matches!(
+            candidate.bases.as_slice(),
+            [base] if matches!(
+                base.value(),
+                CandidateBaseRef::Qualified(path) if path.as_str() == "foo.Model"
+            )
+        ));
     }
 
     #[test]
-    fn unrelated_model_name_not_matched() {
-        // A bare name that happens to not be "Model" should not match
+    fn imported_non_django_base_is_retained_as_a_qualified_candidate() {
         let source = r"
 from pydantic import BaseModel
 
 class NotDjango(BaseModel):
     pass
 ";
-        let graph = extract_model_graph(source, "app.models");
-        assert!(graph.is_empty());
+        let extraction = extract_model_facts(source, "app.models");
+        let candidate = candidate(&extraction, "NotDjango");
+        assert!(matches!(
+            candidate.bases.as_slice(),
+            [base] if matches!(
+                base.value(),
+                CandidateBaseRef::Qualified(path) if path.as_str() == "pydantic.BaseModel"
+            )
+        ));
     }
 
     #[test]
@@ -1235,19 +1154,19 @@ class BaseOrder(models.Model):
 class ConcreteOrder(BaseOrder):
     seller = models.ForeignKey(Seller, on_delete=models.CASCADE)
 ";
-        let graph = extract_model_graph(source, "shop.models");
+        let extraction = extract_model_facts(source, "shop.models");
+        let concrete = candidate(&extraction, "ConcreteOrder");
 
-        let concrete = model(&graph, "ConcreteOrder");
-        assert_eq!(concrete.kind, ModelKind::Concrete);
-        assert_eq!(concrete.relations.len(), 2);
-
-        let targets: Vec<&str> = concrete
-            .relations
-            .iter()
-            .filter_map(bare_target_name)
-            .collect();
-        assert!(targets.contains(&"User"));
-        assert!(targets.contains(&"Seller"));
+        assert_eq!(concrete.model.kind, ModelKind::Concrete);
+        assert_eq!(concrete.model.relations.len(), 1);
+        assert_eq!(
+            bare_target_name(&concrete.model.relations[0]),
+            Some("Seller")
+        );
+        assert!(matches!(
+            concrete.bases.as_slice(),
+            [base] if matches!(base.value(), CandidateBaseRef::SameModule(name) if name.as_str() == "BaseOrder")
+        ));
     }
 
     #[test]
@@ -1267,14 +1186,16 @@ class BaseOrder(models.Model):
 class SpecialOrder(BaseOrder):
     pass
 "#;
-        let graph = extract_model_graph(source, "shop.models");
+        let extraction = extract_model_facts(source, "shop.models");
+        let base = candidate(&extraction, "BaseOrder");
+        let special = candidate(&extraction, "SpecialOrder");
 
-        let special = model(&graph, "SpecialOrder");
-        let rel = &special.relations[0];
-        assert_eq!(
-            rel.effective_related_name("SpecialOrder", "shop.models"),
-            Some("specialorder_set".into())
-        );
+        assert_eq!(base.model.relations.len(), 1);
+        assert!(special.model.relations.is_empty());
+        assert!(matches!(
+            special.bases.as_slice(),
+            [parent] if matches!(parent.value(), CandidateBaseRef::SameModule(name) if name.as_str() == "BaseOrder")
+        ));
     }
 
     #[test]
@@ -1406,14 +1327,19 @@ class AuditMixin(models.Model):
 class Document(TimestampMixin, AuditMixin):
     pass
 ";
-        let graph = extract_model_graph(source, "app.models");
+        let extraction = extract_model_facts(source, "app.models");
+        let document = candidate(&extraction, "Document");
 
-        let doc = model(&graph, "Document");
-        assert_eq!(doc.relations.len(), 2);
-
-        let targets: Vec<&str> = doc.relations.iter().filter_map(bare_target_name).collect();
-        assert!(targets.contains(&"User"));
-        assert!(targets.contains(&"Approver"));
+        assert!(document.model.relations.is_empty());
+        assert_eq!(document.bases.len(), 2);
+        assert!(matches!(
+            document.bases[0].value(),
+            CandidateBaseRef::SameModule(name) if name.as_str() == "TimestampMixin"
+        ));
+        assert!(matches!(
+            document.bases[1].value(),
+            CandidateBaseRef::SameModule(name) if name.as_str() == "AuditMixin"
+        ));
     }
 
     #[test]
@@ -1430,16 +1356,22 @@ class Place(models.Model):
 class Restaurant(Place):
     owner = models.ForeignKey(User, on_delete=models.CASCADE)
 ";
-        let graph = extract_model_graph(source, "app.models");
+        let extraction = extract_model_facts(source, "app.models");
+        let restaurant = candidate(&extraction, "Restaurant");
 
-        let restaurant = model(&graph, "Restaurant");
-        assert_eq!(restaurant.relations.len(), 1);
-        assert_eq!(restaurant.relations[0].field_name.value().as_str(), "owner");
-        assert_eq!(bare_target_name(&restaurant.relations[0]), Some("User"));
+        assert_eq!(restaurant.model.relations.len(), 1);
+        assert_eq!(
+            restaurant.model.relations[0].field_name.value().as_str(),
+            "owner"
+        );
+        assert_eq!(
+            bare_target_name(&restaurant.model.relations[0]),
+            Some("User")
+        );
     }
 
     #[test]
-    fn unresolved_qualified_base_is_not_treated_as_same_module() {
+    fn unresolved_qualified_base_is_retained_without_becoming_same_module() {
         let source = r"
 from django.db import models
 
@@ -1455,9 +1387,17 @@ class BaseOrder(models.Model):
 class ConcreteOrder(some_module.BaseOrder):
     pass
 ";
-        let graph = extract_model_graph(source, "shop.models");
+        let extraction = extract_model_facts(source, "shop.models");
+        let concrete = candidate(&extraction, "ConcreteOrder");
 
-        assert!(!has_model(&graph, "ConcreteOrder"));
+        assert!(matches!(
+            concrete.bases.as_slice(),
+            [base] if matches!(
+                base.value(),
+                CandidateBaseRef::Unresolved { path, .. }
+                    if path == &["some_module".to_string(), "BaseOrder".to_string()]
+            )
+        ));
     }
 
     #[test]
@@ -1481,19 +1421,14 @@ class MiddleMixin(BaseMixin):
 class Concrete(MiddleMixin):
     pass
 ";
-        let graph = extract_model_graph(source, "app.models");
+        let extraction = extract_model_facts(source, "app.models");
+        let middle = candidate(&extraction, "MiddleMixin");
+        let concrete = candidate(&extraction, "Concrete");
 
-        // MiddleMixin inherits BaseMixin's FK to User
-        let middle = model(&graph, "MiddleMixin");
-        assert_eq!(middle.kind, ModelKind::Abstract);
-        assert_eq!(middle.relations.len(), 1);
-        assert_eq!(bare_target_name(&middle.relations[0]), Some("User"));
-
-        // Concrete inherits through MiddleMixin
-        let concrete = model(&graph, "Concrete");
-        assert_eq!(concrete.kind, ModelKind::Concrete);
-        assert_eq!(concrete.relations.len(), 1);
-        assert_eq!(bare_target_name(&concrete.relations[0]), Some("User"));
+        assert_eq!(middle.model.kind, ModelKind::Abstract);
+        assert!(middle.model.relations.is_empty());
+        assert_eq!(concrete.model.kind, ModelKind::Concrete);
+        assert!(concrete.model.relations.is_empty());
     }
 
     #[test]
@@ -1610,18 +1545,16 @@ class GenericMixin(models.Model):
 class TaggedItem(GenericMixin):
     pass
 "#;
-        let graph = extract_model_graph(source, "tagging.models");
+        let extraction = extract_model_facts(source, "tagging.models");
+        let mixin = candidate(&extraction, "GenericMixin");
+        let tagged = candidate(&extraction, "TaggedItem");
 
-        let tagged = model(&graph, "TaggedItem");
-        assert_eq!(tagged.relations.len(), 1);
-        assert_eq!(
-            tagged.relations[0].field_name.value().as_str(),
-            "content_object"
-        );
+        assert_eq!(mixin.model.relations.len(), 1);
         assert!(matches!(
-            tagged.relations[0].relation_type,
+            mixin.model.relations[0].relation_type,
             RelationType::GenericForeignKey { .. }
         ));
+        assert!(tagged.model.relations.is_empty());
     }
 
     #[test]

--- a/crates/djls-project/src/models/extract.rs
+++ b/crates/djls-project/src/models/extract.rs
@@ -168,11 +168,16 @@ fn scan_statements(
     record_local_bindings: bool,
 ) {
     for stmt in stmts {
-        if record_local_bindings && let ModelExtractionTarget::Class { extracted_class } = target {
+        let touched_roots = record_local_bindings.then(|| {
             let mut names = BTreeSet::new();
             collect_touched_roots(stmt, &mut names);
+            names
+        });
+        if let (Some(names), ModelExtractionTarget::Class { extracted_class }) =
+            (&touched_roots, &mut *target)
+        {
             for name in names {
-                extracted_class.bind_local_other(FieldName::new(name));
+                extracted_class.bind_local_other(FieldName::new(name.clone()));
             }
         }
 
@@ -219,8 +224,11 @@ fn scan_statements(
         }
         scan_compound(stmt, state, target, context);
 
-        let mut roots = BTreeSet::new();
-        collect_touched_roots(stmt, &mut roots);
+        let roots = touched_roots.unwrap_or_else(|| {
+            let mut roots = BTreeSet::new();
+            collect_touched_roots(stmt, &mut roots);
+            roots
+        });
         invalidate_names(state, &roots);
     }
 }

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -1,7 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::collections::btree_map::Entry;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -92,7 +91,7 @@ pub struct ModelId {
 
 impl ModelId {
     #[must_use]
-    fn new(module_name: PythonModuleName, name: ModelName) -> Self {
+    pub(super) fn new(module_name: PythonModuleName, name: ModelName) -> Self {
         Self { name, module_name }
     }
 
@@ -197,15 +196,13 @@ pub(crate) enum RelationTargetResolution {
     },
 }
 
-impl Default for RelationTargetResolution {
-    fn default() -> Self {
+impl RelationTargetResolution {
+    fn file_local() -> Self {
         Self::Unresolved {
             reason: RelationTargetUnresolvedReason::FileLocal,
         }
     }
-}
 
-impl RelationTargetResolution {
     fn is_file_local_placeholder(&self) -> bool {
         matches!(
             self,
@@ -218,7 +215,6 @@ impl RelationTargetResolution {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub(crate) enum RelationTargetUnresolvedReason {
-    /// per-file extraction cannot resolve targets; the project pass overwrites this placeholder
     FileLocal,
     /// relation has no statically-derivable target, e.g. `GenericForeignKey`
     NoStaticTarget,
@@ -346,8 +342,6 @@ pub(crate) struct Relation {
     pub(crate) field_name: Spanned<FieldName>,
     #[serde(flatten)]
     pub(crate) relation_type: RelationType,
-    #[serde(skip_serializing_if = "RelationTargetResolution::is_file_local_placeholder")]
-    resolution: RelationTargetResolution,
 }
 
 impl Relation {
@@ -361,9 +355,6 @@ impl Relation {
             file,
             field_name,
             relation_type,
-            resolution: RelationTargetResolution::Unresolved {
-                reason: RelationTargetUnresolvedReason::FileLocal,
-            },
         }
     }
 
@@ -537,6 +528,12 @@ fn unresolved_import_path_reason(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LocalBinding {
+    Relation(usize),
+    Other,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ModelDef {
     #[serde(skip)]
@@ -545,6 +542,8 @@ pub struct ModelDef {
     pub(crate) module_name: PythonModuleName,
     pub(crate) relations: Vec<Relation>,
     pub(crate) kind: ModelKind,
+    #[serde(skip)]
+    final_local_bindings: BTreeMap<FieldName, LocalBinding>,
 }
 
 impl ModelDef {
@@ -561,30 +560,235 @@ impl ModelDef {
             module_name,
             relations: Vec::new(),
             kind: ModelKind::Concrete,
+            final_local_bindings: BTreeMap::new(),
         }
     }
+
+    pub(crate) fn push_local_relation(&mut self, relation: Relation) {
+        let name = relation.field_name.value().clone();
+        let relation_index = self.relations.len();
+        self.relations.push(relation);
+        self.final_local_bindings
+            .insert(name, LocalBinding::Relation(relation_index));
+    }
+
+    pub(crate) fn bind_local_other(&mut self, name: FieldName) {
+        self.final_local_bindings.insert(name, LocalBinding::Other);
+    }
+
+    pub(super) fn has_local_relation_binding(&self) -> bool {
+        self.final_local_bindings
+            .values()
+            .any(|binding| matches!(binding, LocalBinding::Relation(_)))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum BaseOutcome {
+    DjangoModelRoot {
+        span: Span,
+    },
+    Model {
+        model: ModelId,
+        span: Span,
+    },
+    NonModelClass {
+        class: ModelId,
+        span: Span,
+    },
+    Unresolved {
+        span: Span,
+        reason: BaseUnresolvedReason,
+    },
+}
+
+impl BaseOutcome {
+    #[must_use]
+    pub(crate) fn span(&self) -> Span {
+        match self {
+            Self::DjangoModelRoot { span }
+            | Self::Model { span, .. }
+            | Self::NonModelClass { span, .. }
+            | Self::Unresolved { span, .. } => *span,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum BaseUnresolvedReason {
+    UnsupportedExpression,
+    MissingImportBinding {
+        path: Vec<String>,
+    },
+    ShadowedImportBinding {
+        path: Vec<String>,
+    },
+    InvalidImportedTarget {
+        target: String,
+    },
+    ImportNotFound {
+        requested: PythonModuleName,
+    },
+    ImportedTargetIsModule {
+        module: PythonModuleName,
+    },
+    PartialImport {
+        resolved_prefix: PythonModuleName,
+        unresolved_tail: Vec<String>,
+    },
+    ModelNotFound {
+        model: ModelId,
+    },
+    ReboundLocalBase {
+        model: ModelId,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum AncestryOutcome {
+    Complete { mro: Vec<ModelId> },
+    Partial,
+    Invalid { error: InheritanceError },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum InheritanceError {
+    Cycle,
+    DuplicateDjangoModelRoot,
+    DuplicateModelBase { model: ModelId },
+    InconsistentC3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InheritanceRecord {
+    pub(crate) bases: Vec<BaseOutcome>,
+    pub(crate) ancestry: AncestryOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ModelRecord {
+    definition: ModelDef,
+    inheritance: InheritanceRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RelationDeclarationId {
+    model: ModelId,
+    index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RelationBindingId {
+    owner: ModelId,
+    declaration: RelationDeclarationId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RelationBinding {
+    owner: ModelId,
+    declaration: RelationDeclarationId,
+    resolution: RelationTargetResolution,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ModelRelationBindings {
+    local_relation_bindings: BTreeMap<FieldName, RelationBindingId>,
+    local_bound_names: BTreeSet<FieldName>,
+    effective_forward_bindings: BTreeMap<FieldName, RelationBindingId>,
 }
 
 /// Dependency graph of Django models and their relations.
 ///
 /// Models are keyed by deterministic import identity (`ModelId`) so
 /// identically-named models from different importable modules can coexist.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default)]
 pub struct ModelGraph {
-    models: BTreeMap<ModelId, ModelDef>,
-    #[serde(skip)]
+    records: BTreeMap<ModelId, ModelRecord>,
     model_ids_by_name: BTreeMap<ModelName, BTreeSet<ModelId>>,
-    #[serde(skip)]
-    overwritten_model_ids: Vec<ModelId>,
+    relation_bindings: BTreeMap<RelationBindingId, RelationBinding>,
+    model_relation_bindings: BTreeMap<ModelId, ModelRelationBindings>,
 }
 
 impl PartialEq for ModelGraph {
     fn eq(&self, other: &Self) -> bool {
-        self.models == other.models
+        self.records == other.records
+            && self.relation_bindings == other.relation_bindings
+            && self.model_relation_bindings == other.model_relation_bindings
     }
 }
 
 impl Eq for ModelGraph {}
+
+#[derive(Serialize)]
+struct SerializedRelation<'a> {
+    #[serde(flatten)]
+    declaration: &'a Relation,
+    #[serde(skip_serializing_if = "RelationTargetResolution::is_file_local_placeholder")]
+    resolution: &'a RelationTargetResolution,
+}
+
+#[derive(Serialize)]
+struct SerializedModel<'a> {
+    name: &'a Spanned<ModelName>,
+    module_name: &'a PythonModuleName,
+    relations: Vec<SerializedRelation<'a>>,
+    kind: ModelKind,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unresolved_bases: Vec<&'a BaseOutcome>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ancestry: Option<&'a AncestryOutcome>,
+}
+
+#[derive(Serialize)]
+struct SerializedGraph<'a> {
+    models: BTreeMap<&'a ModelId, SerializedModel<'a>>,
+}
+
+impl Serialize for ModelGraph {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let models: BTreeMap<&ModelId, SerializedModel<'_>> = self
+            .records
+            .iter()
+            .map(|(id, record)| {
+                let relations = self
+                    .owned_relation_bindings(id)
+                    .map(|(binding, relation)| SerializedRelation {
+                        declaration: relation,
+                        resolution: &binding.resolution,
+                    })
+                    .collect();
+                let model = &record.definition;
+                let unresolved_bases = record
+                    .inheritance
+                    .bases
+                    .iter()
+                    .filter(|base| matches!(base, BaseOutcome::Unresolved { .. }))
+                    .collect();
+                let ancestry = match &record.inheritance.ancestry {
+                    AncestryOutcome::Complete { .. } => None,
+                    AncestryOutcome::Partial | AncestryOutcome::Invalid { .. } => {
+                        Some(&record.inheritance.ancestry)
+                    }
+                };
+                (
+                    id,
+                    SerializedModel {
+                        name: &model.name,
+                        module_name: &model.module_name,
+                        relations,
+                        kind: model.kind,
+                        unresolved_bases,
+                        ancestry,
+                    },
+                )
+            })
+            .collect();
+        SerializedGraph { models }.serialize(serializer)
+    }
+}
 
 impl ModelGraph {
     #[must_use]
@@ -594,28 +798,24 @@ impl ModelGraph {
     }
 
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
     #[cfg(debug_assertions)]
     pub(super) fn debug_assert_no_file_local_placeholders(&self) {
         let placeholders: Vec<String> = self
-            .models
-            .iter()
-            .flat_map(|(id, model)| {
-                model
-                    .relations
-                    .iter()
-                    .filter(|&relation| relation.resolution.is_file_local_placeholder())
-                    .map(|relation| {
-                        format!(
-                            "{}.{}.{}",
-                            id.module_name.as_str(),
-                            id.name.as_str(),
-                            relation.field_name.value().as_str()
-                        )
-                    })
+            .relation_bindings
+            .values()
+            .filter(|binding| binding.resolution.is_file_local_placeholder())
+            .map(|binding| {
+                format!(
+                    "{}.{}.{}",
+                    binding.owner.module_name.as_str(),
+                    binding.owner.name.as_str(),
+                    self.relation_declaration(&binding.declaration)
+                        .map_or("<missing>", |relation| relation.field_name.value().as_str())
+                )
             })
             .collect();
         debug_assert!(
@@ -625,22 +825,27 @@ impl ModelGraph {
         );
     }
 
-    pub(crate) fn add_model(&mut self, model: ModelDef) {
-        let id = ModelId::new(model.module_name.clone(), model.name.value().clone());
-        match self.models.entry(id.clone()) {
-            Entry::Occupied(mut entry) => {
-                self.overwritten_model_ids.push(id.clone());
-                let existing = entry.get();
-                let incoming_is_later = existing.file != model.file
-                    || existing.name.span().start() <= model.name.span().start();
-                if incoming_is_later {
-                    entry.insert(model);
-                }
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(model);
-            }
-        }
+    pub(super) fn insert_resolved_model(
+        &mut self,
+        definition: ModelDef,
+        inheritance: InheritanceRecord,
+    ) {
+        let id = ModelId::new(
+            definition.module_name.clone(),
+            definition.name.value().clone(),
+        );
+        assert!(
+            self.records
+                .insert(
+                    id.clone(),
+                    ModelRecord {
+                        definition,
+                        inheritance,
+                    },
+                )
+                .is_none(),
+            "resolved model inserted more than once: {id:?}",
+        );
         self.model_ids_by_name
             .entry(id.name.clone())
             .or_default()
@@ -648,24 +853,280 @@ impl ModelGraph {
     }
 
     #[cfg(test)]
-    #[must_use]
-    fn overwritten_model_ids(&self) -> &[ModelId] {
-        &self.overwritten_model_ids
+    fn add_standalone_model(&mut self, definition: ModelDef) {
+        let id = ModelId::new(
+            definition.module_name.clone(),
+            definition.name.value().clone(),
+        );
+        self.insert_resolved_model(
+            definition,
+            InheritanceRecord {
+                bases: Vec::new(),
+                ancestry: AncestryOutcome::Complete {
+                    mro: vec![id.clone()],
+                },
+            },
+        );
+        self.build_effective_relation_bindings();
+    }
+
+    fn install_local_relation_bindings(
+        &mut self,
+        id: &ModelId,
+        local_bindings: BTreeMap<FieldName, LocalBinding>,
+    ) {
+        let local_bound_names = local_bindings.keys().cloned().collect();
+        let mut local_relation_bindings = BTreeMap::new();
+        for (field_name, binding) in local_bindings {
+            let LocalBinding::Relation(index) = binding else {
+                continue;
+            };
+            let declaration = RelationDeclarationId {
+                model: id.clone(),
+                index,
+            };
+            let binding_id = RelationBindingId {
+                owner: id.clone(),
+                declaration: declaration.clone(),
+            };
+            self.relation_bindings.insert(
+                binding_id.clone(),
+                RelationBinding {
+                    owner: id.clone(),
+                    declaration,
+                    resolution: RelationTargetResolution::file_local(),
+                },
+            );
+            local_relation_bindings.insert(field_name, binding_id);
+        }
+        let effective_forward_bindings = local_relation_bindings.clone();
+        assert!(
+            self.model_relation_bindings
+                .insert(
+                    id.clone(),
+                    ModelRelationBindings {
+                        local_relation_bindings,
+                        local_bound_names,
+                        effective_forward_bindings,
+                    },
+                )
+                .is_none(),
+            "relation bindings installed more than once: {id:?}",
+        );
+    }
+
+    pub(super) fn add_non_model_class(&mut self, id: &ModelId, class: &ModelDef) {
+        let local_bound_names = class.final_local_bindings.keys().cloned().collect();
+        assert!(
+            self.model_relation_bindings
+                .insert(
+                    id.clone(),
+                    ModelRelationBindings {
+                        local_bound_names,
+                        ..ModelRelationBindings::default()
+                    },
+                )
+                .is_none(),
+            "non-model class inserted more than once: {id:?}",
+        );
+    }
+
+    #[cfg(test)]
+    pub(super) fn contains_model(&self, id: &ModelId) -> bool {
+        self.records.contains_key(id)
+    }
+
+    pub(crate) fn inheritance(&self, id: &ModelId) -> Option<&InheritanceRecord> {
+        self.records.get(id).map(|record| &record.inheritance)
+    }
+
+    pub(super) fn build_effective_relation_bindings(&mut self) {
+        self.relation_bindings.clear();
+        let records = &self.records;
+        self.model_relation_bindings
+            .retain(|id, _bindings| !records.contains_key(id));
+
+        let local_bindings: Vec<_> = self
+            .records
+            .iter()
+            .map(|(id, record)| (id.clone(), record.definition.final_local_bindings.clone()))
+            .collect();
+        for (id, bindings) in local_bindings {
+            self.install_local_relation_bindings(&id, bindings);
+        }
+
+        let mut complete: Vec<(ModelId, Vec<ModelId>)> = self
+            .records
+            .iter()
+            .filter_map(|(id, record)| match &record.inheritance.ancestry {
+                AncestryOutcome::Complete { mro } => Some((id.clone(), mro.clone())),
+                AncestryOutcome::Partial | AncestryOutcome::Invalid { .. } => None,
+            })
+            .collect();
+        complete.sort_by_key(|(_id, mro)| mro.len());
+
+        for (id, mro) in &complete {
+            self.clone_abstract_relation_bindings(id, mro);
+        }
+        for (id, mro) in complete {
+            self.install_effective_relation_bindings(id, &mro);
+        }
+    }
+
+    fn clone_abstract_relation_bindings(&mut self, id: &ModelId, mro: &[ModelId]) {
+        let mut occupied = self
+            .model_relation_bindings
+            .get(id)
+            .map(|bindings| bindings.local_bound_names.clone())
+            .unwrap_or_default();
+        let mut local_relations = self
+            .model_relation_bindings
+            .get(id)
+            .map(|bindings| bindings.local_relation_bindings.clone())
+            .unwrap_or_default();
+        let mut cloned_names = BTreeSet::new();
+
+        for ancestor_id in mro.iter().skip(1) {
+            let ancestor_names = self
+                .model_relation_bindings
+                .get(ancestor_id)
+                .map(|bindings| bindings.local_bound_names.clone())
+                .unwrap_or_default();
+            let ancestor_relations = self
+                .model_relation_bindings
+                .get(ancestor_id)
+                .map(|bindings| bindings.local_relation_bindings.clone())
+                .unwrap_or_default();
+            let ancestor_is_abstract = self
+                .records
+                .get(ancestor_id)
+                .is_some_and(|record| record.definition.kind == ModelKind::Abstract);
+
+            for name in ancestor_names {
+                if !occupied.insert(name.clone()) || !ancestor_is_abstract {
+                    continue;
+                }
+                let Some(ancestor_binding_id) = ancestor_relations.get(&name) else {
+                    continue;
+                };
+                let Some(ancestor_binding) =
+                    self.relation_bindings.get(ancestor_binding_id).cloned()
+                else {
+                    continue;
+                };
+                let binding_id = RelationBindingId {
+                    owner: id.clone(),
+                    declaration: ancestor_binding.declaration.clone(),
+                };
+                self.relation_bindings.insert(
+                    binding_id.clone(),
+                    RelationBinding {
+                        owner: id.clone(),
+                        declaration: ancestor_binding.declaration,
+                        resolution: RelationTargetResolution::file_local(),
+                    },
+                );
+                local_relations.insert(name.clone(), binding_id);
+                cloned_names.insert(name);
+            }
+        }
+
+        let bindings = self.model_relation_bindings.entry(id.clone()).or_default();
+        bindings.local_bound_names.extend(cloned_names);
+        bindings.local_relation_bindings = local_relations;
+    }
+
+    fn install_effective_relation_bindings(&mut self, id: ModelId, mro: &[ModelId]) {
+        let mut occupied = self
+            .model_relation_bindings
+            .get(&id)
+            .map(|bindings| bindings.local_bound_names.clone())
+            .unwrap_or_default();
+        let mut forward = self
+            .model_relation_bindings
+            .get(&id)
+            .map(|bindings| bindings.local_relation_bindings.clone())
+            .unwrap_or_default();
+
+        for ancestor_id in mro.iter().skip(1) {
+            let ancestor_names = self
+                .model_relation_bindings
+                .get(ancestor_id)
+                .map(|bindings| bindings.local_bound_names.clone())
+                .unwrap_or_default();
+            let ancestor_relations = self
+                .model_relation_bindings
+                .get(ancestor_id)
+                .map(|bindings| bindings.local_relation_bindings.clone())
+                .unwrap_or_default();
+            for name in ancestor_names {
+                if occupied.insert(name.clone())
+                    && let Some(binding_id) = ancestor_relations.get(&name)
+                {
+                    forward.insert(name, binding_id.clone());
+                }
+            }
+        }
+
+        self.model_relation_bindings
+            .entry(id)
+            .or_default()
+            .effective_forward_bindings = forward;
+    }
+
+    fn relation_declaration(&self, id: &RelationDeclarationId) -> Option<&Relation> {
+        self.records
+            .get(&id.model)?
+            .definition
+            .relations
+            .get(id.index)
+    }
+
+    fn owned_relation_bindings<'a>(
+        &'a self,
+        owner: &'a ModelId,
+    ) -> impl Iterator<Item = (&'a RelationBinding, &'a Relation)> + 'a {
+        let mut bindings: Vec<_> = self
+            .model_relation_bindings
+            .get(owner)
+            .into_iter()
+            .flat_map(|bindings| bindings.local_relation_bindings.values())
+            .filter_map(|binding_id| {
+                let binding = self.relation_bindings.get(binding_id)?;
+                self.relation_declaration(&binding.declaration)
+                    .map(|relation| (binding, relation))
+            })
+            .collect();
+        bindings.sort_by_key(|(binding, _relation)| {
+            let ancestry_order = if binding.declaration.model == *owner {
+                usize::MAX
+            } else {
+                self.records
+                    .get(owner)
+                    .and_then(|record| match &record.inheritance.ancestry {
+                        AncestryOutcome::Complete { mro } => mro
+                            .iter()
+                            .position(|model| model == &binding.declaration.model),
+                        AncestryOutcome::Partial | AncestryOutcome::Invalid { .. } => None,
+                    })
+                    .unwrap_or(usize::MAX - 1)
+            };
+            (ancestry_order, binding.declaration.index)
+        });
+        bindings.into_iter()
+    }
+
+    pub(crate) fn owned_relation_entries<'a>(
+        &'a self,
+        owner: &'a ModelId,
+    ) -> impl Iterator<Item = (&'a Relation, &'a RelationTargetResolution)> + 'a {
+        self.owned_relation_bindings(owner)
+            .map(|(binding, relation)| (relation, &binding.resolution))
     }
 
     #[must_use]
     pub fn get_by_id(&self, id: &ModelId) -> Option<&ModelDef> {
-        self.models.get(id)
-    }
-
-    pub(crate) fn model_id_in_module(
-        &self,
-        module_name: &PythonModuleName,
-        name: &str,
-    ) -> Option<ModelId> {
-        self.models_named(name)
-            .find(|(id, _model)| id.module_name == *module_name)
-            .map(|(id, _model)| id.clone())
+        self.records.get(id).map(|record| &record.definition)
     }
 
     #[must_use = "iterators are lazy and do nothing unless consumed"]
@@ -676,21 +1137,23 @@ impl ModelGraph {
         self.model_ids_by_name
             .get(name)
             .into_iter()
-            .flat_map(move |ids| ids.iter().filter_map(|id| self.models.get_key_value(id)))
-    }
-
-    pub(crate) fn models(&self) -> impl Iterator<Item = &ModelDef> {
-        self.models.values()
+            .flat_map(move |ids| {
+                ids.iter().filter_map(|id| {
+                    self.records
+                        .get_key_value(id)
+                        .map(|(id, record)| (id, &record.definition))
+                })
+            })
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.models.is_empty()
+        self.records.is_empty()
     }
 
     #[must_use]
     pub fn len(&self) -> usize {
-        self.models.len()
+        self.records.len()
     }
 
     /// Look up a model by approximate Django app label and class name.
@@ -708,18 +1171,19 @@ impl ModelGraph {
             return Some(entry);
         }
 
-        self.models.iter().find(|(id, _model)| {
-            django_name_matches(id.name.as_str(), name)
+        self.records.iter().find_map(|(id, record)| {
+            (django_name_matches(id.name.as_str(), name)
                 && app_label_from_module_name(id.module_name.as_str())
-                    .is_some_and(|candidate| django_name_matches(candidate, app_label))
+                    .is_some_and(|candidate| django_name_matches(candidate, app_label)))
+            .then_some((id, &record.definition))
         })
     }
 
     fn lookup_entry_exact(&self, app_label: &str, name: &str) -> Option<(&ModelId, &ModelDef)> {
         self.model_ids_by_name.get(name)?.iter().find_map(|id| {
-            let (id, model) = self.models.get_key_value(id)?;
+            let (id, record) = self.records.get_key_value(id)?;
             if app_label_from_module_name(id.module_name.as_str()) == Some(app_label) {
-                Some((id, model))
+                Some((id, &record.definition))
             } else {
                 None
             }
@@ -731,31 +1195,41 @@ impl ModelGraph {
     /// Skips `GenericForeignKey` relations (no static target).
     #[must_use]
     pub fn resolve_forward(&self, scope: &ModelId, field_name: &str) -> Option<&ModelDef> {
-        let relation = self.forward_relation(scope, field_name)?;
-        self.resolve_relation_target_entry(scope, relation)
+        let (binding, relation) = self.forward_relation(scope, field_name)?;
+        self.resolve_relation_target_entry(binding, relation)
             .map(|(_id, model)| model)
     }
 
-    fn forward_relation(&self, scope: &ModelId, field_name: &str) -> Option<&Relation> {
-        let model = self.get_by_id(scope)?;
-        model
-            .relations
-            .iter()
-            .find(|relation| relation.field_name.value().as_str() == field_name)
+    fn forward_relation(
+        &self,
+        scope: &ModelId,
+        field_name: &str,
+    ) -> Option<(&RelationBinding, &Relation)> {
+        let binding_id = self
+            .model_relation_bindings
+            .get(scope)?
+            .effective_forward_bindings
+            .get(field_name)?;
+        let binding = self.relation_bindings.get(binding_id)?;
+        let relation = self.relation_declaration(&binding.declaration)?;
+        Some((binding, relation))
     }
 
     fn resolve_relation_target_entry(
         &self,
-        scope: &ModelId,
+        binding: &RelationBinding,
         relation: &Relation,
     ) -> Option<(&ModelId, &ModelDef)> {
-        match &relation.resolution {
-            RelationTargetResolution::Resolved(id) => self.models.get_key_value(id),
+        match &binding.resolution {
+            RelationTargetResolution::Resolved(id) => self
+                .records
+                .get_key_value(id)
+                .map(|(id, record)| (id, &record.definition)),
             RelationTargetResolution::Unresolved {
                 reason: RelationTargetUnresolvedReason::FileLocal,
-            } => relation
-                .target_model()
-                .and_then(|target| self.resolve_target_entry(scope, target)),
+            } => relation.target_model().and_then(|target| {
+                self.resolve_target_entry(&binding.owner, &binding.declaration.model, target)
+            }),
             RelationTargetResolution::Ambiguous { .. }
             | RelationTargetResolution::Partial { .. }
             | RelationTargetResolution::Unresolved { .. } => None,
@@ -764,19 +1238,40 @@ impl ModelGraph {
 
     fn resolve_target_entry(
         &self,
-        scope: &ModelId,
+        recipient_scope: &ModelId,
+        declaration_scope: &ModelId,
         target: &RelationTarget,
     ) -> Option<(&ModelId, &ModelDef)> {
         match target {
-            RelationTarget::SelfRef => self.models.get_key_value(scope),
-            RelationTarget::Bare { name, .. } => {
-                let app_label = app_label_from_module_name(scope.module_name.as_str())?;
+            RelationTarget::SelfRef => self
+                .records
+                .get_key_value(recipient_scope)
+                .map(|(id, record)| (id, &record.definition)),
+            RelationTarget::Bare {
+                name,
+                import_reference: None,
+            } => {
+                let app_label = app_label_from_module_name(recipient_scope.module_name.as_str())?;
                 self.lookup_entry(app_label, name.as_str())
             }
+            RelationTarget::Bare {
+                name,
+                import_reference:
+                    Some(ModelImportReference::Unresolved(
+                        ModelImportPathResolutionError::MissingBinding,
+                    )),
+            } => {
+                let app_label = app_label_from_module_name(declaration_scope.module_name.as_str())?;
+                self.lookup_entry(app_label, name.as_str())
+            }
+            RelationTarget::Bare {
+                import_reference: Some(_),
+                ..
+            }
+            | RelationTarget::Attribute { .. } => None,
             RelationTarget::Qualified { app_label, name } => {
                 self.lookup_entry(app_label, name.as_str())
             }
-            RelationTarget::Attribute { .. } => None,
         }
     }
 
@@ -789,18 +1284,29 @@ impl ModelGraph {
         &'a self,
         scope: &'a ModelId,
     ) -> impl Iterator<Item = (&'a ModelId, String)> + 'a {
-        self.models.iter().flat_map(move |(source_id, model)| {
-            model.relations.iter().filter_map(move |relation| {
-                let (target_id, _target_model) =
-                    self.resolve_relation_target_entry(source_id, relation)?;
-                if target_id != scope {
-                    return None;
-                }
+        self.records.iter().flat_map(move |(source_id, record)| {
+            let model = &record.definition;
+            (model.kind == ModelKind::Concrete)
+                .then(|| {
+                    self.owned_relation_bindings(source_id).filter_map(
+                        move |(binding, relation)| {
+                            let (target_id, _target_model) =
+                                self.resolve_relation_target_entry(binding, relation)?;
+                            if target_id != scope {
+                                return None;
+                            }
 
-                relation
-                    .effective_related_name(model.name.value().as_str(), model.module_name.as_str())
-                    .map(|name| (source_id, name))
-            })
+                            relation
+                                .effective_related_name(
+                                    model.name.value().as_str(),
+                                    model.module_name.as_str(),
+                                )
+                                .map(|name| (source_id, name))
+                        },
+                    )
+                })
+                .into_iter()
+                .flatten()
         })
     }
 
@@ -812,9 +1318,9 @@ impl ModelGraph {
         scope: &'a ModelId,
         field_name: &str,
     ) -> Option<&'a ModelDef> {
-        if let Some(relation) = self.forward_relation(scope, field_name) {
+        if let Some((binding, relation)) = self.forward_relation(scope, field_name) {
             return self
-                .resolve_relation_target_entry(scope, relation)
+                .resolve_relation_target_entry(binding, relation)
                 .map(|(_id, model)| model);
         }
 
@@ -823,10 +1329,14 @@ impl ModelGraph {
     }
 
     fn resolve_reverse_relation(&self, scope: &ModelId, field_name: &str) -> Option<&ModelId> {
-        for (source_id, model) in &self.models {
-            for relation in &model.relations {
+        for (source_id, record) in &self.records {
+            let model = &record.definition;
+            if model.kind == ModelKind::Abstract {
+                continue;
+            }
+            for (binding, relation) in self.owned_relation_bindings(source_id) {
                 let Some((target_id, _target_model)) =
-                    self.resolve_relation_target_entry(source_id, relation)
+                    self.resolve_relation_target_entry(binding, relation)
                 else {
                     continue;
                 };
@@ -846,22 +1356,27 @@ impl ModelGraph {
     }
 
     pub(crate) fn resolve_relation_targets(&mut self, db: &dyn ProjectDb, project: Project) {
-        let mut updates = Vec::new();
-        for (scope, model) in &self.models {
-            for (index, relation) in model.relations.iter().enumerate() {
-                updates.push((
-                    scope.clone(),
-                    index,
-                    self.resolve_relation_target(db, project, scope, relation),
-                ));
-            }
-        }
+        let updates: Vec<_> = self
+            .relation_bindings
+            .iter()
+            .filter_map(|(binding_id, binding)| {
+                let relation = self.relation_declaration(&binding.declaration)?;
+                Some((
+                    binding_id.clone(),
+                    self.resolve_relation_target(
+                        db,
+                        project,
+                        &binding.owner,
+                        &binding.declaration.model,
+                        relation,
+                    ),
+                ))
+            })
+            .collect();
 
-        for (scope, index, resolution) in updates {
-            if let Some(model) = self.models.get_mut(&scope)
-                && let Some(relation) = model.relations.get_mut(index)
-            {
-                relation.resolution = resolution;
+        for (binding_id, resolution) in updates {
+            if let Some(binding) = self.relation_bindings.get_mut(&binding_id) {
+                binding.resolution = resolution;
             }
         }
     }
@@ -870,7 +1385,8 @@ impl ModelGraph {
         &self,
         db: &dyn ProjectDb,
         project: Project,
-        scope: &ModelId,
+        recipient_scope: &ModelId,
+        declaration_scope: &ModelId,
         relation: &Relation,
     ) -> RelationTargetResolution {
         let Some(target) = relation.target_model() else {
@@ -880,7 +1396,7 @@ impl ModelGraph {
         };
 
         match target {
-            RelationTarget::SelfRef => RelationTargetResolution::Resolved(scope.clone()),
+            RelationTarget::SelfRef => RelationTargetResolution::Resolved(recipient_scope.clone()),
             RelationTarget::Qualified { app_label, name } => self.resolve_app_label_target(
                 app_label,
                 name,
@@ -898,8 +1414,8 @@ impl ModelGraph {
                 }
                 Some(ModelImportReference::Unresolved(
                     ModelImportPathResolutionError::MissingBinding,
-                ))
-                | None => self.resolve_same_app_target(scope, name),
+                )) => self.resolve_same_app_target(declaration_scope, name),
+                None => self.resolve_same_app_target(recipient_scope, name),
                 Some(ModelImportReference::Unresolved(error)) => {
                     RelationTargetResolution::Unresolved {
                         reason: unresolved_import_path_reason(error.clone(), Some(name.as_str())),
@@ -958,14 +1474,14 @@ impl ModelGraph {
         }
 
         let candidates: Vec<ModelId> = self
-            .models
+            .records
             .iter()
-            .filter(|(id, _model)| {
+            .filter(|(id, _record)| {
                 django_name_matches(id.name.as_str(), name.as_str())
                     && app_label_from_module_name(id.module_name.as_str())
                         .is_some_and(|candidate| django_name_matches(candidate, app_label))
             })
-            .map(|(id, _model)| id.clone())
+            .map(|(id, _record)| id.clone())
             .collect();
 
         match candidates.as_slice() {
@@ -1008,7 +1524,7 @@ impl ModelGraph {
                 module.name().clone(),
                 ModelName::new(unresolved_tail[0].clone()),
             );
-            if self.models.contains_key(&candidate) {
+            if self.records.contains_key(&candidate) {
                 return RelationTargetResolution::Resolved(candidate);
             }
         }
@@ -1016,34 +1532,6 @@ impl ModelGraph {
         RelationTargetResolution::Partial {
             resolved_prefix: module.name().clone(),
             unresolved_tail,
-        }
-    }
-
-    /// Merge another graph into this one.
-    ///
-    /// Models from `other` overwrite models with the same import identity in `self`.
-    pub fn merge(&mut self, other: ModelGraph) {
-        let ModelGraph {
-            models,
-            model_ids_by_name,
-            overwritten_model_ids,
-        } = other;
-        self.overwritten_model_ids.extend(overwritten_model_ids);
-
-        for (name, ids) in model_ids_by_name {
-            self.model_ids_by_name.entry(name).or_default().extend(ids);
-        }
-
-        for (id, model) in models {
-            match self.models.entry(id) {
-                Entry::Occupied(mut entry) => {
-                    self.overwritten_model_ids.push(entry.key().clone());
-                    entry.insert(model);
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(model);
-                }
-            }
         }
     }
 }
@@ -1097,7 +1585,7 @@ mod tests {
         let user = model_def("User", module_name("auth.models"), 1);
 
         let mut order = model_def("Order", module_name("shop.models"), 1);
-        order.relations.push(relation(
+        order.push_local_relation(relation(
             "user",
             RelationType::ForeignKey {
                 target: Spanned::new(
@@ -1112,7 +1600,7 @@ mod tests {
         ));
 
         let mut profile = model_def("Profile", module_name("accounts.models"), 1);
-        profile.relations.push(relation(
+        profile.push_local_relation(relation(
             "user",
             RelationType::OneToOne {
                 target: Spanned::new(
@@ -1126,9 +1614,9 @@ mod tests {
             },
         ));
 
-        graph.add_model(user);
-        graph.add_model(order);
-        graph.add_model(profile);
+        graph.add_standalone_model(user);
+        graph.add_standalone_model(order);
+        graph.add_standalone_model(profile);
         graph
     }
 
@@ -1194,7 +1682,7 @@ mod tests {
         let mut graph = ModelGraph::new();
 
         let mut user = model_def("User", module_name("auth.models"), 1);
-        user.relations.push(relation(
+        user.push_local_relation(relation(
             "orders",
             RelationType::ForeignKey {
                 target: Spanned::new(
@@ -1209,7 +1697,7 @@ mod tests {
         ));
 
         let mut order = model_def("Order", module_name("shop.models"), 1);
-        order.relations.push(relation(
+        order.push_local_relation(relation(
             "user",
             RelationType::ForeignKey {
                 target: Spanned::new(
@@ -1223,8 +1711,8 @@ mod tests {
             },
         ));
 
-        graph.add_model(user);
-        graph.add_model(order);
+        graph.add_standalone_model(user);
+        graph.add_standalone_model(order);
 
         assert_eq!(
             graph
@@ -1462,9 +1950,9 @@ mod tests {
     #[test]
     fn models_named_returns_same_name_models_in_module_order() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("User", module_name("zeta.models"), 1));
-        graph.add_model(model_def("Group", module_name("auth.models"), 2));
-        graph.add_model(model_def("User", module_name("alpha.models"), 3));
+        graph.add_standalone_model(model_def("User", module_name("zeta.models"), 1));
+        graph.add_standalone_model(model_def("Group", module_name("auth.models"), 2));
+        graph.add_standalone_model(model_def("User", module_name("alpha.models"), 3));
 
         let users: Vec<_> = graph
             .models_named("User")
@@ -1487,7 +1975,7 @@ mod tests {
     #[test]
     fn lookup_entry_exact_requires_exact_app_label_and_model_name() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("User", module_name("auth.models"), 1));
+        graph.add_standalone_model(model_def("User", module_name("auth.models"), 1));
 
         let exact = graph
             .lookup_entry_exact("auth", "User")
@@ -1507,8 +1995,8 @@ mod tests {
     #[test]
     fn lookup_falls_back_to_django_name_matching() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("User", module_name("auth.models"), 1));
-        graph.add_model(model_def("Éclair", module_name("Café.models"), 2));
+        graph.add_standalone_model(model_def("User", module_name("auth.models"), 1));
+        graph.add_standalone_model(model_def("Éclair", module_name("Café.models"), 2));
 
         let exact = graph
             .lookup("auth", "User")
@@ -1529,7 +2017,7 @@ mod tests {
     #[test]
     fn lookup_normalizes_app_label_and_model_name() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("User", module_name("accounts.models"), 1));
+        graph.add_standalone_model(model_def("User", module_name("accounts.models"), 1));
 
         let model = graph
             .lookup("ACCOUNTS", "user")
@@ -1541,11 +2029,11 @@ mod tests {
     #[test]
     fn relation_target_policy_resolves_self_bare_and_qualified() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("User", module_name("accounts.models"), 1));
-        graph.add_model(model_def("User", module_name("blog.models"), 1));
+        graph.add_standalone_model(model_def("User", module_name("accounts.models"), 1));
+        graph.add_standalone_model(model_def("User", module_name("blog.models"), 1));
 
         let mut post = model_def("Post", module_name("blog.models"), 1);
-        post.relations.push(relation(
+        post.push_local_relation(relation(
             "author",
             RelationType::ForeignKey {
                 target: Spanned::new(
@@ -1558,7 +2046,7 @@ mod tests {
                 related_name: None,
             },
         ));
-        post.relations.push(relation(
+        post.push_local_relation(relation(
             "account_author",
             RelationType::ForeignKey {
                 target: Spanned::new(
@@ -1571,14 +2059,14 @@ mod tests {
                 related_name: None,
             },
         ));
-        post.relations.push(relation(
+        post.push_local_relation(relation(
             "parent",
             RelationType::ForeignKey {
                 target: Spanned::new(RelationTarget::SelfRef, test_span(10)),
                 related_name: None,
             },
         ));
-        graph.add_model(post);
+        graph.add_standalone_model(post);
 
         let post_id = model_id(&graph, "Post");
         assert_eq!(
@@ -1621,14 +2109,14 @@ mod tests {
     fn generic_foreign_key_skipped_in_forward_lookup() {
         let mut graph = ModelGraph::new();
         let mut model = model_def("TaggedItem", module_name("tagging.models"), 1);
-        model.relations.push(relation(
+        model.push_local_relation(relation(
             "content_object",
             RelationType::GenericForeignKey {
                 ct_field: "content_type".into(),
                 fk_field: "object_id".into(),
             },
         ));
-        graph.add_model(model);
+        graph.add_standalone_model(model);
 
         assert_eq!(
             graph.resolve_forward(model_id(&graph, "TaggedItem"), "content_object"),
@@ -1637,62 +2125,28 @@ mod tests {
     }
 
     #[test]
-    fn add_model_overwrites_same_identity() {
+    fn standalone_model_helper_installs_complete_self_ancestry() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("User", module_name("auth.models"), 1));
-        graph.add_model(model_def("User", module_name("auth.models"), 2));
+        graph.add_standalone_model(model_def("User", module_name("auth.models"), 1));
 
-        let expected_id = "auth.models.User"
-            .parse::<ModelId>()
-            .expect("test model ID should be valid");
-        let model = graph
-            .lookup("auth", "User")
-            .expect("overwritten model should exist");
-        assert_eq!(graph.len(), 1);
-        assert_eq!(graph.overwritten_model_ids(), &[expected_id]);
-        assert_eq!(model.name.span().start(), 2);
-    }
-
-    #[test]
-    fn merge_overwrites_same_identity() {
-        let mut g1 = ModelGraph::new();
-        g1.add_model(model_def("User", module_name("auth.models"), 1));
-
-        let mut g2 = ModelGraph::new();
-        g2.add_model(model_def("User", module_name("auth.models"), 2));
-
-        g1.merge(g2);
-        let expected_id = "auth.models.User"
-            .parse::<ModelId>()
-            .expect("test model ID should be valid");
-        let model = g1
-            .lookup("auth", "User")
-            .expect("merged model should exist");
-        assert_eq!(g1.len(), 1);
-        assert_eq!(g1.overwritten_model_ids(), &[expected_id]);
-        assert_eq!(model.name.span().start(), 2);
-    }
-
-    #[test]
-    fn merge_graphs() {
-        let mut g1 = ModelGraph::new();
-        g1.add_model(model_def("User", module_name("auth.models"), 1));
-
-        let mut g2 = ModelGraph::new();
-        g2.add_model(model_def("Order", module_name("shop.models"), 1));
-
-        g1.merge(g2);
-        assert_eq!(g1.len(), 2);
-        assert!(g1.overwritten_model_ids().is_empty());
-        assert!(g1.models_named("User").next().is_some());
-        assert!(g1.models_named("Order").next().is_some());
+        let id = model_id(&graph, "User");
+        let inheritance = graph
+            .inheritance(id)
+            .expect("added model should have inheritance");
+        assert!(inheritance.bases.is_empty());
+        assert_eq!(
+            inheritance.ancestry,
+            AncestryOutcome::Complete {
+                mro: vec![id.clone()]
+            }
+        );
     }
 
     #[test]
     fn same_named_models_in_different_modules_coexist() {
         let mut graph = ModelGraph::new();
-        graph.add_model(model_def("Comment", module_name("blog.models"), 1));
-        graph.add_model(model_def("Comment", module_name("news.models"), 1));
+        graph.add_standalone_model(model_def("Comment", module_name("blog.models"), 1));
+        graph.add_standalone_model(model_def("Comment", module_name("news.models"), 1));
 
         let comments: Vec<_> = graph
             .models_named("Comment")

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::db::Db as ProjectDb;
-use crate::models::imports::ModelImportPathResolutionError;
+use crate::models::imports::ModelImportPathUnresolvedReason;
 use crate::models::imports::ModelImportReference;
 use crate::project::Project;
 use crate::python::InvalidModuleName;
@@ -68,6 +68,11 @@ macro_rules! string_newtype {
 string_newtype! {
     /// A Django model class name (e.g., `"User"`, `"Article"`).
     pub(crate) struct ModelName
+}
+
+string_newtype! {
+    /// A Python class name, whether or not the class is a Django model.
+    pub(crate) struct ClassName
 }
 
 string_newtype! {
@@ -150,6 +155,53 @@ impl TryFrom<String> for ModelId {
 
 impl From<ModelId> for String {
     fn from(value: ModelId) -> Self {
+        format!("{}.{}", value.module_name.as_str(), value.name.as_str())
+    }
+}
+
+/// The import identity of any extracted Python class.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(into = "String")]
+pub(crate) struct ClassId {
+    name: ClassName,
+    module_name: PythonModuleName,
+}
+
+impl ClassId {
+    #[must_use]
+    pub(super) fn new(module_name: PythonModuleName, name: impl Into<String>) -> Self {
+        Self {
+            name: ClassName::new(name),
+            module_name,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    #[must_use]
+    pub(crate) fn module_name(&self) -> &PythonModuleName {
+        &self.module_name
+    }
+
+    /// Promote this class identity after the resolver has admitted it as a
+    /// Django model.
+    #[must_use]
+    pub(super) fn into_admitted_model_id(self) -> ModelId {
+        ModelId::new(self.module_name, ModelName::new(self.name.as_str()))
+    }
+
+    /// Build the class identity used to look up a model in a mixed-class MRO.
+    #[must_use]
+    pub(crate) fn from_model_id(model: &ModelId) -> Self {
+        Self::new(model.module_name.clone(), model.name.as_str())
+    }
+}
+
+impl From<ClassId> for String {
+    fn from(value: ClassId) -> Self {
         format!("{}.{}", value.module_name.as_str(), value.name.as_str())
     }
 }
@@ -512,26 +564,20 @@ fn django_name_matches(candidate: &str, query: &str) -> bool {
 }
 
 fn unresolved_import_path_reason(
-    error: ModelImportPathResolutionError,
+    reason: ModelImportPathUnresolvedReason,
     binding: Option<&str>,
 ) -> RelationTargetUnresolvedReason {
-    match error {
-        ModelImportPathResolutionError::MissingBinding
-        | ModelImportPathResolutionError::ShadowedBinding => {
+    match reason {
+        ModelImportPathUnresolvedReason::MissingBinding
+        | ModelImportPathUnresolvedReason::ShadowedBinding => {
             RelationTargetUnresolvedReason::MissingImportBinding {
                 binding: binding.unwrap_or_default().to_string(),
             }
         }
-        ModelImportPathResolutionError::InvalidTarget { target, .. } => {
+        ModelImportPathUnresolvedReason::InvalidTarget { target } => {
             RelationTargetUnresolvedReason::InvalidImportedTarget { target }
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum LocalBinding {
-    Relation(usize),
-    Other,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -542,8 +588,6 @@ pub struct ModelDef {
     pub(crate) module_name: PythonModuleName,
     pub(crate) relations: Vec<Relation>,
     pub(crate) kind: ModelKind,
-    #[serde(skip)]
-    final_local_bindings: BTreeMap<FieldName, LocalBinding>,
 }
 
 impl ModelDef {
@@ -560,26 +604,12 @@ impl ModelDef {
             module_name,
             relations: Vec::new(),
             kind: ModelKind::Concrete,
-            final_local_bindings: BTreeMap::new(),
         }
     }
 
-    pub(crate) fn push_local_relation(&mut self, relation: Relation) {
-        let name = relation.field_name.value().clone();
-        let relation_index = self.relations.len();
+    #[cfg(test)]
+    fn push_local_relation(&mut self, relation: Relation) {
         self.relations.push(relation);
-        self.final_local_bindings
-            .insert(name, LocalBinding::Relation(relation_index));
-    }
-
-    pub(crate) fn bind_local_other(&mut self, name: FieldName) {
-        self.final_local_bindings.insert(name, LocalBinding::Other);
-    }
-
-    pub(super) fn has_local_relation_binding(&self) -> bool {
-        self.final_local_bindings
-            .values()
-            .any(|binding| matches!(binding, LocalBinding::Relation(_)))
     }
 }
 
@@ -593,7 +623,7 @@ pub(crate) enum BaseOutcome {
         span: Span,
     },
     NonModelClass {
-        class: ModelId,
+        class: ClassId,
         span: Span,
     },
     Unresolved {
@@ -636,27 +666,27 @@ pub(crate) enum BaseUnresolvedReason {
         resolved_prefix: PythonModuleName,
         unresolved_tail: Vec<String>,
     },
-    ModelNotFound {
-        model: ModelId,
+    ClassNotFound {
+        class: ClassId,
     },
     ReboundLocalBase {
-        model: ModelId,
+        class: ClassId,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum AncestryOutcome {
-    Complete { mro: Vec<ModelId> },
+    Complete { mro: Vec<ClassId> },
     Partial,
-    Invalid { error: InheritanceError },
+    Invalid { reason: InvalidAncestryReason },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) enum InheritanceError {
+pub(crate) enum InvalidAncestryReason {
     Cycle,
     DuplicateDjangoModelRoot,
-    DuplicateModelBase { model: ModelId },
-    InconsistentC3,
+    DuplicateClassBase { class: ClassId },
+    InconsistentMethodResolutionOrder,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -669,6 +699,7 @@ pub(crate) struct InheritanceRecord {
 struct ModelRecord {
     definition: ModelDef,
     inheritance: InheritanceRecord,
+    local_bindings: BTreeMap<FieldName, crate::models::extract::LocalBinding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -705,8 +736,10 @@ struct ModelRelationBindings {
 pub struct ModelGraph {
     records: BTreeMap<ModelId, ModelRecord>,
     model_ids_by_name: BTreeMap<ModelName, BTreeSet<ModelId>>,
+    model_ids_by_class: BTreeMap<ClassId, ModelId>,
     relation_bindings: BTreeMap<RelationBindingId, RelationBinding>,
     model_relation_bindings: BTreeMap<ModelId, ModelRelationBindings>,
+    non_model_class_bindings: BTreeMap<ClassId, BTreeSet<FieldName>>,
 }
 
 impl PartialEq for ModelGraph {
@@ -714,6 +747,7 @@ impl PartialEq for ModelGraph {
         self.records == other.records
             && self.relation_bindings == other.relation_bindings
             && self.model_relation_bindings == other.model_relation_bindings
+            && self.non_model_class_bindings == other.non_model_class_bindings
     }
 }
 
@@ -829,6 +863,7 @@ impl ModelGraph {
         &mut self,
         definition: ModelDef,
         inheritance: InheritanceRecord,
+        local_bindings: BTreeMap<FieldName, crate::models::extract::LocalBinding>,
     ) {
         let id = ModelId::new(
             definition.module_name.clone(),
@@ -841,6 +876,7 @@ impl ModelGraph {
                     ModelRecord {
                         definition,
                         inheritance,
+                        local_bindings,
                     },
                 )
                 .is_none(),
@@ -849,7 +885,9 @@ impl ModelGraph {
         self.model_ids_by_name
             .entry(id.name.clone())
             .or_default()
-            .insert(id);
+            .insert(id.clone());
+        self.model_ids_by_class
+            .insert(ClassId::from_model_id(&id), id);
     }
 
     #[cfg(test)]
@@ -858,14 +896,25 @@ impl ModelGraph {
             definition.module_name.clone(),
             definition.name.value().clone(),
         );
+        let class = ClassId::from_model_id(&id);
+        let local_bindings = definition
+            .relations
+            .iter()
+            .enumerate()
+            .map(|(index, relation)| {
+                (
+                    relation.field_name.value().clone(),
+                    crate::models::extract::LocalBinding::Relation(index),
+                )
+            })
+            .collect();
         self.insert_resolved_model(
             definition,
             InheritanceRecord {
                 bases: Vec::new(),
-                ancestry: AncestryOutcome::Complete {
-                    mro: vec![id.clone()],
-                },
+                ancestry: AncestryOutcome::Complete { mro: vec![class] },
             },
+            local_bindings,
         );
         self.build_effective_relation_bindings();
     }
@@ -873,12 +922,12 @@ impl ModelGraph {
     fn install_local_relation_bindings(
         &mut self,
         id: &ModelId,
-        local_bindings: BTreeMap<FieldName, LocalBinding>,
+        local_bindings: BTreeMap<FieldName, crate::models::extract::LocalBinding>,
     ) {
         let local_bound_names = local_bindings.keys().cloned().collect();
         let mut local_relation_bindings = BTreeMap::new();
         for (field_name, binding) in local_bindings {
-            let LocalBinding::Relation(index) = binding else {
+            let crate::models::extract::LocalBinding::Relation(index) = binding else {
                 continue;
             };
             let declaration = RelationDeclarationId {
@@ -915,17 +964,14 @@ impl ModelGraph {
         );
     }
 
-    pub(super) fn add_non_model_class(&mut self, id: &ModelId, class: &ModelDef) {
-        let local_bound_names = class.final_local_bindings.keys().cloned().collect();
+    pub(super) fn add_non_model_class(
+        &mut self,
+        id: &ClassId,
+        local_bindings: BTreeMap<FieldName, crate::models::extract::LocalBinding>,
+    ) {
         assert!(
-            self.model_relation_bindings
-                .insert(
-                    id.clone(),
-                    ModelRelationBindings {
-                        local_bound_names,
-                        ..ModelRelationBindings::default()
-                    },
-                )
+            self.non_model_class_bindings
+                .insert(id.clone(), local_bindings.into_keys().collect())
                 .is_none(),
             "non-model class inserted more than once: {id:?}",
         );
@@ -949,13 +995,13 @@ impl ModelGraph {
         let local_bindings: Vec<_> = self
             .records
             .iter()
-            .map(|(id, record)| (id.clone(), record.definition.final_local_bindings.clone()))
+            .map(|(id, record)| (id.clone(), record.local_bindings.clone()))
             .collect();
         for (id, bindings) in local_bindings {
             self.install_local_relation_bindings(&id, bindings);
         }
 
-        let mut complete: Vec<(ModelId, Vec<ModelId>)> = self
+        let mut complete: Vec<(ModelId, Vec<ClassId>)> = self
             .records
             .iter()
             .filter_map(|(id, record)| match &record.inheritance.ancestry {
@@ -973,7 +1019,29 @@ impl ModelGraph {
         }
     }
 
-    fn clone_abstract_relation_bindings(&mut self, id: &ModelId, mro: &[ModelId]) {
+    fn model_id_for_class(&self, class: &ClassId) -> Option<&ModelId> {
+        self.model_ids_by_class.get(class)
+    }
+
+    fn class_local_bound_names(&self, class: &ClassId) -> BTreeSet<FieldName> {
+        self.model_id_for_class(class)
+            .and_then(|model| self.model_relation_bindings.get(model))
+            .map(|bindings| bindings.local_bound_names.clone())
+            .or_else(|| self.non_model_class_bindings.get(class).cloned())
+            .unwrap_or_default()
+    }
+
+    fn class_local_relation_bindings(
+        &self,
+        class: &ClassId,
+    ) -> BTreeMap<FieldName, RelationBindingId> {
+        self.model_id_for_class(class)
+            .and_then(|model| self.model_relation_bindings.get(model))
+            .map(|bindings| bindings.local_relation_bindings.clone())
+            .unwrap_or_default()
+    }
+
+    fn clone_abstract_relation_bindings(&mut self, id: &ModelId, mro: &[ClassId]) {
         let mut occupied = self
             .model_relation_bindings
             .get(id)
@@ -987,19 +1055,11 @@ impl ModelGraph {
         let mut cloned_names = BTreeSet::new();
 
         for ancestor_id in mro.iter().skip(1) {
-            let ancestor_names = self
-                .model_relation_bindings
-                .get(ancestor_id)
-                .map(|bindings| bindings.local_bound_names.clone())
-                .unwrap_or_default();
-            let ancestor_relations = self
-                .model_relation_bindings
-                .get(ancestor_id)
-                .map(|bindings| bindings.local_relation_bindings.clone())
-                .unwrap_or_default();
+            let ancestor_names = self.class_local_bound_names(ancestor_id);
+            let ancestor_relations = self.class_local_relation_bindings(ancestor_id);
             let ancestor_is_abstract = self
-                .records
-                .get(ancestor_id)
+                .model_id_for_class(ancestor_id)
+                .and_then(|model| self.records.get(model))
                 .is_some_and(|record| record.definition.kind == ModelKind::Abstract);
 
             for name in ancestor_names {
@@ -1036,7 +1096,7 @@ impl ModelGraph {
         bindings.local_relation_bindings = local_relations;
     }
 
-    fn install_effective_relation_bindings(&mut self, id: ModelId, mro: &[ModelId]) {
+    fn install_effective_relation_bindings(&mut self, id: ModelId, mro: &[ClassId]) {
         let mut occupied = self
             .model_relation_bindings
             .get(&id)
@@ -1049,16 +1109,8 @@ impl ModelGraph {
             .unwrap_or_default();
 
         for ancestor_id in mro.iter().skip(1) {
-            let ancestor_names = self
-                .model_relation_bindings
-                .get(ancestor_id)
-                .map(|bindings| bindings.local_bound_names.clone())
-                .unwrap_or_default();
-            let ancestor_relations = self
-                .model_relation_bindings
-                .get(ancestor_id)
-                .map(|bindings| bindings.local_relation_bindings.clone())
-                .unwrap_or_default();
+            let ancestor_names = self.class_local_bound_names(ancestor_id);
+            let ancestor_relations = self.class_local_relation_bindings(ancestor_id);
             for name in ancestor_names {
                 if occupied.insert(name.clone())
                     && let Some(binding_id) = ancestor_relations.get(&name)
@@ -1104,9 +1156,9 @@ impl ModelGraph {
                 self.records
                     .get(owner)
                     .and_then(|record| match &record.inheritance.ancestry {
-                        AncestryOutcome::Complete { mro } => mro
-                            .iter()
-                            .position(|model| model == &binding.declaration.model),
+                        AncestryOutcome::Complete { mro } => mro.iter().position(|class| {
+                            class == &ClassId::from_model_id(&binding.declaration.model)
+                        }),
                         AncestryOutcome::Partial | AncestryOutcome::Invalid { .. } => None,
                     })
                     .unwrap_or(usize::MAX - 1)
@@ -1258,7 +1310,7 @@ impl ModelGraph {
                 name,
                 import_reference:
                     Some(ModelImportReference::Unresolved(
-                        ModelImportPathResolutionError::MissingBinding,
+                        ModelImportPathUnresolvedReason::MissingBinding,
                     )),
             } => {
                 let app_label = app_label_from_module_name(declaration_scope.module_name.as_str())?;
@@ -1413,7 +1465,7 @@ impl ModelGraph {
                     self.resolve_imported_relation_target(db, project, target)
                 }
                 Some(ModelImportReference::Unresolved(
-                    ModelImportPathResolutionError::MissingBinding,
+                    ModelImportPathUnresolvedReason::MissingBinding,
                 )) => self.resolve_same_app_target(declaration_scope, name),
                 None => self.resolve_same_app_target(recipient_scope, name),
                 Some(ModelImportReference::Unresolved(error)) => {
@@ -2137,7 +2189,7 @@ mod tests {
         assert_eq!(
             inheritance.ancestry,
             AncestryOutcome::Complete {
-                mro: vec![id.clone()]
+                mro: vec![ClassId::from_model_id(id)]
             }
         );
     }

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use djls_source::File;
 use djls_source::Span;
 use djls_source::Spanned;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 use thiserror::Error;
 
@@ -445,7 +446,6 @@ impl Relation {
     ///
     /// `module_name` is the dotted Python module name (e.g., `"myapp.models"`);
     /// the app label is derived as the component before `models`.
-    #[cfg(test)]
     #[must_use]
     pub(crate) fn effective_related_name(
         &self,
@@ -473,6 +473,7 @@ impl Relation {
         }
     }
 
+    #[cfg(test)]
     fn effective_related_name_matches(
         &self,
         source_model: &str,
@@ -502,6 +503,7 @@ impl Relation {
     }
 }
 
+#[cfg(test)]
 fn template_related_name_matches(
     template: &str,
     source_model: &str,
@@ -737,10 +739,12 @@ struct ModelRelationBindings {
 #[derive(Debug, Clone, Default)]
 pub struct ModelGraph {
     records: BTreeMap<ModelId, ModelRecord>,
-    model_ids_by_name: BTreeMap<ModelName, BTreeSet<ModelId>>,
+    model_ids_by_name: FxHashMap<ModelName, BTreeSet<ModelId>>,
     model_ids_by_class: BTreeMap<ClassId, ModelId>,
     relation_bindings: BTreeMap<RelationBindingId, RelationBinding>,
     model_relation_bindings: BTreeMap<ModelId, ModelRelationBindings>,
+    forward_relation_targets: FxHashMap<ModelId, FxHashMap<FieldName, Option<ModelId>>>,
+    reverse_relation_bindings: FxHashMap<ModelId, FxHashMap<FieldName, ModelId>>,
     non_model_class_bindings: BTreeMap<ClassId, BTreeSet<FieldName>>,
 }
 
@@ -749,6 +753,8 @@ impl PartialEq for ModelGraph {
         self.records == other.records
             && self.relation_bindings == other.relation_bindings
             && self.model_relation_bindings == other.model_relation_bindings
+            && self.forward_relation_targets == other.forward_relation_targets
+            && self.reverse_relation_bindings == other.reverse_relation_bindings
             && self.non_model_class_bindings == other.non_model_class_bindings
     }
 }
@@ -1019,6 +1025,7 @@ impl ModelGraph {
         for (id, mro) in complete {
             self.install_effective_relation_bindings(id, &mro);
         }
+        self.rebuild_reverse_relation_bindings();
     }
 
     fn model_id_for_class(&self, class: &ClassId) -> Option<&ModelId> {
@@ -1249,24 +1256,12 @@ impl ModelGraph {
     /// Skips `GenericForeignKey` relations (no static target).
     #[must_use]
     pub fn resolve_forward(&self, scope: &ModelId, field_name: &str) -> Option<&ModelDef> {
-        let (binding, relation) = self.forward_relation(scope, field_name)?;
-        self.resolve_relation_target_entry(binding, relation)
-            .map(|(_id, model)| model)
-    }
-
-    fn forward_relation(
-        &self,
-        scope: &ModelId,
-        field_name: &str,
-    ) -> Option<(&RelationBinding, &Relation)> {
-        let binding_id = self
-            .model_relation_bindings
+        let target = self
+            .forward_relation_targets
             .get(scope)?
-            .effective_forward_bindings
-            .get(field_name)?;
-        let binding = self.relation_bindings.get(binding_id)?;
-        let relation = self.relation_declaration(&binding.declaration)?;
-        Some((binding, relation))
+            .get(field_name)?
+            .as_ref()?;
+        self.records.get(target).map(|record| &record.definition)
     }
 
     fn resolve_relation_target_entry(
@@ -1372,10 +1367,15 @@ impl ModelGraph {
         scope: &'a ModelId,
         field_name: &str,
     ) -> Option<&'a ModelDef> {
-        if let Some((binding, relation)) = self.forward_relation(scope, field_name) {
-            return self
-                .resolve_relation_target_entry(binding, relation)
-                .map(|(_id, model)| model);
+        if let Some(target) = self
+            .forward_relation_targets
+            .get(scope)
+            .and_then(|relations| relations.get(field_name))
+        {
+            return target
+                .as_ref()
+                .and_then(|target| self.records.get(target))
+                .map(|record| &record.definition);
         }
 
         self.resolve_reverse_relation(scope, field_name)
@@ -1383,6 +1383,34 @@ impl ModelGraph {
     }
 
     fn resolve_reverse_relation(&self, scope: &ModelId, field_name: &str) -> Option<&ModelId> {
+        self.reverse_relation_bindings.get(scope)?.get(field_name)
+    }
+
+    fn rebuild_reverse_relation_bindings(&mut self) {
+        let mut forward_targets: FxHashMap<ModelId, FxHashMap<FieldName, Option<ModelId>>> =
+            FxHashMap::default();
+        for (owner, bindings) in &self.model_relation_bindings {
+            for (name, binding_id) in &bindings.effective_forward_bindings {
+                let target = self
+                    .relation_bindings
+                    .get(binding_id)
+                    .and_then(|binding| {
+                        self.relation_declaration(&binding.declaration)
+                            .map(|relation| (binding, relation))
+                    })
+                    .and_then(|(binding, relation)| {
+                        self.resolve_relation_target_entry(binding, relation)
+                    })
+                    .map(|(target_id, _target_model)| target_id.clone());
+                forward_targets
+                    .entry(owner.clone())
+                    .or_default()
+                    .insert(name.clone(), target);
+            }
+        }
+
+        let mut reverse_bindings: FxHashMap<ModelId, FxHashMap<FieldName, ModelId>> =
+            FxHashMap::default();
         for (source_id, record) in &self.records {
             let model = &record.definition;
             if model.kind == ModelKind::Abstract {
@@ -1394,19 +1422,21 @@ impl ModelGraph {
                 else {
                     continue;
                 };
-                if target_id == scope
-                    && relation.effective_related_name_matches(
-                        model.name.value().as_str(),
-                        model.module_name.as_str(),
-                        field_name,
-                    )
-                {
-                    return Some(source_id);
-                }
+                let Some(name) = relation.effective_related_name(
+                    model.name.value().as_str(),
+                    model.module_name.as_str(),
+                ) else {
+                    continue;
+                };
+                reverse_bindings
+                    .entry(target_id.clone())
+                    .or_default()
+                    .entry(FieldName::new(name))
+                    .or_insert_with(|| source_id.clone());
             }
         }
-
-        None
+        self.forward_relation_targets = forward_targets;
+        self.reverse_relation_bindings = reverse_bindings;
     }
 
     pub(crate) fn resolve_relation_targets(&mut self, db: &dyn ProjectDb, project: Project) {
@@ -1433,6 +1463,7 @@ impl ModelGraph {
                 binding.resolution = resolution;
             }
         }
+        self.rebuild_reverse_relation_bindings();
     }
 
     fn resolve_relation_target(

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use djls_source::File;
 use djls_source::Span;
@@ -732,6 +733,12 @@ struct ModelRelationBindings {
     effective_forward_bindings: BTreeMap<FieldName, RelationBindingId>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct RelationLookupIndex {
+    forward: FxHashMap<ModelId, FxHashMap<FieldName, Option<ModelId>>>,
+    reverse: FxHashMap<ModelId, FxHashMap<FieldName, ModelId>>,
+}
+
 /// Dependency graph of Django models and their relations.
 ///
 /// Models are keyed by deterministic import identity (`ModelId`) so
@@ -743,8 +750,7 @@ pub struct ModelGraph {
     model_ids_by_class: BTreeMap<ClassId, ModelId>,
     relation_bindings: BTreeMap<RelationBindingId, RelationBinding>,
     model_relation_bindings: BTreeMap<ModelId, ModelRelationBindings>,
-    forward_relation_targets: FxHashMap<ModelId, FxHashMap<FieldName, Option<ModelId>>>,
-    reverse_relation_bindings: FxHashMap<ModelId, FxHashMap<FieldName, ModelId>>,
+    relation_lookup_index: OnceLock<RelationLookupIndex>,
     non_model_class_bindings: BTreeMap<ClassId, BTreeSet<FieldName>>,
 }
 
@@ -753,8 +759,6 @@ impl PartialEq for ModelGraph {
         self.records == other.records
             && self.relation_bindings == other.relation_bindings
             && self.model_relation_bindings == other.model_relation_bindings
-            && self.forward_relation_targets == other.forward_relation_targets
-            && self.reverse_relation_bindings == other.reverse_relation_bindings
             && self.non_model_class_bindings == other.non_model_class_bindings
     }
 }
@@ -1025,7 +1029,7 @@ impl ModelGraph {
         for (id, mro) in complete {
             self.install_effective_relation_bindings(id, &mro);
         }
-        self.rebuild_reverse_relation_bindings();
+        self.relation_lookup_index = OnceLock::new();
     }
 
     fn model_id_for_class(&self, class: &ClassId) -> Option<&ModelId> {
@@ -1257,7 +1261,8 @@ impl ModelGraph {
     #[must_use]
     pub fn resolve_forward(&self, scope: &ModelId, field_name: &str) -> Option<&ModelDef> {
         let target = self
-            .forward_relation_targets
+            .relation_lookup_index()
+            .forward
             .get(scope)?
             .get(field_name)?
             .as_ref()?;
@@ -1368,7 +1373,8 @@ impl ModelGraph {
         field_name: &str,
     ) -> Option<&'a ModelDef> {
         if let Some(target) = self
-            .forward_relation_targets
+            .relation_lookup_index()
+            .forward
             .get(scope)
             .and_then(|relations| relations.get(field_name))
         {
@@ -1383,11 +1389,19 @@ impl ModelGraph {
     }
 
     fn resolve_reverse_relation(&self, scope: &ModelId, field_name: &str) -> Option<&ModelId> {
-        self.reverse_relation_bindings.get(scope)?.get(field_name)
+        self.relation_lookup_index()
+            .reverse
+            .get(scope)?
+            .get(field_name)
     }
 
-    fn rebuild_reverse_relation_bindings(&mut self) {
-        let mut forward_targets: FxHashMap<ModelId, FxHashMap<FieldName, Option<ModelId>>> =
+    fn relation_lookup_index(&self) -> &RelationLookupIndex {
+        self.relation_lookup_index
+            .get_or_init(|| self.build_relation_lookup_index())
+    }
+
+    fn build_relation_lookup_index(&self) -> RelationLookupIndex {
+        let mut forward: FxHashMap<ModelId, FxHashMap<FieldName, Option<ModelId>>> =
             FxHashMap::default();
         for (owner, bindings) in &self.model_relation_bindings {
             for (name, binding_id) in &bindings.effective_forward_bindings {
@@ -1402,7 +1416,7 @@ impl ModelGraph {
                         self.resolve_relation_target_entry(binding, relation)
                     })
                     .map(|(target_id, _target_model)| target_id.clone());
-                forward_targets
+                forward
                     .entry(owner.clone())
                     .or_default()
                     .insert(name.clone(), target);
@@ -1435,8 +1449,10 @@ impl ModelGraph {
                     .or_insert_with(|| source_id.clone());
             }
         }
-        self.forward_relation_targets = forward_targets;
-        self.reverse_relation_bindings = reverse_bindings;
+        RelationLookupIndex {
+            forward,
+            reverse: reverse_bindings,
+        }
     }
 
     pub(crate) fn resolve_relation_targets(&mut self, db: &dyn ProjectDb, project: Project) {
@@ -1463,7 +1479,7 @@ impl ModelGraph {
                 binding.resolution = resolution;
             }
         }
-        self.rebuild_reverse_relation_bindings();
+        self.relation_lookup_index = OnceLock::new();
     }
 
     fn resolve_relation_target(

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -558,9 +558,11 @@ fn app_label_from_module_name(module_name: &str) -> Option<&str> {
 }
 
 fn django_name_matches(candidate: &str, query: &str) -> bool {
-    candidate == query
-        || candidate.eq_ignore_ascii_case(query)
-        || candidate.to_lowercase() == query.to_lowercase()
+    if candidate.is_ascii() && query.is_ascii() {
+        candidate.eq_ignore_ascii_case(query)
+    } else {
+        candidate.to_lowercase() == query.to_lowercase()
+    }
 }
 
 fn unresolved_import_path_reason(
@@ -1670,6 +1672,13 @@ mod tests {
         graph.add_standalone_model(order);
         graph.add_standalone_model(profile);
         graph
+    }
+
+    #[test]
+    fn django_name_matching_preserves_unicode_case_folding() {
+        assert!(django_name_matches("UserProfile", "userprofile"));
+        assert!(django_name_matches("Äccount", "äccount"));
+        assert!(!django_name_matches("User", "Group"));
     }
 
     #[test]

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -560,14 +560,6 @@ fn app_label_from_module_name(module_name: &str) -> Option<&str> {
     }
 }
 
-fn django_name_matches(candidate: &str, query: &str) -> bool {
-    if candidate.is_ascii() && query.is_ascii() {
-        candidate.eq_ignore_ascii_case(query)
-    } else {
-        candidate.to_lowercase() == query.to_lowercase()
-    }
-}
-
 fn unresolved_import_path_reason(
     reason: ModelImportPathUnresolvedReason,
     binding: Option<&str>,
@@ -747,6 +739,7 @@ struct RelationLookupIndex {
 pub struct ModelGraph {
     records: BTreeMap<ModelId, ModelRecord>,
     model_ids_by_name: FxHashMap<ModelName, BTreeSet<ModelId>>,
+    model_ids_by_django_name: FxHashMap<(String, String), Vec<ModelId>>,
     model_ids_by_class: BTreeMap<ClassId, ModelId>,
     relation_bindings: BTreeMap<RelationBindingId, RelationBinding>,
     model_relation_bindings: BTreeMap<ModelId, ModelRelationBindings>,
@@ -898,6 +891,14 @@ impl ModelGraph {
             .entry(id.name.clone())
             .or_default()
             .insert(id.clone());
+        if let Some(app_label) = app_label_from_module_name(id.module_name.as_str()) {
+            let ids = self
+                .model_ids_by_django_name
+                .entry((app_label.to_lowercase(), id.name.as_str().to_lowercase()))
+                .or_default();
+            let index = ids.binary_search(&id).unwrap_or_else(|index| index);
+            ids.insert(index, id.clone());
+        }
         self.model_ids_by_class
             .insert(ClassId::from_model_id(&id), id);
     }
@@ -1236,12 +1237,15 @@ impl ModelGraph {
             return Some(entry);
         }
 
-        self.records.iter().find_map(|(id, record)| {
-            (django_name_matches(id.name.as_str(), name)
-                && app_label_from_module_name(id.module_name.as_str())
-                    .is_some_and(|candidate| django_name_matches(candidate, app_label)))
-            .then_some((id, &record.definition))
-        })
+        let key = (app_label.to_lowercase(), name.to_lowercase());
+        self.model_ids_by_django_name
+            .get(&key)?
+            .iter()
+            .find_map(|id| {
+                self.records
+                    .get_key_value(id)
+                    .map(|(id, record)| (id, &record.definition))
+            })
     }
 
     fn lookup_entry_exact(&self, app_label: &str, name: &str) -> Option<(&ModelId, &ModelDef)> {
@@ -1456,6 +1460,7 @@ impl ModelGraph {
     }
 
     pub(crate) fn resolve_relation_targets(&mut self, db: &dyn ProjectDb, project: Project) {
+        let mut prefix_cache = BTreeMap::new();
         let updates: Vec<_> = self
             .relation_bindings
             .iter()
@@ -1469,6 +1474,7 @@ impl ModelGraph {
                         &binding.owner,
                         &binding.declaration.model,
                         relation,
+                        &mut prefix_cache,
                     ),
                 ))
             })
@@ -1489,6 +1495,7 @@ impl ModelGraph {
         recipient_scope: &ModelId,
         declaration_scope: &ModelId,
         relation: &Relation,
+        prefix_cache: &mut BTreeMap<PythonModuleName, crate::python::ResolvedPrefix>,
     ) -> RelationTargetResolution {
         let Some(target) = relation.target_model() else {
             return RelationTargetResolution::Unresolved {
@@ -1511,7 +1518,7 @@ impl ModelGraph {
                 import_reference,
             } => match import_reference {
                 Some(ModelImportReference::Qualified(target)) => {
-                    self.resolve_imported_relation_target(db, project, target)
+                    self.resolve_imported_relation_target(db, project, target, prefix_cache)
                 }
                 Some(ModelImportReference::Unresolved(
                     ModelImportPathUnresolvedReason::MissingBinding,
@@ -1528,7 +1535,7 @@ impl ModelGraph {
                 import_reference,
             } => match import_reference {
                 ModelImportReference::Qualified(target) => {
-                    self.resolve_imported_relation_target(db, project, target)
+                    self.resolve_imported_relation_target(db, project, target, prefix_cache)
                 }
                 ModelImportReference::Unresolved(error) => RelationTargetResolution::Unresolved {
                     reason: unresolved_import_path_reason(
@@ -1574,16 +1581,12 @@ impl ModelGraph {
             return RelationTargetResolution::Resolved(id.clone());
         }
 
-        let candidates: Vec<ModelId> = self
-            .records
-            .iter()
-            .filter(|(id, _record)| {
-                django_name_matches(id.name.as_str(), name.as_str())
-                    && app_label_from_module_name(id.module_name.as_str())
-                        .is_some_and(|candidate| django_name_matches(candidate, app_label))
-            })
-            .map(|(id, _record)| id.clone())
-            .collect();
+        let key = (app_label.to_lowercase(), name.as_str().to_lowercase());
+        let candidates = self
+            .model_ids_by_django_name
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
 
         match candidates.as_slice() {
             [candidate] => RelationTargetResolution::Resolved(candidate.clone()),
@@ -1601,9 +1604,12 @@ impl ModelGraph {
         db: &dyn ProjectDb,
         project: Project,
         target: &PythonModuleName,
+        prefix_cache: &mut BTreeMap<PythonModuleName, crate::python::ResolvedPrefix>,
     ) -> RelationTargetResolution {
-        let resolved = resolve_prefix(db, project, target.as_str());
-        let Some(module) = resolved.module else {
+        let resolved = prefix_cache
+            .entry(target.clone())
+            .or_insert_with(|| resolve_prefix(db, project, target.as_str()));
+        let Some(module) = &resolved.module else {
             return RelationTargetResolution::Unresolved {
                 reason: RelationTargetUnresolvedReason::ImportNotFound {
                     requested: target.clone(),
@@ -1619,7 +1625,7 @@ impl ModelGraph {
             };
         }
 
-        let unresolved_tail = resolved.unresolved_tail;
+        let unresolved_tail = &resolved.unresolved_tail;
         if unresolved_tail.len() == 1 {
             let candidate = ModelId::new(
                 module.name().clone(),
@@ -1632,7 +1638,7 @@ impl ModelGraph {
 
         RelationTargetResolution::Partial {
             resolved_prefix: module.name().clone(),
-            unresolved_tail,
+            unresolved_tail: unresolved_tail.clone(),
         }
     }
 }
@@ -1719,13 +1725,6 @@ mod tests {
         graph.add_standalone_model(order);
         graph.add_standalone_model(profile);
         graph
-    }
-
-    #[test]
-    fn django_name_matching_preserves_unicode_case_folding() {
-        assert!(django_name_matches("UserProfile", "userprofile"));
-        assert!(django_name_matches("Äccount", "äccount"));
-        assert!(!django_name_matches("User", "Group"));
     }
 
     #[test]

--- a/crates/djls-project/src/models/imports.rs
+++ b/crates/djls-project/src/models/imports.rs
@@ -128,7 +128,7 @@ impl ModelImportState {
     pub(crate) fn resolve_reference(&self, root: &str, tail: &[String]) -> ModelImportReference {
         match self.resolve_qualified_path(root, tail) {
             Ok(target) => ModelImportReference::Qualified(target),
-            Err(error) => ModelImportReference::Unresolved(error),
+            Err(error) => ModelImportReference::Unresolved(error.into()),
         }
     }
 }
@@ -141,7 +141,15 @@ pub(crate) enum ModelImportReference {
     Qualified(PythonModuleName),
     /// The spelling could not be symbolically qualified; the reason is
     /// preserved for downstream resolution and diagnostics.
-    Unresolved(ModelImportPathResolutionError),
+    Unresolved(ModelImportPathUnresolvedReason),
+}
+
+/// Stored evidence explaining why an import path could not be qualified.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ModelImportPathUnresolvedReason {
+    MissingBinding,
+    ShadowedBinding,
+    InvalidTarget { target: String },
 }
 
 #[derive(Clone, Debug, Error, PartialEq, Eq, Hash)]
@@ -156,6 +164,18 @@ pub(crate) enum ModelImportPathResolutionError {
         #[source]
         source: InvalidModuleName,
     },
+}
+
+impl From<ModelImportPathResolutionError> for ModelImportPathUnresolvedReason {
+    fn from(error: ModelImportPathResolutionError) -> Self {
+        match error {
+            ModelImportPathResolutionError::MissingBinding => Self::MissingBinding,
+            ModelImportPathResolutionError::ShadowedBinding => Self::ShadowedBinding,
+            ModelImportPathResolutionError::InvalidTarget { target, .. } => {
+                Self::InvalidTarget { target }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -302,7 +322,7 @@ mod tests {
         assert!(state.aliases.is_empty());
         assert_eq!(
             state.resolve_reference("c", &[]),
-            ModelImportReference::Unresolved(ModelImportPathResolutionError::ShadowedBinding)
+            ModelImportReference::Unresolved(ModelImportPathUnresolvedReason::ShadowedBinding)
         );
     }
 
@@ -315,7 +335,7 @@ mod tests {
         );
         assert_eq!(
             state.resolve_reference("missing", &[]),
-            ModelImportReference::Unresolved(ModelImportPathResolutionError::MissingBinding)
+            ModelImportReference::Unresolved(ModelImportPathUnresolvedReason::MissingBinding)
         );
     }
 }

--- a/crates/djls-project/src/models/resolve.rs
+++ b/crates/djls-project/src/models/resolve.rs
@@ -2,66 +2,84 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use djls_source::Span;
+use djls_source::Spanned;
 
 use crate::db::Db;
-use crate::models::extract::CandidateBaseRef;
-use crate::models::extract::CandidateBaseReferenceError;
-use crate::models::extract::ModelCandidate;
-use crate::models::extract::ModelExtraction;
+use crate::models::extract::ExtractedBaseRef;
+use crate::models::extract::ExtractedClass;
+use crate::models::extract::ExtractedClasses;
 use crate::models::graph::AncestryOutcome;
 use crate::models::graph::BaseOutcome;
 use crate::models::graph::BaseUnresolvedReason;
-use crate::models::graph::InheritanceError;
+use crate::models::graph::ClassId;
 use crate::models::graph::InheritanceRecord;
+use crate::models::graph::InvalidAncestryReason;
 use crate::models::graph::ModelGraph;
-use crate::models::graph::ModelId;
 use crate::models::graph::ModelKind;
 use crate::project::Project;
 use crate::python::PythonModuleName;
 use crate::python::resolve_prefix;
 
+/// An extracted base after project and occurrence resolution, before admission.
 #[derive(Clone)]
-enum ResolvedBase {
-    DjangoModelRoot {
-        span: Span,
-    },
-    Model {
-        model: ModelId,
-        span: Span,
-    },
+enum ResolvedClassBase {
+    DjangoModelRoot,
+    Class(ClassId),
     ReboundLocalBase {
-        span: Span,
-        model: ModelId,
+        class: ClassId,
         has_positive_model_evidence: bool,
     },
-    Unresolved {
-        span: Span,
-        reason: BaseUnresolvedReason,
+    Unresolved(ClassBaseUnresolvedReason),
+}
+
+/// A failure that can occur while resolving an extracted base, before model
+/// admission assigns terminal model/class meaning.
+#[derive(Clone)]
+enum ClassBaseUnresolvedReason {
+    UnsupportedExpression,
+    MissingImportBinding {
+        path: Vec<String>,
+    },
+    ShadowedImportBinding {
+        path: Vec<String>,
+    },
+    InvalidImportedTarget {
+        target: String,
+    },
+    ImportNotFound {
+        requested: PythonModuleName,
+    },
+    ImportedTargetIsModule {
+        module: PythonModuleName,
+    },
+    PartialImport {
+        resolved_prefix: PythonModuleName,
+        unresolved_tail: Vec<String>,
     },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum C3Node {
+enum MroEntry {
     DjangoModelRoot,
-    Model(ModelId),
+    Class(ClassId),
 }
 
 #[derive(Clone)]
 enum ComputedAncestry {
-    Complete { mro: Vec<C3Node> },
-    Partial { known_mro: Vec<C3Node> },
-    Invalid { error: InheritanceError },
+    Complete { mro: Vec<MroEntry> },
+    Partial { known_mro: Vec<MroEntry> },
+    Invalid { reason: InvalidAncestryReason },
 }
 
 #[derive(Clone, Copy)]
-struct CandidateOccurrence {
+struct ClassOccurrence {
     span: Span,
     has_positive_model_evidence: bool,
 }
 
-struct ResolvedCandidate {
-    candidate: ModelCandidate,
-    bases: Vec<ResolvedBase>,
+struct ResolvedClass {
+    extracted: ExtractedClass,
+    bases: Vec<Spanned<ResolvedClassBase>>,
 }
 
 #[derive(Clone, Copy)]
@@ -73,103 +91,94 @@ enum AdmissionPolicy {
 pub(super) fn resolve_model_inheritance(
     db: &dyn Db,
     project: Project,
-    candidates: Vec<ModelCandidate>,
+    classes: Vec<ExtractedClass>,
 ) -> ModelGraph {
     let mut prefix_cache = BTreeMap::new();
-    assemble_model_graph(
-        candidates,
-        AdmissionPolicy::Production,
-        |candidate, base, span| {
-            resolve_candidate_base(candidate, base, span, &mut |path, span| {
-                resolve_project_qualified_base(db, project, path, span, &mut prefix_cache)
-            })
-        },
-    )
+    assemble_model_graph(classes, AdmissionPolicy::Production, |class, base| {
+        resolve_class_base(class, base, &mut |path| {
+            resolve_project_qualified_base(db, project, path, &mut prefix_cache)
+        })
+    })
 }
 
-/// Resolve one file's extracted model candidates without consulting a Project.
+/// Resolve one file's extracted classes without consulting a Project.
 ///
 /// This keeps corpus extraction deterministic and limited to classes whose
 /// Django model ancestry can be proven within the file. Qualified bases remain
 /// unresolved and cannot seed local model admission.
-pub(crate) fn resolve_local_model_graph(extraction: &ModelExtraction) -> ModelGraph {
+pub(crate) fn resolve_local_model_graph(extraction: &ExtractedClasses) -> ModelGraph {
     assemble_model_graph(
-        extraction.candidates.iter().cloned(),
+        extraction.as_slice().iter().cloned(),
         AdmissionPolicy::Local,
-        |candidate, base, span| {
-            resolve_candidate_base(candidate, base, span, &mut |path, span| {
-                ResolvedBase::Unresolved {
-                    span,
-                    reason: BaseUnresolvedReason::ImportNotFound {
-                        requested: path.clone(),
-                    },
-                }
+        |class, base| {
+            resolve_class_base(class, base, &mut |path| {
+                ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::ImportNotFound {
+                    requested: path.clone(),
+                })
             })
         },
     )
 }
 
 fn assemble_model_graph(
-    candidates: impl IntoIterator<Item = ModelCandidate>,
+    classes: impl IntoIterator<Item = ExtractedClass>,
     policy: AdmissionPolicy,
-    mut resolve_base: impl FnMut(&ModelCandidate, &CandidateBaseRef, Span) -> ResolvedBase,
+    mut resolve_base: impl FnMut(&ExtractedClass, &ExtractedBaseRef) -> ResolvedClassBase,
 ) -> ModelGraph {
-    let mut occurrences: BTreeMap<ModelId, Vec<CandidateOccurrence>> = BTreeMap::new();
+    let mut occurrences: BTreeMap<ClassId, Vec<ClassOccurrence>> = BTreeMap::new();
     let mut winners = BTreeMap::new();
 
-    // Candidates retain source order within their selected module file. Keep
-    // every occurrence and its proven model evidence before reducing to the
-    // final module binding: a base expression may refer to an earlier class
-    // that a later declaration replaces. Evidence can flow through an earlier
-    // same-module base only after that base occurrence has itself been proven.
-    for candidate in candidates {
-        let id = candidate_id(&candidate);
+    // Keep each declaration until occurrence-local rebinding has been resolved;
+    // only then does the final module/name winner replace earlier declarations.
+    for class in classes {
+        let id = class_id(&class);
         let has_positive_model_evidence =
-            candidate_occurrence_has_positive_model_evidence(&candidate, &occurrences);
+            class_occurrence_has_positive_model_evidence(&class, &occurrences);
         occurrences
             .entry(id.clone())
             .or_default()
-            .push(CandidateOccurrence {
-                span: candidate.model.name.span(),
+            .push(ClassOccurrence {
+                span: class.name.span(),
                 has_positive_model_evidence,
             });
-        winners.insert(id, candidate);
+        winners.insert(id, class);
     }
-    let selected_spans: BTreeMap<ModelId, Span> = winners
+    let selected_spans: BTreeMap<ClassId, Span> = winners
         .iter()
-        .map(|(id, candidate)| (id.clone(), candidate.model.name.span()))
+        .map(|(id, class)| (id.clone(), class.name.span()))
         .collect();
 
-    let resolved: BTreeMap<ModelId, ResolvedCandidate> = winners
+    let resolved: BTreeMap<ClassId, ResolvedClass> = winners
         .into_iter()
-        .map(|(id, candidate)| {
-            let bases = candidate
+        .map(|(id, extracted)| {
+            let bases = extracted
                 .bases
                 .iter()
                 .map(|base| {
-                    resolve_candidate_base_rebinding(
-                        &candidate,
+                    let resolved = resolve_class_base_rebinding(
+                        &extracted,
                         base.value(),
                         base.span(),
                         &occurrences,
                         &selected_spans,
                     )
-                    .unwrap_or_else(|| resolve_base(&candidate, base.value(), base.span()))
+                    .unwrap_or_else(|| resolve_base(&extracted, base.value()));
+                    Spanned::new(resolved, base.span())
                 })
                 .collect();
-            (id, ResolvedCandidate { candidate, bases })
+            (id, ResolvedClass { extracted, bases })
         })
         .collect();
-    let admitted = admitted_candidate_ids(&resolved, policy);
+    let admitted = admitted_class_ids(&resolved, policy);
 
-    let bases_by_class: BTreeMap<ModelId, Vec<BaseOutcome>> = resolved
+    // Terminal outcomes are the evidence retained by ModelGraph.
+    let bases_by_class: BTreeMap<ClassId, Vec<BaseOutcome>> = resolved
         .iter()
-        .map(|(id, candidate)| {
-            let bases = candidate
+        .map(|(id, class)| {
+            let bases = class
                 .bases
                 .iter()
-                .cloned()
-                .map(|base| terminal_outcome(base, candidate, &resolved, &admitted, policy))
+                .map(|base| terminal_outcome(base, class, &resolved, &admitted, policy))
                 .collect();
             (id.clone(), bases)
         })
@@ -188,78 +197,81 @@ fn assemble_model_graph(
             .get(id)
             .cloned()
             .unwrap_or(ComputedAncestry::Complete {
-                mro: vec![C3Node::Model(id.clone())],
+                mro: vec![MroEntry::Class(id.clone())],
             }) {
             ComputedAncestry::Complete { mro } => AncestryOutcome::Complete {
                 mro: mro
                     .into_iter()
-                    .filter_map(|node| match node {
-                        C3Node::DjangoModelRoot => None,
-                        C3Node::Model(class) => Some(class),
+                    .filter_map(|entry| match entry {
+                        MroEntry::DjangoModelRoot => None,
+                        MroEntry::Class(class) => Some(class),
                     })
                     .collect(),
             },
             ComputedAncestry::Partial { .. } => AncestryOutcome::Partial,
-            ComputedAncestry::Invalid { error } => AncestryOutcome::Invalid { error },
+            ComputedAncestry::Invalid { reason } => AncestryOutcome::Invalid { reason },
         };
         inheritance_by_model.insert(id.clone(), InheritanceRecord { bases, ancestry });
     }
 
     let mut graph = ModelGraph::new();
-    for (id, candidate) in resolved {
+    for (id, resolved_class) in resolved {
         if let Some(inheritance) = inheritance_by_model.remove(&id) {
-            graph.insert_resolved_model(candidate.candidate.model, inheritance);
+            let (definition, local_bindings) = resolved_class.extracted.into_admitted_model();
+            graph.insert_resolved_model(definition, inheritance, local_bindings);
         } else {
-            graph.add_non_model_class(&id, &candidate.candidate.model);
+            graph.add_non_model_class(&id, resolved_class.extracted.local_bindings);
         }
     }
     graph.build_effective_relation_bindings();
     graph
 }
 
-fn admitted_candidate_ids(
-    candidates: &BTreeMap<ModelId, ResolvedCandidate>,
+fn admitted_class_ids(
+    classes: &BTreeMap<ClassId, ResolvedClass>,
     policy: AdmissionPolicy,
-) -> BTreeSet<ModelId> {
-    let mut ids: BTreeSet<ModelId> = candidates
+) -> BTreeSet<ClassId> {
+    let mut ids: BTreeSet<ClassId> = classes
         .iter()
         .filter(|(_id, resolved)| match policy {
             AdmissionPolicy::Production => {
                 has_django_root(resolved)
                     || has_positive_rebound_local_base(resolved)
-                    || (!has_negative_django_root_evidence(resolved, candidates)
-                        && (resolved.candidate.model.kind != ModelKind::Concrete
-                            || resolved.candidate.model.has_local_relation_binding()))
+                    || (!has_negative_django_root_evidence(resolved, classes)
+                        && (resolved.extracted.declared_model_kind != ModelKind::Concrete
+                            || resolved.extracted.has_local_relation_binding()))
             }
             AdmissionPolicy::Local => {
                 has_django_root(resolved)
                     || has_positive_rebound_local_base(resolved)
-                    || (!has_negative_django_root_evidence(resolved, candidates)
-                        && resolved.candidate.model.kind != ModelKind::Concrete)
+                    || (!has_negative_django_root_evidence(resolved, classes)
+                        && resolved.extracted.declared_model_kind != ModelKind::Concrete)
             }
         })
         .map(|(id, _resolved)| id.clone())
         .collect();
 
     loop {
-        let descendants: Vec<ModelId> = candidates
+        let descendants: Vec<ClassId> = classes
             .iter()
-            .filter(|(id, _candidate)| !ids.contains(*id))
-            .filter(|(_id, candidate)| {
-                candidate.bases.iter().any(|base| {
-                    let ResolvedBase::Model { model, .. } = base else {
+            .filter(|(id, _class)| !ids.contains(*id))
+            .filter(|(_id, class)| {
+                class.bases.iter().any(|base| {
+                    let ResolvedClassBase::Class(parent_id) = base.value() else {
                         return false;
                     };
-                    ids.contains(model)
+                    ids.contains(parent_id)
                         && match policy {
                             AdmissionPolicy::Production => true,
-                            AdmissionPolicy::Local => candidates.get(model).is_some_and(|parent| {
-                                parent.candidate.model.file == candidate.candidate.model.file
-                            }),
+                            AdmissionPolicy::Local => {
+                                classes.get(parent_id).is_some_and(|parent| {
+                                    parent.extracted.file == class.extracted.file
+                                })
+                            }
                         }
                 })
             })
-            .map(|(id, _candidate)| id.clone())
+            .map(|(id, _class)| id.clone())
             .collect();
         if descendants.is_empty() {
             break;
@@ -270,44 +282,42 @@ fn admitted_candidate_ids(
     ids
 }
 
-fn has_django_root(candidate: &ResolvedCandidate) -> bool {
-    candidate
+fn has_django_root(class: &ResolvedClass) -> bool {
+    class
         .bases
         .iter()
-        .any(|base| matches!(base, ResolvedBase::DjangoModelRoot { .. }))
+        .any(|base| matches!(base.value(), ResolvedClassBase::DjangoModelRoot))
 }
 
 fn has_negative_django_root_evidence(
-    candidate: &ResolvedCandidate,
-    candidates: &BTreeMap<ModelId, ResolvedCandidate>,
+    class: &ResolvedClass,
+    classes: &BTreeMap<ClassId, ResolvedClass>,
 ) -> bool {
-    candidate.bases.iter().any(|base| match base {
-        ResolvedBase::Model { model, .. } => {
-            model.name() == "Model" && !candidates.contains_key(model)
+    class.bases.iter().any(|base| match base.value() {
+        ResolvedClassBase::Class(base_class) => {
+            base_class.name() == "Model" && !classes.contains_key(base_class)
         }
-        ResolvedBase::Unresolved { reason, .. } => {
+        ResolvedClassBase::Unresolved(reason) => {
             let path = match reason {
-                BaseUnresolvedReason::MissingImportBinding { path }
-                | BaseUnresolvedReason::ShadowedImportBinding { path } => path,
-                BaseUnresolvedReason::UnsupportedExpression
-                | BaseUnresolvedReason::InvalidImportedTarget { .. }
-                | BaseUnresolvedReason::ImportNotFound { .. }
-                | BaseUnresolvedReason::ImportedTargetIsModule { .. }
-                | BaseUnresolvedReason::PartialImport { .. }
-                | BaseUnresolvedReason::ModelNotFound { .. }
-                | BaseUnresolvedReason::ReboundLocalBase { .. } => return false,
+                ClassBaseUnresolvedReason::MissingImportBinding { path }
+                | ClassBaseUnresolvedReason::ShadowedImportBinding { path } => path,
+                ClassBaseUnresolvedReason::UnsupportedExpression
+                | ClassBaseUnresolvedReason::InvalidImportedTarget { .. }
+                | ClassBaseUnresolvedReason::ImportNotFound { .. }
+                | ClassBaseUnresolvedReason::ImportedTargetIsModule { .. }
+                | ClassBaseUnresolvedReason::PartialImport { .. } => return false,
             };
             path.last().is_some_and(|name| name == "Model")
         }
-        ResolvedBase::DjangoModelRoot { .. } | ResolvedBase::ReboundLocalBase { .. } => false,
+        ResolvedClassBase::DjangoModelRoot | ResolvedClassBase::ReboundLocalBase { .. } => false,
     })
 }
 
-fn has_positive_rebound_local_base(candidate: &ResolvedCandidate) -> bool {
-    candidate.bases.iter().any(|base| {
+fn has_positive_rebound_local_base(class: &ResolvedClass) -> bool {
+    class.bases.iter().any(|base| {
         matches!(
-            base,
-            ResolvedBase::ReboundLocalBase {
+            base.value(),
+            ResolvedClassBase::ReboundLocalBase {
                 has_positive_model_evidence: true,
                 ..
             }
@@ -315,44 +325,41 @@ fn has_positive_rebound_local_base(candidate: &ResolvedCandidate) -> bool {
     })
 }
 
-fn candidate_occurrence_has_positive_model_evidence(
-    candidate: &ModelCandidate,
-    occurrences: &BTreeMap<ModelId, Vec<CandidateOccurrence>>,
+fn class_occurrence_has_positive_model_evidence(
+    class: &ExtractedClass,
+    occurrences: &BTreeMap<ClassId, Vec<ClassOccurrence>>,
 ) -> bool {
-    has_direct_model_evidence(candidate)
-        || candidate.bases.iter().any(|base| {
-            let CandidateBaseRef::SameModule(name) = base.value() else {
+    has_direct_model_evidence(class)
+        || class.bases.iter().any(|base| {
+            let ExtractedBaseRef::SameModule(name) = base.value() else {
                 return false;
             };
-            let model = ModelId::new(candidate.model.module_name.clone(), name.clone());
-            nearest_preceding_occurrence(occurrences, &model, base.span(), None)
+            let base_class = ClassId::new(class.module_name.clone(), name.as_str());
+            nearest_preceding_occurrence(occurrences, &base_class, base.span(), None)
                 .is_some_and(|occurrence| occurrence.has_positive_model_evidence)
         })
 }
 
-fn has_direct_model_evidence(candidate: &ModelCandidate) -> bool {
-    candidate.model.kind != ModelKind::Concrete
-        || candidate
+fn has_direct_model_evidence(class: &ExtractedClass) -> bool {
+    class.declared_model_kind != ModelKind::Concrete
+        || class
             .bases
             .iter()
-            .any(|base| matches!(base.value(), CandidateBaseRef::DjangoModelRoot))
+            .any(|base| matches!(base.value(), ExtractedBaseRef::DjangoModelRoot))
 }
 
-fn candidate_id(candidate: &ModelCandidate) -> ModelId {
-    ModelId::new(
-        candidate.model.module_name.clone(),
-        candidate.model.name.value().clone(),
-    )
+fn class_id(class: &ExtractedClass) -> ClassId {
+    ClassId::new(class.module_name.clone(), class.name.value().as_str())
 }
 
 fn nearest_preceding_occurrence<'a>(
-    occurrences: &'a BTreeMap<ModelId, Vec<CandidateOccurrence>>,
-    model: &ModelId,
+    occurrences: &'a BTreeMap<ClassId, Vec<ClassOccurrence>>,
+    class: &ClassId,
     before: Span,
     excluded_span: Option<Span>,
-) -> Option<&'a CandidateOccurrence> {
+) -> Option<&'a ClassOccurrence> {
     occurrences
-        .get(model)?
+        .get(class)?
         .iter()
         .filter(|occurrence| {
             Some(occurrence.span) != excluded_span && occurrence.span.start() < before.start()
@@ -360,63 +367,58 @@ fn nearest_preceding_occurrence<'a>(
         .max_by_key(|occurrence| occurrence.span.start())
 }
 
-fn resolve_candidate_base_rebinding(
-    candidate: &ModelCandidate,
-    base: &CandidateBaseRef,
+fn resolve_class_base_rebinding(
+    extracted: &ExtractedClass,
+    base: &ExtractedBaseRef,
     span: Span,
-    occurrences: &BTreeMap<ModelId, Vec<CandidateOccurrence>>,
-    selected_spans: &BTreeMap<ModelId, Span>,
-) -> Option<ResolvedBase> {
-    let CandidateBaseRef::SameModule(name) = base else {
+    occurrences: &BTreeMap<ClassId, Vec<ClassOccurrence>>,
+    selected_spans: &BTreeMap<ClassId, Span>,
+) -> Option<ResolvedClassBase> {
+    let ExtractedBaseRef::SameModule(name) = base else {
         return None;
     };
-    let model = ModelId::new(candidate.model.module_name.clone(), name.clone());
+    let class = ClassId::new(extracted.module_name.clone(), name.as_str());
     let nearest =
-        nearest_preceding_occurrence(occurrences, &model, span, Some(candidate.model.name.span()))?;
-    if selected_spans.get(&model) == Some(&nearest.span) {
+        nearest_preceding_occurrence(occurrences, &class, span, Some(extracted.name.span()))?;
+    if selected_spans.get(&class) == Some(&nearest.span) {
         return None;
     }
 
-    Some(ResolvedBase::ReboundLocalBase {
-        span,
-        model,
+    Some(ResolvedClassBase::ReboundLocalBase {
+        class,
         has_positive_model_evidence: nearest.has_positive_model_evidence,
     })
 }
 
-fn resolve_candidate_base(
-    candidate: &ModelCandidate,
-    base: &CandidateBaseRef,
-    span: Span,
-    resolve_qualified: &mut impl FnMut(&PythonModuleName, Span) -> ResolvedBase,
-) -> ResolvedBase {
+fn resolve_class_base(
+    extracted: &ExtractedClass,
+    base: &ExtractedBaseRef,
+    resolve_qualified: &mut impl FnMut(&PythonModuleName) -> ResolvedClassBase,
+) -> ResolvedClassBase {
     match base {
-        CandidateBaseRef::DjangoModelRoot => ResolvedBase::DjangoModelRoot { span },
-        CandidateBaseRef::SameModule(name) => ResolvedBase::Model {
-            model: ModelId::new(candidate.model.module_name.clone(), name.clone()),
-            span,
-        },
-        CandidateBaseRef::UnsupportedExpression => ResolvedBase::Unresolved {
-            span,
-            reason: BaseUnresolvedReason::UnsupportedExpression,
-        },
-        CandidateBaseRef::Qualified(path) => resolve_qualified(path, span),
-        CandidateBaseRef::Unresolved { path, reason } => ResolvedBase::Unresolved {
-            span,
-            reason: match reason {
-                CandidateBaseReferenceError::MissingBinding => {
-                    BaseUnresolvedReason::MissingImportBinding { path: path.clone() }
-                }
-                CandidateBaseReferenceError::ShadowedBinding => {
-                    BaseUnresolvedReason::ShadowedImportBinding { path: path.clone() }
-                }
-                CandidateBaseReferenceError::InvalidTarget { target } => {
-                    BaseUnresolvedReason::InvalidImportedTarget {
-                        target: target.clone(),
-                    }
-                }
-            },
-        },
+        ExtractedBaseRef::DjangoModelRoot => ResolvedClassBase::DjangoModelRoot,
+        ExtractedBaseRef::SameModule(name) => {
+            ResolvedClassBase::Class(ClassId::new(extracted.module_name.clone(), name.as_str()))
+        }
+        ExtractedBaseRef::UnsupportedExpression => {
+            ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::UnsupportedExpression)
+        }
+        ExtractedBaseRef::Qualified(path) => resolve_qualified(path),
+        ExtractedBaseRef::MissingBinding { path } => {
+            ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::MissingImportBinding {
+                path: path.clone(),
+            })
+        }
+        ExtractedBaseRef::ShadowedBinding { path } => {
+            ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::ShadowedImportBinding {
+                path: path.clone(),
+            })
+        }
+        ExtractedBaseRef::InvalidTarget { target } => {
+            ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::InvalidImportedTarget {
+                target: target.clone(),
+            })
+        }
     }
 }
 
@@ -424,95 +426,130 @@ fn resolve_project_qualified_base(
     db: &dyn Db,
     project: Project,
     path: &PythonModuleName,
-    span: Span,
     prefix_cache: &mut BTreeMap<PythonModuleName, crate::python::ResolvedPrefix>,
-) -> ResolvedBase {
+) -> ResolvedClassBase {
     let resolved = prefix_cache
         .entry(path.clone())
         .or_insert_with(|| resolve_prefix(db, project, path.as_str()));
     let Some(module) = &resolved.module else {
-        return ResolvedBase::Unresolved {
-            span,
-            reason: BaseUnresolvedReason::ImportNotFound {
-                requested: path.clone(),
-            },
-        };
+        return ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::ImportNotFound {
+            requested: path.clone(),
+        });
     };
     match resolved.unresolved_tail.as_slice() {
-        [] => ResolvedBase::Unresolved {
-            span,
-            reason: BaseUnresolvedReason::ImportedTargetIsModule {
-                module: module.name().clone(),
-            },
-        },
-        [name] => ResolvedBase::Model {
-            model: ModelId::new(module.name().clone(), name.as_str().into()),
-            span,
-        },
-        unresolved_tail => ResolvedBase::Unresolved {
-            span,
-            reason: BaseUnresolvedReason::PartialImport {
+        [] => ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::ImportedTargetIsModule {
+            module: module.name().clone(),
+        }),
+        [name] => ResolvedClassBase::Class(ClassId::new(module.name().clone(), name.as_str())),
+        unresolved_tail => {
+            ResolvedClassBase::Unresolved(ClassBaseUnresolvedReason::PartialImport {
                 resolved_prefix: module.name().clone(),
                 unresolved_tail: unresolved_tail.to_vec(),
-            },
-        },
+            })
+        }
     }
 }
 
 fn terminal_outcome(
-    base: ResolvedBase,
-    candidate: &ResolvedCandidate,
-    selected: &BTreeMap<ModelId, ResolvedCandidate>,
-    admitted: &BTreeSet<ModelId>,
+    base: &Spanned<ResolvedClassBase>,
+    class: &ResolvedClass,
+    selected: &BTreeMap<ClassId, ResolvedClass>,
+    admitted: &BTreeSet<ClassId>,
     policy: AdmissionPolicy,
 ) -> BaseOutcome {
-    match base {
-        ResolvedBase::DjangoModelRoot { span } => BaseOutcome::DjangoModelRoot { span },
-        ResolvedBase::Model { model, span } => {
-            let known = selected.get(&model).is_some_and(|target| match policy {
+    let span = base.span();
+    match base.value() {
+        ResolvedClassBase::DjangoModelRoot => BaseOutcome::DjangoModelRoot { span },
+        ResolvedClassBase::Class(base_class) => {
+            let known = selected.get(base_class).is_some_and(|target| match policy {
                 AdmissionPolicy::Production => true,
-                AdmissionPolicy::Local => {
-                    target.candidate.model.file == candidate.candidate.model.file
-                }
+                AdmissionPolicy::Local => target.extracted.file == class.extracted.file,
             });
             if !known {
                 return BaseOutcome::Unresolved {
                     span,
-                    reason: BaseUnresolvedReason::ModelNotFound { model },
+                    reason: BaseUnresolvedReason::ClassNotFound {
+                        class: base_class.clone(),
+                    },
                 };
             }
-            if admitted.contains(&model) {
-                BaseOutcome::Model { model, span }
+            if admitted.contains(base_class) {
+                BaseOutcome::Model {
+                    model: base_class.clone().into_admitted_model_id(),
+                    span,
+                }
             } else {
-                BaseOutcome::NonModelClass { class: model, span }
+                BaseOutcome::NonModelClass {
+                    class: base_class.clone(),
+                    span,
+                }
             }
         }
-        ResolvedBase::ReboundLocalBase { span, model, .. } => BaseOutcome::Unresolved {
+        ResolvedClassBase::ReboundLocalBase {
+            class: base_class, ..
+        } => BaseOutcome::Unresolved {
             span,
-            reason: BaseUnresolvedReason::ReboundLocalBase { model },
+            reason: BaseUnresolvedReason::ReboundLocalBase {
+                class: base_class.clone(),
+            },
         },
-        ResolvedBase::Unresolved { span, reason } => BaseOutcome::Unresolved { span, reason },
+        ResolvedClassBase::Unresolved(reason) => BaseOutcome::Unresolved {
+            span,
+            reason: match reason {
+                ClassBaseUnresolvedReason::UnsupportedExpression => {
+                    BaseUnresolvedReason::UnsupportedExpression
+                }
+                ClassBaseUnresolvedReason::MissingImportBinding { path } => {
+                    BaseUnresolvedReason::MissingImportBinding { path: path.clone() }
+                }
+                ClassBaseUnresolvedReason::ShadowedImportBinding { path } => {
+                    BaseUnresolvedReason::ShadowedImportBinding { path: path.clone() }
+                }
+                ClassBaseUnresolvedReason::InvalidImportedTarget { target } => {
+                    BaseUnresolvedReason::InvalidImportedTarget {
+                        target: target.clone(),
+                    }
+                }
+                ClassBaseUnresolvedReason::ImportNotFound { requested } => {
+                    BaseUnresolvedReason::ImportNotFound {
+                        requested: requested.clone(),
+                    }
+                }
+                ClassBaseUnresolvedReason::ImportedTargetIsModule { module } => {
+                    BaseUnresolvedReason::ImportedTargetIsModule {
+                        module: module.clone(),
+                    }
+                }
+                ClassBaseUnresolvedReason::PartialImport {
+                    resolved_prefix,
+                    unresolved_tail,
+                } => BaseUnresolvedReason::PartialImport {
+                    resolved_prefix: resolved_prefix.clone(),
+                    unresolved_tail: unresolved_tail.clone(),
+                },
+            },
+        },
     }
 }
 
 fn compute_ancestry(
-    id: &ModelId,
-    bases_by_model: &BTreeMap<ModelId, Vec<BaseOutcome>>,
-    memo: &mut BTreeMap<ModelId, ComputedAncestry>,
-    visiting: &mut BTreeSet<ModelId>,
+    id: &ClassId,
+    bases_by_class: &BTreeMap<ClassId, Vec<BaseOutcome>>,
+    memo: &mut BTreeMap<ClassId, ComputedAncestry>,
+    visiting: &mut BTreeSet<ClassId>,
 ) -> ComputedAncestry {
     if let Some(outcome) = memo.get(id) {
         return outcome.clone();
     }
     if !visiting.insert(id.clone()) {
         return ComputedAncestry::Invalid {
-            error: InheritanceError::Cycle,
+            reason: InvalidAncestryReason::Cycle,
         };
     }
 
-    let Some(bases) = bases_by_model.get(id) else {
+    let Some(bases) = bases_by_class.get(id) else {
         let outcome = ComputedAncestry::Complete {
-            mro: vec![C3Node::Model(id.clone())],
+            mro: vec![MroEntry::Class(id.clone())],
         };
         visiting.remove(id);
         memo.insert(id.clone(), outcome.clone());
@@ -524,58 +561,58 @@ fn compute_ancestry(
     let mut seen = BTreeSet::new();
     let mut duplicate = None;
     for base in bases {
-        let node = match base {
-            BaseOutcome::DjangoModelRoot { .. } => C3Node::DjangoModelRoot,
-            BaseOutcome::Model { model, .. } => C3Node::Model(model.clone()),
-            BaseOutcome::NonModelClass { class, .. } => C3Node::Model(class.clone()),
+        let entry = match base {
+            BaseOutcome::DjangoModelRoot { .. } => MroEntry::DjangoModelRoot,
+            BaseOutcome::Model { model, .. } => MroEntry::Class(ClassId::from_model_id(model)),
+            BaseOutcome::NonModelClass { class, .. } => MroEntry::Class(class.clone()),
             BaseOutcome::Unresolved { .. } => {
                 has_unresolved = true;
                 continue;
             }
         };
-        if !seen.insert(node.clone()) && duplicate.is_none() {
-            duplicate = Some(match &node {
-                C3Node::DjangoModelRoot => InheritanceError::DuplicateDjangoModelRoot,
-                C3Node::Model(model) => InheritanceError::DuplicateModelBase {
-                    model: model.clone(),
+        if !seen.insert(entry.clone()) && duplicate.is_none() {
+            duplicate = Some(match &entry {
+                MroEntry::DjangoModelRoot => InvalidAncestryReason::DuplicateDjangoModelRoot,
+                MroEntry::Class(class) => InvalidAncestryReason::DuplicateClassBase {
+                    class: class.clone(),
                 },
             });
         }
-        direct_parents.push(node);
+        direct_parents.push(entry);
     }
 
     let mut parent_mros = Vec::new();
     let mut parent_is_partial = false;
-    let mut inherited_error = None;
+    let mut inherited_reason = None;
     for parent in &direct_parents {
         match parent {
-            C3Node::DjangoModelRoot => {
-                parent_mros.push(vec![C3Node::DjangoModelRoot]);
+            MroEntry::DjangoModelRoot => {
+                parent_mros.push(vec![MroEntry::DjangoModelRoot]);
             }
-            C3Node::Model(parent) => {
-                match compute_ancestry(parent, bases_by_model, memo, visiting) {
+            MroEntry::Class(parent) => {
+                match compute_ancestry(parent, bases_by_class, memo, visiting) {
                     ComputedAncestry::Complete { mro } => parent_mros.push(mro),
                     ComputedAncestry::Partial { known_mro } => {
                         parent_mros.push(known_mro);
                         parent_is_partial = true;
                     }
-                    ComputedAncestry::Invalid { error } => {
-                        inherited_error.get_or_insert(error);
+                    ComputedAncestry::Invalid { reason } => {
+                        inherited_reason.get_or_insert(reason);
                     }
                 }
             }
         }
     }
 
-    let outcome = if let Some(error) = duplicate.or(inherited_error) {
-        ComputedAncestry::Invalid { error }
+    let outcome = if let Some(reason) = duplicate.or(inherited_reason) {
+        ComputedAncestry::Invalid { reason }
     } else {
         match c3_merge(parent_mros, direct_parents) {
             None => ComputedAncestry::Invalid {
-                error: InheritanceError::InconsistentC3,
+                reason: InvalidAncestryReason::InconsistentMethodResolutionOrder,
             },
             Some(mut tail) => {
-                tail.insert(0, C3Node::Model(id.clone()));
+                tail.insert(0, MroEntry::Class(id.clone()));
                 if has_unresolved || parent_is_partial {
                     ComputedAncestry::Partial { known_mro: tail }
                 } else {
@@ -589,7 +626,10 @@ fn compute_ancestry(
     outcome
 }
 
-fn c3_merge(mut parent_mros: Vec<Vec<C3Node>>, direct_parents: Vec<C3Node>) -> Option<Vec<C3Node>> {
+fn c3_merge(
+    mut parent_mros: Vec<Vec<MroEntry>>,
+    direct_parents: Vec<MroEntry>,
+) -> Option<Vec<MroEntry>> {
     parent_mros.push(direct_parents);
     let mut result = Vec::new();
 
@@ -617,22 +657,22 @@ mod tests {
     use camino::Utf8Path;
     use djls_testing::TestDatabase;
 
-    use super::C3Node;
+    use super::MroEntry;
     use super::c3_merge;
     use super::resolve_local_model_graph;
     use crate::models::extract::extract_models_impl;
     use crate::models::graph::AncestryOutcome;
+    use crate::models::graph::ClassId;
     use crate::models::graph::ModelGraph;
     use crate::models::graph::ModelId;
     use crate::python::PythonModuleName;
     use crate::python::import::ModuleKind;
 
-    fn model(value: &str) -> C3Node {
-        C3Node::Model(
-            value
-                .parse::<ModelId>()
-                .expect("test model id should parse"),
-        )
+    fn class(value: &str) -> MroEntry {
+        let model = value
+            .parse::<ModelId>()
+            .expect("test class id should parse");
+        MroEntry::Class(ClassId::from_model_id(&model))
     }
 
     fn local_graph(source: &str) -> ModelGraph {
@@ -653,9 +693,9 @@ mod tests {
 
     #[test]
     fn c3_prefers_the_left_parent_at_a_collision() {
-        let left = model("app.models.Left");
-        let right = model("app.models.Right");
-        let root = C3Node::DjangoModelRoot;
+        let left = class("app.models.Left");
+        let right = class("app.models.Right");
+        let root = MroEntry::DjangoModelRoot;
         assert_eq!(
             c3_merge(
                 vec![
@@ -670,8 +710,8 @@ mod tests {
 
     #[test]
     fn c3_rejects_inconsistent_parent_order() {
-        let x = model("app.models.X");
-        let y = model("app.models.Y");
+        let x = class("app.models.X");
+        let y = class("app.models.Y");
         assert_eq!(
             c3_merge(
                 vec![vec![x.clone(), y.clone()], vec![y.clone(), x.clone()]],
@@ -737,7 +777,10 @@ class Unsupported(make_base()):
                 .expect("Child should retain inheritance")
                 .ancestry,
             AncestryOutcome::Complete { mro }
-                if mro == &[child.clone(), abstract_base]
+                if mro == &[
+                    ClassId::from_model_id(&child),
+                    ClassId::from_model_id(&abstract_base),
+                ]
         ));
 
         let abstract_qualified: ModelId = "app.models.AbstractQualified"

--- a/crates/djls-project/src/models/resolve.rs
+++ b/crates/djls-project/src/models/resolve.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 
 use djls_source::Span;
 use djls_source::Spanned;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use crate::db::Db;
 use crate::models::extract::ExtractedBaseRef;
@@ -58,7 +59,7 @@ enum ClassBaseUnresolvedReason {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum MroEntry {
     DjangoModelRoot,
     Class(ClassId),
@@ -125,8 +126,8 @@ fn assemble_model_graph(
     policy: AdmissionPolicy,
     mut resolve_base: impl FnMut(&ExtractedClass, &ExtractedBaseRef) -> ResolvedClassBase,
 ) -> ModelGraph {
-    let mut occurrences: BTreeMap<ClassId, Vec<ClassOccurrence>> = BTreeMap::new();
-    let mut winners = BTreeMap::new();
+    let mut occurrences: FxHashMap<ClassId, Vec<ClassOccurrence>> = FxHashMap::default();
+    let mut winners = FxHashMap::default();
 
     // Keep each declaration until occurrence-local rebinding has been resolved;
     // only then does the final module/name winner replace earlier declarations.
@@ -143,12 +144,12 @@ fn assemble_model_graph(
             });
         winners.insert(id, class);
     }
-    let selected_spans: BTreeMap<ClassId, Span> = winners
+    let selected_spans: FxHashMap<ClassId, Span> = winners
         .iter()
         .map(|(id, class)| (id.clone(), class.name.span()))
         .collect();
 
-    let resolved: BTreeMap<ClassId, ResolvedClass> = winners
+    let resolved: FxHashMap<ClassId, ResolvedClass> = winners
         .into_iter()
         .map(|(id, extracted)| {
             let bases = extracted
@@ -172,7 +173,7 @@ fn assemble_model_graph(
     let admitted = admitted_class_ids(&resolved, policy);
 
     // Terminal outcomes are the evidence retained by ModelGraph.
-    let bases_by_class: BTreeMap<ClassId, Vec<BaseOutcome>> = resolved
+    let bases_by_class: FxHashMap<ClassId, Vec<BaseOutcome>> = resolved
         .iter()
         .map(|(id, class)| {
             let bases = class
@@ -184,13 +185,13 @@ fn assemble_model_graph(
         })
         .collect();
 
-    let mut ancestry = BTreeMap::new();
+    let mut ancestry = FxHashMap::default();
     for id in resolved.keys() {
-        let mut visiting = BTreeSet::new();
+        let mut visiting = FxHashSet::default();
         compute_ancestry(id, &bases_by_class, &mut ancestry, &mut visiting);
     }
 
-    let mut inheritance_by_model = BTreeMap::new();
+    let mut inheritance_by_model = FxHashMap::default();
     for id in &admitted {
         let bases = bases_by_class.get(id).cloned().unwrap_or_default();
         let ancestry = match ancestry
@@ -228,10 +229,10 @@ fn assemble_model_graph(
 }
 
 fn admitted_class_ids(
-    classes: &BTreeMap<ClassId, ResolvedClass>,
+    classes: &FxHashMap<ClassId, ResolvedClass>,
     policy: AdmissionPolicy,
-) -> BTreeSet<ClassId> {
-    let mut ids: BTreeSet<ClassId> = classes
+) -> FxHashSet<ClassId> {
+    let mut ids: FxHashSet<ClassId> = classes
         .iter()
         .filter(|(_id, resolved)| match policy {
             AdmissionPolicy::Production => {
@@ -291,7 +292,7 @@ fn has_django_root(class: &ResolvedClass) -> bool {
 
 fn has_negative_django_root_evidence(
     class: &ResolvedClass,
-    classes: &BTreeMap<ClassId, ResolvedClass>,
+    classes: &FxHashMap<ClassId, ResolvedClass>,
 ) -> bool {
     class.bases.iter().any(|base| match base.value() {
         ResolvedClassBase::Class(base_class) => {
@@ -327,7 +328,7 @@ fn has_positive_rebound_local_base(class: &ResolvedClass) -> bool {
 
 fn class_occurrence_has_positive_model_evidence(
     class: &ExtractedClass,
-    occurrences: &BTreeMap<ClassId, Vec<ClassOccurrence>>,
+    occurrences: &FxHashMap<ClassId, Vec<ClassOccurrence>>,
 ) -> bool {
     has_direct_model_evidence(class)
         || class.bases.iter().any(|base| {
@@ -353,7 +354,7 @@ fn class_id(class: &ExtractedClass) -> ClassId {
 }
 
 fn nearest_preceding_occurrence<'a>(
-    occurrences: &'a BTreeMap<ClassId, Vec<ClassOccurrence>>,
+    occurrences: &'a FxHashMap<ClassId, Vec<ClassOccurrence>>,
     class: &ClassId,
     before: Span,
     excluded_span: Option<Span>,
@@ -371,8 +372,8 @@ fn resolve_class_base_rebinding(
     extracted: &ExtractedClass,
     base: &ExtractedBaseRef,
     span: Span,
-    occurrences: &BTreeMap<ClassId, Vec<ClassOccurrence>>,
-    selected_spans: &BTreeMap<ClassId, Span>,
+    occurrences: &FxHashMap<ClassId, Vec<ClassOccurrence>>,
+    selected_spans: &FxHashMap<ClassId, Span>,
 ) -> Option<ResolvedClassBase> {
     let ExtractedBaseRef::SameModule(name) = base else {
         return None;
@@ -453,8 +454,8 @@ fn resolve_project_qualified_base(
 fn terminal_outcome(
     base: &Spanned<ResolvedClassBase>,
     class: &ResolvedClass,
-    selected: &BTreeMap<ClassId, ResolvedClass>,
-    admitted: &BTreeSet<ClassId>,
+    selected: &FxHashMap<ClassId, ResolvedClass>,
+    admitted: &FxHashSet<ClassId>,
     policy: AdmissionPolicy,
 ) -> BaseOutcome {
     let span = base.span();
@@ -534,9 +535,9 @@ fn terminal_outcome(
 
 fn compute_ancestry(
     id: &ClassId,
-    bases_by_class: &BTreeMap<ClassId, Vec<BaseOutcome>>,
-    memo: &mut BTreeMap<ClassId, ComputedAncestry>,
-    visiting: &mut BTreeSet<ClassId>,
+    bases_by_class: &FxHashMap<ClassId, Vec<BaseOutcome>>,
+    memo: &mut FxHashMap<ClassId, ComputedAncestry>,
+    visiting: &mut FxHashSet<ClassId>,
 ) -> ComputedAncestry {
     if let Some(outcome) = memo.get(id) {
         return outcome.clone();
@@ -558,7 +559,7 @@ fn compute_ancestry(
 
     let mut direct_parents = Vec::new();
     let mut has_unresolved = false;
-    let mut seen = BTreeSet::new();
+    let mut seen = FxHashSet::default();
     let mut duplicate = None;
     for base in bases {
         let entry = match base {

--- a/crates/djls-project/src/models/resolve.rs
+++ b/crates/djls-project/src/models/resolve.rs
@@ -1,71 +1,799 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use djls_source::Span;
 
 use crate::db::Db;
-use crate::models::extract::DeferredBaseRef;
-use crate::models::extract::DeferredModel;
+use crate::models::extract::CandidateBaseRef;
+use crate::models::extract::CandidateBaseReferenceError;
+use crate::models::extract::ModelCandidate;
+use crate::models::extract::ModelExtraction;
+use crate::models::graph::AncestryOutcome;
+use crate::models::graph::BaseOutcome;
+use crate::models::graph::BaseUnresolvedReason;
+use crate::models::graph::InheritanceError;
+use crate::models::graph::InheritanceRecord;
 use crate::models::graph::ModelGraph;
 use crate::models::graph::ModelId;
 use crate::models::graph::ModelKind;
 use crate::project::Project;
+use crate::python::PythonModuleName;
 use crate::python::resolve_prefix;
 
-pub(super) fn resolve_deferred_models(
+#[derive(Clone)]
+enum ResolvedBase {
+    DjangoModelRoot {
+        span: Span,
+    },
+    Model {
+        model: ModelId,
+        span: Span,
+    },
+    ReboundLocalBase {
+        span: Span,
+        model: ModelId,
+        has_positive_model_evidence: bool,
+    },
+    Unresolved {
+        span: Span,
+        reason: BaseUnresolvedReason,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum C3Node {
+    DjangoModelRoot,
+    Model(ModelId),
+}
+
+#[derive(Clone)]
+enum ComputedAncestry {
+    Complete { mro: Vec<C3Node> },
+    Partial { known_mro: Vec<C3Node> },
+    Invalid { error: InheritanceError },
+}
+
+#[derive(Clone, Copy)]
+struct CandidateOccurrence {
+    span: Span,
+    has_positive_model_evidence: bool,
+}
+
+struct ResolvedCandidate {
+    candidate: ModelCandidate,
+    bases: Vec<ResolvedBase>,
+}
+
+#[derive(Clone, Copy)]
+enum AdmissionPolicy {
+    Production,
+    Local,
+}
+
+pub(super) fn resolve_model_inheritance(
     db: &dyn Db,
     project: Project,
-    graph: &mut ModelGraph,
-    deferred: Vec<DeferredModel>,
-) {
-    let mut remaining = deferred;
+    candidates: Vec<ModelCandidate>,
+) -> ModelGraph {
     let mut prefix_cache = BTreeMap::new();
+    assemble_model_graph(
+        candidates,
+        AdmissionPolicy::Production,
+        |candidate, base, span| {
+            resolve_candidate_base(candidate, base, span, &mut |path, span| {
+                resolve_project_qualified_base(db, project, path, span, &mut prefix_cache)
+            })
+        },
+    )
+}
 
-    loop {
-        let before = remaining.len();
-        let mut unresolved = Vec::new();
+/// Resolve one file's extracted model candidates without consulting a Project.
+///
+/// This keeps corpus extraction deterministic and limited to classes whose
+/// Django model ancestry can be proven within the file. Qualified bases remain
+/// unresolved and cannot seed local model admission.
+pub(crate) fn resolve_local_model_graph(extraction: &ModelExtraction) -> ModelGraph {
+    assemble_model_graph(
+        extraction.candidates.iter().cloned(),
+        AdmissionPolicy::Local,
+        |candidate, base, span| {
+            resolve_candidate_base(candidate, base, span, &mut |path, span| {
+                ResolvedBase::Unresolved {
+                    span,
+                    reason: BaseUnresolvedReason::ImportNotFound {
+                        requested: path.clone(),
+                    },
+                }
+            })
+        },
+    )
+}
 
-        for deferred in remaining {
-            let resolved_bases: Vec<ModelId> = deferred
+fn assemble_model_graph(
+    candidates: impl IntoIterator<Item = ModelCandidate>,
+    policy: AdmissionPolicy,
+    mut resolve_base: impl FnMut(&ModelCandidate, &CandidateBaseRef, Span) -> ResolvedBase,
+) -> ModelGraph {
+    let mut occurrences: BTreeMap<ModelId, Vec<CandidateOccurrence>> = BTreeMap::new();
+    let mut winners = BTreeMap::new();
+
+    // Candidates retain source order within their selected module file. Keep
+    // every occurrence and its proven model evidence before reducing to the
+    // final module binding: a base expression may refer to an earlier class
+    // that a later declaration replaces. Evidence can flow through an earlier
+    // same-module base only after that base occurrence has itself been proven.
+    for candidate in candidates {
+        let id = candidate_id(&candidate);
+        let has_positive_model_evidence =
+            candidate_occurrence_has_positive_model_evidence(&candidate, &occurrences);
+        occurrences
+            .entry(id.clone())
+            .or_default()
+            .push(CandidateOccurrence {
+                span: candidate.model.name.span(),
+                has_positive_model_evidence,
+            });
+        winners.insert(id, candidate);
+    }
+    let selected_spans: BTreeMap<ModelId, Span> = winners
+        .iter()
+        .map(|(id, candidate)| (id.clone(), candidate.model.name.span()))
+        .collect();
+
+    let resolved: BTreeMap<ModelId, ResolvedCandidate> = winners
+        .into_iter()
+        .map(|(id, candidate)| {
+            let bases = candidate
                 .bases
                 .iter()
-                .filter_map(|base| match base {
-                    DeferredBaseRef::Qualified(path) => {
-                        let resolved = prefix_cache
-                            .entry(path.clone())
-                            .or_insert_with(|| resolve_prefix(db, project, path.as_str()));
-                        let module = resolved.module.as_ref()?;
-                        let [name] = resolved.unresolved_tail.as_slice() else {
-                            return None;
-                        };
-
-                        graph.model_id_in_module(module.name(), name)
-                    }
-                    DeferredBaseRef::SameModule(name) => {
-                        graph.model_id_in_module(&deferred.model.module_name, name.as_str())
-                    }
+                .map(|base| {
+                    resolve_candidate_base_rebinding(
+                        &candidate,
+                        base.value(),
+                        base.span(),
+                        &occurrences,
+                        &selected_spans,
+                    )
+                    .unwrap_or_else(|| resolve_base(&candidate, base.value(), base.span()))
                 })
                 .collect();
+            (id, ResolvedCandidate { candidate, bases })
+        })
+        .collect();
+    let admitted = admitted_candidate_ids(&resolved, policy);
 
-            if resolved_bases.is_empty() {
-                unresolved.push(deferred);
-                continue;
-            }
+    let bases_by_class: BTreeMap<ModelId, Vec<BaseOutcome>> = resolved
+        .iter()
+        .map(|(id, candidate)| {
+            let bases = candidate
+                .bases
+                .iter()
+                .cloned()
+                .map(|base| terminal_outcome(base, candidate, &resolved, &admitted, policy))
+                .collect();
+            (id.clone(), bases)
+        })
+        .collect();
 
-            let mut model = deferred.model.clone();
-            let own_relations = std::mem::take(&mut model.relations);
-            for base_id in &resolved_bases {
-                let Some(parent) = graph.get_by_id(base_id) else {
-                    continue;
-                };
-                if parent.kind == ModelKind::Abstract {
-                    model.relations.extend(parent.relations.iter().cloned());
-                }
-            }
-            model.relations.extend(own_relations);
-            graph.add_model(model);
+    let mut ancestry = BTreeMap::new();
+    for id in resolved.keys() {
+        let mut visiting = BTreeSet::new();
+        compute_ancestry(id, &bases_by_class, &mut ancestry, &mut visiting);
+    }
+
+    let mut inheritance_by_model = BTreeMap::new();
+    for id in &admitted {
+        let bases = bases_by_class.get(id).cloned().unwrap_or_default();
+        let ancestry = match ancestry
+            .get(id)
+            .cloned()
+            .unwrap_or(ComputedAncestry::Complete {
+                mro: vec![C3Node::Model(id.clone())],
+            }) {
+            ComputedAncestry::Complete { mro } => AncestryOutcome::Complete {
+                mro: mro
+                    .into_iter()
+                    .filter_map(|node| match node {
+                        C3Node::DjangoModelRoot => None,
+                        C3Node::Model(class) => Some(class),
+                    })
+                    .collect(),
+            },
+            ComputedAncestry::Partial { .. } => AncestryOutcome::Partial,
+            ComputedAncestry::Invalid { error } => AncestryOutcome::Invalid { error },
+        };
+        inheritance_by_model.insert(id.clone(), InheritanceRecord { bases, ancestry });
+    }
+
+    let mut graph = ModelGraph::new();
+    for (id, candidate) in resolved {
+        if let Some(inheritance) = inheritance_by_model.remove(&id) {
+            graph.insert_resolved_model(candidate.candidate.model, inheritance);
+        } else {
+            graph.add_non_model_class(&id, &candidate.candidate.model);
         }
+    }
+    graph.build_effective_relation_bindings();
+    graph
+}
 
-        remaining = unresolved;
-        if remaining.len() == before {
+fn admitted_candidate_ids(
+    candidates: &BTreeMap<ModelId, ResolvedCandidate>,
+    policy: AdmissionPolicy,
+) -> BTreeSet<ModelId> {
+    let mut ids: BTreeSet<ModelId> = candidates
+        .iter()
+        .filter(|(_id, resolved)| match policy {
+            AdmissionPolicy::Production => {
+                has_django_root(resolved)
+                    || has_positive_rebound_local_base(resolved)
+                    || (!has_negative_django_root_evidence(resolved, candidates)
+                        && (resolved.candidate.model.kind != ModelKind::Concrete
+                            || resolved.candidate.model.has_local_relation_binding()))
+            }
+            AdmissionPolicy::Local => {
+                has_django_root(resolved)
+                    || has_positive_rebound_local_base(resolved)
+                    || (!has_negative_django_root_evidence(resolved, candidates)
+                        && resolved.candidate.model.kind != ModelKind::Concrete)
+            }
+        })
+        .map(|(id, _resolved)| id.clone())
+        .collect();
+
+    loop {
+        let descendants: Vec<ModelId> = candidates
+            .iter()
+            .filter(|(id, _candidate)| !ids.contains(*id))
+            .filter(|(_id, candidate)| {
+                candidate.bases.iter().any(|base| {
+                    let ResolvedBase::Model { model, .. } = base else {
+                        return false;
+                    };
+                    ids.contains(model)
+                        && match policy {
+                            AdmissionPolicy::Production => true,
+                            AdmissionPolicy::Local => candidates.get(model).is_some_and(|parent| {
+                                parent.candidate.model.file == candidate.candidate.model.file
+                            }),
+                        }
+                })
+            })
+            .map(|(id, _candidate)| id.clone())
+            .collect();
+        if descendants.is_empty() {
             break;
         }
+        ids.extend(descendants);
+    }
+
+    ids
+}
+
+fn has_django_root(candidate: &ResolvedCandidate) -> bool {
+    candidate
+        .bases
+        .iter()
+        .any(|base| matches!(base, ResolvedBase::DjangoModelRoot { .. }))
+}
+
+fn has_negative_django_root_evidence(
+    candidate: &ResolvedCandidate,
+    candidates: &BTreeMap<ModelId, ResolvedCandidate>,
+) -> bool {
+    candidate.bases.iter().any(|base| match base {
+        ResolvedBase::Model { model, .. } => {
+            model.name() == "Model" && !candidates.contains_key(model)
+        }
+        ResolvedBase::Unresolved { reason, .. } => {
+            let path = match reason {
+                BaseUnresolvedReason::MissingImportBinding { path }
+                | BaseUnresolvedReason::ShadowedImportBinding { path } => path,
+                BaseUnresolvedReason::UnsupportedExpression
+                | BaseUnresolvedReason::InvalidImportedTarget { .. }
+                | BaseUnresolvedReason::ImportNotFound { .. }
+                | BaseUnresolvedReason::ImportedTargetIsModule { .. }
+                | BaseUnresolvedReason::PartialImport { .. }
+                | BaseUnresolvedReason::ModelNotFound { .. }
+                | BaseUnresolvedReason::ReboundLocalBase { .. } => return false,
+            };
+            path.last().is_some_and(|name| name == "Model")
+        }
+        ResolvedBase::DjangoModelRoot { .. } | ResolvedBase::ReboundLocalBase { .. } => false,
+    })
+}
+
+fn has_positive_rebound_local_base(candidate: &ResolvedCandidate) -> bool {
+    candidate.bases.iter().any(|base| {
+        matches!(
+            base,
+            ResolvedBase::ReboundLocalBase {
+                has_positive_model_evidence: true,
+                ..
+            }
+        )
+    })
+}
+
+fn candidate_occurrence_has_positive_model_evidence(
+    candidate: &ModelCandidate,
+    occurrences: &BTreeMap<ModelId, Vec<CandidateOccurrence>>,
+) -> bool {
+    has_direct_model_evidence(candidate)
+        || candidate.bases.iter().any(|base| {
+            let CandidateBaseRef::SameModule(name) = base.value() else {
+                return false;
+            };
+            let model = ModelId::new(candidate.model.module_name.clone(), name.clone());
+            nearest_preceding_occurrence(occurrences, &model, base.span(), None)
+                .is_some_and(|occurrence| occurrence.has_positive_model_evidence)
+        })
+}
+
+fn has_direct_model_evidence(candidate: &ModelCandidate) -> bool {
+    candidate.model.kind != ModelKind::Concrete
+        || candidate
+            .bases
+            .iter()
+            .any(|base| matches!(base.value(), CandidateBaseRef::DjangoModelRoot))
+}
+
+fn candidate_id(candidate: &ModelCandidate) -> ModelId {
+    ModelId::new(
+        candidate.model.module_name.clone(),
+        candidate.model.name.value().clone(),
+    )
+}
+
+fn nearest_preceding_occurrence<'a>(
+    occurrences: &'a BTreeMap<ModelId, Vec<CandidateOccurrence>>,
+    model: &ModelId,
+    before: Span,
+    excluded_span: Option<Span>,
+) -> Option<&'a CandidateOccurrence> {
+    occurrences
+        .get(model)?
+        .iter()
+        .filter(|occurrence| {
+            Some(occurrence.span) != excluded_span && occurrence.span.start() < before.start()
+        })
+        .max_by_key(|occurrence| occurrence.span.start())
+}
+
+fn resolve_candidate_base_rebinding(
+    candidate: &ModelCandidate,
+    base: &CandidateBaseRef,
+    span: Span,
+    occurrences: &BTreeMap<ModelId, Vec<CandidateOccurrence>>,
+    selected_spans: &BTreeMap<ModelId, Span>,
+) -> Option<ResolvedBase> {
+    let CandidateBaseRef::SameModule(name) = base else {
+        return None;
+    };
+    let model = ModelId::new(candidate.model.module_name.clone(), name.clone());
+    let nearest =
+        nearest_preceding_occurrence(occurrences, &model, span, Some(candidate.model.name.span()))?;
+    if selected_spans.get(&model) == Some(&nearest.span) {
+        return None;
+    }
+
+    Some(ResolvedBase::ReboundLocalBase {
+        span,
+        model,
+        has_positive_model_evidence: nearest.has_positive_model_evidence,
+    })
+}
+
+fn resolve_candidate_base(
+    candidate: &ModelCandidate,
+    base: &CandidateBaseRef,
+    span: Span,
+    resolve_qualified: &mut impl FnMut(&PythonModuleName, Span) -> ResolvedBase,
+) -> ResolvedBase {
+    match base {
+        CandidateBaseRef::DjangoModelRoot => ResolvedBase::DjangoModelRoot { span },
+        CandidateBaseRef::SameModule(name) => ResolvedBase::Model {
+            model: ModelId::new(candidate.model.module_name.clone(), name.clone()),
+            span,
+        },
+        CandidateBaseRef::UnsupportedExpression => ResolvedBase::Unresolved {
+            span,
+            reason: BaseUnresolvedReason::UnsupportedExpression,
+        },
+        CandidateBaseRef::Qualified(path) => resolve_qualified(path, span),
+        CandidateBaseRef::Unresolved { path, reason } => ResolvedBase::Unresolved {
+            span,
+            reason: match reason {
+                CandidateBaseReferenceError::MissingBinding => {
+                    BaseUnresolvedReason::MissingImportBinding { path: path.clone() }
+                }
+                CandidateBaseReferenceError::ShadowedBinding => {
+                    BaseUnresolvedReason::ShadowedImportBinding { path: path.clone() }
+                }
+                CandidateBaseReferenceError::InvalidTarget { target } => {
+                    BaseUnresolvedReason::InvalidImportedTarget {
+                        target: target.clone(),
+                    }
+                }
+            },
+        },
+    }
+}
+
+fn resolve_project_qualified_base(
+    db: &dyn Db,
+    project: Project,
+    path: &PythonModuleName,
+    span: Span,
+    prefix_cache: &mut BTreeMap<PythonModuleName, crate::python::ResolvedPrefix>,
+) -> ResolvedBase {
+    let resolved = prefix_cache
+        .entry(path.clone())
+        .or_insert_with(|| resolve_prefix(db, project, path.as_str()));
+    let Some(module) = &resolved.module else {
+        return ResolvedBase::Unresolved {
+            span,
+            reason: BaseUnresolvedReason::ImportNotFound {
+                requested: path.clone(),
+            },
+        };
+    };
+    match resolved.unresolved_tail.as_slice() {
+        [] => ResolvedBase::Unresolved {
+            span,
+            reason: BaseUnresolvedReason::ImportedTargetIsModule {
+                module: module.name().clone(),
+            },
+        },
+        [name] => ResolvedBase::Model {
+            model: ModelId::new(module.name().clone(), name.as_str().into()),
+            span,
+        },
+        unresolved_tail => ResolvedBase::Unresolved {
+            span,
+            reason: BaseUnresolvedReason::PartialImport {
+                resolved_prefix: module.name().clone(),
+                unresolved_tail: unresolved_tail.to_vec(),
+            },
+        },
+    }
+}
+
+fn terminal_outcome(
+    base: ResolvedBase,
+    candidate: &ResolvedCandidate,
+    selected: &BTreeMap<ModelId, ResolvedCandidate>,
+    admitted: &BTreeSet<ModelId>,
+    policy: AdmissionPolicy,
+) -> BaseOutcome {
+    match base {
+        ResolvedBase::DjangoModelRoot { span } => BaseOutcome::DjangoModelRoot { span },
+        ResolvedBase::Model { model, span } => {
+            let known = selected.get(&model).is_some_and(|target| match policy {
+                AdmissionPolicy::Production => true,
+                AdmissionPolicy::Local => {
+                    target.candidate.model.file == candidate.candidate.model.file
+                }
+            });
+            if !known {
+                return BaseOutcome::Unresolved {
+                    span,
+                    reason: BaseUnresolvedReason::ModelNotFound { model },
+                };
+            }
+            if admitted.contains(&model) {
+                BaseOutcome::Model { model, span }
+            } else {
+                BaseOutcome::NonModelClass { class: model, span }
+            }
+        }
+        ResolvedBase::ReboundLocalBase { span, model, .. } => BaseOutcome::Unresolved {
+            span,
+            reason: BaseUnresolvedReason::ReboundLocalBase { model },
+        },
+        ResolvedBase::Unresolved { span, reason } => BaseOutcome::Unresolved { span, reason },
+    }
+}
+
+fn compute_ancestry(
+    id: &ModelId,
+    bases_by_model: &BTreeMap<ModelId, Vec<BaseOutcome>>,
+    memo: &mut BTreeMap<ModelId, ComputedAncestry>,
+    visiting: &mut BTreeSet<ModelId>,
+) -> ComputedAncestry {
+    if let Some(outcome) = memo.get(id) {
+        return outcome.clone();
+    }
+    if !visiting.insert(id.clone()) {
+        return ComputedAncestry::Invalid {
+            error: InheritanceError::Cycle,
+        };
+    }
+
+    let Some(bases) = bases_by_model.get(id) else {
+        let outcome = ComputedAncestry::Complete {
+            mro: vec![C3Node::Model(id.clone())],
+        };
+        visiting.remove(id);
+        memo.insert(id.clone(), outcome.clone());
+        return outcome;
+    };
+
+    let mut direct_parents = Vec::new();
+    let mut has_unresolved = false;
+    let mut seen = BTreeSet::new();
+    let mut duplicate = None;
+    for base in bases {
+        let node = match base {
+            BaseOutcome::DjangoModelRoot { .. } => C3Node::DjangoModelRoot,
+            BaseOutcome::Model { model, .. } => C3Node::Model(model.clone()),
+            BaseOutcome::NonModelClass { class, .. } => C3Node::Model(class.clone()),
+            BaseOutcome::Unresolved { .. } => {
+                has_unresolved = true;
+                continue;
+            }
+        };
+        if !seen.insert(node.clone()) && duplicate.is_none() {
+            duplicate = Some(match &node {
+                C3Node::DjangoModelRoot => InheritanceError::DuplicateDjangoModelRoot,
+                C3Node::Model(model) => InheritanceError::DuplicateModelBase {
+                    model: model.clone(),
+                },
+            });
+        }
+        direct_parents.push(node);
+    }
+
+    let mut parent_mros = Vec::new();
+    let mut parent_is_partial = false;
+    let mut inherited_error = None;
+    for parent in &direct_parents {
+        match parent {
+            C3Node::DjangoModelRoot => {
+                parent_mros.push(vec![C3Node::DjangoModelRoot]);
+            }
+            C3Node::Model(parent) => {
+                match compute_ancestry(parent, bases_by_model, memo, visiting) {
+                    ComputedAncestry::Complete { mro } => parent_mros.push(mro),
+                    ComputedAncestry::Partial { known_mro } => {
+                        parent_mros.push(known_mro);
+                        parent_is_partial = true;
+                    }
+                    ComputedAncestry::Invalid { error } => {
+                        inherited_error.get_or_insert(error);
+                    }
+                }
+            }
+        }
+    }
+
+    let outcome = if let Some(error) = duplicate.or(inherited_error) {
+        ComputedAncestry::Invalid { error }
+    } else {
+        match c3_merge(parent_mros, direct_parents) {
+            None => ComputedAncestry::Invalid {
+                error: InheritanceError::InconsistentC3,
+            },
+            Some(mut tail) => {
+                tail.insert(0, C3Node::Model(id.clone()));
+                if has_unresolved || parent_is_partial {
+                    ComputedAncestry::Partial { known_mro: tail }
+                } else {
+                    ComputedAncestry::Complete { mro: tail }
+                }
+            }
+        }
+    };
+    visiting.remove(id);
+    memo.insert(id.clone(), outcome.clone());
+    outcome
+}
+
+fn c3_merge(mut parent_mros: Vec<Vec<C3Node>>, direct_parents: Vec<C3Node>) -> Option<Vec<C3Node>> {
+    parent_mros.push(direct_parents);
+    let mut result = Vec::new();
+
+    while parent_mros.iter().any(|sequence| !sequence.is_empty()) {
+        let candidate = parent_mros.iter().find_map(|sequence| {
+            let head = sequence.first()?;
+            parent_mros
+                .iter()
+                .all(|other| !other.iter().skip(1).any(|item| item == head))
+                .then(|| head.clone())
+        })?;
+        result.push(candidate.clone());
+        for sequence in &mut parent_mros {
+            if sequence.first() == Some(&candidate) {
+                sequence.remove(0);
+            }
+        }
+    }
+
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use djls_testing::TestDatabase;
+
+    use super::C3Node;
+    use super::c3_merge;
+    use super::resolve_local_model_graph;
+    use crate::models::extract::extract_models_impl;
+    use crate::models::graph::AncestryOutcome;
+    use crate::models::graph::ModelGraph;
+    use crate::models::graph::ModelId;
+    use crate::python::PythonModuleName;
+    use crate::python::import::ModuleKind;
+
+    fn model(value: &str) -> C3Node {
+        C3Node::Model(
+            value
+                .parse::<ModelId>()
+                .expect("test model id should parse"),
+        )
+    }
+
+    fn local_graph(source: &str) -> ModelGraph {
+        let db = TestDatabase::new();
+        db.add_file("/test.py", source)
+            .expect("local model fixture should be added to the test database");
+        let file = db
+            .file(Utf8Path::new("/test.py"))
+            .expect("local model fixture should exist in the test database");
+        let module_name =
+            PythonModuleName::parse("app.models").expect("test module name should be valid");
+        let module = ruff_python_parser::parse_module(source)
+            .expect("local model fixture should parse")
+            .into_syntax();
+        let extraction = extract_models_impl(&module.body, &module_name, file, ModuleKind::Module);
+        resolve_local_model_graph(&extraction)
+    }
+
+    #[test]
+    fn c3_prefers_the_left_parent_at_a_collision() {
+        let left = model("app.models.Left");
+        let right = model("app.models.Right");
+        let root = C3Node::DjangoModelRoot;
+        assert_eq!(
+            c3_merge(
+                vec![
+                    vec![left.clone(), root.clone()],
+                    vec![right.clone(), root.clone()]
+                ],
+                vec![left.clone(), right.clone()],
+            ),
+            Some(vec![left, right, root])
+        );
+    }
+
+    #[test]
+    fn c3_rejects_inconsistent_parent_order() {
+        let x = model("app.models.X");
+        let y = model("app.models.Y");
+        assert_eq!(
+            c3_merge(
+                vec![vec![x.clone(), y.clone()], vec![y.clone(), x.clone()]],
+                vec![x, y],
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn local_resolution_admits_proven_descendants_and_explicit_abstract_models() {
+        let graph = local_graph(
+            r"
+from django.db import models
+from external.models import ImportedBase
+
+class Target(models.Model):
+    pass
+
+class AbstractBase(models.Model):
+    owner = models.ForeignKey(Target)
+
+    class Meta:
+        abstract = True
+
+class Child(AbstractBase):
+    pass
+
+class Qualified(ImportedBase):
+    pass
+
+class RelationOnly(ImportedBase):
+    direct = models.ForeignKey(Target)
+
+class AbstractQualified(ImportedBase):
+    class Meta:
+        abstract = True
+
+class Unresolved(missing.Base):
+    pass
+
+class Unsupported(make_base()):
+    pass
+",
+        );
+
+        let child: ModelId = "app.models.Child"
+            .parse()
+            .expect("child model id should parse");
+        let abstract_base: ModelId = "app.models.AbstractBase"
+            .parse()
+            .expect("abstract base model id should parse");
+        assert_eq!(
+            graph
+                .owned_relation_entries(&child)
+                .map(|(relation, _resolution)| relation.field_name.value().as_str())
+                .collect::<Vec<_>>(),
+            ["owner"]
+        );
+        assert!(matches!(
+            &graph
+                .inheritance(&child)
+                .expect("Child should retain inheritance")
+                .ancestry,
+            AncestryOutcome::Complete { mro }
+                if mro == &[child.clone(), abstract_base]
+        ));
+
+        let abstract_qualified: ModelId = "app.models.AbstractQualified"
+            .parse()
+            .expect("abstract model id should parse");
+        assert!(graph.contains_model(&abstract_qualified));
+        assert!(matches!(
+            &graph
+                .inheritance(&abstract_qualified)
+                .expect("abstract model should retain inheritance")
+                .ancestry,
+            AncestryOutcome::Partial
+        ));
+
+        for absent in ["Qualified", "RelationOnly", "Unresolved", "Unsupported"] {
+            let id = ModelId::new(
+                PythonModuleName::parse("app.models").expect("test module name should be valid"),
+                absent.into(),
+            );
+            assert!(
+                !graph.contains_model(&id),
+                "{absent} should not be admitted"
+            );
+        }
+    }
+
+    #[test]
+    fn unresolved_local_base_makes_proven_ancestry_partial() {
+        let graph = local_graph(
+            r"
+from django.db import models
+
+class Target(models.Model):
+    pass
+
+class AbstractBase(models.Model):
+    owner = models.ForeignKey(Target)
+
+    class Meta:
+        abstract = True
+
+class Child(AbstractBase, missing.Base):
+    pass
+",
+        );
+        let child: ModelId = "app.models.Child"
+            .parse()
+            .expect("child model id should parse");
+
+        assert_eq!(
+            graph
+                .inheritance(&child)
+                .expect("Child should retain inheritance")
+                .ancestry,
+            AncestryOutcome::Partial,
+        );
+        assert!(graph.owned_relation_entries(&child).next().is_none());
     }
 }

--- a/crates/djls-project/src/testing.rs
+++ b/crates/djls-project/src/testing.rs
@@ -30,9 +30,15 @@ use serde::Serialize;
 use crate::db::Db;
 pub use crate::discovery::compute_django_environment;
 pub use crate::discovery::compute_project_facts;
+use crate::models::AncestryOutcome;
+use crate::models::BaseOutcome;
+use crate::models::BaseUnresolvedReason;
+use crate::models::InheritanceError;
 use crate::models::ModelGraph;
+use crate::models::ModelId;
 use crate::models::extract_models;
 pub use crate::models::model_modules;
+use crate::models::resolve_local_model_graph;
 pub use crate::models::resolve_model_graph_from_modules;
 use crate::project::Project;
 use crate::python::PythonModuleName;
@@ -56,8 +62,8 @@ pub fn extract_model_graph(
     db: &dyn SourceDb,
     file: File,
     module_name: PythonModuleName,
-) -> &ModelGraph {
-    extract_models(db, file, module_name).graph()
+) -> ModelGraph {
+    resolve_local_model_graph(extract_models(db, file, module_name))
 }
 
 #[must_use]
@@ -73,6 +79,167 @@ pub fn model_location(
 }
 
 #[must_use]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelBaseOutcomeView {
+    DjangoModelRoot {
+        span: Span,
+    },
+    Model {
+        model: ModelId,
+        span: Span,
+    },
+    NonModelClass {
+        class: ModelId,
+        span: Span,
+    },
+    Unresolved {
+        span: Span,
+        reason: ModelBaseUnresolvedReasonView,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelBaseUnresolvedReasonView {
+    UnsupportedExpression,
+    MissingImportBinding {
+        path: Vec<String>,
+    },
+    ShadowedImportBinding {
+        path: Vec<String>,
+    },
+    InvalidImportedTarget {
+        target: String,
+    },
+    ImportNotFound {
+        requested: PythonModuleName,
+    },
+    ImportedTargetIsModule {
+        module: PythonModuleName,
+    },
+    PartialImport {
+        resolved_prefix: PythonModuleName,
+        unresolved_tail: Vec<String>,
+    },
+    ModelNotFound {
+        model: ModelId,
+    },
+    ReboundLocalBase {
+        model: ModelId,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelAncestryOutcomeView {
+    Complete { mro: Vec<ModelId> },
+    Partial,
+    Invalid { error: ModelInheritanceErrorView },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelInheritanceErrorView {
+    Cycle,
+    DuplicateDjangoModelRoot,
+    DuplicateModelBase { model: ModelId },
+    InconsistentC3,
+}
+
+#[must_use]
+pub fn model_inheritance_outcomes(
+    graph: &ModelGraph,
+    module_name: &str,
+    model_name: &str,
+) -> Option<(Vec<ModelBaseOutcomeView>, ModelAncestryOutcomeView)> {
+    let (id, _model) = graph
+        .models_named(model_name)
+        .find(|(id, _model)| id.module_name().as_str() == module_name)?;
+    let record = graph.inheritance(id)?;
+    let bases = record
+        .bases
+        .iter()
+        .map(|base| match base {
+            BaseOutcome::DjangoModelRoot { .. } => {
+                ModelBaseOutcomeView::DjangoModelRoot { span: base.span() }
+            }
+            BaseOutcome::Model { model, .. } => ModelBaseOutcomeView::Model {
+                model: model.clone(),
+                span: base.span(),
+            },
+            BaseOutcome::NonModelClass { class, .. } => ModelBaseOutcomeView::NonModelClass {
+                class: class.clone(),
+                span: base.span(),
+            },
+            BaseOutcome::Unresolved { reason, .. } => ModelBaseOutcomeView::Unresolved {
+                span: base.span(),
+                reason: match reason {
+                    BaseUnresolvedReason::UnsupportedExpression => {
+                        ModelBaseUnresolvedReasonView::UnsupportedExpression
+                    }
+                    BaseUnresolvedReason::MissingImportBinding { path } => {
+                        ModelBaseUnresolvedReasonView::MissingImportBinding { path: path.clone() }
+                    }
+                    BaseUnresolvedReason::ShadowedImportBinding { path } => {
+                        ModelBaseUnresolvedReasonView::ShadowedImportBinding { path: path.clone() }
+                    }
+                    BaseUnresolvedReason::InvalidImportedTarget { target } => {
+                        ModelBaseUnresolvedReasonView::InvalidImportedTarget {
+                            target: target.clone(),
+                        }
+                    }
+                    BaseUnresolvedReason::ImportNotFound { requested } => {
+                        ModelBaseUnresolvedReasonView::ImportNotFound {
+                            requested: requested.clone(),
+                        }
+                    }
+                    BaseUnresolvedReason::ImportedTargetIsModule { module } => {
+                        ModelBaseUnresolvedReasonView::ImportedTargetIsModule {
+                            module: module.clone(),
+                        }
+                    }
+                    BaseUnresolvedReason::PartialImport {
+                        resolved_prefix,
+                        unresolved_tail,
+                    } => ModelBaseUnresolvedReasonView::PartialImport {
+                        resolved_prefix: resolved_prefix.clone(),
+                        unresolved_tail: unresolved_tail.clone(),
+                    },
+                    BaseUnresolvedReason::ModelNotFound { model } => {
+                        ModelBaseUnresolvedReasonView::ModelNotFound {
+                            model: model.clone(),
+                        }
+                    }
+                    BaseUnresolvedReason::ReboundLocalBase { model } => {
+                        ModelBaseUnresolvedReasonView::ReboundLocalBase {
+                            model: model.clone(),
+                        }
+                    }
+                },
+            },
+        })
+        .collect();
+    let ancestry = match &record.ancestry {
+        AncestryOutcome::Complete { mro } => {
+            ModelAncestryOutcomeView::Complete { mro: mro.clone() }
+        }
+        AncestryOutcome::Partial => ModelAncestryOutcomeView::Partial,
+        AncestryOutcome::Invalid { error } => ModelAncestryOutcomeView::Invalid {
+            error: match error {
+                InheritanceError::Cycle => ModelInheritanceErrorView::Cycle,
+                InheritanceError::DuplicateDjangoModelRoot => {
+                    ModelInheritanceErrorView::DuplicateDjangoModelRoot
+                }
+                InheritanceError::DuplicateModelBase { model } => {
+                    ModelInheritanceErrorView::DuplicateModelBase {
+                        model: model.clone(),
+                    }
+                }
+                InheritanceError::InconsistentC3 => ModelInheritanceErrorView::InconsistentC3,
+            },
+        },
+    };
+    Some((bases, ancestry))
+}
+
+#[must_use]
 pub fn model_relation_locations(
     graph: &ModelGraph,
     module_name: &str,
@@ -81,11 +248,10 @@ pub fn model_relation_locations(
     graph
         .models_named(model_name)
         .find(|(id, _model)| id.module_name().as_str() == module_name)
-        .map(|(_id, model)| {
-            model
-                .relations
-                .iter()
-                .map(|relation| {
+        .map(|(id, _model)| {
+            graph
+                .owned_relation_entries(id)
+                .map(|(relation, _resolution)| {
                     (
                         relation.field_name.value().as_str().to_string(),
                         relation.file,

--- a/crates/djls-project/src/testing.rs
+++ b/crates/djls-project/src/testing.rs
@@ -33,7 +33,8 @@ pub use crate::discovery::compute_project_facts;
 use crate::models::AncestryOutcome;
 use crate::models::BaseOutcome;
 use crate::models::BaseUnresolvedReason;
-use crate::models::InheritanceError;
+use crate::models::ClassId;
+use crate::models::InvalidAncestryReason;
 use crate::models::ModelGraph;
 use crate::models::ModelId;
 use crate::models::extract_models;
@@ -78,6 +79,35 @@ pub fn model_location(
         .map(|(_id, model)| (model.file, model.name.span()))
 }
 
+/// The import identity of an extracted Python class without claiming that the
+/// resolver admitted it as a Django model.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelClassIdentityView {
+    module_name: PythonModuleName,
+    name: String,
+}
+
+impl ModelClassIdentityView {
+    #[must_use]
+    pub fn module_name(&self) -> &PythonModuleName {
+        &self.module_name
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl From<&ClassId> for ModelClassIdentityView {
+    fn from(class: &ClassId) -> Self {
+        Self {
+            module_name: class.module_name().clone(),
+            name: class.name().to_string(),
+        }
+    }
+}
+
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ModelBaseOutcomeView {
@@ -89,7 +119,7 @@ pub enum ModelBaseOutcomeView {
         span: Span,
     },
     NonModelClass {
-        class: ModelId,
+        class: ModelClassIdentityView,
         span: Span,
     },
     Unresolved {
@@ -120,27 +150,146 @@ pub enum ModelBaseUnresolvedReasonView {
         resolved_prefix: PythonModuleName,
         unresolved_tail: Vec<String>,
     },
-    ModelNotFound {
-        model: ModelId,
+    ClassNotFound {
+        class: ModelClassIdentityView,
     },
     ReboundLocalBase {
-        model: ModelId,
+        class: ModelClassIdentityView,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelMroEntryView {
+    Model(ModelId),
+    NonModelClass(ModelClassIdentityView),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ModelAncestryOutcomeView {
-    Complete { mro: Vec<ModelId> },
+    Complete {
+        mro: Vec<ModelMroEntryView>,
+    },
     Partial,
-    Invalid { error: ModelInheritanceErrorView },
+    Invalid {
+        reason: ModelInvalidAncestryReasonView,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ModelInheritanceErrorView {
+pub enum ModelInvalidAncestryReasonView {
     Cycle,
     DuplicateDjangoModelRoot,
-    DuplicateModelBase { model: ModelId },
-    InconsistentC3,
+    DuplicateClassBase { class: ModelClassIdentityView },
+    InconsistentMethodResolutionOrder,
+}
+
+fn model_base_unresolved_reason_view(
+    reason: &BaseUnresolvedReason,
+) -> ModelBaseUnresolvedReasonView {
+    match reason {
+        BaseUnresolvedReason::UnsupportedExpression => {
+            ModelBaseUnresolvedReasonView::UnsupportedExpression
+        }
+        BaseUnresolvedReason::MissingImportBinding { path } => {
+            ModelBaseUnresolvedReasonView::MissingImportBinding { path: path.clone() }
+        }
+        BaseUnresolvedReason::ShadowedImportBinding { path } => {
+            ModelBaseUnresolvedReasonView::ShadowedImportBinding { path: path.clone() }
+        }
+        BaseUnresolvedReason::InvalidImportedTarget { target } => {
+            ModelBaseUnresolvedReasonView::InvalidImportedTarget {
+                target: target.clone(),
+            }
+        }
+        BaseUnresolvedReason::ImportNotFound { requested } => {
+            ModelBaseUnresolvedReasonView::ImportNotFound {
+                requested: requested.clone(),
+            }
+        }
+        BaseUnresolvedReason::ImportedTargetIsModule { module } => {
+            ModelBaseUnresolvedReasonView::ImportedTargetIsModule {
+                module: module.clone(),
+            }
+        }
+        BaseUnresolvedReason::PartialImport {
+            resolved_prefix,
+            unresolved_tail,
+        } => ModelBaseUnresolvedReasonView::PartialImport {
+            resolved_prefix: resolved_prefix.clone(),
+            unresolved_tail: unresolved_tail.clone(),
+        },
+        BaseUnresolvedReason::ClassNotFound { class } => {
+            ModelBaseUnresolvedReasonView::ClassNotFound {
+                class: class.into(),
+            }
+        }
+        BaseUnresolvedReason::ReboundLocalBase { class } => {
+            ModelBaseUnresolvedReasonView::ReboundLocalBase {
+                class: class.into(),
+            }
+        }
+    }
+}
+
+fn model_base_outcome_view(base: &BaseOutcome) -> ModelBaseOutcomeView {
+    match base {
+        BaseOutcome::DjangoModelRoot { .. } => {
+            ModelBaseOutcomeView::DjangoModelRoot { span: base.span() }
+        }
+        BaseOutcome::Model { model, .. } => ModelBaseOutcomeView::Model {
+            model: model.clone(),
+            span: base.span(),
+        },
+        BaseOutcome::NonModelClass { class, .. } => ModelBaseOutcomeView::NonModelClass {
+            class: class.into(),
+            span: base.span(),
+        },
+        BaseOutcome::Unresolved { reason, .. } => ModelBaseOutcomeView::Unresolved {
+            span: base.span(),
+            reason: model_base_unresolved_reason_view(reason),
+        },
+    }
+}
+
+fn model_mro_entry_view(graph: &ModelGraph, class: &ClassId) -> ModelMroEntryView {
+    graph
+        .models_named(class.name())
+        .find(|(model, _definition)| ClassId::from_model_id(model) == *class)
+        .map_or_else(
+            || ModelMroEntryView::NonModelClass(class.into()),
+            |(model, _definition)| ModelMroEntryView::Model(model.clone()),
+        )
+}
+
+fn model_ancestry_outcome_view(
+    graph: &ModelGraph,
+    ancestry: &AncestryOutcome,
+) -> ModelAncestryOutcomeView {
+    match ancestry {
+        AncestryOutcome::Complete { mro } => ModelAncestryOutcomeView::Complete {
+            mro: mro
+                .iter()
+                .map(|class| model_mro_entry_view(graph, class))
+                .collect(),
+        },
+        AncestryOutcome::Partial => ModelAncestryOutcomeView::Partial,
+        AncestryOutcome::Invalid { reason } => ModelAncestryOutcomeView::Invalid {
+            reason: match reason {
+                InvalidAncestryReason::Cycle => ModelInvalidAncestryReasonView::Cycle,
+                InvalidAncestryReason::DuplicateDjangoModelRoot => {
+                    ModelInvalidAncestryReasonView::DuplicateDjangoModelRoot
+                }
+                InvalidAncestryReason::DuplicateClassBase { class } => {
+                    ModelInvalidAncestryReasonView::DuplicateClassBase {
+                        class: class.into(),
+                    }
+                }
+                InvalidAncestryReason::InconsistentMethodResolutionOrder => {
+                    ModelInvalidAncestryReasonView::InconsistentMethodResolutionOrder
+                }
+            },
+        },
+    }
 }
 
 #[must_use]
@@ -153,90 +302,10 @@ pub fn model_inheritance_outcomes(
         .models_named(model_name)
         .find(|(id, _model)| id.module_name().as_str() == module_name)?;
     let record = graph.inheritance(id)?;
-    let bases = record
-        .bases
-        .iter()
-        .map(|base| match base {
-            BaseOutcome::DjangoModelRoot { .. } => {
-                ModelBaseOutcomeView::DjangoModelRoot { span: base.span() }
-            }
-            BaseOutcome::Model { model, .. } => ModelBaseOutcomeView::Model {
-                model: model.clone(),
-                span: base.span(),
-            },
-            BaseOutcome::NonModelClass { class, .. } => ModelBaseOutcomeView::NonModelClass {
-                class: class.clone(),
-                span: base.span(),
-            },
-            BaseOutcome::Unresolved { reason, .. } => ModelBaseOutcomeView::Unresolved {
-                span: base.span(),
-                reason: match reason {
-                    BaseUnresolvedReason::UnsupportedExpression => {
-                        ModelBaseUnresolvedReasonView::UnsupportedExpression
-                    }
-                    BaseUnresolvedReason::MissingImportBinding { path } => {
-                        ModelBaseUnresolvedReasonView::MissingImportBinding { path: path.clone() }
-                    }
-                    BaseUnresolvedReason::ShadowedImportBinding { path } => {
-                        ModelBaseUnresolvedReasonView::ShadowedImportBinding { path: path.clone() }
-                    }
-                    BaseUnresolvedReason::InvalidImportedTarget { target } => {
-                        ModelBaseUnresolvedReasonView::InvalidImportedTarget {
-                            target: target.clone(),
-                        }
-                    }
-                    BaseUnresolvedReason::ImportNotFound { requested } => {
-                        ModelBaseUnresolvedReasonView::ImportNotFound {
-                            requested: requested.clone(),
-                        }
-                    }
-                    BaseUnresolvedReason::ImportedTargetIsModule { module } => {
-                        ModelBaseUnresolvedReasonView::ImportedTargetIsModule {
-                            module: module.clone(),
-                        }
-                    }
-                    BaseUnresolvedReason::PartialImport {
-                        resolved_prefix,
-                        unresolved_tail,
-                    } => ModelBaseUnresolvedReasonView::PartialImport {
-                        resolved_prefix: resolved_prefix.clone(),
-                        unresolved_tail: unresolved_tail.clone(),
-                    },
-                    BaseUnresolvedReason::ModelNotFound { model } => {
-                        ModelBaseUnresolvedReasonView::ModelNotFound {
-                            model: model.clone(),
-                        }
-                    }
-                    BaseUnresolvedReason::ReboundLocalBase { model } => {
-                        ModelBaseUnresolvedReasonView::ReboundLocalBase {
-                            model: model.clone(),
-                        }
-                    }
-                },
-            },
-        })
-        .collect();
-    let ancestry = match &record.ancestry {
-        AncestryOutcome::Complete { mro } => {
-            ModelAncestryOutcomeView::Complete { mro: mro.clone() }
-        }
-        AncestryOutcome::Partial => ModelAncestryOutcomeView::Partial,
-        AncestryOutcome::Invalid { error } => ModelAncestryOutcomeView::Invalid {
-            error: match error {
-                InheritanceError::Cycle => ModelInheritanceErrorView::Cycle,
-                InheritanceError::DuplicateDjangoModelRoot => {
-                    ModelInheritanceErrorView::DuplicateDjangoModelRoot
-                }
-                InheritanceError::DuplicateModelBase { model } => {
-                    ModelInheritanceErrorView::DuplicateModelBase {
-                        model: model.clone(),
-                    }
-                }
-                InheritanceError::InconsistentC3 => ModelInheritanceErrorView::InconsistentC3,
-            },
-        },
-    };
-    Some((bases, ancestry))
+    Some((
+        record.bases.iter().map(model_base_outcome_view).collect(),
+        model_ancestry_outcome_view(graph, &record.ancestry),
+    ))
 }
 
 #[must_use]

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -10,11 +10,17 @@ use djls_project::Project;
 use djls_project::PythonModuleName;
 use djls_project::SearchPaths;
 use djls_project::compute_model_graph;
+use djls_project::testing::ModelAncestryOutcomeView;
+use djls_project::testing::ModelBaseOutcomeView;
+use djls_project::testing::ModelBaseUnresolvedReasonView;
+use djls_project::testing::ModelInheritanceErrorView;
 use djls_project::testing::PythonSyntaxErrorClass;
 use djls_project::testing::extract_model_graph;
+use djls_project::testing::model_inheritance_outcomes;
 use djls_project::testing::model_location;
 use djls_project::testing::model_relation_locations;
 use djls_project::testing::python_syntax_errors;
+use djls_project::testing::resolve_model_graph_from_modules;
 use djls_source::ChangeEvent;
 use djls_source::Db as _;
 use djls_source::SourceChanges;
@@ -289,6 +295,41 @@ fn model_graph_span_probe_reexecutes_when_relation_is_added() {
         .expect("Salsa event log should be readable after the relation edit");
 
     assert_ne!(after, before);
+    assert!(execution_count(&db, &events, "model_graph_span_probe") > 0);
+}
+
+#[test]
+fn model_graph_span_probe_reexecutes_for_base_only_edit() {
+    let initial = concat!(
+        "from django.db import models\n",
+        "class A(models.Model):\n    pass\n",
+        "class B(models.Model):\n    pass\n",
+        "class Child(A):\n    pass\n",
+    );
+    let updated = initial.replace("class Child(A)", "class Child(B)");
+    let event_log = SalsaEventLog::default();
+    let mut db = TestDatabase::with_event_log(event_log.clone());
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", initial)
+        .build(&db)
+        .expect("base-only fixture should build");
+
+    let before = probe_model(&db, project, "app.models", "Child")
+        .expect("test model graph should fit in u32");
+    drop(
+        event_log
+            .take()
+            .expect("Salsa event log should be readable before the base edit"),
+    );
+    update_file(&mut db, "/project/app/models.py", &updated)
+        .expect("updated base fixture should be written");
+    let after = probe_model(&db, project, "app.models", "Child")
+        .expect("test model graph should fit in u32");
+    let events = event_log
+        .take()
+        .expect("Salsa event log should be readable after the base edit");
+
+    assert_eq!(after, before);
     assert!(execution_count(&db, &events, "model_graph_span_probe") > 0);
 }
 
@@ -1560,7 +1601,7 @@ fn class_body_relations_capture_alias_state_at_each_occurrence() {
 }
 
 #[test]
-fn class_body_compound_aliases_apply_only_to_contained_relations() {
+fn class_body_conditional_relation_remains_a_possible_field() {
     let source = concat!(
         "from django.db import models\n",
         "class Post(models.Model):\n",
@@ -1582,7 +1623,16 @@ fn class_body_compound_aliases_apply_only_to_contained_relations() {
     let graph = compute_model_graph(&db, project);
     let post = model_id(graph, "Post", "blog.models")
         .expect("model fixture should contain the requested model");
-    assert!(graph.resolve_relation(post, "conditional").is_some());
+    let user = model_id(graph, "User", "accounts.models")
+        .expect("model fixture should contain the conditional relation target");
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(post, "conditional")
+            .expect("conditional relation should remain a possible field"),
+        graph
+            .get_by_id(user)
+            .expect("conditional relation target should resolve"),
+    ));
     assert_eq!(graph.resolve_relation(post, "outside"), None);
 }
 
@@ -1749,15 +1799,530 @@ fn explicitly_shadowed_relation_does_not_fall_back_to_same_app_model() {
 }
 
 #[test]
-fn unresolved_qualified_base_does_not_collapse_to_local_class_name() {
+fn unresolved_only_model_is_retained_with_ordered_typed_base_outcomes() {
     let source = concat!(
         "from django.db import models\n",
-        "class AbstractBase(models.Model):\n",
-        "    class Meta:\n        abstract = True\n",
-        "class Child(missing.AbstractBase):\n",
-        "    pass\n",
+        "class Target(models.Model):\n    pass\n",
+        "class Child(missing.AbstractBase, make_base()):\n",
+        "    direct = models.ForeignKey(Target, on_delete=models.CASCADE)\n",
     );
-    assert!(!detects_model!(source, "Child"));
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("unresolved-only inheritance fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models")
+        .expect("an unresolved-only candidate should remain in the graph");
+    assert!(graph.resolve_relation(child, "direct").is_some());
+
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain inheritance outcomes");
+    assert_eq!(bases.len(), 2);
+    assert!(matches!(
+        &bases[0],
+        ModelBaseOutcomeView::Unresolved {
+            span,
+            reason: ModelBaseUnresolvedReasonView::MissingImportBinding { path },
+        } if *span == expected_span(source, "missing.AbstractBase").expect("base should occur")
+            && path == &["missing".to_string(), "AbstractBase".to_string()]
+    ));
+    assert!(matches!(
+        &bases[1],
+        ModelBaseOutcomeView::Unresolved {
+            span,
+            reason: ModelBaseUnresolvedReasonView::UnsupportedExpression,
+        } if *span == expected_span(source, "make_base()").expect("unsupported base should occur")
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn relation_evidence_retains_partial_model_without_promoting_arbitrary_subclass() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class BaseFormatter:\n    pass\n",
+        "class Formatter(BaseFormatter):\n    pass\n",
+        "class WebhookBase:\n    pass\n",
+        "class Webhook(WebhookBase):\n",
+        "    target = models.ForeignKey(Target, on_delete=models.CASCADE)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("candidate-admission fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    assert!(model_id(graph, "Formatter", "app.models").is_err());
+    let webhook =
+        model_id(graph, "Webhook", "app.models").expect("relation evidence should retain Webhook");
+    assert!(graph.resolve_relation(webhook, "target").is_some());
+
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Webhook")
+        .expect("Webhook should retain its plain-class base outcome");
+    assert!(matches!(
+        bases.as_slice(),
+        [ModelBaseOutcomeView::NonModelClass { class, .. }]
+            if class.name() == "WebhookBase"
+    ));
+    assert!(matches!(
+        ancestry,
+        ModelAncestryOutcomeView::Complete { ref mro }
+            if mro.iter().map(ModelId::name).collect::<Vec<_>>() == ["Webhook", "WebhookBase"]
+    ));
+}
+
+#[test]
+fn plain_same_file_mixin_keeps_local_ancestry_complete() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class PlainMixin:\n    pass\n",
+        "class Child(PlainMixin, models.Model):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/project/app/models.py");
+    db.add_file(path.as_str(), source)
+        .expect("plain-mixin fixture should be added to the test database");
+    let file = db
+        .file(path)
+        .expect("plain-mixin fixture should exist in the test database");
+    let module_name =
+        PythonModuleName::parse("app.models").expect("test module name should be valid");
+
+    let graph = extract_model_graph(&db, file, module_name);
+    assert!(model_id(&graph, "PlainMixin", "app.models").is_err());
+    let (bases, ancestry) = model_inheritance_outcomes(&graph, "app.models", "Child")
+        .expect("Child should retain its plain-class base outcome");
+    assert!(matches!(
+        &bases[0],
+        ModelBaseOutcomeView::NonModelClass { class, .. } if class.name() == "PlainMixin"
+    ));
+    assert!(matches!(
+        ancestry,
+        ModelAncestryOutcomeView::Complete { ref mro }
+            if mro.iter().map(ModelId::name).collect::<Vec<_>>() == ["Child", "PlainMixin"]
+    ));
+}
+
+#[test]
+fn plain_mixin_local_name_blocks_an_older_abstract_relation() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class AbstractBase(models.Model):\n",
+        "    owner = models.ForeignKey(Target)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class PlainMixin:\n    owner = None\n",
+        "class Child(PlainMixin, AbstractBase):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("plain-mixin shadow fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models").expect("Child should exist");
+    assert_eq!(graph.resolve_relation(child, "owner"), None);
+    let (_bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain complete ancestry");
+    assert!(matches!(
+        ancestry,
+        ModelAncestryOutcomeView::Complete { .. }
+    ));
+}
+
+#[test]
+fn unresolved_plain_mixin_ancestry_propagates_partial() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class BrokenMixin(missing.Base):\n    pass\n",
+        "class Child(BrokenMixin, models.Model):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("unresolved plain-mixin fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain its plain-class base outcome");
+    assert!(matches!(
+        &bases[0],
+        ModelBaseOutcomeView::NonModelClass { class, .. } if class.name() == "BrokenMixin"
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn same_file_abstract_order_resolves_through_plain_mixins() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class StatusMixin:\n    pass\n",
+        "class TransitionMixin:\n    pass\n",
+        "class Order(StatusMixin, TransitionMixin, models.Model):\n",
+        "    class Meta:\n        abstract = True\n",
+        "class PurchaseOrder(Order):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/project/order/models.py");
+    db.add_file(path.as_str(), source)
+        .expect("abstract-order fixture should be added to the test database");
+    let file = db
+        .file(path)
+        .expect("abstract-order fixture should exist in the test database");
+    let module_name =
+        PythonModuleName::parse("order.models").expect("test module name should be valid");
+
+    let graph = extract_model_graph(&db, file, module_name);
+    for model_name in ["Order", "PurchaseOrder"] {
+        let (_bases, ancestry) = model_inheritance_outcomes(&graph, "order.models", model_name)
+            .expect("same-file model should retain inheritance outcomes");
+        assert!(
+            matches!(ancestry, ModelAncestryOutcomeView::Complete { .. }),
+            "{model_name} ancestry should be complete"
+        );
+    }
+}
+
+#[test]
+fn mixed_resolved_and_unresolved_bases_keep_only_direct_fields() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class AbstractBase(models.Model):\n",
+        "    inherited = models.ForeignKey(Target, on_delete=models.CASCADE)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Child(AbstractBase, missing.OtherBase):\n",
+        "    direct = models.ForeignKey(Target, on_delete=models.CASCADE)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("mixed inheritance fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models").expect("Child should remain present");
+    assert!(graph.resolve_relation(child, "direct").is_some());
+    assert_eq!(graph.resolve_relation(child, "inherited"), None);
+
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain inheritance outcomes");
+    assert!(
+        matches!(&bases[0], ModelBaseOutcomeView::Model { model, .. } if model.name() == "AbstractBase")
+    );
+    assert!(matches!(
+        &bases[1],
+        ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::MissingImportBinding { .. },
+            ..
+        }
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn partial_qualified_base_target_is_retained() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/base/models.py",
+            "from django.db import models\nclass Root(models.Model):\n    pass\n",
+        )
+        .file(
+            "/project/app/models.py",
+            concat!(
+                "import base.models as base_models\n",
+                "class Child(base_models.nested.AbstractBase):\n",
+                "    class Meta:\n",
+                "        abstract = True\n",
+            ),
+        )
+        .build(&db)
+        .expect("partial qualified base fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    model_id(graph, "Child", "app.models").expect("partial candidate should remain present");
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain inheritance outcomes");
+    assert!(matches!(
+        bases.as_slice(),
+        [ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::PartialImport {
+                resolved_prefix,
+                unresolved_tail,
+            },
+            ..
+        }] if resolved_prefix.as_str() == "base.models"
+            && unresolved_tail == &["nested".to_string(), "AbstractBase".to_string()]
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn resolved_empty_mixin_does_not_hide_an_unresolved_field_base() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class EmptyMixin(models.Model):\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Child(EmptyMixin, missing.FieldBase):\n",
+        "    direct = models.ForeignKey(Target, on_delete=models.CASCADE)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("empty-mixin inheritance fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models").expect("Child should remain present");
+    assert!(graph.resolve_relation(child, "direct").is_some());
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain both base outcomes");
+    assert_eq!(bases.len(), 2);
+    assert!(
+        matches!(&bases[0], ModelBaseOutcomeView::Model { model, .. } if model.name() == "EmptyMixin")
+    );
+    assert!(matches!(&bases[1], ModelBaseOutcomeView::Unresolved { .. }));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn c3_left_base_wins_a_forward_field_collision() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class LeftTarget(models.Model):\n    pass\n",
+        "class RightTarget(models.Model):\n    pass\n",
+        "class Left(models.Model):\n",
+        "    owner = models.ForeignKey(LeftTarget, on_delete=models.CASCADE)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Right(models.Model):\n",
+        "    owner = models.ForeignKey(RightTarget, on_delete=models.CASCADE)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Child(Left, Right):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("C3 collision fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models").expect("Child should exist");
+    let left_target = model_id(graph, "LeftTarget", "app.models").expect("LeftTarget should exist");
+    let resolved = graph
+        .resolve_relation(child, "owner")
+        .expect("the left C3 field should resolve");
+    assert!(ptr::eq(
+        resolved,
+        graph
+            .get_by_id(left_target)
+            .expect("LeftTarget should resolve")
+    ));
+}
+
+#[test]
+fn known_c3_conflict_propagates_through_partial_ancestry() {
+    let source = concat!(
+        "class X:\n    pass\n",
+        "class Y:\n    pass\n",
+        "class A(X, Y, missing.Base):\n",
+        "    class Meta:\n        abstract = True\n",
+        "class B(Y, X):\n",
+        "    class Meta:\n        abstract = True\n",
+        "class C(A, B):\n",
+        "    class Meta:\n        abstract = True\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("partial-parent C3 fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    let (a_bases, a_ancestry) = model_inheritance_outcomes(graph, "app.models", "A")
+        .expect("A should remain admitted with partial ancestry");
+    assert!(matches!(
+        &a_bases[2],
+        ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::MissingImportBinding { .. },
+            ..
+        }
+    ));
+    assert_eq!(a_ancestry, ModelAncestryOutcomeView::Partial);
+
+    let (_c_bases, c_ancestry) = model_inheritance_outcomes(graph, "app.models", "C")
+        .expect("C should remain admitted with invalid ancestry");
+    assert_eq!(
+        c_ancestry,
+        ModelAncestryOutcomeView::Invalid {
+            error: ModelInheritanceErrorView::InconsistentC3,
+        }
+    );
+}
+
+#[test]
+fn inherited_concrete_field_target_uses_the_declaring_models_scope() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/base/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Target(models.Model):\n    pass\n",
+                "class Parent(models.Model):\n",
+                "    target = models.ForeignKey(\"Target\", on_delete=models.CASCADE)\n",
+            ),
+        )
+        .file(
+            "/project/child/models.py",
+            concat!(
+                "from django.db import models\n",
+                "from base.models import Parent\n",
+                "class Target(models.Model):\n    pass\n",
+                "class Child(Parent):\n    pass\n",
+            ),
+        )
+        .build(&db)
+        .expect("owner-scope inheritance fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "child.models").expect("Child should exist");
+    let base_target = model_id(graph, "Target", "base.models").expect("base Target should exist");
+    let child_target =
+        model_id(graph, "Target", "child.models").expect("child Target should exist");
+    let resolved = graph
+        .resolve_relation(child, "target")
+        .expect("inherited concrete field should resolve");
+    assert!(ptr::eq(
+        resolved,
+        graph
+            .get_by_id(base_target)
+            .expect("base Target should resolve")
+    ));
+    assert!(!ptr::eq(
+        resolved,
+        graph
+            .get_by_id(child_target)
+            .expect("child Target should resolve")
+    ));
+    assert!(model_relation_locations(graph, "child.models", "Child").is_empty());
+}
+
+#[test]
+fn a_base_declared_later_still_produces_complete_ancestry() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class Child(LateBase):\n    pass\n",
+        "class LateBase(models.Model):\n",
+        "    target = models.ForeignKey(Target, on_delete=models.CASCADE)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("late-base fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models").expect("Child should exist");
+    assert!(graph.resolve_relation(child, "target").is_some());
+    let (_bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain complete ancestry");
+    assert!(matches!(
+        ancestry,
+        ModelAncestryOutcomeView::Complete { .. }
+    ));
+}
+
+#[test]
+fn a_same_module_base_rebound_after_the_child_is_unresolved() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class Base(models.Model):\n",
+        "    old = models.ForeignKey(Target)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Child(Base):\n    pass\n",
+        "class Base(models.Model):\n",
+        "    new = models.ForeignKey(Target)\n",
+        "    class Meta:\n        abstract = True\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("rebound local base fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "app.models").expect("Child should remain present");
+
+    assert_eq!(graph.resolve_relation(child, "old"), None);
+    assert_eq!(graph.resolve_relation(child, "new"), None);
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain inheritance outcomes");
+    assert!(matches!(
+        bases.as_slice(),
+        [ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::ReboundLocalBase { model },
+            ..
+        }] if model.name() == "Base" && model.module_name().as_str() == "app.models"
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn rebound_local_base_admission_uses_proven_same_module_ancestry() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Root(models.Model):\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Base(Root):\n    pass\n",
+        "class Child(Base):\n    pass\n",
+        "class Base:\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("ancestral rebound local base fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    model_id(graph, "Child", "app.models").expect("proven same-module ancestry should admit Child");
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain inheritance outcomes");
+    assert!(matches!(
+        bases.as_slice(),
+        [ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::ReboundLocalBase { model },
+            ..
+        }] if model.name() == "Base" && model.module_name().as_str() == "app.models"
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn a_plain_rebound_local_base_does_not_admit_its_child() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Base:\n    pass\n",
+        "class Child(Base):\n    pass\n",
+        "class Base(models.Model):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("plain rebound local base fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Child", "app.models").is_err());
+    assert!(model_id(graph, "Base", "app.models").is_ok());
 }
 
 #[test]
@@ -1796,4 +2361,686 @@ fn earlier_deferred_model_cannot_overwrite_a_later_direct_definition() {
         expected_span_after(source, "class Thing(models.Model)", "Thing")
             .expect("later Thing model name should occur after its class declaration")
     );
+}
+
+#[test]
+fn sole_unsupported_base_candidate_is_retained_with_relation_evidence() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Child(make_base()):\n",
+        "    parent = models.ForeignKey(\"self\", on_delete=models.CASCADE)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("unsupported-base fixture should build");
+
+    let graph = compute_model_graph(&db, project);
+    model_id(graph, "Child", "app.models").expect("unsupported candidate should remain present");
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("unsupported candidate should retain its base outcome");
+    assert!(matches!(
+        bases.as_slice(),
+        [ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::UnsupportedExpression,
+            ..
+        }]
+    ));
+    assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
+}
+
+#[test]
+fn later_search_root_deferred_duplicate_wins() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/low/duplicate/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Base(models.Model):\n    class Meta:\n        abstract = True\n",
+                "class Thing(Base):\n    low = models.ForeignKey(\"self\")\n",
+            ),
+        )
+        .file(
+            "/high/duplicate/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Base(models.Model):\n    class Meta:\n        abstract = True\n",
+                "class Thing(Base):\n    high = models.ForeignKey(\"self\")\n",
+            ),
+        )
+        .build(&db)
+        .expect("duplicate-root fixture should build");
+    let low = db
+        .file(Utf8Path::new("/low/duplicate/models.py"))
+        .expect("low-priority module should exist");
+    let high = db
+        .file(Utf8Path::new("/high/duplicate/models.py"))
+        .expect("high-priority module should exist");
+    let module = PythonModuleName::parse("duplicate.models").expect("module name should parse");
+
+    // This is the order produced by reversing search-path discovery: the
+    // higher-priority root arrives last and must replace the earlier candidate.
+    let graph =
+        resolve_model_graph_from_modules(&db, project, [(low, module.clone()), (high, module)]);
+    let thing = model_id(&graph, "Thing", "duplicate.models").expect("Thing should exist");
+    assert_eq!(graph.resolve_relation(thing, "low"), None);
+    assert!(graph.resolve_relation(thing, "high").is_some());
+    assert_eq!(
+        model_location(&graph, "duplicate.models", "Thing")
+            .expect("winner should have a location")
+            .0,
+        high
+    );
+}
+
+#[test]
+fn django_root_before_derived_base_is_invalid() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class AbstractBase(models.Model):\n",
+        "    inherited = models.ForeignKey(Target)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Bad(models.Model, AbstractBase):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("root-order fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let bad = model_id(graph, "Bad", "app.models").expect("Bad should remain present");
+    let (_bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Bad")
+        .expect("Bad should retain invalid ancestry");
+    assert_eq!(
+        ancestry,
+        ModelAncestryOutcomeView::Invalid {
+            error: ModelInheritanceErrorView::InconsistentC3,
+        }
+    );
+    assert_eq!(graph.resolve_relation(bad, "inherited"), None);
+}
+
+#[test]
+fn duplicate_model_base_is_invalid() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Base(models.Model):\n    pass\n",
+        "class Child(Base, Base):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("duplicate-base fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let (_bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "Child")
+        .expect("Child should retain invalid ancestry");
+    assert!(matches!(
+        ancestry,
+        ModelAncestryOutcomeView::Invalid {
+            error: ModelInheritanceErrorView::DuplicateModelBase { ref model },
+        } if model.name() == "Base"
+    ));
+}
+
+#[test]
+fn cycle_wins_over_unresolved_ancestry() {
+    let source = concat!(
+        "class A(B, missing.Base):\n",
+        "    class Meta:\n",
+        "        abstract = True\n",
+        "class B(A):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("cycle fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let (bases, ancestry) = model_inheritance_outcomes(graph, "app.models", "A")
+        .expect("A should retain invalid ancestry");
+    assert!(matches!(
+        &bases[1],
+        ModelBaseOutcomeView::Unresolved {
+            reason: ModelBaseUnresolvedReasonView::MissingImportBinding { .. },
+            ..
+        }
+    ));
+    assert_eq!(
+        ancestry,
+        ModelAncestryOutcomeView::Invalid {
+            error: ModelInheritanceErrorView::Cycle,
+        }
+    );
+}
+
+#[test]
+fn abstract_clone_stops_at_concrete_owner_scope() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/base/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Target(models.Model):\n    pass\n",
+                "class AbstractBase(models.Model):\n",
+                "    target = models.ForeignKey(\"Target\")\n",
+                "    class Meta:\n        abstract = True\n",
+                "class ConcreteParent(AbstractBase):\n    pass\n",
+            ),
+        )
+        .file(
+            "/project/child/models.py",
+            concat!(
+                "from django.db import models\n",
+                "from base.models import ConcreteParent\n",
+                "class Target(models.Model):\n    pass\n",
+                "class Child(ConcreteParent):\n    pass\n",
+            ),
+        )
+        .build(&db)
+        .expect("abstract concrete chain should build");
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "child.models").expect("Child should exist");
+    let base_target = model_id(graph, "Target", "base.models").expect("base Target should exist");
+    let resolved = graph
+        .resolve_relation(child, "target")
+        .expect("inherited field should resolve");
+    assert!(ptr::eq(
+        resolved,
+        graph
+            .get_by_id(base_target)
+            .expect("base target should resolve")
+    ));
+    assert!(model_relation_locations(graph, "child.models", "Child").is_empty());
+}
+
+#[test]
+fn abstract_clone_expression_target_keeps_its_declaration_scope() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/base/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Target(models.Model):\n    pass\n",
+                "class AbstractBase(models.Model):\n",
+                "    target = models.ForeignKey(Target)\n",
+                "    class Meta:\n        abstract = True\n",
+            ),
+        )
+        .file(
+            "/project/child/models.py",
+            concat!(
+                "from django.db import models\n",
+                "from base.models import AbstractBase\n",
+                "class Target(models.Model):\n    pass\n",
+                "class Child(AbstractBase):\n    pass\n",
+            ),
+        )
+        .build(&db)
+        .expect("cross-app abstract clone fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let child = model_id(graph, "Child", "child.models").expect("Child should exist");
+    let base_target = model_id(graph, "Target", "base.models").expect("base Target should exist");
+    let child_target =
+        model_id(graph, "Target", "child.models").expect("child Target should exist");
+
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(child, "target")
+            .expect("cloned expression target should resolve"),
+        graph
+            .get_by_id(base_target)
+            .expect("base Target should resolve"),
+    ));
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(base_target, "child_set")
+            .expect("base Target should receive the cloned reverse relation"),
+        graph.get_by_id(child).expect("Child should resolve"),
+    ));
+    assert_eq!(graph.resolve_relation(child_target, "child_set"), None);
+}
+
+#[test]
+fn local_non_field_names_block_abstract_relation_cloning() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class AbstractBase(models.Model):\n",
+        "    owner = models.ForeignKey(Target)\n",
+        "    class Meta:\n        abstract = True\n",
+        "class AssignedChild(AbstractBase):\n    owner = None\n",
+        "class MethodChild(AbstractBase):\n    def owner(self):\n        pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("local-shadow fixture should build");
+    let graph = compute_model_graph(&db, project);
+    for name in ["AssignedChild", "MethodChild"] {
+        let child = model_id(graph, name, "app.models").expect("child should exist");
+        assert_eq!(graph.resolve_relation(child, "owner"), None);
+        assert!(model_relation_locations(graph, "app.models", name).is_empty());
+    }
+}
+
+#[test]
+fn abstract_declarations_do_not_create_reverse_descriptors() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class User(models.Model):\n    pass\n",
+        "class AbstractBase(models.Model):\n",
+        "    user = models.ForeignKey(User)\n",
+        "    editor = models.ForeignKey(User, related_name=\"%(class)s_editors\")\n",
+        "    class Meta:\n        abstract = True\n",
+        "class Child(AbstractBase):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("abstract reverse fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let user = model_id(graph, "User", "app.models").expect("User should exist");
+    assert!(graph.resolve_relation(user, "child_set").is_some());
+    assert!(graph.resolve_relation(user, "child_editors").is_some());
+    assert_eq!(graph.resolve_relation(user, "abstractbase_set"), None);
+    assert_eq!(graph.resolve_relation(user, "abstractbase_editors"), None);
+}
+
+#[test]
+fn c3_uses_local_bindings_across_a_shared_ancestor_diamond() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class XTarget(models.Model):\n    pass\n",
+        "class CTarget(models.Model):\n    pass\n",
+        "class X(models.Model):\n",
+        "    owner = models.ForeignKey(XTarget)\n",
+        "class B(X):\n    pass\n",
+        "class C(X):\n",
+        "    owner = models.ForeignKey(CTarget)\n",
+        "class D(B, C):\n    pass\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("shared-ancestor C3 fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let d = model_id(graph, "D", "app.models").expect("D should exist");
+    let c_target = model_id(graph, "CTarget", "app.models").expect("CTarget should exist");
+
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(d, "owner")
+            .expect("D.owner should resolve"),
+        graph.get_by_id(c_target).expect("CTarget should resolve"),
+    ));
+}
+
+#[test]
+fn later_non_relation_suppresses_an_earlier_relation() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class User(models.Model):\n    pass\n",
+        "class Order(models.Model):\n",
+        "    user = models.ForeignKey(User, related_name=\"orders\")\n",
+        "    user = None\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("relation suppression fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let order = model_id(graph, "Order", "app.models").expect("Order should exist");
+    let value = graph_value(graph).expect("model graph should serialize");
+
+    assert_eq!(graph.resolve_relation(order, "user"), None);
+    assert!(
+        value["models"]["app.models.Order"]["relations"]
+            .as_array()
+            .is_some_and(Vec::is_empty)
+    );
+}
+
+#[test]
+fn later_relation_restores_a_name_after_a_non_relation() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class User(models.Model):\n    pass\n",
+        "class Order(models.Model):\n",
+        "    user = None\n",
+        "    user = models.ForeignKey(User)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("relation restoration fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let order = model_id(graph, "Order", "app.models").expect("Order should exist");
+
+    assert!(graph.resolve_relation(order, "user").is_some());
+}
+
+#[test]
+fn later_relation_replaces_an_earlier_relation() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class First(models.Model):\n    pass\n",
+        "class Second(models.Model):\n    pass\n",
+        "class Choice(models.Model):\n",
+        "    selected = models.ForeignKey(First)\n",
+        "    selected = models.ForeignKey(Second)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("relation replacement fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let choice = model_id(graph, "Choice", "app.models").expect("Choice should exist");
+    let second = model_id(graph, "Second", "app.models").expect("Second should exist");
+    let value = graph_value(graph).expect("model graph should serialize");
+    let relations = value["models"]["app.models.Choice"]["relations"]
+        .as_array()
+        .expect("Choice relations should be an array");
+
+    assert!(ptr::eq(
+        graph
+            .resolve_relation(choice, "selected")
+            .expect("the final relation should resolve"),
+        graph.get_by_id(second).expect("Second should resolve"),
+    ));
+    assert_eq!(relations.len(), 1);
+    assert_eq!(relations[0]["target"]["value"]["name"], json!("Second"));
+}
+
+#[test]
+fn suppressed_local_relation_creates_no_reverse_descriptor() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class User(models.Model):\n    pass\n",
+        "class Order(models.Model):\n",
+        "    user = models.ForeignKey(User, related_name=\"orders\")\n",
+        "    user = None\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("reverse suppression fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let user = model_id(graph, "User", "app.models").expect("User should exist");
+
+    assert_eq!(graph.resolve_relation(user, "orders"), None);
+}
+
+#[test]
+fn final_static_meta_abstract_assignment_wins() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Concrete(models.Model):\n",
+        "    class Meta:\n",
+        "        abstract = True\n",
+        "        abstract = False\n",
+        "class Abstract(models.Model):\n",
+        "    class Meta:\n",
+        "        abstract = False\n",
+        "        abstract = True\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("Meta.abstract ordering fixture should build");
+    let value = graph_value(compute_model_graph(&db, project)).expect("graph should serialize");
+
+    assert_eq!(value["models"]["app.models.Concrete"]["kind"], "concrete");
+    assert_eq!(value["models"]["app.models.Abstract"]["kind"], "abstract");
+}
+
+#[test]
+fn final_duplicate_meta_class_controls_model_kind() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class ResetToDefault(models.Model):\n",
+        "    class Meta:\n        abstract = True\n",
+        "    class Meta:\n        pass\n",
+        "class ResetToFalse(models.Model):\n",
+        "    class Meta:\n        abstract = True\n",
+        "    class Meta:\n        abstract = False\n",
+        "class ResetToTrue(models.Model):\n",
+        "    class Meta:\n        abstract = False\n",
+        "    class Meta:\n        abstract = True\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("duplicate Meta fixture should build");
+    let value = graph_value(compute_model_graph(&db, project)).expect("graph should serialize");
+
+    assert_eq!(
+        value["models"]["app.models.ResetToDefault"]["kind"],
+        "concrete"
+    );
+    assert_eq!(
+        value["models"]["app.models.ResetToFalse"]["kind"],
+        "concrete"
+    );
+    assert_eq!(
+        value["models"]["app.models.ResetToTrue"]["kind"],
+        "abstract"
+    );
+}
+
+#[test]
+fn reassigned_model_alias_cannot_be_admitted_by_a_relation() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "models = None\n",
+        "class Shadowed(models.Model):\n",
+        "    target = models.ForeignKey(Target)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("reassigned alias fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Shadowed", "app.models").is_err());
+}
+
+#[test]
+fn shadowed_direct_model_import_is_negative_django_root_evidence() {
+    let source = concat!(
+        "from django.db.models import Model, ForeignKey\n",
+        "Model = object()\n",
+        "class Fake(Model):\n",
+        "    parent = ForeignKey(\"self\")\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("shadowed direct Model import fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Fake", "app.models").is_err());
+}
+
+#[test]
+fn missing_direct_model_name_is_negative_django_root_evidence() {
+    let source = concat!(
+        "class Fake(Model):\n",
+        "    parent = ForeignKey(\"self\")\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("missing direct Model fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Fake", "app.models").is_err());
+}
+
+#[test]
+fn proven_model_base_can_admit_a_candidate_with_negative_model_evidence() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class ProvenBase(models.Model):\n    pass\n",
+        "models = None\n",
+        "class Child(ProvenBase, models.Model):\n",
+        "    target = ForeignKey(Target)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("proven alternate base fixture should build");
+    let graph = compute_model_graph(&db, project);
+    let child =
+        model_id(graph, "Child", "app.models").expect("the proven model base should admit Child");
+
+    assert!(graph.resolve_relation(child, "target").is_some());
+}
+
+#[test]
+fn deleted_and_branch_shadowed_model_aliases_are_negative_evidence() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "del models\n",
+        "class Deleted(models.Model):\n",
+        "    target = object()\n",
+        "    relation = ForeignKey(Target)\n",
+        "from django.db import models\n",
+        "if enabled:\n    models = None\n",
+        "class BranchShadowed(models.Model):\n",
+        "    target = ForeignKey(Target)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("uncertain alias fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Deleted", "app.models").is_err());
+    assert!(model_id(graph, "BranchShadowed", "app.models").is_err());
+}
+
+#[test]
+fn later_reimport_admits_only_later_relation_bearing_models() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "models = None\n",
+        "class Before(models.Model):\n",
+        "    target = ForeignKey(Target)\n",
+        "from django.db import models\n",
+        "class After(models.Model):\n",
+        "    target = models.ForeignKey(Target)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("alias reimport fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Before", "app.models").is_err());
+    assert!(model_id(graph, "After", "app.models").is_ok());
+}
+
+#[test]
+fn later_alias_shadow_does_not_change_an_earlier_candidate() {
+    let source = concat!(
+        "from django.db import models\n",
+        "class Target(models.Model):\n    pass\n",
+        "class Before(models.Model):\n",
+        "    target = models.ForeignKey(Target)\n",
+        "models = None\n",
+        "class After(models.Model):\n",
+        "    target = ForeignKey(Target)\n",
+    );
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file("/project/app/models.py", source)
+        .build(&db)
+        .expect("later alias shadow fixture should build");
+    let graph = compute_model_graph(&db, project);
+
+    assert!(model_id(graph, "Before", "app.models").is_ok());
+    assert!(model_id(graph, "After", "app.models").is_err());
+}
+
+#[test]
+fn final_module_file_hides_all_lower_priority_classes() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/low/app/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Legacy(models.Model):\n    pass\n",
+            ),
+        )
+        .file(
+            "/high/app/models.py",
+            concat!(
+                "from django.db import models\n",
+                "class Current(models.Model):\n    pass\n",
+            ),
+        )
+        .build(&db)
+        .expect("module precedence fixture should build");
+    let low = db
+        .file(Utf8Path::new("/low/app/models.py"))
+        .expect("low-priority module should exist");
+    let high = db
+        .file(Utf8Path::new("/high/app/models.py"))
+        .expect("high-priority module should exist");
+    let module = PythonModuleName::parse("app.models").expect("module should parse");
+    let graph =
+        resolve_model_graph_from_modules(&db, project, [(low, module.clone()), (high, module)]);
+
+    assert!(model_id(&graph, "Legacy", "app.models").is_err());
+    assert!(model_id(&graph, "Current", "app.models").is_ok());
+}
+
+#[test]
+fn model_free_winning_module_hides_a_lower_model() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/low/app/models.py",
+            "from django.db import models\nclass Legacy(models.Model):\n    pass\n",
+        )
+        .file("/high/app/models.py", "class Helper:\n    pass\n")
+        .build(&db)
+        .expect("model-free module precedence fixture should build");
+    let low = db
+        .file(Utf8Path::new("/low/app/models.py"))
+        .expect("low-priority module should exist");
+    let high = db
+        .file(Utf8Path::new("/high/app/models.py"))
+        .expect("high-priority module should exist");
+    let module = PythonModuleName::parse("app.models").expect("module should parse");
+    let graph =
+        resolve_model_graph_from_modules(&db, project, [(low, module.clone()), (high, module)]);
+
+    assert!(graph.is_empty());
 }

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -13,7 +13,8 @@ use djls_project::compute_model_graph;
 use djls_project::testing::ModelAncestryOutcomeView;
 use djls_project::testing::ModelBaseOutcomeView;
 use djls_project::testing::ModelBaseUnresolvedReasonView;
-use djls_project::testing::ModelInheritanceErrorView;
+use djls_project::testing::ModelInvalidAncestryReasonView;
+use djls_project::testing::ModelMroEntryView;
 use djls_project::testing::PythonSyntaxErrorClass;
 use djls_project::testing::extract_model_graph;
 use djls_project::testing::model_inheritance_outcomes;
@@ -1871,7 +1872,13 @@ fn relation_evidence_retains_partial_model_without_promoting_arbitrary_subclass(
     assert!(matches!(
         ancestry,
         ModelAncestryOutcomeView::Complete { ref mro }
-            if mro.iter().map(ModelId::name).collect::<Vec<_>>() == ["Webhook", "WebhookBase"]
+            if matches!(
+                mro.as_slice(),
+                [
+                    ModelMroEntryView::Model(model),
+                    ModelMroEntryView::NonModelClass(class),
+                ] if model.name() == "Webhook" && class.name() == "WebhookBase"
+            )
     ));
 }
 
@@ -1903,7 +1910,13 @@ fn plain_same_file_mixin_keeps_local_ancestry_complete() {
     assert!(matches!(
         ancestry,
         ModelAncestryOutcomeView::Complete { ref mro }
-            if mro.iter().map(ModelId::name).collect::<Vec<_>>() == ["Child", "PlainMixin"]
+            if matches!(
+                mro.as_slice(),
+                [
+                    ModelMroEntryView::Model(model),
+                    ModelMroEntryView::NonModelClass(class),
+                ] if model.name() == "Child" && class.name() == "PlainMixin"
+            )
     ));
 }
 
@@ -2162,7 +2175,7 @@ fn known_c3_conflict_propagates_through_partial_ancestry() {
     assert_eq!(
         c_ancestry,
         ModelAncestryOutcomeView::Invalid {
-            error: ModelInheritanceErrorView::InconsistentC3,
+            reason: ModelInvalidAncestryReasonView::InconsistentMethodResolutionOrder,
         }
     );
 }
@@ -2269,9 +2282,9 @@ fn a_same_module_base_rebound_after_the_child_is_unresolved() {
     assert!(matches!(
         bases.as_slice(),
         [ModelBaseOutcomeView::Unresolved {
-            reason: ModelBaseUnresolvedReasonView::ReboundLocalBase { model },
+            reason: ModelBaseUnresolvedReasonView::ReboundLocalBase { class },
             ..
-        }] if model.name() == "Base" && model.module_name().as_str() == "app.models"
+        }] if class.name() == "Base" && class.module_name().as_str() == "app.models"
     ));
     assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
 }
@@ -2299,9 +2312,9 @@ fn rebound_local_base_admission_uses_proven_same_module_ancestry() {
     assert!(matches!(
         bases.as_slice(),
         [ModelBaseOutcomeView::Unresolved {
-            reason: ModelBaseUnresolvedReasonView::ReboundLocalBase { model },
+            reason: ModelBaseUnresolvedReasonView::ReboundLocalBase { class },
             ..
-        }] if model.name() == "Base" && model.module_name().as_str() == "app.models"
+        }] if class.name() == "Base" && class.module_name().as_str() == "app.models"
     ));
     assert_eq!(ancestry, ModelAncestryOutcomeView::Partial);
 }
@@ -2457,14 +2470,14 @@ fn django_root_before_derived_base_is_invalid() {
     assert_eq!(
         ancestry,
         ModelAncestryOutcomeView::Invalid {
-            error: ModelInheritanceErrorView::InconsistentC3,
+            reason: ModelInvalidAncestryReasonView::InconsistentMethodResolutionOrder,
         }
     );
     assert_eq!(graph.resolve_relation(bad, "inherited"), None);
 }
 
 #[test]
-fn duplicate_model_base_is_invalid() {
+fn duplicate_class_base_is_invalid() {
     let source = concat!(
         "from django.db import models\n",
         "class Base(models.Model):\n    pass\n",
@@ -2481,8 +2494,8 @@ fn duplicate_model_base_is_invalid() {
     assert!(matches!(
         ancestry,
         ModelAncestryOutcomeView::Invalid {
-            error: ModelInheritanceErrorView::DuplicateModelBase { ref model },
-        } if model.name() == "Base"
+            reason: ModelInvalidAncestryReasonView::DuplicateClassBase { ref class },
+        } if class.name() == "Base"
     ));
 }
 
@@ -2512,7 +2525,7 @@ fn cycle_wins_over_unresolved_ancestry() {
     assert_eq!(
         ancestry,
         ModelAncestryOutcomeView::Invalid {
-            error: ModelInheritanceErrorView::Cycle,
+            reason: ModelInvalidAncestryReasonView::Cycle,
         }
     );
 }
@@ -2607,7 +2620,7 @@ fn abstract_clone_expression_target_keeps_its_declaration_scope() {
 }
 
 #[test]
-fn local_non_field_names_block_abstract_relation_cloning() {
+fn extracted_class_bindings_block_abstract_relation_cloning() {
     let source = concat!(
         "from django.db import models\n",
         "class Target(models.Model):\n    pass\n",

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__archivebox__archivebox__workers__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__archivebox__archivebox__workers__models.py.snap
@@ -12,6 +12,15 @@ models:
     module_name: archivebox.workers.models
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 949
+            length: 12
+          reason:
+            ImportNotFound:
+              requested: statemachine.mixins.MachineMixin
+    ancestry: Partial
   archivebox.workers.models.ModelWithStateMachine:
     name:
       value: ModelWithStateMachine
@@ -21,3 +30,4 @@ models:
     module_name: archivebox.workers.models
     relations: []
     kind: abstract
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__auth__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__auth__models.py.snap
@@ -10,36 +10,17 @@ models:
         start: 15618
         length: 12
     module_name: django.contrib.auth.models
-    relations:
-      - field_name:
-          value: groups
-          span:
-            start: 11376
-            length: 6
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Group
-          span:
-            start: 11417
-            length: 5
-        related_name: user_set
-      - field_name:
-          value: user_permissions
-          span:
-            start: 11715
-            length: 16
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Permission
-          span:
-            start: 11766
-            length: 10
-        related_name: user_set
+    relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 15631
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django.contrib.auth.base_user.AbstractBaseUser
+    ancestry: Partial
   django.contrib.auth.models.Group:
     name:
       value: Group
@@ -130,33 +111,6 @@ models:
         start: 17888
         length: 4
     module_name: django.contrib.auth.models
-    relations:
-      - field_name:
-          value: groups
-          span:
-            start: 11376
-            length: 6
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Group
-          span:
-            start: 11417
-            length: 5
-        related_name: user_set
-      - field_name:
-          value: user_permissions
-          span:
-            start: 11715
-            length: 16
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Permission
-          span:
-            start: 11766
-            length: 10
-        related_name: user_set
+    relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__gis__db__backends__oracle__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__gis__db__backends__oracle__models.py.snap
@@ -21,3 +21,12 @@ models:
     module_name: django.contrib.gis.db.backends.oracle.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1461
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__gis__db__backends__postgis__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__gis__db__backends__postgis__models.py.snap
@@ -21,3 +21,12 @@ models:
     module_name: django.contrib.gis.db.backends.postgis.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1472
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__gis__db__backends__spatialite__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-5.2__django__contrib__gis__db__backends__spatialite__models.py.snap
@@ -21,3 +21,12 @@ models:
     module_name: django.contrib.gis.db.backends.spatialite.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1393
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__auth__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__auth__models.py.snap
@@ -10,36 +10,17 @@ models:
         start: 15591
         length: 12
     module_name: django.contrib.auth.models
-    relations:
-      - field_name:
-          value: groups
-          span:
-            start: 11349
-            length: 6
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Group
-          span:
-            start: 11390
-            length: 5
-        related_name: user_set
-      - field_name:
-          value: user_permissions
-          span:
-            start: 11688
-            length: 16
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Permission
-          span:
-            start: 11739
-            length: 10
-        related_name: user_set
+    relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 15604
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django.contrib.auth.base_user.AbstractBaseUser
+    ancestry: Partial
   django.contrib.auth.models.Group:
     name:
       value: Group
@@ -130,33 +111,6 @@ models:
         start: 17861
         length: 4
     module_name: django.contrib.auth.models
-    relations:
-      - field_name:
-          value: groups
-          span:
-            start: 11349
-            length: 6
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Group
-          span:
-            start: 11390
-            length: 5
-        related_name: user_set
-      - field_name:
-          value: user_permissions
-          span:
-            start: 11688
-            length: 16
-        relation_type: ManyToMany
-        target:
-          value:
-            kind: Bare
-            name: Permission
-          span:
-            start: 11739
-            length: 10
-        related_name: user_set
+    relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__gis__db__backends__oracle__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__gis__db__backends__oracle__models.py.snap
@@ -21,3 +21,12 @@ models:
     module_name: django.contrib.gis.db.backends.oracle.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1461
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__gis__db__backends__postgis__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__gis__db__backends__postgis__models.py.snap
@@ -21,3 +21,12 @@ models:
     module_name: django.contrib.gis.db.backends.postgis.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1472
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__gis__db__backends__spatialite__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.0__django__contrib__gis__db__backends__spatialite__models.py.snap
@@ -21,3 +21,12 @@ models:
     module_name: django.contrib.gis.db.backends.spatialite.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1393
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-cms__cms__test_utils__project__emailuserapp__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-cms__cms__test_utils__project__emailuserapp__models.py.snap
@@ -1,0 +1,40 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  cms.test_utils.project.emailuserapp.models.AbstractEmailUser:
+    name:
+      value: AbstractEmailUser
+      span:
+        start: 1335
+        length: 17
+    module_name: cms.test_utils.project.emailuserapp.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1353
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django.contrib.auth.models.AbstractBaseUser
+      - Unresolved:
+          span:
+            start: 1371
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django.contrib.auth.models.PermissionsMixin
+    ancestry: Partial
+  cms.test_utils.project.emailuserapp.models.EmailUser:
+    name:
+      value: EmailUser
+      span:
+        start: 3378
+        length: 9
+    module_name: cms.test_utils.project.emailuserapp.models
+    relations: []
+    kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-cms__cms__test_utils__project__extensionapp__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-cms__cms__test_utils__project__extensionapp__models.py.snap
@@ -21,6 +21,15 @@ models:
     module_name: cms.test_utils.project.extensionapp.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1424
+            length: 20
+          reason:
+            ImportNotFound:
+              requested: cms.extensions.PageContentExtension
+    ancestry: Partial
   cms.test_utils.project.extensionapp.models.MultiTablePageExtension:
     name:
       value: MultiTablePageExtension
@@ -30,6 +39,15 @@ models:
     module_name: cms.test_utils.project.extensionapp.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1054
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: cms.extensions.PageExtension
+    ancestry: Partial
   cms.test_utils.project.extensionapp.models.MultiTablePageExtensionParent:
     name:
       value: MultiTablePageExtensionParent

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-cms__cms__test_utils__project__mti_pluginapp__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-cms__cms__test_utils__project__mti_pluginapp__models.py.snap
@@ -3,6 +3,24 @@ source: crates/djls-project/tests/corpus_models.rs
 expression: graph
 ---
 models:
+  cms.test_utils.project.mti_pluginapp.models.AbstractPluginParent:
+    name:
+      value: AbstractPluginParent
+      span:
+        start: 1229
+        length: 20
+    module_name: cms.test_utils.project.mti_pluginapp.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1250
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: cms.models.CMSPlugin
+    ancestry: Partial
   cms.test_utils.project.mti_pluginapp.models.LessMixedPlugin:
     name:
       value: LessMixedPlugin
@@ -12,6 +30,15 @@ models:
     module_name: cms.test_utils.project.mti_pluginapp.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2125
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: cms.models.CMSPlugin
+    ancestry: Partial
   cms.test_utils.project.mti_pluginapp.models.MixedPlugin:
     name:
       value: MixedPlugin
@@ -21,6 +48,7 @@ models:
     module_name: cms.test_utils.project.mti_pluginapp.models
     relations: []
     kind: concrete
+    ancestry: Partial
   cms.test_utils.project.mti_pluginapp.models.NonPluginModel:
     name:
       value: NonPluginModel
@@ -30,3 +58,13 @@ models:
     module_name: cms.test_utils.project.mti_pluginapp.models
     relations: []
     kind: concrete
+  cms.test_utils.project.mti_pluginapp.models.TestPluginGammaModel:
+    name:
+      value: TestPluginGammaModel
+      span:
+        start: 1435
+        length: 20
+    module_name: cms.test_utils.project.mti_pluginapp.models
+    relations: []
+    kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-guardian__guardian__models__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-guardian__guardian__models__models.py.snap
@@ -66,6 +66,34 @@ models:
     module_name: guardian.models.models
     relations:
       - field_name:
+          value: group
+          span:
+            start: 6734
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Group
+          span:
+            start: 6760
+            length: 5
+        related_name: ~
+      - field_name:
+          value: permission
+          span:
+            start: 769
+            length: 10
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Permission
+          span:
+            start: 800
+            length: 10
+        related_name: ~
+      - field_name:
           value: content_type
           span:
             start: 2144
@@ -96,6 +124,34 @@ models:
         length: 29
     module_name: guardian.models.models
     relations:
+      - field_name:
+          value: group
+          span:
+            start: 6734
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Group
+          span:
+            start: 6760
+            length: 5
+        related_name: ~
+      - field_name:
+          value: permission
+          span:
+            start: 769
+            length: 10
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Permission
+          span:
+            start: 800
+            length: 10
+        related_name: ~
       - field_name:
           value: content_type
           span:
@@ -165,6 +221,34 @@ models:
     module_name: guardian.models.models
     relations:
       - field_name:
+          value: user
+          span:
+            start: 3923
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: user_model_label
+          span:
+            start: 3948
+            length: 16
+        related_name: ~
+      - field_name:
+          value: permission
+          span:
+            start: 769
+            length: 10
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Permission
+          span:
+            start: 800
+            length: 10
+        related_name: ~
+      - field_name:
           value: content_type
           span:
             start: 2144
@@ -195,6 +279,34 @@ models:
         length: 28
     module_name: guardian.models.models
     relations:
+      - field_name:
+          value: user
+          span:
+            start: 3923
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: user_model_label
+          span:
+            start: 3948
+            length: 16
+        related_name: ~
+      - field_name:
+          value: permission
+          span:
+            start: 769
+            length: 10
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Permission
+          span:
+            start: 800
+            length: 10
+        related_name: ~
       - field_name:
           value: content_type
           span:

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__fundraising__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__fundraising__models.py.snap
@@ -12,6 +12,15 @@ models:
     module_name: fundraising.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1824
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: djangoproject.thumbnails.LogoThumbnailMixin
+    ancestry: Partial
   fundraising.models.Donation:
     name:
       value: Donation
@@ -53,6 +62,15 @@ models:
     module_name: fundraising.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 4750
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: djangoproject.thumbnails.LogoThumbnailMixin
+    ancestry: Partial
   fundraising.models.Payment:
     name:
       value: Payment

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__members__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__djangoproject.com__members__models.py.snap
@@ -12,6 +12,15 @@ models:
     module_name: members.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2692
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: djangoproject.thumbnails.LogoThumbnailMixin
+    ancestry: Partial
   members.models.IndividualMember:
     name:
       value: IndividualMember

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__layers__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__geonode__geonode__layers__models.py.snap
@@ -35,3 +35,12 @@ models:
     module_name: geonode.layers.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2130
+            length: 20
+          reason:
+            ImportNotFound:
+              requested: geonode.security.models.PermissionLevelMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__InvenTree__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__InvenTree__models.py.snap
@@ -57,6 +57,24 @@ models:
     module_name: src.backend.InvenTree.InvenTree.models
     relations: []
     kind: abstract
+  src.backend.InvenTree.InvenTree.models.InvenTreeTree:
+    name:
+      value: InvenTreeTree
+      span:
+        start: 23499
+        length: 13
+    module_name: src.backend.InvenTree.InvenTree.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 23531
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: mptt.models.MPTTModel
+    ancestry: Partial
   src.backend.InvenTree.InvenTree.models.MetadataMixin:
     name:
       value: MetadataMixin

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__common__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__common__models.py.snap
@@ -248,20 +248,6 @@ models:
     module_name: src.backend.InvenTree.common.models
     relations:
       - field_name:
-          value: updated_by
-          span:
-            start: 4235
-            length: 10
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Bare
-            name: User
-          span:
-            start: 4275
-            length: 4
-        related_name: "%(class)s_updated"
-      - field_name:
           value: model_type
           span:
             start: 87810
@@ -298,6 +284,22 @@ models:
             length: 17
         related_name: parameters
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 81343
+            length: 30
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.MetadataMixin
+      - Unresolved:
+          span:
+            start: 81375
+            length: 31
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeModel
+    ancestry: Partial
   src.backend.InvenTree.common.models.PriceBreak:
     name:
       value: PriceBreak

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__order__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__order__models.py.snap
@@ -3,6 +3,205 @@ source: crates/djls-project/tests/corpus_models.rs
 expression: graph
 ---
 models:
+  src.backend.InvenTree.order.models.Order:
+    name:
+      value: Order
+      span:
+        start: 9132
+        length: 5
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: project_code
+          span:
+            start: 15402
+            length: 12
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Attribute
+            path:
+              - common_models
+              - ProjectCode
+          span:
+            start: 15444
+            length: 25
+        related_name: ~
+      - field_name:
+          value: created_by
+          span:
+            start: 16342
+            length: 10
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: User
+          span:
+            start: 16382
+            length: 4
+        related_name: ~
+      - field_name:
+          value: responsible
+          span:
+            start: 16702
+            length: 11
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Attribute
+            path:
+              - UserModels
+              - Owner
+          span:
+            start: 16743
+            length: 16
+        related_name: ~
+      - field_name:
+          value: contact
+          span:
+            start: 16976
+            length: 7
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Contact
+          span:
+            start: 17013
+            length: 7
+        related_name: ~
+      - field_name:
+          value: address
+          span:
+            start: 17224
+            length: 7
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Address
+          span:
+            start: 17261
+            length: 7
+        related_name: ~
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 9143
+            length: 15
+          reason:
+            ImportNotFound:
+              requested: generic.states.StatusCodeMixin
+      - Unresolved:
+          span:
+            start: 9164
+            length: 20
+          reason:
+            ImportNotFound:
+              requested: generic.states.StateTransitionMixin
+      - Unresolved:
+          span:
+            start: 9190
+            length: 40
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeParameterMixin
+      - Unresolved:
+          span:
+            start: 9236
+            length: 41
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeAttachmentMixin
+      - Unresolved:
+          span:
+            start: 9283
+            length: 38
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeBarcodeMixin
+      - Unresolved:
+          span:
+            start: 9327
+            length: 36
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeNotesMixin
+      - Unresolved:
+          span:
+            start: 9369
+            length: 34
+          reason:
+            ImportNotFound:
+              requested: report.mixins.InvenTreeReportMixin
+      - Unresolved:
+          span:
+            start: 9409
+            length: 30
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.MetadataMixin
+      - Unresolved:
+          span:
+            start: 9445
+            length: 39
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.ReferenceIndexingMixin
+      - Unresolved:
+          span:
+            start: 9490
+            length: 31
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeModel
+    ancestry: Partial
+  src.backend.InvenTree.order.models.OrderExtraLine:
+    name:
+      value: OrderExtraLine
+      span:
+        start: 61918
+        length: 14
+    module_name: src.backend.InvenTree.order.models
+    relations: []
+    kind: abstract
+    ancestry: Partial
+  src.backend.InvenTree.order.models.OrderLineItem:
+    name:
+      value: OrderLineItem
+      span:
+        start: 59042
+        length: 13
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: project_code
+          span:
+            start: 61662
+            length: 12
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Attribute
+            path:
+              - common_models
+              - ProjectCode
+          span:
+            start: 61704
+            length: 25
+        related_name: ~
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 59056
+            length: 39
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeMetadataModel
+    ancestry: Partial
   src.backend.InvenTree.order.models.PurchaseOrder:
     name:
       value: PurchaseOrder
@@ -40,6 +239,84 @@ models:
             length: 4
         related_name: ~
     kind: concrete
+    ancestry: Partial
+  src.backend.InvenTree.order.models.PurchaseOrderExtraLine:
+    name:
+      value: PurchaseOrderExtraLine
+      span:
+        start: 68718
+        length: 22
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: order
+          span:
+            start: 69198
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: PurchaseOrder
+          span:
+            start: 69233
+            length: 13
+        related_name: extra_lines
+    kind: concrete
+    ancestry: Partial
+  src.backend.InvenTree.order.models.PurchaseOrderLineItem:
+    name:
+      value: PurchaseOrderLineItem
+      span:
+        start: 62802
+        length: 21
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: order
+          span:
+            start: 65468
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: PurchaseOrder
+          span:
+            start: 65503
+            length: 13
+        related_name: lines
+      - field_name:
+          value: part
+          span:
+            start: 65914
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: SupplierPart
+          span:
+            start: 65948
+            length: 12
+        related_name: purchase_order_line_items
+      - field_name:
+          value: build_order
+          span:
+            start: 66723
+            length: 11
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: build
+            name: Build
+          span:
+            start: 66764
+            length: 13
+        related_name: external_line_items
+    kind: concrete
+    ancestry: Partial
   src.backend.InvenTree.order.models.ReturnOrder:
     name:
       value: ReturnOrder
@@ -63,6 +340,80 @@ models:
             length: 7
         related_name: sales_orders
     kind: concrete
+    ancestry: Partial
+  src.backend.InvenTree.order.models.ReturnOrderExtraLine:
+    name:
+      value: ReturnOrderExtraLine
+      span:
+        start: 101711
+        length: 20
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: order
+          span:
+            start: 102111
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: ReturnOrder
+          span:
+            start: 102146
+            length: 11
+        related_name: extra_lines
+    kind: concrete
+    ancestry: Partial
+  src.backend.InvenTree.order.models.ReturnOrderLineItem:
+    name:
+      value: ReturnOrderLineItem
+      span:
+        start: 98984
+        length: 19
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: order
+          span:
+            start: 100233
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: ReturnOrder
+          span:
+            start: 100268
+            length: 11
+        related_name: lines
+      - field_name:
+          value: item
+          span:
+            start: 100426
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Attribute
+            path:
+              - stock
+              - models
+              - StockItem
+          span:
+            start: 100460
+            length: 22
+        related_name: return_order_lines
+    kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 99004
+            length: 15
+          reason:
+            ImportNotFound:
+              requested: generic.states.StatusCodeMixin
+    ancestry: Partial
   src.backend.InvenTree.order.models.SalesOrder:
     name:
       value: SalesOrder
@@ -100,6 +451,7 @@ models:
             length: 4
         related_name: ~
     kind: concrete
+    ancestry: Partial
   src.backend.InvenTree.order.models.SalesOrderAllocation:
     name:
       value: SalesOrderAllocation
@@ -152,6 +504,69 @@ models:
             length: 17
         related_name: sales_order_allocations
     kind: concrete
+  src.backend.InvenTree.order.models.SalesOrderExtraLine:
+    name:
+      value: SalesOrderExtraLine
+      span:
+        start: 81921
+        length: 19
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: order
+          span:
+            start: 82379
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: SalesOrder
+          span:
+            start: 82414
+            length: 10
+        related_name: extra_lines
+    kind: concrete
+    ancestry: Partial
+  src.backend.InvenTree.order.models.SalesOrderLineItem:
+    name:
+      value: SalesOrderLineItem
+      span:
+        start: 69404
+        length: 18
+    module_name: src.backend.InvenTree.order.models
+    relations:
+      - field_name:
+          value: order
+          span:
+            start: 70723
+            length: 5
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: SalesOrder
+          span:
+            start: 70758
+            length: 10
+        related_name: lines
+      - field_name:
+          value: part
+          span:
+            start: 70914
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Qualified
+            app_label: part
+            name: Part
+          span:
+            start: 70948
+            length: 11
+        related_name: sales_order_line_items
+    kind: concrete
+    ancestry: Partial
   src.backend.InvenTree.order.models.TotalPriceMixin:
     name:
       value: TotalPriceMixin

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__plugin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__plugin__models.py.snap
@@ -12,3 +12,12 @@ models:
     module_name: src.backend.InvenTree.plugin.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 538
+            length: 30
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.MetadataMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__report__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__report__models.py.snap
@@ -3,6 +3,16 @@ source: crates/djls-project/tests/corpus_models.rs
 expression: graph
 ---
 models:
+  src.backend.InvenTree.report.models.LabelTemplate:
+    name:
+      value: LabelTemplate
+      span:
+        start: 23017
+        length: 13
+    module_name: src.backend.InvenTree.report.models
+    relations: []
+    kind: concrete
+    ancestry: Partial
   src.backend.InvenTree.report.models.ReportAsset:
     name:
       value: ReportAsset
@@ -21,3 +31,38 @@ models:
     module_name: src.backend.InvenTree.report.models
     relations: []
     kind: concrete
+  src.backend.InvenTree.report.models.ReportTemplate:
+    name:
+      value: ReportTemplate
+      span:
+        start: 11472
+        length: 14
+    module_name: src.backend.InvenTree.report.models
+    relations: []
+    kind: concrete
+    ancestry: Partial
+  src.backend.InvenTree.report.models.ReportTemplateBase:
+    name:
+      value: ReportTemplateBase
+      span:
+        start: 6245
+        length: 18
+    module_name: src.backend.InvenTree.report.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 6264
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.MetadataMixin
+      - Unresolved:
+          span:
+            start: 6279
+            length: 31
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.InvenTreeModel
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__stock__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__inventree__src__backend__InvenTree__stock__models.py.snap
@@ -12,3 +12,12 @@ models:
     module_name: src.backend.InvenTree.stock.models
     relations: []
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1855
+            length: 30
+          reason:
+            ImportNotFound:
+              requested: InvenTree.models.MetadataMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__wireless__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__netbox__netbox__wireless__models.py.snap
@@ -66,6 +66,22 @@ models:
             length: 16
         related_name: wireless_lans
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2113
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: dcim.models.mixins.CachedScopeMixin
+      - Unresolved:
+          span:
+            start: 2131
+            length: 12
+          reason:
+            ImportNotFound:
+              requested: netbox.models.PrimaryModel
+    ancestry: Partial
   netbox.wireless.models.WirelessLink:
     name:
       value: WirelessLink
@@ -150,3 +166,19 @@ models:
             length: 13
         related_name: ~
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 3585
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: netbox.models.mixins.DistanceMixin
+      - Unresolved:
+          span:
+            start: 3600
+            length: 12
+          reason:
+            ImportNotFound:
+              requested: netbox.models.PrimaryModel
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__nomnom__src__nomnom__advise__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__nomnom__src__nomnom__advise__models.py.snap
@@ -49,3 +49,12 @@ models:
             length: 8
         related_name: ~
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 3847
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: model_utils.models.TimeStampedModel
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__pretix__src__pretix__plugins__sendmail__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__pretix__src__pretix__plugins__sendmail__models.py.snap
@@ -54,6 +54,15 @@ models:
             length: 4
         related_name: ~
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 9794
+            length: 12
+          reason:
+            ImportNotFound:
+              requested: pretix.base.models.base.LoggingMixin
+    ancestry: Partial
   src.pretix.plugins.sendmail.models.ScheduledMail:
     name:
       value: ScheduledMail

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__readthedocs.org__readthedocs__projects__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__readthedocs.org__readthedocs__projects__models.py.snap
@@ -12,6 +12,16 @@ models:
     module_name: readthedocs.projects.models
     relations: []
     kind: concrete
+  readthedocs.projects.models.EmailHook:
+    name:
+      value: EmailHook
+      span:
+        start: 61194
+        length: 9
+    module_name: readthedocs.projects.models
+    relations: []
+    kind: concrete
+    ancestry: Partial
   readthedocs.projects.models.EnvironmentVariable:
     name:
       value: EnvironmentVariable
@@ -35,6 +45,15 @@ models:
             length: 7
         related_name: ~
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 75542
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django_extensions.db.models.TimeStampedModel
+    ancestry: Partial
   readthedocs.projects.models.Feature:
     name:
       value: Feature
@@ -90,6 +109,15 @@ models:
             length: 6
         related_name: http_headers
     kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 69122
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django_extensions.db.models.TimeStampedModel
+    ancestry: Partial
   readthedocs.projects.models.ImportedFile:
     name:
       value: ImportedFile
@@ -128,6 +156,38 @@ models:
             length: 16
         related_name: imported_files
     kind: concrete
+  readthedocs.projects.models.Notification:
+    name:
+      value: Notification
+      span:
+        start: 60548
+        length: 12
+    module_name: readthedocs.projects.models
+    relations:
+      - field_name:
+          value: project
+          span:
+            start: 60961
+            length: 7
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Project
+          span:
+            start: 60998
+            length: 7
+        related_name: "%(class)s_notifications"
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 60561
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django_extensions.db.models.TimeStampedModel
+    ancestry: Partial
   readthedocs.projects.models.Project:
     name:
       value: Project
@@ -246,6 +306,30 @@ models:
             length: 18
         related_name: superprojects
     kind: concrete
+  readthedocs.projects.models.WebHook:
+    name:
+      value: WebHook
+      span:
+        start: 61764
+        length: 7
+    module_name: readthedocs.projects.models
+    relations:
+      - field_name:
+          value: events
+          span:
+            start: 62088
+            length: 6
+        relation_type: ManyToMany
+        target:
+          value:
+            kind: Bare
+            name: WebHookEvent
+          span:
+            start: 62129
+            length: 12
+        related_name: webhooks
+    kind: concrete
+    ancestry: Partial
   readthedocs.projects.models.WebHookEvent:
     name:
       value: WebHookEvent

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__sentry__src__sentry__remote_subscriptions__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__sentry__src__sentry__remote_subscriptions__models.py.snap
@@ -4,8 +4,20 @@ expression: graph
 ---
 models:
   src.sentry.remote_subscriptions.models.BaseRemoteSubscription:
-    name: BaseRemoteSubscription
+    name:
+      value: BaseRemoteSubscription
+      span:
+        start: 96
+        length: 22
     module_name: src.sentry.remote_subscriptions.models
-    line: 8
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 119
+            length: 5
+          reason:
+            ImportNotFound:
+              requested: sentry.db.models.Model
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__sentry__src__sentry__sentry_metrics__indexer__postgres__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__sentry__src__sentry__sentry_metrics__indexer__postgres__models.py.snap
@@ -4,20 +4,40 @@ expression: graph
 ---
 models:
   src.sentry.sentry_metrics.indexer.postgres.models.BaseIndexer:
-    name: BaseIndexer
+    name:
+      value: BaseIndexer
+      span:
+        start: 503
+        length: 11
     module_name: src.sentry.sentry_metrics.indexer.postgres.models
-    line: 17
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 515
+            length: 5
+          reason:
+            ImportNotFound:
+              requested: sentry.db.models.Model
+    ancestry: Partial
   src.sentry.sentry_metrics.indexer.postgres.models.PerfStringIndexer:
-    name: PerfStringIndexer
+    name:
+      value: PerfStringIndexer
+      span:
+        start: 1368
+        length: 17
     module_name: src.sentry.sentry_metrics.indexer.postgres.models
-    line: 44
     relations: []
     kind: concrete
+    ancestry: Partial
   src.sentry.sentry_metrics.indexer.postgres.models.StringIndexer:
-    name: StringIndexer
+    name:
+      value: StringIndexer
+      span:
+        start: 1038
+        length: 13
     module_name: src.sentry.sentry_metrics.indexer.postgres.models
-    line: 32
     relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__contrib__forms__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__contrib__forms__models.py.snap
@@ -12,6 +12,51 @@ models:
     module_name: wagtail.contrib.forms.models
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 11926
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractForm:
+    name:
+      value: AbstractForm
+      span:
+        start: 9888
+        length: 12
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 9912
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractFormField:
+    name:
+      value: AbstractFormField
+      span:
+        start: 2065
+        length: 17
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2083
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Orderable
+    ancestry: Partial
   wagtail.contrib.forms.models.AbstractFormSubmission:
     name:
       value: AbstractFormSubmission

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__contrib__routable_page__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__contrib__routable_page__models.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  wagtail.contrib.routable_page.models.RoutablePage:
+    name:
+      value: RoutablePage
+      span:
+        start: 7414
+        length: 12
+    module_name: wagtail.contrib.routable_page.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 7446
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__documents__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 739
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 757
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.documents.models.Document:
     name:
       value: Document
@@ -35,21 +51,6 @@ models:
         start: 6518
         length: 8
     module_name: wagtail.documents.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 1023
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 1069
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-6.3__wagtail__images__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 7989
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 8007
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.images.models.AbstractRendition:
     name:
       value: AbstractRendition
@@ -44,24 +60,9 @@ models:
         start: 32369
         length: 5
     module_name: wagtail.images.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 8736
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 8782
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial
   wagtail.images.models.Rendition:
     name:
       value: Rendition

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__contrib__forms__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__contrib__forms__models.py.snap
@@ -12,6 +12,51 @@ models:
     module_name: wagtail.contrib.forms.models
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 12038
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractForm:
+    name:
+      value: AbstractForm
+      span:
+        start: 10000
+        length: 12
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 10024
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractFormField:
+    name:
+      value: AbstractFormField
+      span:
+        start: 2065
+        length: 17
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2083
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Orderable
+    ancestry: Partial
   wagtail.contrib.forms.models.AbstractFormSubmission:
     name:
       value: AbstractFormSubmission

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__contrib__routable_page__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__contrib__routable_page__models.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  wagtail.contrib.routable_page.models.RoutablePage:
+    name:
+      value: RoutablePage
+      span:
+        start: 7414
+        length: 12
+    module_name: wagtail.contrib.routable_page.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 7446
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__documents__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 739
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 757
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.documents.models.Document:
     name:
       value: Document
@@ -35,21 +51,6 @@ models:
         start: 6559
         length: 8
     module_name: wagtail.documents.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 1023
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 1069
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.0__wagtail__images__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 7989
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 8007
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.images.models.AbstractRendition:
     name:
       value: AbstractRendition
@@ -44,24 +60,9 @@ models:
         start: 32369
         length: 5
     module_name: wagtail.images.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 8736
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 8782
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial
   wagtail.images.models.Rendition:
     name:
       value: Rendition

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__contrib__forms__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__contrib__forms__models.py.snap
@@ -12,6 +12,51 @@ models:
     module_name: wagtail.contrib.forms.models
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 12038
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractForm:
+    name:
+      value: AbstractForm
+      span:
+        start: 10000
+        length: 12
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 10024
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractFormField:
+    name:
+      value: AbstractFormField
+      span:
+        start: 2065
+        length: 17
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2083
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Orderable
+    ancestry: Partial
   wagtail.contrib.forms.models.AbstractFormSubmission:
     name:
       value: AbstractFormSubmission

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__contrib__routable_page__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__contrib__routable_page__models.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  wagtail.contrib.routable_page.models.RoutablePage:
+    name:
+      value: RoutablePage
+      span:
+        start: 7414
+        length: 12
+    module_name: wagtail.contrib.routable_page.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 7446
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__documents__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 739
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 757
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.documents.models.Document:
     name:
       value: Document
@@ -35,21 +51,6 @@ models:
         start: 6540
         length: 8
     module_name: wagtail.documents.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 1023
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 1069
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.2__wagtail__images__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 8020
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 8038
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.images.models.AbstractRendition:
     name:
       value: AbstractRendition
@@ -44,24 +60,9 @@ models:
         start: 33901
         length: 5
     module_name: wagtail.images.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 8767
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 8813
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial
   wagtail.images.models.Rendition:
     name:
       value: Rendition

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__contrib__forms__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__contrib__forms__models.py.snap
@@ -12,6 +12,51 @@ models:
     module_name: wagtail.contrib.forms.models
     relations: []
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 12038
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractForm:
+    name:
+      value: AbstractForm
+      span:
+        start: 10000
+        length: 12
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 10024
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial
+  wagtail.contrib.forms.models.AbstractFormField:
+    name:
+      value: AbstractFormField
+      span:
+        start: 2065
+        length: 17
+    module_name: wagtail.contrib.forms.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 2083
+            length: 9
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Orderable
+    ancestry: Partial
   wagtail.contrib.forms.models.AbstractFormSubmission:
     name:
       value: AbstractFormSubmission

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__contrib__routable_page__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__contrib__routable_page__models.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  wagtail.contrib.routable_page.models.RoutablePage:
+    name:
+      value: RoutablePage
+      span:
+        start: 7414
+        length: 12
+    module_name: wagtail.contrib.routable_page.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 7446
+            length: 4
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.Page
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__documents__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__documents__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 739
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 757
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.documents.models.Document:
     name:
       value: Document
@@ -35,21 +51,6 @@ models:
         start: 6547
         length: 8
     module_name: wagtail.documents.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 1023
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 1069
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__images__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__wagtail-7.3__wagtail__images__models.py.snap
@@ -28,6 +28,22 @@ models:
             length: 24
         related_name: ~
     kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 8046
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: wagtail.models.CollectionMember
+      - Unresolved:
+          span:
+            start: 8064
+            length: 13
+          reason:
+            ImportNotFound:
+              requested: wagtail.search.index.Indexed
+    ancestry: Partial
   wagtail.images.models.AbstractRendition:
     name:
       value: AbstractRendition
@@ -44,24 +60,9 @@ models:
         start: 33939
         length: 5
     module_name: wagtail.images.models
-    relations:
-      - field_name:
-          value: uploaded_by_user
-          span:
-            start: 8793
-            length: 16
-        relation_type: ForeignKey
-        target:
-          value:
-            kind: Attribute
-            path:
-              - settings
-              - AUTH_USER_MODEL
-          span:
-            start: 8839
-            length: 24
-        related_name: ~
+    relations: []
     kind: concrete
+    ancestry: Partial
   wagtail.images.models.Rendition:
     name:
       value: Rendition


### PR DESCRIPTION
## Summary

- retain ordered, span-bearing terminal outcomes for every admitted model base
- compute Python method-resolution order across Django models and ordinary mixins, with explicit partial and invalid states
- separate extracted class identity from admitted model identity
- separate real import errors from stored unresolved reasons
- keep class-body binding state outside `ModelDef` and construct model definitions only after admission
- separate relation declarations from derived bindings so abstract clones and concrete inheritance keep correct ownership and target scope
- preserve source occurrence identity, module winner rules, class-body shadowing, and Salsa invalidation
- update model corpus snapshots and the model benchmark for project assembly

## Verification

- `cargo test -q`
- `just test`
- `cargo bench -p djls-bench --bench models -- resolve_relations`
- `just clippy`
- `just fmt --check`
- `just lint`
- `cargo build -q`
- `just hawk`