### PR TITLE
Add Django 6.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
+- Added support for Django 6.1.
 - Added quick-fix code actions for loading missing Django template tag libraries.
 - Added quick-fix code actions for choosing among ambiguous unloaded Django template tag libraries.
 - Added a quick-fix code action for renaming mismatched `{% endblock %}` names.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cog.outl(f"![Django Version](https://img.shields.io/badge/django-{'%20%7C%20'.jo
 ]]] -->
 [![PyPI](https://img.shields.io/pypi/v/django-language-server)](https://pypi.org/project/django-language-server/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-language-server)
-![Django Version](https://img.shields.io/badge/django-5.2%20%7C%206.0%20%7C%20main-%2344B78B?labelColor=%23092E20)
+![Django Version](https://img.shields.io/badge/django-5.2%20%7C%206.0%20%7C%206.1%20%7C%20main-%2344B78B?labelColor=%23092E20)
 <!-- [[[end]]] -->
 
 A language server for the Django web framework.

--- a/crates/djls-bench/fixtures/python/large/defaulttags.py
+++ b/crates/djls-bench/fixtures/python/large/defaulttags.py
@@ -10,7 +10,7 @@ from itertools import cycle as itertools_cycle
 from itertools import groupby
 
 from django.conf import settings
-from django.utils import timezone
+from django.utils import csp, timezone
 from django.utils.html import conditional_escape, escape, format_html
 from django.utils.lorem_ipsum import paragraphs, words
 from django.utils.safestring import mark_safe
@@ -1540,3 +1540,8 @@ def do_with(parser, token):
     nodelist = parser.parse(("endwith",))
     parser.delete_first_token()
     return WithNode(None, None, nodelist, extra_context=extra_context)
+
+
+@register.simple_tag(takes_context=True)
+def csp_nonce_attr(context, media=None):
+    return csp.nonce_attr(context, media)

--- a/crates/djls-bench/src/snapshots/djls_bench__check__tests__check_workload_corpus_all.snap
+++ b/crates/djls-bench/src/snapshots/djls_bench__check__tests__check_workload_corpus_all.snap
@@ -3,30 +3,30 @@ source: crates/djls-bench/src/check.rs
 expression: "CorpusWorkloadSnapshot\n{\n    input: corpus_input_snapshot(corpus), output:\n    checked_workload_snapshot(&db, &files, WorkloadDetail::Corpus, true),\n}"
 ---
 input:
-  discovered_file_count: 7145
-  synchronized_file_count: 7145
-  total_bytes: 11783514
-  sorted_records_sha256: 0ff9858e3e67be19c0938a7674ef07b6472828d464f0bd5c777be0f4b0e5969a
+  discovered_file_count: 7269
+  synchronized_file_count: 7269
+  total_bytes: 11921621
+  sorted_records_sha256: 8ffe302b4b0d09aae1d18f434e1a468a2bf6d0947a48b36b9ea66a7b8a49b690
 output:
   check_parser_count: 0
-  check_validation_count: 19327
+  check_validation_count: 19448
   check_code_counts:
     S101: 1
-    S108: 10363
-    S111: 4033
-    S120: 4930
-  per_file_checks_sha256: 0eb663b34c4cde42682f299a8205fd67344c5b6ce4ddad0ff9ba414e32e1d90f
-  ide_eligible_file_count: 6099
-  ide_diagnostic_count: 19327
+    S108: 10384
+    S111: 4107
+    S120: 4956
+  per_file_checks_sha256: 40a2f378fbe97261bbe9d0528a30cfdbedc226e28914c01818456b0e207bffa2
+  ide_eligible_file_count: 6214
+  ide_diagnostic_count: 19448
   ide_code_counts:
     S101: 1
-    S108: 10363
-    S111: 4033
-    S120: 4930
-  normalized_ide_diagnostics_sha256: f9c6cead4f15059688eab3fb9f4c7c7519aec8b6dcbdfdc1a0e8857b4e500586
-  files_with_diagnostics: 3680
-  diagnostic_bearing_paths_sha256: 0517e3a28d83b7037dee984b7c76260f415c94ac38b9dfa9007f8a7d0a63a580
+    S108: 10384
+    S111: 4107
+    S120: 4956
+  normalized_ide_diagnostics_sha256: ddef6fcdc534b86f9770f46e8bb4ffb59bc6a47897bddf41b05b60af4753e0e6
+  files_with_diagnostics: 3714
+  diagnostic_bearing_paths_sha256: 901f10dec884fad8ce8991475b6f9c627dbdac1dd749c255f618963f850eaf97
   rendered:
-    item_count: 19327
-    total_bytes: 5145573
-    output_sha256: 188fee2eb6302b3896f09a463b60e59a3be4ceac18d70a97245f2cd8796d7dac
+    item_count: 19448
+    total_bytes: 5180960
+    output_sha256: 1c08314ad1e274d0e069d8bb24e77f0b4c94e0421e7f4a2e5cbeb6b77006a8ae

--- a/crates/djls-bench/src/snapshots/djls_bench__check__tests__check_workload_corpus_django.snap
+++ b/crates/djls-bench/src/snapshots/djls_bench__check__tests__check_workload_corpus_django.snap
@@ -3,28 +3,28 @@ source: crates/djls-bench/src/check.rs
 expression: "CorpusWorkloadSnapshot\n{\n    input: corpus_input_snapshot(corpus), output:\n    checked_workload_snapshot(&db, &files, WorkloadDetail::Corpus, true),\n}"
 ---
 input:
-  discovered_file_count: 123
-  synchronized_file_count: 123
-  total_bytes: 134038
-  sorted_records_sha256: 19f8f883847c75c5fde26a904d82d803c3ec3b3ef5f4db227dfcc2b0b6cb61d0
+  discovered_file_count: 124
+  synchronized_file_count: 124
+  total_bytes: 138107
+  sorted_records_sha256: ea3cd77a6ea886927c6309d830eff37d6830b5c0a0321f8fa612dae0219d8150
 output:
   check_parser_count: 0
-  check_validation_count: 104
+  check_validation_count: 121
   check_code_counts:
-    S108: 19
-    S111: 67
-    S120: 18
-  per_file_checks_sha256: 22c114d24893e0e0ae41a2f6c239d797835611d5e750e959baee003467b3def4
-  ide_eligible_file_count: 114
-  ide_diagnostic_count: 104
+    S108: 21
+    S111: 74
+    S120: 26
+  per_file_checks_sha256: a2bc58a3d534b88173dbe2d1240810fc89f7ede90c75c77cfad4074e489cf14f
+  ide_eligible_file_count: 115
+  ide_diagnostic_count: 121
   ide_code_counts:
-    S108: 19
-    S111: 67
-    S120: 18
-  normalized_ide_diagnostics_sha256: 8ad7b24d71c1ff5957b3dfa494d8b91312dacf5f2dd2b89fce83502afb58032b
+    S108: 21
+    S111: 74
+    S120: 26
+  normalized_ide_diagnostics_sha256: 3630218fbaee3425ce63878d079c881f43fef682096d6fabb94bf9b086488dbe
   files_with_diagnostics: 34
-  diagnostic_bearing_paths_sha256: 2d4019df1a70f410189b904e17672d3f07a6bc1380edab81681d22d290c9edc3
+  diagnostic_bearing_paths_sha256: 6c68aa755a9cb32f0ad8432f81bc2ff14fa7895917790e1209f05202a7b472ce
   rendered:
-    item_count: 104
-    total_bytes: 29551
-    output_sha256: 24359b325d6e304ec3aa0dc5283472a7472e5b10e754282eb429070c2c92e0f1
+    item_count: 121
+    total_bytes: 35387
+    output_sha256: d3b3b98a80852a8c2ea70b297ffde5b1d77f0a1ce0fb5bb3e0388db3271a0cc7

--- a/crates/djls-bench/src/snapshots/djls_bench__fixtures__tests__fixture_identity_python.snap
+++ b/crates/djls-bench/src/snapshots/djls_bench__fixtures__tests__fixture_identity_python.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/djls-bench/src/fixtures.rs
-expression: fixture_set_snapshot(python_fixtures())
+expression: "fixture_set_snapshot(python_fixtures().expect(\"Python benchmark fixtures should load\"))"
 ---
 file_count: 3
-total_bytes: 69940
+total_bytes: 70071
 files:
   - path: large/defaulttags.py
-    bytes: 49669
-    source_sha256: 115e2326b49c8c3c330493769c98412cc627e5b236b418f95e9594e7cc1dba69
+    bytes: 49800
+    source_sha256: 0f0f3e766669d62bb483ba81e7bdb9e58ae7279e09f73df2e0358eea243b1a78
   - path: medium/i18n.py
     bytes: 19961
     source_sha256: 52b4be684dd70842bfa17d7c9261fc812800d743061cc78c4cb3801120edb9f2

--- a/crates/djls-project/src/templates/tags/testdata/django_admin_urls.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_admin_urls.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/django/contrib/admin/templatetags/admin_urls.py
+# Corpus: django-6.1/django/contrib/admin/templatetags/admin_urls.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_custom.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_custom.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/tests/template_tests/templatetags/custom.py
+# Corpus: django-6.1/tests/template_tests/templatetags/custom.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_defaultfilters.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_defaultfilters.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/django/template/defaultfilters.py
+# Corpus: django-6.1/django/template/defaultfilters.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_defaulttags.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_defaulttags.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/django/template/defaulttags.py
+# Corpus: django-6.1/django/template/defaulttags.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_i18n.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_i18n.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/django/templatetags/i18n.py
+# Corpus: django-6.1/django/templatetags/i18n.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_inclusion.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_inclusion.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/tests/template_tests/templatetags/inclusion.py
+# Corpus: django-6.1/tests/template_tests/templatetags/inclusion.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_loader_tags.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_loader_tags.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/django/template/loader_tags.py
+# Corpus: django-6.1/django/template/loader_tags.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_testtags.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_testtags.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/tests/template_tests/templatetags/testtags.py
+# Corpus: django-6.1/tests/template_tests/templatetags/testtags.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/src/templates/tags/testdata/django_tz.py
+++ b/crates/djls-project/src/templates/tags/testdata/django_tz.py
@@ -1,5 +1,5 @@
 # Vendored unit-test fixture.
-# Corpus: django-6.0/django/templatetags/tz.py
+# Corpus: django-6.1/django/templatetags/tz.py
 # Keep snippets minimal: live corpus drift is covered by crates/djls-project/tests/corpus*.rs.
 
 from django import template

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_filters.py.snap
@@ -1,0 +1,13 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities:
+  "django.contrib.admin.templatetags.admin_filters::filter::to_object_display_value":
+    expects_arg: false
+    arg_optional: false
+  "django.contrib.admin.templatetags.admin_filters::filter::truncated_unordered_list":
+    expects_arg: true
+    arg_optional: false
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_list.py.snap
@@ -1,0 +1,41 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.contrib.admin.templatetags.admin_list::tag::admin_list_filter":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: cl
+        required: true
+        kind: Variable
+        position: 0
+      - name: spec
+        required: true
+        kind: Variable
+        position: 1
+    as_var: strip
+  "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: cl
+        required: true
+        kind: Variable
+        position: 0
+      - name: i
+        required: true
+        kind: Variable
+        position: 1
+    as_var: strip
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_modify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_modify.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities:
+  "django.contrib.admin.templatetags.admin_modify::filter::cell_count":
+    expects_arg: false
+    arg_optional: false
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -1,0 +1,34 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.contrib.admin.templatetags.admin_urls::tag::add_preserved_filters":
+    arg_constraints:
+      - Min: 2
+      - Max: 4
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: url
+        required: true
+        kind: Variable
+        position: 0
+      - name: popup
+        required: false
+        kind: Variable
+        position: 1
+      - name: to_field
+        required: false
+        kind: Variable
+        position: 2
+    as_var: strip
+filter_arities:
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname":
+    expects_arg: true
+    arg_optional: false
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote":
+    expects_arg: false
+    arg_optional: false
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__base.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__base.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__log.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__log.py.snap
@@ -1,0 +1,59 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.contrib.admin.templatetags.log::tag::get_admin_log":
+    arg_constraints:
+      - Min: 4
+    required_keywords:
+      - position:
+          Forward: 2
+        value: as
+      - position:
+          Forward: 4
+        value: for_user
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 4
+        message:
+          Static: "'get_admin_log' statements require two arguments"
+      - constraint:
+          RequiredKeyword:
+            position:
+              Forward: 2
+            value: as
+        message:
+          Static: "Second argument to 'get_admin_log' must be 'as'"
+      - constraint:
+          RequiredKeyword:
+            position:
+              Forward: 4
+            value: for_user
+        message:
+          Static: "Fourth argument to 'get_admin_log' must be 'for_user'"
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 1
+      - name: arg3
+        required: true
+        kind: Variable
+        position: 2
+      - name: for_user
+        required: true
+        kind:
+          Literal: for_user
+        position: 3
+    as_var: keep
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__auth__templatetags__auth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__auth__templatetags__auth.py.snap
@@ -1,0 +1,20 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.contrib.auth.templatetags.auth::tag::render_password_as_hash":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: value
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -1,0 +1,20 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.contrib.flatpages.templatetags.flatpages::tag::get_flatpages":
+    arg_constraints: []
+    required_keywords:
+      - position:
+          Backward: 2
+        value: as
+      - position:
+          Backward: 4
+        value: for
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__humanize__templatetags__humanize.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__humanize__templatetags__humanize.py.snap
@@ -1,0 +1,25 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities:
+  "django.contrib.humanize.templatetags.humanize::filter::apnumber":
+    expects_arg: false
+    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::intcomma":
+    expects_arg: true
+    arg_optional: true
+  "django.contrib.humanize.templatetags.humanize::filter::intword":
+    expects_arg: false
+    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::naturalday":
+    expects_arg: true
+    arg_optional: true
+  "django.contrib.humanize.templatetags.humanize::filter::naturaltime":
+    expects_arg: false
+    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::ordinal":
+    expects_arg: false
+    arg_optional: false
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaultfilters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaultfilters.py.snap
@@ -1,0 +1,178 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities:
+  "django.template.defaultfilters::filter::add":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::addslashes":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::capfirst":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::center":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::cut":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::date":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::default":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::default_if_none":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::dictsort":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::dictsortreversed":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::divisibleby":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::escape":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::escapejs":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::escapeseq":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::filesizeformat":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::first":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::floatformat":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::force_escape":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::get_digit":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::iriencode":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::join":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::json_script":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::last":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::length":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::linebreaks":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::linebreaksbr":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::linenumbers":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::ljust":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::lower":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::make_list":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::phone2numeric":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::pluralize":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::pprint":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::random":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::rjust":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::safe":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::safeseq":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::slice":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::slugify":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::stringformat":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::striptags":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::time":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::timesince":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::timeuntil":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::title":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::truncatechars":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::truncatechars_html":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::truncatewords":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::truncatewords_html":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::unordered_list":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::upper":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::urlencode":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::urlize":
+    expects_arg: true
+    arg_optional: true
+  "django.template.defaultfilters::filter::urlizetrunc":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::wordcount":
+    expects_arg: false
+    arg_optional: false
+  "django.template.defaultfilters::filter::wordwrap":
+    expects_arg: true
+    arg_optional: false
+  "django.template.defaultfilters::filter::yesno":
+    expects_arg: true
+    arg_optional: true
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
@@ -1,0 +1,390 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.template.defaulttags::tag::autoescape":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - "on"
+          - "off"
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          Static: "'autoescape' tag requires exactly one argument."
+      - constraint:
+          ChoiceAt:
+            position:
+              Forward: 1
+            values:
+              - "on"
+              - "off"
+        message:
+          Static: "'autoescape' argument should be 'on' or 'off'"
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.defaulttags::tag::csp_nonce_attr":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: media
+        required: false
+        kind: Variable
+        position: 0
+    as_var: strip
+  "django.template.defaulttags::tag::cycle":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 2
+        message:
+          Static: "'cycle' tag requires at least two arguments"
+      - constraint:
+          RequiredKeyword:
+            position:
+              Backward: 1
+            value: silent
+        message:
+          PercentFormat:
+            template: "Only 'silent' flag is allowed after cycle's name, not '%s'."
+            args:
+              - SplitElement:
+                  Backward: 1
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.defaulttags::tag::for":
+    arg_constraints:
+      - Min: 4
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+      - name: arg3
+        required: true
+        kind: Variable
+        position: 2
+    as_var: keep
+  "django.template.defaulttags::tag::lorem":
+    arg_constraints:
+      - Exact: 4
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 4
+        message:
+          PercentFormat:
+            template: Incorrect format for %r tag
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+      - name: arg3
+        required: true
+        kind: Variable
+        position: 2
+    as_var: keep
+  "django.template.defaulttags::tag::now":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          Static: "'now' statement takes one argument"
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+  "django.template.defaulttags::tag::partial":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.defaulttags::tag::partialdef":
+    arg_constraints:
+      - OneOf:
+          - 2
+          - 3
+    required_keywords:
+      - position:
+          Forward: 2
+        value: inline
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+      - name: inline
+        required: true
+        kind:
+          Literal: inline
+        position: 1
+    as_var: keep
+  "django.template.defaulttags::tag::querystring":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 0
+    as_var: strip
+  "django.template.defaulttags::tag::regroup":
+    arg_constraints:
+      - Exact: 6
+    required_keywords:
+      - position:
+          Forward: 2
+        value: by
+      - position:
+          Forward: 4
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 6
+        message:
+          Static: "'regroup' tag takes five arguments"
+      - constraint:
+          RequiredKeyword:
+            position:
+              Forward: 2
+            value: by
+        message:
+          Static: "second argument to 'regroup' tag must be 'by'"
+      - constraint:
+          RequiredKeyword:
+            position:
+              Forward: 4
+            value: as
+        message:
+          Static: "next-to-last argument to 'regroup' tag must be 'as'"
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+      - name: by
+        required: true
+        kind:
+          Literal: by
+        position: 1
+      - name: arg3
+        required: true
+        kind: Variable
+        position: 2
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 3
+      - name: var_name
+        required: true
+        kind: Variable
+        position: 4
+    as_var: keep
+  "django.template.defaulttags::tag::resetcycle":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Max: 2
+        message:
+          PercentFormat:
+            template: "%r tag accepts at most one argument."
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: name
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.defaulttags::tag::templatetag":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          Static: "'templatetag' statement takes one argument"
+    extracted_args:
+      - name: tag
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.defaulttags::tag::url":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes at least one argument, a URL pattern name."
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+  "django.template.defaulttags::tag::widthratio":
+    arg_constraints: []
+    required_keywords:
+      - position:
+          Forward: 4
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          RequiredKeyword:
+            position:
+              Forward: 4
+            value: as
+        message:
+          Static: "Invalid syntax in widthratio tag. Expecting 'as' keyword"
+    extracted_args:
+      - name: this_value_expr
+        required: true
+        kind: Variable
+        position: 0
+      - name: max_value_expr
+        required: true
+        kind: Variable
+        position: 1
+      - name: max_width
+        required: true
+        kind: Variable
+        position: 2
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 3
+      - name: asvar
+        required: true
+        kind: Variable
+        position: 4
+    as_var: keep
+filter_arities: {}
+block_specs:
+  "django.template.defaulttags::tag::autoescape":
+    end_tag: endautoescape
+    intermediates: []
+    opaque: false
+  "django.template.defaulttags::tag::comment":
+    end_tag: endcomment
+    intermediates: []
+    opaque: true
+  "django.template.defaulttags::tag::filter":
+    end_tag: endfilter
+    intermediates: []
+    opaque: false
+  "django.template.defaulttags::tag::for":
+    end_tag: endfor
+    intermediates:
+      - empty
+    opaque: false
+  "django.template.defaulttags::tag::if":
+    end_tag: endif
+    intermediates:
+      - elif
+      - else
+    opaque: false
+  "django.template.defaulttags::tag::ifchanged":
+    end_tag: endifchanged
+    intermediates:
+      - else
+    opaque: false
+  "django.template.defaulttags::tag::spaceless":
+    end_tag: endspaceless
+    intermediates: []
+    opaque: false
+  "django.template.defaulttags::tag::verbatim":
+    end_tag: endverbatim
+    intermediates: []
+    opaque: false
+  "django.template.defaulttags::tag::with":
+    end_tag: endwith
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
@@ -1,0 +1,82 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.template.loader_tags::tag::block":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "'%s' tag takes only one argument"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: block_name
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.loader_tags::tag::extends":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes one argument"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.template.loader_tags::tag::include":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options:
+      values:
+        - with
+        - only
+      allow_duplicates: false
+      rejects_unknown: true
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 2
+        message:
+          PercentFormat:
+            template: "%r tag takes at least one argument: the name of the template to be included."
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+filter_arities: {}
+block_specs:
+  "django.template.loader_tags::tag::block":
+    end_tag: endblock
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__cache.py.snap
@@ -1,0 +1,37 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.templatetags.cache::tag::cache":
+    arg_constraints:
+      - Min: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 3
+        message:
+          PercentFormat:
+            template: "'%r' tag requires at least 2 arguments."
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+filter_arities: {}
+block_specs:
+  "django.templatetags.cache::tag::cache":
+    end_tag: endcache
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
@@ -1,0 +1,265 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.templatetags.i18n::tag::blocktrans":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options:
+      values:
+        - with
+        - count
+        - context
+        - trimmed
+        - asvar
+      allow_duplicates: false
+      rejects_unknown: true
+    extracted_args: []
+    as_var: keep
+  "django.templatetags.i18n::tag::blocktranslate":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options:
+      values:
+        - with
+        - count
+        - context
+        - trimmed
+        - asvar
+      allow_duplicates: false
+      rejects_unknown: true
+    extracted_args: []
+    as_var: keep
+  "django.templatetags.i18n::tag::get_available_languages":
+    arg_constraints:
+      - Exact: 3
+    required_keywords:
+      - position:
+          Forward: 1
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "django.templatetags.i18n::tag::get_current_language":
+    arg_constraints:
+      - Exact: 3
+    required_keywords:
+      - position:
+          Forward: 1
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "django.templatetags.i18n::tag::get_current_language_bidi":
+    arg_constraints:
+      - Exact: 3
+    required_keywords:
+      - position:
+          Forward: 1
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "django.templatetags.i18n::tag::get_language_info":
+    arg_constraints:
+      - Exact: 5
+    required_keywords:
+      - position:
+          Forward: 1
+        value: for
+      - position:
+          Forward: 3
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: for
+        required: true
+        kind:
+          Literal: for
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 2
+      - name: arg4
+        required: true
+        kind: Variable
+        position: 3
+    as_var: keep
+  "django.templatetags.i18n::tag::get_language_info_list":
+    arg_constraints:
+      - Exact: 5
+    required_keywords:
+      - position:
+          Forward: 1
+        value: for
+      - position:
+          Forward: 3
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: for
+        required: true
+        kind:
+          Literal: for
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 2
+      - name: arg4
+        required: true
+        kind: Variable
+        position: 3
+    as_var: keep
+  "django.templatetags.i18n::tag::language":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes one argument (language)"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.templatetags.i18n::tag::trans":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options:
+      values:
+        - noop
+        - context
+        - as
+      allow_duplicates: false
+      rejects_unknown: true
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes at least one argument"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.templatetags.i18n::tag::translate":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options:
+      values:
+        - noop
+        - context
+        - as
+      allow_duplicates: false
+      rejects_unknown: true
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes at least one argument"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+filter_arities:
+  "django.templatetags.i18n::filter::language_bidi":
+    expects_arg: false
+    arg_optional: false
+  "django.templatetags.i18n::filter::language_name":
+    expects_arg: false
+    arg_optional: false
+  "django.templatetags.i18n::filter::language_name_local":
+    expects_arg: false
+    arg_optional: false
+  "django.templatetags.i18n::filter::language_name_translated":
+    expects_arg: false
+    arg_optional: false
+block_specs:
+  "django.templatetags.i18n::tag::blocktrans":
+    end_tag: endblocktrans
+    intermediates:
+      - plural
+    opaque: false
+  "django.templatetags.i18n::tag::blocktranslate":
+    end_tag: endblocktranslate
+    intermediates:
+      - plural
+    opaque: false
+  "django.templatetags.i18n::tag::language":
+    end_tag: endlanguage
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
@@ -1,0 +1,57 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.templatetags.l10n::tag::localize":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - "on"
+          - "off"
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Max: 2
+        message:
+          PercentFormat:
+            template: "%r argument should be 'on' or 'off'"
+            args:
+              - SplitElement:
+                  Forward: 0
+      - constraint:
+          ChoiceAt:
+            position:
+              Forward: 1
+            values:
+              - "on"
+              - "off"
+        message:
+          PercentFormat:
+            template: "%r argument should be 'on' or 'off'"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+filter_arities:
+  "django.templatetags.l10n::filter::localize":
+    expects_arg: false
+    arg_optional: false
+  "django.templatetags.l10n::filter::unlocalize":
+    expects_arg: false
+    arg_optional: false
+block_specs:
+  "django.templatetags.l10n::tag::localize":
+    end_tag: endlocalize
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__static.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__static.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
@@ -1,0 +1,106 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "django.templatetags.tz::tag::get_current_timezone":
+    arg_constraints:
+      - Exact: 3
+    required_keywords:
+      - position:
+          Forward: 1
+        value: as
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: as
+        required: true
+        kind:
+          Literal: as
+        position: 0
+      - name: arg2
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "django.templatetags.tz::tag::localtime":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - "on"
+          - "off"
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Max: 2
+        message:
+          PercentFormat:
+            template: "%r argument should be 'on' or 'off'"
+            args:
+              - SplitElement:
+                  Forward: 0
+      - constraint:
+          ChoiceAt:
+            position:
+              Forward: 1
+            values:
+              - "on"
+              - "off"
+        message:
+          PercentFormat:
+            template: "%r argument should be 'on' or 'off'"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "django.templatetags.tz::tag::timezone":
+    arg_constraints:
+      - Exact: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "'%s' takes one argument (timezone)"
+            args:
+              - SplitElement:
+                  Forward: 0
+    extracted_args:
+      - name: arg1
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+filter_arities:
+  "django.templatetags.tz::filter::localtime":
+    expects_arg: false
+    arg_optional: false
+  "django.templatetags.tz::filter::timezone":
+    expects_arg: true
+    arg_optional: false
+  "django.templatetags.tz::filter::utc":
+    expects_arg: false
+    arg_optional: false
+block_specs:
+  "django.templatetags.tz::tag::localtime":
+    end_tag: endlocaltime
+    intermediates: []
+    opaque: false
+  "django.templatetags.tz::tag::timezone":
+    end_tag: endtimezone
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__check_framework__template_test_apps__different_tags_app__templatetags__different_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__check_framework__template_test_apps__different_tags_app__templatetags__different_tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__check_framework__template_test_apps__same_tags_app_1__templatetags__same_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__check_framework__template_test_apps__same_tags_app_1__templatetags__same_tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__check_framework__template_test_apps__same_tags_app_2__templatetags__same_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__check_framework__template_test_apps__same_tags_app_2__templatetags__same_tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__forms_tests__templatetags__tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__forms_tests__templatetags__tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__empty.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__empty.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__good_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__good_tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__override.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__override.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__subpackage__tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__good__templatetags__subpackage__tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__importerror__templatetags__broken_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_backends__apps__importerror__templatetags__broken_tags.py.snap
@@ -1,0 +1,7 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__bad_tag.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__bad_tag.py.snap
@@ -1,0 +1,15 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "tests.template_tests.templatetags.bad_tag::tag::badsimpletag":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
@@ -1,0 +1,241 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "tests.template_tests.templatetags.custom::tag::context_stack_length":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::current_app":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_explicit":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_format_html":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_naive":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::minustwo":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: value
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::no_params":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::one_param":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::params_and_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: kwarg
+        required: false
+        kind: Keyword
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: kwarg
+        required: true
+        kind: Keyword
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_one_default":
+    arg_constraints:
+      - Min: 2
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 0
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_two_params":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: true
+        kind: Variable
+        position: 1
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 2
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 2
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::use_l10n":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+filter_arities:
+  "tests.template_tests.templatetags.custom::filter::make_data_div":
+    expects_arg: false
+    arg_optional: false
+  "tests.template_tests.templatetags.custom::filter::noop":
+    expects_arg: true
+    arg_optional: true
+  "tests.template_tests.templatetags.custom::filter::trim":
+    expects_arg: true
+    arg_optional: false
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__inclusion.py.snap
@@ -1,0 +1,303 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_extends2":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_keyword_only_default":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: kwarg
+        required: false
+        kind: Keyword
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_from_template":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context_from_template":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default":
+    arg_constraints:
+      - Min: 2
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
+    arg_constraints:
+      - Min: 2
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: true
+        kind: Variable
+        position: 1
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 2
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 2
+    as_var: keep
+  "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: one
+        required: true
+        kind: Variable
+        position: 0
+      - name: two
+        required: false
+        kind: Variable
+        position: 1
+      - name: args
+        required: false
+        kind: VarArgs
+        position: 2
+    as_var: keep
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -1,0 +1,20 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "tests.template_tests.templatetags.subpackage.echo::tag::echo2":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args:
+      - name: arg
+        required: true
+        kind: Variable
+        position: 0
+    as_var: strip
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__tag_27584.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__tag_27584.py.snap
@@ -1,0 +1,11 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities: {}
+block_specs:
+  "tests.template_tests.templatetags.tag_27584::tag::badtag":
+    end_tag: endbadtag
+    intermediates: []
+    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__testtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__testtags.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules: {}
+filter_arities:
+  "tests.template_tests.templatetags.testtags::filter::upper":
+    expects_arg: false
+    arg_optional: false
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__view_tests__templatetags__debugtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__view_tests__templatetags__debugtags.py.snap
@@ -1,0 +1,15 @@
+---
+source: crates/djls-project/tests/corpus.rs
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
+---
+tag_rules:
+  "tests.view_tests.templatetags.debugtags::tag::go_boom":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    extracted_args: []
+    as_var: strip
+filter_arities: {}
+block_specs: {}

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__admin__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__admin__models.py.snap
@@ -1,0 +1,44 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.admin.models.LogEntry:
+    name:
+      value: LogEntry
+      span:
+        start: 1563
+        length: 8
+    module_name: django.contrib.admin.models
+    relations:
+      - field_name:
+          value: user
+          span:
+            start: 1717
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Attribute
+            path:
+              - settings
+              - AUTH_USER_MODEL
+          span:
+            start: 1751
+            length: 24
+        related_name: ~
+      - field_name:
+          value: content_type
+          span:
+            start: 1843
+            length: 12
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: ContentType
+          span:
+            start: 1885
+            length: 11
+        related_name: ~
+    kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__auth__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__auth__models.py.snap
@@ -1,0 +1,116 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.auth.models.AbstractUser:
+    name:
+      value: AbstractUser
+      span:
+        start: 15766
+        length: 12
+    module_name: django.contrib.auth.models
+    relations: []
+    kind: abstract
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 15779
+            length: 16
+          reason:
+            ImportNotFound:
+              requested: django.contrib.auth.base_user.AbstractBaseUser
+    ancestry: Partial
+  django.contrib.auth.models.Group:
+    name:
+      value: Group
+      span:
+        start: 3536
+        length: 5
+    module_name: django.contrib.auth.models
+    relations:
+      - field_name:
+          value: permissions
+          span:
+            start: 4418
+            length: 11
+        relation_type: ManyToMany
+        target:
+          value:
+            kind: Bare
+            name: Permission
+          span:
+            start: 4464
+            length: 10
+        related_name: ~
+    kind: concrete
+  django.contrib.auth.models.Permission:
+    name:
+      value: Permission
+      span:
+        start: 1170
+        length: 10
+    module_name: django.contrib.auth.models
+    relations:
+      - field_name:
+          value: content_type
+          span:
+            start: 2358
+            length: 12
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: ContentType
+          span:
+            start: 2400
+            length: 11
+        related_name: ~
+    kind: concrete
+  django.contrib.auth.models.PermissionsMixin:
+    name:
+      value: PermissionsMixin
+      span:
+        start: 11117
+        length: 16
+    module_name: django.contrib.auth.models
+    relations:
+      - field_name:
+          value: groups
+          span:
+            start: 11524
+            length: 6
+        relation_type: ManyToMany
+        target:
+          value:
+            kind: Bare
+            name: Group
+          span:
+            start: 11565
+            length: 5
+        related_name: user_set
+      - field_name:
+          value: user_permissions
+          span:
+            start: 11863
+            length: 16
+        relation_type: ManyToMany
+        target:
+          value:
+            kind: Bare
+            name: Permission
+          span:
+            start: 11914
+            length: 10
+        related_name: user_set
+    kind: abstract
+  django.contrib.auth.models.User:
+    name:
+      value: User
+      span:
+        start: 18036
+        length: 4
+    module_name: django.contrib.auth.models
+    relations: []
+    kind: concrete
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__contenttypes__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__contenttypes__models.py.snap
@@ -1,0 +1,14 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.contenttypes.models.ContentType:
+    name:
+      value: ContentType
+      span:
+        start: 5017
+        length: 11
+    module_name: django.contrib.contenttypes.models
+    relations: []
+    kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__flatpages__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__flatpages__models.py.snap
@@ -1,0 +1,28 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.flatpages.models.FlatPage:
+    name:
+      value: FlatPage
+      span:
+        start: 249
+        length: 8
+    module_name: django.contrib.flatpages.models
+    relations:
+      - field_name:
+          value: sites
+          span:
+            start: 1066
+            length: 5
+        relation_type: ManyToMany
+        target:
+          value:
+            kind: Bare
+            name: Site
+          span:
+            start: 1097
+            length: 4
+        related_name: ~
+    kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__gis__db__backends__oracle__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__gis__db__backends__oracle__models.py.snap
@@ -1,0 +1,32 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.gis.db.backends.oracle.models.OracleGeometryColumns:
+    name:
+      value: OracleGeometryColumns
+      span:
+        start: 494
+        length: 21
+    module_name: django.contrib.gis.db.backends.oracle.models
+    relations: []
+    kind: concrete
+  django.contrib.gis.db.backends.oracle.models.OracleSpatialRefSys:
+    name:
+      value: OracleSpatialRefSys
+      span:
+        start: 1427
+        length: 19
+    module_name: django.contrib.gis.db.backends.oracle.models
+    relations: []
+    kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1461
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__gis__db__backends__postgis__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__gis__db__backends__postgis__models.py.snap
@@ -1,0 +1,32 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.gis.db.backends.postgis.models.PostGISGeometryColumns:
+    name:
+      value: PostGISGeometryColumns
+      span:
+        start: 190
+        length: 22
+    module_name: django.contrib.gis.db.backends.postgis.models
+    relations: []
+    kind: concrete
+  django.contrib.gis.db.backends.postgis.models.PostGISSpatialRefSys:
+    name:
+      value: PostGISSpatialRefSys
+      span:
+        start: 1437
+        length: 20
+    module_name: django.contrib.gis.db.backends.postgis.models
+    relations: []
+    kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1472
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__gis__db__backends__spatialite__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__gis__db__backends__spatialite__models.py.snap
@@ -1,0 +1,32 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.gis.db.backends.spatialite.models.SpatialiteGeometryColumns:
+    name:
+      value: SpatialiteGeometryColumns
+      span:
+        start: 193
+        length: 25
+    module_name: django.contrib.gis.db.backends.spatialite.models
+    relations: []
+    kind: concrete
+  django.contrib.gis.db.backends.spatialite.models.SpatialiteSpatialRefSys:
+    name:
+      value: SpatialiteSpatialRefSys
+      span:
+        start: 1355
+        length: 23
+    module_name: django.contrib.gis.db.backends.spatialite.models
+    relations: []
+    kind: concrete
+    unresolved_bases:
+      - Unresolved:
+          span:
+            start: 1393
+            length: 18
+          reason:
+            ImportNotFound:
+              requested: django.contrib.gis.db.backends.base.models.SpatialRefSysMixin
+    ancestry: Partial

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__redirects__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__redirects__models.py.snap
@@ -1,0 +1,28 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.redirects.models.Redirect:
+    name:
+      value: Redirect
+      span:
+        start: 137
+        length: 8
+    module_name: django.contrib.redirects.models
+    relations:
+      - field_name:
+          value: site
+          span:
+            start: 165
+            length: 4
+        relation_type: ForeignKey
+        target:
+          value:
+            kind: Bare
+            name: Site
+          span:
+            start: 190
+            length: 4
+        related_name: ~
+    kind: concrete

--- a/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__sites__models.py.snap
+++ b/crates/djls-project/tests/snapshots/models/corpus_models__repos__django-6.1__django__contrib__sites__models.py.snap
@@ -1,0 +1,14 @@
+---
+source: crates/djls-project/tests/corpus_models.rs
+expression: graph
+---
+models:
+  django.contrib.sites.models.Site:
+    name:
+      value: Site
+      span:
+        start: 2651
+        length: 4
+    module_name: django.contrib.sites.models
+    relations: []
+    kind: concrete

--- a/crates/djls-testing/licenses/django-6.1
+++ b/crates/djls-testing/licenses/django-6.1
@@ -1,0 +1,27 @@
+Copyright (c) Django Software Foundation and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of Django nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crates/djls-testing/manifest.lock
+++ b/crates/djls-testing/manifest.lock
@@ -211,6 +211,12 @@ tag = "6.0.2"
 ref = "ba00558ddac694d92b05d12ecd2a5b7fcc1de025"
 
 [[repo]]
+name = "django-6.1"
+url = "https://github.com/django/django.git"
+tag = "6.1rc1"
+ref = "0f1b39b28b20a1094c4c02dd72d0ba840ed7e10b"
+
+[[repo]]
 name = "djangopackages.org"
 url = "https://github.com/djangopackages/djangopackages.git"
 tag = "main"

--- a/crates/djls-testing/manifest.toml
+++ b/crates/djls-testing/manifest.toml
@@ -180,6 +180,11 @@ url = "https://github.com/django/django.git"
 ref = "6.0.2"
 
 [[repo]]
+name = "django-6.1"
+url = "https://github.com/django/django.git"
+ref = "6.1rc1"
+
+[[repo]]
 name = "djangopackages.org"
 url = "https://github.com/djangopackages/djangopackages.git"
 ref = "main"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -27,7 +27,7 @@ cog.outl(f"- Python {', '.join(PY_VERSIONS)}")
 cog.outl(f"- Django {', '.join(django_versions)}")
 ]]] -->
 - Python 3.10, 3.11, 3.12, 3.13, 3.14
-- Django 5.2, 6.0
+- Django 5.2, 6.0, 6.1
 <!-- [[[end]]] -->
 
 ## Version numbering

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,9 +25,10 @@ PY_LATEST = PY_VERSIONS[-1]
 DJ52 = "5.2"
 DJ52_CORPUS_VERSION = "5.2.11"
 DJ60 = "6.0"
+DJ61 = "6.1rc1"
 DJMAIN = "main"
 DJMAIN_MIN_PY = PY312
-DJ_VERSIONS = [DJ52, DJ60, DJMAIN]
+DJ_VERSIONS = [DJ52, DJ60, DJ61, DJMAIN]
 DJ_LTS = [
     version for version in DJ_VERSIONS if version.endswith(".2") and version != DJMAIN
 ]
@@ -49,11 +50,11 @@ def should_skip(python: str, django: str) -> bool:
     """Return True if the test should be skipped"""
 
     if django == DJMAIN and version(python) < version(DJMAIN_MIN_PY):
-        # Django main requires Python 3.10+
+        # Django main requires Python 3.12+
         return True
 
-    if django == DJ60 and version(python) < version(PY312):
-        # Django main requires Python 3.12+
+    if django in {DJ60, DJ61} and version(python) < version(PY312):
+        # Django 6.0 and 6.1 require Python 3.12+
         return True
 
     if django == DJ52 and version(python) < version(PY310):
@@ -204,7 +205,7 @@ def lint(session):
 
 
 @nox.session
-@nox.parametrize("django", [DJ52, DJ60, DJMAIN])
+@nox.parametrize("django", DJ_VERSIONS)
 def analyze_tags(session, django):
     """Analyze Django template tags and generate TagSpec suggestions."""
     if django == DJMAIN:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ classifiers = [
   # ]]] -->
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   # [[[end]]]
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Summary

- add Django 6.1rc1 to the supported Nox and CI matrices on Python 3.12–3.14
- regenerate package metadata and support documentation while retaining Django 5.2 and 6.0
- pin Django 6.1 in the corpus and record its tag, filter, model, and benchmark fixtures

## Testing

- `cargo test -q`
- `just clippy`
- `just fmt --check`
- `just lint`
- Hawk equivalent with cargo-hawk 0.1.9 and Rust 1.95.0: 0 findings
- `just docs build`

The full Nox Django matrix was not run locally.