### PR TITLE
Preserve uncertain template library inventories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Fixed false unknown tag and filter diagnostics when a template library imports or dynamically mutates its Django registration object.
 - Fixed static path evaluation to follow imported helper aliases without mistaking shadowed `Path`, `str`, or `os` bindings for standard-library helpers.
 - Fixed static Django settings evaluation through ordinary and `from` imports, including dotted module chains, module attributes, named package children, and `__all__`-controlled star exports.
 - Fixed Python settings evaluation to distinguish list and tuple concatenation while preserving known collection facts through supported iterable extensions.

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -683,9 +683,10 @@ fn completion_symbol_candidates(
     nodelist.map_or_else(
         || scoped_libraries.scoped_symbol_candidates(name, kind),
         |nodelist| {
-            effective_symbol_candidate_at(db, file, nodelist, offset.get(), name, kind)
-                .into_iter()
-                .collect()
+            effective_symbol_candidate_at(db, file, nodelist, offset.get(), name, kind).map_or_else(
+                || scoped_libraries.scoped_symbol_candidates(name, kind),
+                |candidate| vec![candidate],
+            )
         },
     )
 }

--- a/crates/djls-project/src/templates/libraries.rs
+++ b/crates/djls-project/src/templates/libraries.rs
@@ -70,6 +70,16 @@ enum TemplateSymbolObservation {
     Unobserved,
 }
 
+impl TemplateSymbolObservation {
+    fn from_source_inventory(symbols_unobserved: bool) -> Self {
+        if symbols_unobserved {
+            Self::Unobserved
+        } else {
+            Self::Observed
+        }
+    }
+}
+
 impl TemplateLibraryModule {
     fn name(&self) -> &PythonModuleName {
         match self {
@@ -133,13 +143,14 @@ impl TemplateLibrary {
     fn builtin(
         id: TemplateLibraryId,
         module: PythonSourceModule,
+        symbol_observation: TemplateSymbolObservation,
         symbols: Vec<TemplateSymbol>,
     ) -> Self {
         Self::new(
             id,
             TemplateLibraryModule::Source(module),
             TemplateLibraryKind::Builtin,
-            TemplateSymbolObservation::Observed,
+            symbol_observation,
             symbols,
         )
     }
@@ -175,13 +186,14 @@ impl TemplateLibrary {
         id: TemplateLibraryId,
         load_name: LibraryName,
         module: PythonSourceModule,
+        symbol_observation: TemplateSymbolObservation,
         symbols: Vec<TemplateSymbol>,
     ) -> Self {
         Self::new(
             id,
             TemplateLibraryModule::Source(module),
             TemplateLibraryKind::Loadable { load_name },
-            TemplateSymbolObservation::Observed,
+            symbol_observation,
             symbols,
         )
     }
@@ -240,13 +252,14 @@ impl TemplateLibrary {
         load_name: LibraryName,
         app: PythonModuleName,
         module: PythonSourceModule,
+        symbol_observation: TemplateSymbolObservation,
         symbols: Vec<TemplateSymbol>,
     ) -> Self {
         Self::new(
             id,
             TemplateLibraryModule::Source(module),
             TemplateLibraryKind::AvailableInApp { load_name, app },
-            TemplateSymbolObservation::Observed,
+            symbol_observation,
             symbols,
         )
     }
@@ -637,6 +650,7 @@ type DiscoveredLibrary = (
     LibraryName,
     TemplateLibraryId,
     PythonSourceModule,
+    TemplateSymbolObservation,
     Vec<TemplateSymbol>,
 );
 
@@ -667,6 +681,7 @@ enum ConfiguredLibraryModule {
         id: TemplateLibraryId,
         module: PythonSourceModule,
         symbols: Vec<TemplateSymbol>,
+        symbol_observation: TemplateSymbolObservation,
         recovered: bool,
     },
     SourceLess {
@@ -1083,6 +1098,29 @@ impl TemplateLibraryCatalog {
                 })
                 .next_back();
             candidates.extend(candidate);
+        }
+
+        if matches!(lookup, ScopedTemplateSymbolLookup::Inconclusive)
+            && libraries.iter().any(|library| {
+                library.symbols_are_unobserved() && library.symbol(kind, name).is_some()
+            })
+        {
+            candidates.extend(libraries.iter().filter_map(|library| {
+                let symbol = library.symbol(kind, name)?.clone();
+                let availability = library.load_name().map_or_else(
+                    || TemplateSymbolAvailability::Builtin {
+                        module: library.module_name().clone(),
+                    },
+                    |load_name| TemplateSymbolAvailability::RequiresLoad {
+                        load_name: load_name.clone(),
+                    },
+                );
+                Some(TemplateSymbolCandidate {
+                    symbol,
+                    availability,
+                })
+            }));
+            return candidates;
         }
 
         let ScopedTemplateSymbolLookup::RequiresLoad(required_names) = lookup else {
@@ -1941,6 +1979,9 @@ impl TemplateLibraryCatalog {
                     candidate.name.clone(),
                     candidate.app.clone(),
                     candidate.into_python_module(),
+                    TemplateSymbolObservation::from_source_inventory(
+                        facts.symbols_are_unobserved(),
+                    ),
                     symbols,
                 ));
             }
@@ -2071,7 +2112,7 @@ fn discover_installed_app_libraries(
         let (discovered, issues) = templatetag_package_libraries(db, project, &package_module);
         let discovered_names = discovered
             .iter()
-            .map(|(load_name, _, _, _)| load_name)
+            .map(|(load_name, _, _, _, _)| load_name)
             .collect::<BTreeSet<_>>();
         for load_name in &discovered_names {
             unresolved_names.remove(*load_name);
@@ -2090,7 +2131,7 @@ fn discover_installed_app_libraries(
             discovery_remainder = true;
             names_after_remainder.clear();
         } else if app_remainder || discovery_remainder {
-            names_after_remainder.extend(discovered.iter().map(|(name, _, _, _)| name.clone()));
+            names_after_remainder.extend(discovered.iter().map(|(name, _, _, _, _)| name.clone()));
         }
         libraries.issues.extend(
             issues
@@ -2234,6 +2275,7 @@ fn insert_backend_library_values(
                 id,
                 module,
                 symbols,
+                symbol_observation,
                 recovered,
             } => {
                 if recovered {
@@ -2241,7 +2283,13 @@ fn insert_backend_library_values(
                         .issues
                         .push(TemplateLibraryIssue::NamedSource(load_name.clone()));
                 }
-                TemplateLibrary::loadable(id, load_name.clone(), module, symbols)
+                TemplateLibrary::loadable(
+                    id,
+                    load_name.clone(),
+                    module,
+                    symbol_observation,
+                    symbols,
+                )
             }
             ConfiguredLibraryModule::SourceLess { id, module } => {
                 TemplateLibrary::source_less_loadable(id, load_name.clone(), module)
@@ -2275,12 +2323,13 @@ fn insert_backend_library_values(
                 id,
                 module,
                 symbols,
+                symbol_observation,
                 recovered,
             } => {
                 if recovered {
                     libraries.issues.push(TemplateLibraryIssue::BuiltinSource);
                 }
-                TemplateLibrary::builtin(id, module, symbols)
+                TemplateLibrary::builtin(id, module, symbol_observation, symbols)
             }
             ConfiguredLibraryModule::SourceLess { id, module } => {
                 TemplateLibrary::source_less_builtin(id, module)
@@ -2303,12 +2352,13 @@ fn insert_loadable_libraries(
     loadable_by_name: &mut BTreeMap<LibraryName, usize>,
     discovered: Vec<DiscoveredLibrary>,
 ) {
-    for (load_name, id, module, symbols) in discovered {
+    for (load_name, id, module, symbol_observation, symbols) in discovered {
         loadable_modules.insert(module.name().clone());
         let index = libraries.insert_library(TemplateLibrary::loadable(
             id,
             load_name.clone(),
             module,
+            symbol_observation,
             symbols,
         ));
         loadable_by_name.insert(load_name, index);
@@ -2347,6 +2397,7 @@ fn templatetag_package_libraries(
                 candidate.name.clone(),
                 id,
                 candidate.into_python_module(),
+                TemplateSymbolObservation::from_source_inventory(facts.symbols_are_unobserved()),
                 facts.symbols().cloned().collect(),
             ));
         }
@@ -2373,6 +2424,9 @@ fn library_from_module_name(
             id,
             module,
             symbols: facts.symbols().cloned().collect(),
+            symbol_observation: TemplateSymbolObservation::from_source_inventory(
+                facts.symbols_are_unobserved(),
+            ),
             recovered: facts.is_recovered(),
         }
     } else {

--- a/crates/djls-project/src/templates/registrations.rs
+++ b/crates/djls-project/src/templates/registrations.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeMap;
-use std::ops::ControlFlow;
 
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::Keyword;
 use ruff_python_ast::Stmt;
-use ruff_python_ast::StmtAssign;
 use ruff_python_ast::StmtExpr;
 use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::visitor;
+use ruff_python_ast::visitor::Visitor;
 
 use super::filters::FilterArityMap;
 use super::libraries::TemplateLibraryId;
@@ -22,10 +22,10 @@ use super::tags::BlockSpecs;
 use super::tags::TagRuleMap;
 use super::tags::blocks::EndTagEvidence;
 use crate::ast::ExprExt;
-use crate::ast::Recurse;
-use crate::ast::walk_stmts;
 use crate::db::Db as ProjectDb;
 use crate::python::RecoveredPythonModule;
+use crate::python::import::DirectImportClause;
+use crate::python::import::FromImportSyntax;
 
 /// Decorator helper names on `django.template.Library` that register filters.
 const FILTER_DECORATORS: &[&str] = &["filter"];
@@ -48,60 +48,393 @@ pub(crate) enum RegistrationKind {
     Filter,
 }
 
-/// Collect registrations from a pre-parsed module body.
-///
-/// This avoids re-parsing the source when the caller already has the AST.
-#[must_use]
-pub(crate) fn collect_registrations_from_body(body: &[Stmt]) -> Vec<RegistrationInfo> {
-    let mut registrations = Vec::new();
-    walk_stmts(body, Recurse::IntoClasses, |stmt| {
+#[derive(Debug, Default)]
+struct RegistrationSourceAnalysis {
+    registrations: Vec<RegistrationInfo>,
+    defines_library: bool,
+    inventory_open: bool,
+    saw_register_use: bool,
+}
+
+struct RegisterUseVisitor {
+    found: bool,
+}
+
+impl<'a> Visitor<'a> for RegisterUseVisitor {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if expr.name_target() == Some("register") {
+            self.found = true;
+            return;
+        }
+        visitor::walk_expr(self, expr);
+    }
+}
+
+fn contains_register(expr: &Expr) -> bool {
+    let mut visitor = RegisterUseVisitor { found: false };
+    visitor.visit_expr(expr);
+    visitor.found
+}
+
+fn statement_contains_register(stmt: &Stmt) -> bool {
+    let mut visitor = RegisterUseVisitor { found: false };
+    visitor.visit_stmt(stmt);
+    visitor.found
+}
+
+fn body_contains_register(body: &[Stmt]) -> bool {
+    body.iter().any(statement_contains_register)
+}
+
+fn collect_from_class_body(body: &[Stmt], analysis: &mut RegistrationSourceAnalysis) {
+    let mut register_is_module_binding = true;
+    for stmt in body {
+        if let Stmt::FunctionDef(function) = stmt
+            && register_is_module_binding
+        {
+            collect_from_decorated_function(function, analysis);
+            if body_contains_register(&function.body) {
+                analysis.inventory_open = true;
+            }
+            continue;
+        }
+        if let Stmt::ClassDef(class) = stmt {
+            collect_from_class_body(&class.body, analysis);
+            continue;
+        }
+        if let Stmt::Assign(assign) = stmt
+            && assign
+                .targets
+                .iter()
+                .any(|target| target.name_target() == Some("register"))
+        {
+            register_is_module_binding = false;
+        }
+    }
+}
+
+fn is_register_inventory_target(expr: &Expr) -> bool {
+    if let Expr::Subscript(subscript) = expr {
+        return is_register_inventory_target(&subscript.value);
+    }
+    expr.path_segments().is_some_and(|path| {
+        matches!(path.as_slice(), [register, inventory, ..]
+            if register == "register" && matches!(inventory.as_str(), "tags" | "filters"))
+    })
+}
+
+fn call_rooted_at_register(call: &ExprCall) -> bool {
+    call.func
+        .path_segments()
+        .is_some_and(|path| path.first().is_some_and(|root| root == "register"))
+}
+
+fn call_escapes_register(call: &ExprCall) -> bool {
+    contains_register(&call.func)
+        || call.arguments.args.iter().any(contains_register)
+        || call
+            .arguments
+            .keywords
+            .iter()
+            .any(|keyword| contains_register(&keyword.value))
+}
+
+fn is_fresh_canonical_library(
+    expr: &Expr,
+    template_is_django: bool,
+    library_constructor: Option<&str>,
+) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    if !call.arguments.args.is_empty() || !call.arguments.keywords.is_empty() {
+        return false;
+    }
+    if template_is_django
+        && call.func.path_segments().is_some_and(|path| {
+            matches!(path.as_slice(), [template, library]
+                if template == "template" && library == "Library")
+        })
+    {
+        return true;
+    }
+    call.func
+        .name_target()
+        .is_some_and(|name| Some(name) == library_constructor)
+}
+
+fn is_canonical_library_import(syntax: &FromImportSyntax, module_name: &str) -> bool {
+    (syntax.level() == 0
+        && matches!(
+            syntax.module(),
+            Some("django.template" | "django.template.library")
+        ))
+        || (syntax.level() == 1
+            && syntax.module() == Some("library")
+            && module_name.starts_with("django.template."))
+}
+
+#[allow(clippy::too_many_lines)]
+fn analyze_registrations_from_body_in_module(
+    body: &[Stmt],
+    module_name: &str,
+) -> RegistrationSourceAnalysis {
+    let mut analysis = RegistrationSourceAnalysis::default();
+    let mut template_is_django = false;
+    let mut library_constructor = None;
+
+    for stmt in body {
         match stmt {
-            Stmt::FunctionDef(func_def) => {
-                collect_from_decorated_function(func_def, &mut registrations);
+            Stmt::Import(import) => {
+                for clause in DirectImportClause::lower(import) {
+                    if clause.bound() == "template" {
+                        template_is_django = false;
+                    }
+                    if library_constructor == Some(clause.bound()) {
+                        library_constructor = None;
+                    }
+                    if clause.bound() == "register" {
+                        analysis.registrations.clear();
+                        analysis.defines_library = true;
+                        analysis.inventory_open = true;
+                    }
+                }
+            }
+            Stmt::ImportFrom(import) => {
+                let syntax = FromImportSyntax::lower(import);
+                if syntax.has_star() {
+                    template_is_django = false;
+                    library_constructor = None;
+                }
+                let canonical_library_import = is_canonical_library_import(&syntax, module_name);
+                for member in syntax.named_members() {
+                    if member.bound() == "template" {
+                        template_is_django = syntax.level() == 0
+                            && syntax.module() == Some("django")
+                            && member.imported() == "template";
+                    }
+                    if library_constructor == Some(member.bound()) {
+                        library_constructor = None;
+                    }
+                    if canonical_library_import && member.imported() == "Library" {
+                        library_constructor = Some(member.bound());
+                    }
+                    if member.bound() == "register" {
+                        analysis.registrations.clear();
+                        analysis.defines_library = true;
+                        analysis.inventory_open = true;
+                    }
+                }
+            }
+            Stmt::Assign(assign) => {
+                let binds_register = assign
+                    .targets
+                    .iter()
+                    .any(|target| target.name_target() == Some("register"));
+                let binds_template = assign
+                    .targets
+                    .iter()
+                    .any(|target| target.name_target() == Some("template"));
+                let shares_register_binding = binds_register
+                    && (assign.targets.len() != 1
+                        || assign.targets[0].name_target() != Some("register"));
+                if assign.targets.iter().any(|target| {
+                    target
+                        .name_target()
+                        .is_some_and(|name| library_constructor == Some(name))
+                }) {
+                    library_constructor = None;
+                }
+                if binds_register {
+                    let fresh_canonical = is_fresh_canonical_library(
+                        &assign.value,
+                        template_is_django,
+                        library_constructor,
+                    );
+                    if !fresh_canonical {
+                        analysis.registrations.clear();
+                    }
+                    analysis.defines_library = true;
+                    analysis.inventory_open |=
+                        binds_template || shares_register_binding || !fresh_canonical;
+                }
+                if assign.targets.iter().any(is_register_inventory_target)
+                    || (contains_register(&assign.value) && !binds_register)
+                {
+                    analysis.inventory_open = true;
+                }
+                if binds_template {
+                    template_is_django = false;
+                }
+            }
+            Stmt::AnnAssign(assign) => {
+                if assign.target.name_target() == Some("register") {
+                    analysis.registrations.clear();
+                    analysis.defines_library = true;
+                    analysis.inventory_open = true;
+                }
+                if is_register_inventory_target(&assign.target)
+                    || assign.value.as_deref().is_some_and(contains_register)
+                {
+                    analysis.inventory_open = true;
+                }
+                if assign.target.name_target() == Some("template") {
+                    template_is_django = false;
+                }
+                if assign
+                    .target
+                    .name_target()
+                    .is_some_and(|name| library_constructor == Some(name))
+                {
+                    library_constructor = None;
+                }
+            }
+            Stmt::AugAssign(assign) => {
+                if assign.target.name_target() == Some("register")
+                    || is_register_inventory_target(&assign.target)
+                    || contains_register(&assign.value)
+                {
+                    analysis.inventory_open = true;
+                }
+                if assign.target.name_target() == Some("template") {
+                    template_is_django = false;
+                }
+                if assign
+                    .target
+                    .name_target()
+                    .is_some_and(|name| library_constructor == Some(name))
+                {
+                    library_constructor = None;
+                }
+            }
+            Stmt::Delete(delete) => {
+                if delete.targets.iter().any(|target| {
+                    target.name_target() == Some("register")
+                        || is_register_inventory_target(target)
+                        || contains_register(target)
+                }) {
+                    analysis.inventory_open = true;
+                }
+                if delete
+                    .targets
+                    .iter()
+                    .any(|target| target.name_target() == Some("template"))
+                {
+                    template_is_django = false;
+                }
+                if delete.targets.iter().any(|target| {
+                    target
+                        .name_target()
+                        .is_some_and(|name| library_constructor == Some(name))
+                }) {
+                    library_constructor = None;
+                }
+            }
+            Stmt::FunctionDef(function) => {
+                if function.name.as_str() == "template" {
+                    template_is_django = false;
+                }
+                if library_constructor == Some(function.name.as_str()) {
+                    library_constructor = None;
+                }
+                if function.name.as_str() == "register" {
+                    analysis.registrations.clear();
+                    analysis.defines_library = true;
+                    analysis.inventory_open = true;
+                }
+                collect_from_decorated_function(function, &mut analysis);
+                if body_contains_register(&function.body) {
+                    analysis.saw_register_use = true;
+                    analysis.inventory_open = true;
+                }
+            }
+            Stmt::ClassDef(class) => {
+                if class.name.as_str() == "template" {
+                    template_is_django = false;
+                }
+                if library_constructor == Some(class.name.as_str()) {
+                    library_constructor = None;
+                }
+                if class.name.as_str() == "register" {
+                    analysis.registrations.clear();
+                    analysis.defines_library = true;
+                    analysis.inventory_open = true;
+                }
+                collect_from_class_body(&class.body, &mut analysis);
+                if statement_contains_register(stmt) {
+                    analysis.saw_register_use = true;
+                    analysis.inventory_open = true;
+                }
             }
             Stmt::Expr(StmtExpr { value, .. }) => {
                 if let Expr::Call(call) = value.as_ref() {
-                    collect_from_call_statement(call, &mut registrations);
+                    collect_from_call_statement(call, &mut analysis);
+                } else if contains_register(value) {
+                    analysis.saw_register_use = true;
+                    analysis.inventory_open = true;
                 }
             }
-            Stmt::ClassDef(_)
-            | Stmt::Return(_)
-            | Stmt::Delete(_)
-            | Stmt::TypeAlias(_)
-            | Stmt::Assign(_)
-            | Stmt::AugAssign(_)
-            | Stmt::AnnAssign(_)
-            | Stmt::For(_)
+            Stmt::For(_)
             | Stmt::While(_)
             | Stmt::If(_)
             | Stmt::With(_)
             | Stmt::Match(_)
+            | Stmt::Try(_) => {
+                template_is_django = false;
+                library_constructor = None;
+                if statement_contains_register(stmt) {
+                    analysis.saw_register_use = true;
+                    analysis.inventory_open = true;
+                }
+            }
+            Stmt::Return(_)
+            | Stmt::TypeAlias(_)
             | Stmt::Raise(_)
-            | Stmt::Try(_)
             | Stmt::Assert(_)
-            | Stmt::Import(_)
-            | Stmt::ImportFrom(_)
             | Stmt::Global(_)
             | Stmt::Nonlocal(_)
             | Stmt::Pass(_)
             | Stmt::Break(_)
             | Stmt::Continue(_)
-            | Stmt::IpyEscapeCommand(_) => {}
+            | Stmt::IpyEscapeCommand(_) => {
+                if statement_contains_register(stmt) {
+                    analysis.saw_register_use = true;
+                    analysis.inventory_open = true;
+                }
+            }
         }
-        ControlFlow::Continue(())
-    });
-    registrations
+    }
+
+    if analysis.saw_register_use && !analysis.defines_library {
+        analysis.defines_library = true;
+        analysis.inventory_open = true;
+    }
+    analysis
+}
+
+#[cfg(test)]
+fn analyze_registrations_from_body(body: &[Stmt]) -> RegistrationSourceAnalysis {
+    analyze_registrations_from_body_in_module(body, "")
+}
+
+/// Collect registrations from a pre-parsed module body.
+///
+/// This avoids re-parsing the source when the caller already has the AST.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn collect_registrations_from_body(body: &[Stmt]) -> Vec<RegistrationInfo> {
+    analyze_registrations_from_body(body).registrations
 }
 
 fn for_each_registration(
+    analysis: &RegistrationSourceAnalysis,
     body: &[Stmt],
     module_name: &str,
     mut f: impl FnMut(&RegistrationInfo, Option<&StmtFunctionDef>, SymbolKey),
 ) {
-    let registrations = collect_registrations_from_body(body);
     let func_defs = collect_func_defs(body);
 
-    for reg in &registrations {
+    for reg in &analysis.registrations {
         let func = reg.func_name.as_deref().and_then(|name| {
             func_defs
                 .iter()
@@ -120,16 +453,17 @@ fn for_each_registration(
     }
 }
 
-/// Recursively collect all function definitions from a module body.
+/// Collect module-level function definitions that can own definite registrations.
 fn collect_func_defs(body: &[Stmt]) -> Vec<&StmtFunctionDef> {
-    let mut defs = Vec::new();
-    walk_stmts(body, Recurse::IntoClasses, |stmt| {
-        if let Stmt::FunctionDef(func) = stmt {
-            defs.push(func);
-        }
-        ControlFlow::Continue(())
-    });
-    defs
+    body.iter()
+        .filter_map(|stmt| {
+            if let Stmt::FunctionDef(function) = stmt {
+                Some(function)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Extract registrations from a decorated function definition.
@@ -141,14 +475,28 @@ fn collect_func_defs(body: &[Stmt]) -> Vec<&StmtFunctionDef> {
 /// - `@register.filter`
 fn collect_from_decorated_function(
     func_def: &StmtFunctionDef,
-    registrations: &mut Vec<RegistrationInfo>,
+    analysis: &mut RegistrationSourceAnalysis,
 ) {
     let func_name = func_def.name.as_str();
 
     for decorator in &func_def.decorator_list {
-        // Try tag decorator
-        if let Some((name, kind)) = tag_name_from_decorator(&decorator.expression, func_name) {
-            registrations.push(RegistrationInfo {
+        let expression = &decorator.expression;
+        if !registration_decorator_rooted_at_register(expression) {
+            if contains_register(expression) {
+                analysis.inventory_open = true;
+                analysis.saw_register_use = true;
+            }
+            continue;
+        }
+        analysis.saw_register_use = true;
+
+        if registration_decorator_has_dynamic_name(expression) {
+            analysis.inventory_open = true;
+            continue;
+        }
+
+        if let Some((name, kind)) = tag_name_from_decorator(expression, func_name) {
+            analysis.registrations.push(RegistrationInfo {
                 name,
                 kind,
                 func_name: Some(func_name.to_string()),
@@ -156,15 +504,109 @@ fn collect_from_decorated_function(
             continue;
         }
 
-        // Try filter decorator
-        if let Some(name) = filter_name_from_decorator(&decorator.expression, func_name) {
-            registrations.push(RegistrationInfo {
+        if let Some(name) = filter_name_from_decorator(expression, func_name) {
+            analysis.registrations.push(RegistrationInfo {
                 name,
                 kind: RegistrationKind::Filter,
                 func_name: Some(func_name.to_string()),
             });
+        } else {
+            analysis.inventory_open = true;
         }
     }
+}
+
+fn direct_register_helper(expr: &Expr) -> Option<&str> {
+    let Expr::Attribute(ExprAttribute { value, attr, .. }) = expr else {
+        return None;
+    };
+    (value.name_target() == Some("register")).then_some(attr.as_str())
+}
+
+fn registration_decorator_rooted_at_register(expr: &Expr) -> bool {
+    let helper = if matches!(expr, Expr::Attribute(_)) {
+        direct_register_helper(expr)
+    } else if let Expr::Call(call) = expr {
+        direct_register_helper(&call.func)
+    } else {
+        None
+    };
+    helper.is_some_and(|helper| {
+        tag_decorator_kind(helper).is_some() || FILTER_DECORATORS.contains(&helper)
+    })
+}
+
+fn has_dynamic_name_keyword(keywords: &[Keyword]) -> bool {
+    keywords.iter().any(|keyword| {
+        keyword.arg.as_ref().is_some_and(|arg| arg == "name")
+            && keyword.value.string_literal().is_none()
+    })
+}
+
+fn registration_arguments_are_unsupported(helper: &str, call: &ExprCall) -> bool {
+    if call
+        .arguments
+        .args
+        .iter()
+        .any(|arg| matches!(arg, Expr::Starred(_)))
+    {
+        return true;
+    }
+    call.arguments.keywords.iter().any(|keyword| {
+        let Some(name) = keyword
+            .arg
+            .as_ref()
+            .map(ruff_python_ast::Identifier::as_str)
+        else {
+            return true;
+        };
+        match helper {
+            "tag" => !matches!(name, "name" | "compile_function" | "func"),
+            "filter" => false,
+            "simple_tag" => !matches!(name, "func" | "takes_context" | "name"),
+            "inclusion_tag" => !matches!(name, "filename" | "func" | "takes_context" | "name"),
+            "simple_block_tag" => !matches!(name, "func" | "takes_context" | "name" | "end_name"),
+            _ => true,
+        }
+    })
+}
+
+fn registration_decorator_has_dynamic_name(expr: &Expr) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    if has_dynamic_name_keyword(&call.arguments.keywords) {
+        return true;
+    }
+    direct_register_helper(&call.func).is_some_and(|helper| {
+        if registration_arguments_are_unsupported(helper, call) {
+            return true;
+        }
+        let args = &call.arguments.args;
+        match helper {
+            "tag" | "filter" => {
+                args.len() > 1
+                    || args
+                        .first()
+                        .is_some_and(|arg| arg.string_literal().is_none())
+            }
+            "simple_tag" | "simple_block_tag" => !args.is_empty(),
+            "inclusion_tag" => args.len() > 1,
+            _ => true,
+        }
+    })
+}
+
+fn registration_call_has_dynamic_name(call: &ExprCall) -> bool {
+    if has_dynamic_name_keyword(&call.arguments.keywords) {
+        return true;
+    }
+    direct_register_helper(&call.func).is_some_and(|helper| {
+        registration_arguments_are_unsupported(helper, call)
+            || (matches!(helper, "tag" | "filter")
+                && call.arguments.args.len() >= 2
+                && call.arguments.args[0].string_literal().is_none())
+    })
 }
 
 /// Extract a tag name from a decorator expression.
@@ -172,8 +614,8 @@ fn collect_from_decorated_function(
 /// Returns `Some((name, kind))` if the decorator is a tag registration.
 fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, RegistrationKind)> {
     // Bare decorator: `@register.tag`
-    if let Expr::Attribute(ExprAttribute { attr, .. }) = expr
-        && let Some(kind) = tag_decorator_kind(attr.as_str())
+    if let Some(attr) = direct_register_helper(expr)
+        && let Some(kind) = tag_decorator_kind(attr)
     {
         return Some((func_name.to_string(), kind));
     }
@@ -182,13 +624,13 @@ fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, Regi
     if let Expr::Call(ExprCall {
         func, arguments, ..
     }) = expr
-        && let Expr::Attribute(ExprAttribute { attr, .. }) = func.as_ref()
-        && let Some(kind) = tag_decorator_kind(attr.as_str())
+        && let Some(attr) = direct_register_helper(func)
+        && let Some(kind) = tag_decorator_kind(attr)
     {
         // Priority: name= kwarg > first positional string (for @register.tag only) > func_name
         let name_override = kw_name_from(&arguments.keywords);
 
-        let positional_name = if attr.as_str() == "tag" {
+        let positional_name = if attr == "tag" {
             first_string_arg(&arguments.args)
         } else {
             None
@@ -209,8 +651,8 @@ fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, Regi
 /// Returns `Some(name)` if the decorator is a filter registration.
 fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
     // Bare decorator: `@register.filter`
-    if let Expr::Attribute(ExprAttribute { attr, .. }) = expr
-        && FILTER_DECORATORS.contains(&attr.as_str())
+    if let Some(attr) = direct_register_helper(expr)
+        && FILTER_DECORATORS.contains(&attr)
     {
         return Some(func_name.to_string());
     }
@@ -219,8 +661,8 @@ fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
     if let Expr::Call(ExprCall {
         func, arguments, ..
     }) = expr
-        && let Expr::Attribute(ExprAttribute { attr, .. }) = func.as_ref()
-        && FILTER_DECORATORS.contains(&attr.as_str())
+        && let Some(attr) = direct_register_helper(func)
+        && FILTER_DECORATORS.contains(&attr)
     {
         let name_override = kw_name_from(&arguments.keywords);
         let positional_name = first_string_arg(&arguments.args);
@@ -240,10 +682,31 @@ fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
 /// - `register.tag("name", SomeNode.handle)`
 /// - `register.filter("name", filter_func)`
 /// - `register.simple_tag(func, name="alias")`
-fn collect_from_call_statement(call: &ExprCall, registrations: &mut Vec<RegistrationInfo>) {
-    // Try tag call-style registration
+fn collect_from_call_statement(call: &ExprCall, analysis: &mut RegistrationSourceAnalysis) {
+    if !call_rooted_at_register(call) {
+        if call_escapes_register(call) {
+            analysis.saw_register_use = true;
+            analysis.inventory_open = true;
+        }
+        return;
+    }
+    analysis.saw_register_use = true;
+
+    let Some(helper) = direct_register_helper(&call.func) else {
+        analysis.inventory_open = true;
+        return;
+    };
+    if tag_decorator_kind(helper).is_none() && !FILTER_DECORATORS.contains(&helper) {
+        analysis.inventory_open = true;
+        return;
+    }
+    if registration_call_has_dynamic_name(call) {
+        analysis.inventory_open = true;
+        return;
+    }
+
     if let Some((name, kind, func_name)) = tag_registration_from_call(call) {
-        registrations.push(RegistrationInfo {
+        analysis.registrations.push(RegistrationInfo {
             name,
             kind,
             func_name,
@@ -251,13 +714,14 @@ fn collect_from_call_statement(call: &ExprCall, registrations: &mut Vec<Registra
         return;
     }
 
-    // Try filter call-style registration
     if let Some((name, func_name)) = filter_registration_from_call(call) {
-        registrations.push(RegistrationInfo {
+        analysis.registrations.push(RegistrationInfo {
             name,
             kind: RegistrationKind::Filter,
             func_name,
         });
+    } else {
+        analysis.inventory_open = true;
     }
 }
 
@@ -269,47 +733,59 @@ fn collect_from_call_statement(call: &ExprCall, registrations: &mut Vec<Registra
 fn tag_registration_from_call(
     call: &ExprCall,
 ) -> Option<(String, RegistrationKind, Option<String>)> {
-    let Expr::Attribute(ExprAttribute { attr, .. }) = call.func.as_ref() else {
-        return None;
-    };
-    let kind = tag_decorator_kind(attr.as_str())?;
-
+    let helper = direct_register_helper(&call.func)?;
+    let kind = tag_decorator_kind(helper)?;
     let name_override = kw_name_from(&call.arguments.keywords);
-    let func_name = kw_callable_name(&call.arguments.keywords, &["compile_function", "func"]);
-
+    let keyword_func = kw_callable_name(&call.arguments.keywords, &["compile_function", "func"]);
     let args = &call.arguments.args;
 
-    if args.len() >= 2 {
-        // `register.tag("name", func)` — first arg is string name, second is callable
-        if let Some(name) = args[0].string_literal() {
-            let fn_name = callable_name(&args[1]).or(func_name);
-            return Some((
-                name_override.unwrap_or_else(|| name.to_string()),
-                kind,
-                fn_name,
-            ));
+    match helper {
+        "tag" => match &args[..] {
+            [name, callable] => {
+                let name = name.string_literal()?.to_string();
+                let func_name = callable_name(callable).or(keyword_func);
+                Some((name, kind, func_name))
+            }
+            [name] if name.string_literal().is_some() => {
+                let name = name.string_literal()?.to_string();
+                let func_name = keyword_func?;
+                Some((name, kind, Some(func_name)))
+            }
+            [callable] if name_override.is_none() => {
+                let func_name = callable_name(callable)?;
+                Some((func_name.clone(), kind, Some(func_name)))
+            }
+            [] => {
+                let func_name = keyword_func?;
+                let name = name_override.unwrap_or_else(|| func_name.clone());
+                Some((name, kind, Some(func_name)))
+            }
+            _ => None,
+        },
+        "simple_tag" | "simple_block_tag" => match &args[..] {
+            [callable] => {
+                let func_name = callable_name(callable).or(keyword_func)?;
+                let name = name_override.unwrap_or_else(|| func_name.clone());
+                Some((name, kind, Some(func_name)))
+            }
+            [] => {
+                let func_name = keyword_func?;
+                let name = name_override.unwrap_or_else(|| func_name.clone());
+                Some((name, kind, Some(func_name)))
+            }
+            _ => None,
+        },
+        "inclusion_tag" => {
+            let func_name = match &args[..] {
+                [_template, callable] => callable_name(callable).or(keyword_func),
+                [_] | [] => keyword_func,
+                _ => None,
+            }?;
+            let name = name_override.unwrap_or_else(|| func_name.clone());
+            Some((name, kind, Some(func_name)))
         }
+        _ => None,
     }
-
-    if args.len() == 1 {
-        // `register.simple_tag(func, name="alias")` or `register.tag(func)`
-        let fn_name = callable_name(&args[0]).or(func_name.clone());
-        if let Some(name) = name_override {
-            return Some((name, kind, fn_name));
-        }
-        // Fallback: use the callable name as the registration name.
-        // Handles both simple names (`do_for`) and attribute callables (`ForNode.handle`).
-        if let Some(name) = callable_name(&args[0]) {
-            return Some((name.clone(), kind, Some(name)));
-        }
-    }
-
-    // No positional args but has name= kwarg
-    if let Some(name) = name_override {
-        return Some((name, kind, func_name));
-    }
-
-    None
 }
 
 /// Extract filter registration info from a call expression.
@@ -318,43 +794,34 @@ fn tag_registration_from_call(
 /// - `register.filter("name", func)`
 /// - `register.filter(func, name="alias")`
 fn filter_registration_from_call(call: &ExprCall) -> Option<(String, Option<String>)> {
-    let Expr::Attribute(ExprAttribute { attr, .. }) = call.func.as_ref() else {
-        return None;
-    };
-    if !FILTER_DECORATORS.contains(&attr.as_str()) {
+    let helper = direct_register_helper(&call.func)?;
+    if !FILTER_DECORATORS.contains(&helper) {
         return None;
     }
 
     let name_override = kw_name_from(&call.arguments.keywords);
-    let func_name = kw_callable_name(&call.arguments.keywords, &["filter_func", "func"]);
-
-    let args = &call.arguments.args;
-
-    if args.len() >= 2 {
-        // `register.filter("name", func)`
-        if let Some(name) = args[0].string_literal() {
-            let fn_name = callable_name(&args[1]).or(func_name);
-            return Some((name_override.unwrap_or_else(|| name.to_string()), fn_name));
+    let keyword_func = kw_callable_name(&call.arguments.keywords, &["filter_func", "func"]);
+    match &call.arguments.args[..] {
+        [name, callable] => {
+            let name = name.string_literal()?.to_string();
+            Some((name, callable_name(callable).or(keyword_func)))
         }
-    }
-
-    if args.len() == 1 {
-        let fn_name = callable_name(&args[0]).or(func_name.clone());
-        if let Some(name) = name_override {
-            return Some((name, fn_name));
+        [name] if name.string_literal().is_some() => {
+            let name = name.string_literal()?.to_string();
+            let func_name = keyword_func?;
+            Some((name, Some(func_name)))
         }
-        // Fallback: use the callable name as the registration name.
-        // Handles both simple names (`my_func`) and attribute callables (`MyClass.method`).
-        if let Some(name) = callable_name(&args[0]) {
-            return Some((name.clone(), Some(name)));
+        [callable] if name_override.is_none() => {
+            let func_name = callable_name(callable)?;
+            Some((func_name.clone(), Some(func_name)))
         }
+        [] => {
+            let func_name = keyword_func?;
+            let name = name_override.unwrap_or_else(|| func_name.clone());
+            Some((name, Some(func_name)))
+        }
+        _ => None,
     }
-
-    if let Some(name) = name_override {
-        return Some((name, func_name));
-    }
-
-    None
 }
 
 /// Map decorator attr name to `RegistrationKind`.
@@ -461,7 +928,14 @@ enum TemplateLibraryDefinitionState {
     },
     Library {
         parse_quality: TemplateLibraryParseQuality,
+        inventory: TemplateLibrarySymbolInventory,
     },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TemplateLibrarySymbolInventory {
+    Observed,
+    Open,
 }
 
 /// Equality-bearing registration facts for one Template Library source module.
@@ -486,6 +960,7 @@ impl TemplateLibraryDefinitionFacts {
                 parse_quality: TemplateLibraryParseQuality::Recovered,
             } | TemplateLibraryDefinitionState::Library {
                 parse_quality: TemplateLibraryParseQuality::Recovered,
+                ..
             }
         )
     }
@@ -493,6 +968,17 @@ impl TemplateLibraryDefinitionFacts {
     #[must_use]
     pub(crate) fn source_failed(&self) -> bool {
         matches!(self.state, TemplateLibraryDefinitionState::Failed)
+    }
+
+    #[must_use]
+    pub(crate) fn symbols_are_unobserved(&self) -> bool {
+        matches!(
+            self.state,
+            TemplateLibraryDefinitionState::Library {
+                inventory: TemplateLibrarySymbolInventory::Open,
+                ..
+            }
+        )
     }
 
     pub(crate) fn symbols(&self) -> impl Iterator<Item = &TemplateSymbol> {
@@ -564,8 +1050,13 @@ fn template_library_source_analysis(
     let mut block_specs = BlockSpecs::default();
     let mut filter_arities = FilterArityMap::default();
     let registration_module = key.module(db).as_str();
+    let registration_analysis =
+        analyze_registrations_from_body_in_module(module.body(db), registration_module);
+    let mut symbols_unobserved = parse_quality == TemplateLibraryParseQuality::Recovered
+        || registration_analysis.inventory_open;
 
     for_each_registration(
+        &registration_analysis,
         module.body(db),
         registration_module,
         |registration, func, symbol_key| {
@@ -587,6 +1078,8 @@ fn template_library_source_analysis(
                         filters.insert(symbol.name().to_string(), symbol);
                     }
                 }
+            } else {
+                symbols_unobserved = true;
             }
 
             let Some(func) = func else {
@@ -616,12 +1109,17 @@ fn template_library_source_analysis(
         },
     );
 
-    let defines_library = module
-        .body(db)
-        .iter()
-        .any(TemplateLibraryDefinitionFacts::stmt_defines_library);
-    let state = if defines_library || !tags.is_empty() || !filters.is_empty() {
-        TemplateLibraryDefinitionState::Library { parse_quality }
+    let state = if registration_analysis.defines_library || !tags.is_empty() || !filters.is_empty()
+    {
+        let inventory = if symbols_unobserved {
+            TemplateLibrarySymbolInventory::Open
+        } else {
+            TemplateLibrarySymbolInventory::Observed
+        };
+        TemplateLibraryDefinitionState::Library {
+            parse_quality,
+            inventory,
+        }
     } else {
         TemplateLibraryDefinitionState::ParsedNotLibrary { parse_quality }
     };
@@ -703,61 +1201,6 @@ pub fn template_library_filter_facts(
     }
 }
 
-impl TemplateLibraryDefinitionFacts {
-    fn stmt_defines_library(stmt: &Stmt) -> bool {
-        let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt else {
-            return false;
-        };
-        if !targets
-            .iter()
-            .any(|target| target.name_target() == Some("register"))
-        {
-            return false;
-        }
-
-        let Expr::Call(ExprCall { func, .. }) = value.as_ref() else {
-            return false;
-        };
-        match func.as_ref() {
-            Expr::Attribute(ExprAttribute { value, attr, .. }) => {
-                attr.as_str() == "Library" && value.name_target() == Some("template")
-            }
-            expr @ (Expr::BoolOp(_)
-            | Expr::Named(_)
-            | Expr::BinOp(_)
-            | Expr::UnaryOp(_)
-            | Expr::Lambda(_)
-            | Expr::If(_)
-            | Expr::Dict(_)
-            | Expr::Set(_)
-            | Expr::ListComp(_)
-            | Expr::SetComp(_)
-            | Expr::DictComp(_)
-            | Expr::Generator(_)
-            | Expr::Await(_)
-            | Expr::Yield(_)
-            | Expr::YieldFrom(_)
-            | Expr::Compare(_)
-            | Expr::Call(_)
-            | Expr::FString(_)
-            | Expr::TString(_)
-            | Expr::StringLiteral(_)
-            | Expr::BytesLiteral(_)
-            | Expr::NumberLiteral(_)
-            | Expr::BooleanLiteral(_)
-            | Expr::NoneLiteral(_)
-            | Expr::EllipsisLiteral(_)
-            | Expr::Subscript(_)
-            | Expr::Starred(_)
-            | Expr::Name(_)
-            | Expr::List(_)
-            | Expr::Tuple(_)
-            | Expr::Slice(_)
-            | Expr::IpyEscapeCommand(_)) => expr.name_target() == Some("Library"),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -767,10 +1210,14 @@ mod tests {
         fixture_source(path).expect("requested corpus fixture should exist")
     }
 
-    fn collect_registrations(source: &str) -> Vec<RegistrationInfo> {
+    fn analyze_registrations(source: &str) -> RegistrationSourceAnalysis {
         let parsed = ruff_python_parser::parse_module(source).expect("valid Python");
         let module = parsed.into_syntax();
-        collect_registrations_from_body(&module.body)
+        analyze_registrations_from_body(&module.body)
+    }
+
+    fn collect_registrations(source: &str) -> Vec<RegistrationInfo> {
+        analyze_registrations(source).registrations
     }
 
     fn find_reg<'a>(regs: &'a [RegistrationInfo], name: &str) -> &'a RegistrationInfo {
@@ -1047,5 +1494,121 @@ def my_tag(parser, token):
         let regs = collect_registrations(source);
         assert_eq!(regs.len(), 1);
         assert_eq!(regs[0].name, "kwarg_name");
+    }
+
+    #[test]
+    fn imported_register_preserves_known_symbols_but_opens_inventory() {
+        let analysis = analyze_registrations(
+            "from shared import register\n@register.simple_tag\ndef known(): pass\n@register.filter\ndef known_filter(value): return value\n",
+        );
+        assert!(analysis.defines_library);
+        assert!(analysis.inventory_open);
+        assert_eq!(analysis.registrations.len(), 2);
+    }
+
+    #[test]
+    fn only_unshadowed_canonical_constructor_is_closed() {
+        let canonical = analyze_registrations(
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known(): pass\n",
+        );
+        assert!(!canonical.inventory_open);
+        let direct_import =
+            analyze_registrations("from django.template import Library\nregister = Library()\n");
+        assert!(!direct_import.inventory_open);
+
+        for source in [
+            "register = Library()\n",
+            "from django import template as dt\nregister = dt.Library()\n",
+            "import django.template as template\nregister = template.Library()\n",
+            "from django import template\nalias = register = template.Library()\n",
+            "from django import template\nimport other as template\nregister = template.Library()\n",
+            "from django import template\nregister = template.Library()\nfrom shared import register\n",
+        ] {
+            assert!(
+                analyze_registrations(source).inventory_open,
+                "constructor should remain open: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn uncertain_scopes_open_inventory_without_contributing_symbols() {
+        for uncertain in [
+            "if enabled:\n    @register.simple_tag\n    def conditional(): pass",
+            "class Helpers:\n    register = template.Library()\n    @register.simple_tag\n    def class_local(): pass",
+        ] {
+            let source = format!(
+                "from django import template\nregister = template.Library()\n{uncertain}\n"
+            );
+            let analysis = analyze_registrations(&source);
+            assert!(analysis.inventory_open);
+            assert!(analysis.registrations.is_empty());
+        }
+    }
+
+    #[test]
+    fn nested_helper_mutation_opens_inventory() {
+        let analysis = analyze_registrations(
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known(): pass\ndef configure():\n    register.tags.update(dynamic_tags)\n",
+        );
+        assert!(analysis.inventory_open);
+        assert_eq!(analysis.registrations.len(), 1);
+        assert_eq!(analysis.registrations[0].name, "known");
+    }
+
+    #[test]
+    fn mixed_positional_keyword_calls_are_known_and_closed() {
+        let analysis = analyze_registrations(
+            "from django import template\nregister = template.Library()\nregister.tag('known', compile_function=tag_func)\nregister.filter('known_filter', filter_func=filter_func)\n",
+        );
+        assert!(!analysis.inventory_open);
+        assert!(
+            analysis
+                .registrations
+                .iter()
+                .any(|registration| registration.name == "known")
+        );
+        assert!(
+            analysis
+                .registrations
+                .iter()
+                .any(|registration| registration.name == "known_filter")
+        );
+    }
+
+    #[test]
+    fn only_register_root_contributes_symbols() {
+        let analysis = analyze_registrations(
+            "from django import template\nregister = template.Library()\n@other.tag\ndef invented(parser, token): pass\nother.filter('also_invented', func)\n",
+        );
+        assert!(analysis.registrations.is_empty());
+        assert!(!analysis.inventory_open);
+    }
+
+    #[test]
+    fn uncertain_operations_open_inventory_without_dropping_known_symbols() {
+        for operation in [
+            "@register.tag(name=dynamic_name)\ndef dynamic(parser, token): pass",
+            "register.tags.update(dynamic_tags)",
+            "register.tags['dynamic'] = func",
+            "del register.filters['dynamic']",
+            "register.tag()",
+            "configure(register)",
+        ] {
+            let source = format!(
+                "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known(): pass\n{operation}\n"
+            );
+            let analysis = analyze_registrations(&source);
+            assert!(
+                analysis.inventory_open,
+                "operation should open inventory: {operation}"
+            );
+            assert!(
+                analysis
+                    .registrations
+                    .iter()
+                    .any(|registration| registration.name == "known")
+            );
+        }
     }
 }

--- a/crates/djls-project/src/templates/registrations.rs
+++ b/crates/djls-project/src/templates/registrations.rs
@@ -48,22 +48,61 @@ pub(crate) enum RegistrationKind {
     Filter,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum RegistrationInventory {
+    #[default]
+    NotLibrary,
+    Observed,
+    Open,
+}
+
 #[derive(Debug, Default)]
 struct RegistrationSourceAnalysis {
     registrations: Vec<RegistrationInfo>,
-    defines_library: bool,
-    inventory_open: bool,
-    saw_register_use: bool,
+    inventory: RegistrationInventory,
+}
+
+impl RegistrationSourceAnalysis {
+    fn observe_fresh_library(&mut self) {
+        if matches!(self.inventory, RegistrationInventory::NotLibrary) {
+            self.inventory = RegistrationInventory::Observed;
+        }
+    }
+
+    fn observe_register_use(&mut self) {
+        if matches!(self.inventory, RegistrationInventory::NotLibrary) {
+            self.inventory = RegistrationInventory::Open;
+        }
+    }
+
+    fn open_inventory(&mut self) {
+        self.inventory = RegistrationInventory::Open;
+    }
+
+    fn defines_library(&self) -> bool {
+        !matches!(self.inventory, RegistrationInventory::NotLibrary)
+    }
+
+    fn inventory_is_open(&self) -> bool {
+        matches!(self.inventory, RegistrationInventory::Open)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum RegisterReference {
+    #[default]
+    Absent,
+    Present,
 }
 
 struct RegisterUseVisitor {
-    found: bool,
+    reference: RegisterReference,
 }
 
 impl<'a> Visitor<'a> for RegisterUseVisitor {
     fn visit_expr(&mut self, expr: &'a Expr) {
         if expr.name_target() == Some("register") {
-            self.found = true;
+            self.reference = RegisterReference::Present;
             return;
         }
         visitor::walk_expr(self, expr);
@@ -71,15 +110,19 @@ impl<'a> Visitor<'a> for RegisterUseVisitor {
 }
 
 fn contains_register(expr: &Expr) -> bool {
-    let mut visitor = RegisterUseVisitor { found: false };
+    let mut visitor = RegisterUseVisitor {
+        reference: RegisterReference::Absent,
+    };
     visitor.visit_expr(expr);
-    visitor.found
+    matches!(visitor.reference, RegisterReference::Present)
 }
 
 fn statement_contains_register(stmt: &Stmt) -> bool {
-    let mut visitor = RegisterUseVisitor { found: false };
+    let mut visitor = RegisterUseVisitor {
+        reference: RegisterReference::Absent,
+    };
     visitor.visit_stmt(stmt);
-    visitor.found
+    matches!(visitor.reference, RegisterReference::Present)
 }
 
 fn body_contains_register(body: &[Stmt]) -> bool {
@@ -94,7 +137,7 @@ fn collect_from_class_body(body: &[Stmt], analysis: &mut RegistrationSourceAnaly
         {
             collect_from_decorated_function(function, analysis);
             if body_contains_register(&function.body) {
-                analysis.inventory_open = true;
+                analysis.open_inventory();
             }
             continue;
         }
@@ -195,8 +238,7 @@ fn analyze_registrations_from_body_in_module(
                     }
                     if clause.bound() == "register" {
                         analysis.registrations.clear();
-                        analysis.defines_library = true;
-                        analysis.inventory_open = true;
+                        analysis.open_inventory();
                     }
                 }
             }
@@ -221,8 +263,7 @@ fn analyze_registrations_from_body_in_module(
                     }
                     if member.bound() == "register" {
                         analysis.registrations.clear();
-                        analysis.defines_library = true;
-                        analysis.inventory_open = true;
+                        analysis.open_inventory();
                     }
                 }
             }
@@ -251,17 +292,17 @@ fn analyze_registrations_from_body_in_module(
                         template_is_django,
                         library_constructor,
                     );
-                    if !fresh_canonical {
+                    if fresh_canonical && !binds_template && !shares_register_binding {
+                        analysis.observe_fresh_library();
+                    } else {
                         analysis.registrations.clear();
+                        analysis.open_inventory();
                     }
-                    analysis.defines_library = true;
-                    analysis.inventory_open |=
-                        binds_template || shares_register_binding || !fresh_canonical;
                 }
                 if assign.targets.iter().any(is_register_inventory_target)
                     || (contains_register(&assign.value) && !binds_register)
                 {
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 if binds_template {
                     template_is_django = false;
@@ -270,13 +311,12 @@ fn analyze_registrations_from_body_in_module(
             Stmt::AnnAssign(assign) => {
                 if assign.target.name_target() == Some("register") {
                     analysis.registrations.clear();
-                    analysis.defines_library = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 if is_register_inventory_target(&assign.target)
                     || assign.value.as_deref().is_some_and(contains_register)
                 {
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 if assign.target.name_target() == Some("template") {
                     template_is_django = false;
@@ -294,7 +334,7 @@ fn analyze_registrations_from_body_in_module(
                     || is_register_inventory_target(&assign.target)
                     || contains_register(&assign.value)
                 {
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 if assign.target.name_target() == Some("template") {
                     template_is_django = false;
@@ -313,7 +353,7 @@ fn analyze_registrations_from_body_in_module(
                         || is_register_inventory_target(target)
                         || contains_register(target)
                 }) {
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 if delete
                     .targets
@@ -339,13 +379,11 @@ fn analyze_registrations_from_body_in_module(
                 }
                 if function.name.as_str() == "register" {
                     analysis.registrations.clear();
-                    analysis.defines_library = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 collect_from_decorated_function(function, &mut analysis);
                 if body_contains_register(&function.body) {
-                    analysis.saw_register_use = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
             }
             Stmt::ClassDef(class) => {
@@ -357,21 +395,18 @@ fn analyze_registrations_from_body_in_module(
                 }
                 if class.name.as_str() == "register" {
                     analysis.registrations.clear();
-                    analysis.defines_library = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
                 collect_from_class_body(&class.body, &mut analysis);
                 if statement_contains_register(stmt) {
-                    analysis.saw_register_use = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
             }
             Stmt::Expr(StmtExpr { value, .. }) => {
                 if let Expr::Call(call) = value.as_ref() {
                     collect_from_call_statement(call, &mut analysis);
                 } else if contains_register(value) {
-                    analysis.saw_register_use = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
             }
             Stmt::For(_)
@@ -383,8 +418,7 @@ fn analyze_registrations_from_body_in_module(
                 template_is_django = false;
                 library_constructor = None;
                 if statement_contains_register(stmt) {
-                    analysis.saw_register_use = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
             }
             Stmt::Return(_)
@@ -398,17 +432,12 @@ fn analyze_registrations_from_body_in_module(
             | Stmt::Continue(_)
             | Stmt::IpyEscapeCommand(_) => {
                 if statement_contains_register(stmt) {
-                    analysis.saw_register_use = true;
-                    analysis.inventory_open = true;
+                    analysis.open_inventory();
                 }
             }
         }
     }
 
-    if analysis.saw_register_use && !analysis.defines_library {
-        analysis.defines_library = true;
-        analysis.inventory_open = true;
-    }
     analysis
 }
 
@@ -483,15 +512,14 @@ fn collect_from_decorated_function(
         let expression = &decorator.expression;
         if !registration_decorator_rooted_at_register(expression) {
             if contains_register(expression) {
-                analysis.inventory_open = true;
-                analysis.saw_register_use = true;
+                analysis.open_inventory();
             }
             continue;
         }
-        analysis.saw_register_use = true;
+        analysis.observe_register_use();
 
         if registration_decorator_has_dynamic_name(expression) {
-            analysis.inventory_open = true;
+            analysis.open_inventory();
             continue;
         }
 
@@ -511,7 +539,7 @@ fn collect_from_decorated_function(
                 func_name: Some(func_name.to_string()),
             });
         } else {
-            analysis.inventory_open = true;
+            analysis.open_inventory();
         }
     }
 }
@@ -685,23 +713,22 @@ fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
 fn collect_from_call_statement(call: &ExprCall, analysis: &mut RegistrationSourceAnalysis) {
     if !call_rooted_at_register(call) {
         if call_escapes_register(call) {
-            analysis.saw_register_use = true;
-            analysis.inventory_open = true;
+            analysis.open_inventory();
         }
         return;
     }
-    analysis.saw_register_use = true;
+    analysis.observe_register_use();
 
     let Some(helper) = direct_register_helper(&call.func) else {
-        analysis.inventory_open = true;
+        analysis.open_inventory();
         return;
     };
     if tag_decorator_kind(helper).is_none() && !FILTER_DECORATORS.contains(&helper) {
-        analysis.inventory_open = true;
+        analysis.open_inventory();
         return;
     }
     if registration_call_has_dynamic_name(call) {
-        analysis.inventory_open = true;
+        analysis.open_inventory();
         return;
     }
 
@@ -721,7 +748,7 @@ fn collect_from_call_statement(call: &ExprCall, analysis: &mut RegistrationSourc
             func_name,
         });
     } else {
-        analysis.inventory_open = true;
+        analysis.open_inventory();
     }
 }
 
@@ -1053,7 +1080,7 @@ fn template_library_source_analysis(
     let registration_analysis =
         analyze_registrations_from_body_in_module(module.body(db), registration_module);
     let mut symbols_unobserved = parse_quality == TemplateLibraryParseQuality::Recovered
-        || registration_analysis.inventory_open;
+        || registration_analysis.inventory_is_open();
 
     for_each_registration(
         &registration_analysis,
@@ -1109,20 +1136,20 @@ fn template_library_source_analysis(
         },
     );
 
-    let state = if registration_analysis.defines_library || !tags.is_empty() || !filters.is_empty()
-    {
-        let inventory = if symbols_unobserved {
-            TemplateLibrarySymbolInventory::Open
+    let state =
+        if registration_analysis.defines_library() || !tags.is_empty() || !filters.is_empty() {
+            let inventory = if symbols_unobserved {
+                TemplateLibrarySymbolInventory::Open
+            } else {
+                TemplateLibrarySymbolInventory::Observed
+            };
+            TemplateLibraryDefinitionState::Library {
+                parse_quality,
+                inventory,
+            }
         } else {
-            TemplateLibrarySymbolInventory::Observed
+            TemplateLibraryDefinitionState::ParsedNotLibrary { parse_quality }
         };
-        TemplateLibraryDefinitionState::Library {
-            parse_quality,
-            inventory,
-        }
-    } else {
-        TemplateLibraryDefinitionState::ParsedNotLibrary { parse_quality }
-    };
     TemplateLibrarySourceAnalysis {
         definitions: TemplateLibraryDefinitionFacts {
             state,
@@ -1501,8 +1528,8 @@ def my_tag(parser, token):
         let analysis = analyze_registrations(
             "from shared import register\n@register.simple_tag\ndef known(): pass\n@register.filter\ndef known_filter(value): return value\n",
         );
-        assert!(analysis.defines_library);
-        assert!(analysis.inventory_open);
+        assert!(analysis.defines_library());
+        assert!(analysis.inventory_is_open());
         assert_eq!(analysis.registrations.len(), 2);
     }
 
@@ -1511,10 +1538,10 @@ def my_tag(parser, token):
         let canonical = analyze_registrations(
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known(): pass\n",
         );
-        assert!(!canonical.inventory_open);
+        assert!(!canonical.inventory_is_open());
         let direct_import =
             analyze_registrations("from django.template import Library\nregister = Library()\n");
-        assert!(!direct_import.inventory_open);
+        assert!(!direct_import.inventory_is_open());
 
         for source in [
             "register = Library()\n",
@@ -1525,7 +1552,7 @@ def my_tag(parser, token):
             "from django import template\nregister = template.Library()\nfrom shared import register\n",
         ] {
             assert!(
-                analyze_registrations(source).inventory_open,
+                analyze_registrations(source).inventory_is_open(),
                 "constructor should remain open: {source}"
             );
         }
@@ -1541,7 +1568,7 @@ def my_tag(parser, token):
                 "from django import template\nregister = template.Library()\n{uncertain}\n"
             );
             let analysis = analyze_registrations(&source);
-            assert!(analysis.inventory_open);
+            assert!(analysis.inventory_is_open());
             assert!(analysis.registrations.is_empty());
         }
     }
@@ -1551,7 +1578,7 @@ def my_tag(parser, token):
         let analysis = analyze_registrations(
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known(): pass\ndef configure():\n    register.tags.update(dynamic_tags)\n",
         );
-        assert!(analysis.inventory_open);
+        assert!(analysis.inventory_is_open());
         assert_eq!(analysis.registrations.len(), 1);
         assert_eq!(analysis.registrations[0].name, "known");
     }
@@ -1561,7 +1588,7 @@ def my_tag(parser, token):
         let analysis = analyze_registrations(
             "from django import template\nregister = template.Library()\nregister.tag('known', compile_function=tag_func)\nregister.filter('known_filter', filter_func=filter_func)\n",
         );
-        assert!(!analysis.inventory_open);
+        assert!(!analysis.inventory_is_open());
         assert!(
             analysis
                 .registrations
@@ -1582,7 +1609,7 @@ def my_tag(parser, token):
             "from django import template\nregister = template.Library()\n@other.tag\ndef invented(parser, token): pass\nother.filter('also_invented', func)\n",
         );
         assert!(analysis.registrations.is_empty());
-        assert!(!analysis.inventory_open);
+        assert!(!analysis.inventory_is_open());
     }
 
     #[test]
@@ -1600,7 +1627,7 @@ def my_tag(parser, token):
             );
             let analysis = analyze_registrations(&source);
             assert!(
-                analysis.inventory_open,
+                analysis.inventory_is_open(),
                 "operation should open inventory: {operation}"
             );
             assert!(

--- a/crates/djls-project/tests/template_libraries.rs
+++ b/crates/djls-project/tests/template_libraries.rs
@@ -689,3 +689,87 @@ fn resolved_library_inventory_deduplicates_identical_builtin_identity() {
         "configured test evidence must not invent source origins"
     );
 }
+
+#[test]
+fn imported_register_opens_only_its_symbol_inventory_and_keeps_known_symbols() {
+    let db = TestDatabase::new();
+    let project = ProjectFixture::new("/project")
+        .django_settings_module("project.settings")
+        .file(
+            "/project/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'OPTIONS': {'libraries': {'open': 'open_tags', 'closed': 'closed_tags', 'recovered': 'recovered_tags'}, 'builtins': ['open_builtin_tags']}}]\n",
+        )
+        .file("/project/django/template/defaulttags.py", "from django import template\nregister = template.Library()\n")
+        .file("/project/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
+        .file("/project/django/template/loader_tags.py", "from django import template\nregister = template.Library()\n")
+        .file("/project/open_tags.py", "from shared import register\n@register.simple_tag\ndef known_tag(): pass\n@register.filter\ndef known_filter(value): return value\n")
+        .file("/project/open_builtin_tags.py", "from shared import register\n@register.simple_tag\ndef builtin_known(): pass\n")
+        .file("/project/closed_tags.py", "from django import template\nregister = template.Library()\n")
+        .file("/project/recovered_tags.py", "from django import template\nregister = template.Library()\n@register.simple_tag\ndef recovered_known(): pass\ndef broken(\n")
+        .build(&db)
+        .expect("registration-inventory project fixture should build");
+
+    let catalog = template_library_catalog(&db, project);
+    let scoped = project_inventory(catalog);
+    let open = scoped
+        .loadable_library_str("open")
+        .found()
+        .expect("open library should resolve");
+    assert!(open.symbols_are_unobserved());
+    assert!(open.symbol(TemplateSymbolKind::Tag, "known_tag").is_some());
+    assert!(
+        open.symbol(TemplateSymbolKind::Filter, "known_filter")
+            .is_some()
+    );
+    assert!(matches!(
+        scoped
+            .effective_definition_libraries("known_tag", TemplateSymbolKind::Tag, &["open"])
+            .as_slice(),
+        [EffectiveDefinitionLibrary::Known(Some(library))] if library.id() == open.id()
+    ));
+    assert_eq!(
+        scoped.symbol("builtin_known", TemplateSymbolKind::Tag),
+        ScopedTemplateSymbolLookup::Builtin
+    );
+    let open_builtin = scoped
+        .resolved_libraries()
+        .into_iter()
+        .find(|library| library.module_name_str() == "open_builtin_tags")
+        .expect("open builtin should resolve");
+    assert!(open_builtin.symbols_are_unobserved());
+    assert!(
+        open_builtin
+            .symbol(TemplateSymbolKind::Tag, "builtin_known")
+            .is_some()
+    );
+    assert_eq!(
+        scoped.symbol("absent_tag", TemplateSymbolKind::Tag),
+        ScopedTemplateSymbolLookup::Inconclusive
+    );
+    assert!(matches!(
+        scoped
+            .effective_definition_libraries("absent_tag", TemplateSymbolKind::Tag, &["open"])
+            .as_slice(),
+        [EffectiveDefinitionLibrary::Unobserved(library)] if library.id() == open.id()
+    ));
+
+    let closed = scoped
+        .loadable_library_str("closed")
+        .found()
+        .expect("closed library should resolve");
+    assert!(!closed.symbols_are_unobserved());
+    let recovered = scoped
+        .loadable_library_str("recovered")
+        .found()
+        .expect("recovered library should resolve");
+    assert!(recovered.symbols_are_unobserved());
+    assert!(
+        recovered
+            .symbol(TemplateSymbolKind::Tag, "recovered_known")
+            .is_some()
+    );
+    assert_eq!(
+        scoped.loadable_library_str("missing"),
+        LoadableLibraryLookup::Absent
+    );
+}

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -2753,6 +2753,63 @@ fn corpus_templates_have_no_argument_false_positives() {
 }
 
 #[test]
+fn imported_register_keeps_known_symbols_and_makes_only_symbol_misses_inconclusive() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/proj")
+        .django_settings_module("project.settings")
+        .file(
+            "/proj/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'open': 'open_tags'}}}]\n",
+        )
+        .file("/proj/django/template/defaulttags.py", "from django import template\nregister = template.Library()\n@register.tag\ndef load(parser, token): pass\n")
+        .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/django/template/loader_tags.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/open_tags.py", "from shared import register\n@register.simple_tag\ndef known_tag(): pass\n@register.filter\ndef known_filter(value): return value\n")
+        .file("/proj/templates/open.html", "{% load missing_library %}{% load open %}{% known_tag %}{% absent_tag %}{{ value|known_filter }}{{ value|absent_filter }}")
+        .install(&mut db)
+        .expect("imported-register fixture should install");
+
+    let open_errors = collect_file_errors(&db, "/proj/templates/open.html")
+        .expect("open library errors should collect");
+    assert!(!open_errors.iter().any(|error| matches!(error,
+        ValidationError::UnknownTag { tag, .. } if matches!(tag.as_str(), "known_tag" | "absent_tag")
+    )));
+    assert!(!open_errors.iter().any(|error| matches!(error,
+        ValidationError::UnknownFilter { filter, .. } if matches!(filter.as_str(), "known_filter" | "absent_filter")
+    )));
+    assert!(open_errors.iter().any(|error| matches!(error,
+        ValidationError::UnknownLibrary { name, .. } if name == "missing_library"
+    )));
+}
+
+#[test]
+fn closed_registration_source_still_produces_symbol_negatives() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/proj")
+        .django_settings_module("project.settings")
+        .file(
+            "/proj/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'closed': 'closed_tags'}}}]\n",
+        )
+        .file("/proj/django/template/defaulttags.py", "from django import template\nregister = template.Library()\n@register.tag\ndef load(parser, token): pass\n")
+        .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/django/template/loader_tags.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/closed_tags.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/templates/page.html", "{% load closed %}{% absent_tag %}{{ value|absent_filter }}")
+        .install(&mut db)
+        .expect("closed-register fixture should install");
+
+    let errors = collect_file_errors(&db, "/proj/templates/page.html")
+        .expect("closed library errors should collect");
+    assert!(errors.iter().any(|error| matches!(error,
+        ValidationError::UnknownTag { tag, .. } if tag == "absent_tag"
+    )));
+    assert!(errors.iter().any(|error| matches!(error,
+        ValidationError::UnknownFilter { filter, .. } if filter == "absent_filter"
+    )));
+}
+
+#[test]
 fn corpus_known_invalid_templates_produce_errors() {
     let corpus = Corpus::require().expect("synced corpus should be available for corpus tests");
 


### PR DESCRIPTION
## Summary

- distinguish closed Django `Library()` inventories from imported, recovered, or dynamically mutated registration objects
- retain statically proven tags and filters while treating unobserved names as an open remainder
- keep known completion candidates under source uncertainty and suppress unknown tag/filter diagnostics unless absence is proven
- keep unrelated missing library names and closed inventories diagnostic

## Testing

- `cargo test -q`
- `just clippy`
- `just fmt --check`
- `just lint`
- direct cargo-hawk analysis with the matching Rust 1.95 toolchain: 0 findings

`just hawk` itself currently passes the unsupported `check` argument to the installed cargo-hawk 0.1.9 binary; the equivalent direct analysis passed.