### PR TITLE
Navigate template block inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Added a quick-fix code action for renaming mismatched `{% endblock %}` names.
 - Added completion for resolvable template names inside quoted `{% extends %}` and `{% include %}` arguments.
 - Added document links for resolvable Django template and template-library references.
-- Added go to definition from overridden Django template blocks to their nearest parent blocks.
+- Added find references across Django template block inheritance chains.
+- Added go to definition for Django template block names, resolving overrides to their nearest parent blocks.
 - Added go to definition for Django Template Libraries, Tags, and Filters.
 - Added opt-in whole-document Django template formatting through `djangofmt`.
 - Added startup progress reporting for Django project discovery and IDE cache warm-up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Added a quick-fix code action for renaming mismatched `{% endblock %}` names.
 - Added completion for resolvable template names inside quoted `{% extends %}` and `{% include %}` arguments.
 - Added document links for resolvable Django template and template-library references.
+- Added go to definition from overridden Django template blocks to their nearest parent blocks.
 - Added go to definition for Django Template Libraries, Tags, and Filters.
 - Added opt-in whole-document Django template formatting through `djangofmt`.
 - Added startup progress reporting for Django project discovery and IDE cache warm-up.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ A language server for the Django web framework.
     - [x] Template navigation for `{% extends %}` and `{% include %}`
     - [x] Template Library, Tag, Filter, and selective-load symbol navigation
     - [x] Exact source highlighting in editors that support definition links
-    - [ ] Block and variable definitions
+    - [x] Parent block definitions across template inheritance
+    - [ ] Variable definitions
 - [ ] **Find references** - See where templates, blocks, and variables are used
     - [x] Template references for `{% extends %}` and `{% include %}`
     - [ ] Block and variable references
@@ -79,7 +80,7 @@ Once configured, open any Django template file in your project to get:
 - Template tag and filter completions with snippets
 - Real-time syntax validation and diagnostics
 - Hover documentation for template tags, filters, libraries, and template references
-- Navigation to templates and to Python definitions for Template Libraries, Tags, and Filters
+- Navigation to templates, parent blocks, and Python definitions for Template Libraries, Tags, and Filters
 - Clickable links for `{% extends %}`, `{% include %}`, and `{% load %}` names
 - Quick fixes for unloaded template tags/filters and mismatched `{% endblock %}` names
 - Folding for Django template regions

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ A language server for the Django web framework.
     - [x] Template navigation for `{% extends %}` and `{% include %}`
     - [x] Template Library, Tag, Filter, and selective-load symbol navigation
     - [x] Exact source highlighting in editors that support definition links
-    - [x] Parent block definitions across template inheritance
+    - [x] Block definitions across template inheritance
     - [ ] Variable definitions
 - [ ] **Find references** - See where templates, blocks, and variables are used
     - [x] Template references for `{% extends %}` and `{% include %}`
-    - [ ] Block and variable references
+    - [x] Block references across template inheritance
+    - [ ] Variable references
 - [x] **Document links** - Click through resolved template references and template libraries
     - [x] Template names in `{% extends %}` and `{% include %}`
     - [x] Template libraries in `{% load %}`
@@ -80,7 +81,8 @@ Once configured, open any Django template file in your project to get:
 - Template tag and filter completions with snippets
 - Real-time syntax validation and diagnostics
 - Hover documentation for template tags, filters, libraries, and template references
-- Navigation to templates, parent blocks, and Python definitions for Template Libraries, Tags, and Filters
+- Navigation to templates, inherited blocks, and Python definitions for Template Libraries, Tags, and Filters
+- Reference search across template inheritance blocks
 - Clickable links for `{% extends %}`, `{% include %}`, and `{% load %}` names
 - Quick fixes for unloaded template tags/filters and mismatched `{% endblock %}` names
 - Folding for Django template regions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,9 +32,9 @@ Prefer conservative diagnostics over false positives when project facts are part
 
 #### Inheritance block intelligence
 
-**Status:** 📅 Planned
+**Status:** 🚧 Partially supported
 
-Users should be able to navigate and understand Django template inheritance without manual search. The first pass should support going to parent block definitions, finding child block overrides, and completing block names from parent templates.
+Go to definition resolves an overridden block name to its nearest parent block across the template inheritance chain. Finding child block overrides and completing block names from parent templates remain.
 
 #### Code actions for safe diagnostics
 
@@ -102,7 +102,7 @@ Hover is supported for template tags, filters, libraries, selectively loaded sym
 
 **Status:** 🚧 Partially supported
 
-Go to definition works for literal template references in `{% extends %}` and `{% include %}`, Template Library arguments in `{% load %}`, selective-load symbols, and available Template Tags and Filters with definite local Python declarations. Clients that support definition links receive exact origin and declaration ranges; older clients receive plain locations. Ambiguous definitions and dynamic, imported, or member callables do not produce guessed targets. The next improvement is parent block navigation across inheritance.
+Go to definition works for literal template references in `{% extends %}` and `{% include %}`, overridden block names, Template Library arguments in `{% load %}`, selective-load symbols, and available Template Tags and Filters with definite local Python declarations. Block overrides resolve to the nearest parent block only when the inheritance chain is known. Clients that support definition links receive exact origin and declaration ranges; older clients receive plain locations. Ambiguous definitions and dynamic, imported, or member callables do not produce guessed targets.
 
 #### Find references
 
@@ -217,13 +217,12 @@ Execute commands may be useful for hierarchy views, project-status inspection, o
 ## Priority Order
 
 1. Template-name completion for `{% extends %}` and `{% include %}`.
-2. Block navigation across inheritance.
-3. Block references and block-name completion.
-4. Code actions for existing diagnostics.
-5. URL/static completions and diagnostics.
-6. Settings hover and typo diagnostics.
-7. Model facts surfaced through navigation and hover.
-8. Template context and variable intelligence.
+2. Block references and block-name completion.
+3. Code actions for existing diagnostics.
+4. URL/static completions and diagnostics.
+5. Settings hover and typo diagnostics.
+6. Model facts surfaced through navigation and hover.
+7. Template context and variable intelligence.
 
 ## Deferred or Not Planned
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Prefer conservative diagnostics over false positives when project facts are part
 
 **Status:** 🚧 Partially supported
 
-Go to definition resolves an overridden block name to its nearest parent block across the template inheritance chain. Finding child block overrides and completing block names from parent templates remain.
+Go to definition resolves block names across template inheritance, and find references returns the root block and its definite overrides. Completing block names from parent templates remains.
 
 #### Code actions for safe diagnostics
 
@@ -102,13 +102,13 @@ Hover is supported for template tags, filters, libraries, selectively loaded sym
 
 **Status:** 🚧 Partially supported
 
-Go to definition works for literal template references in `{% extends %}` and `{% include %}`, overridden block names, Template Library arguments in `{% load %}`, selective-load symbols, and available Template Tags and Filters with definite local Python declarations. Block overrides resolve to the nearest parent block only when the inheritance chain is known. Clients that support definition links receive exact origin and declaration ranges; older clients receive plain locations. Ambiguous definitions and dynamic, imported, or member callables do not produce guessed targets.
+Go to definition works for literal template references in `{% extends %}` and `{% include %}`, block names, Template Library arguments in `{% load %}`, selective-load symbols, and available Template Tags and Filters with definite local Python declarations. Block overrides resolve to the nearest definite parent; root or uncertain-parent blocks resolve to themselves. Clients that support definition links receive exact origin and declaration ranges; older clients receive plain locations. Ambiguous definitions and dynamic, imported, or member callables do not produce guessed targets.
 
 #### Find references
 
 **Status:** 🚧 Partially supported
 
-Find references works for templates used by `{% extends %}` and `{% include %}`. Block override/reference search should come next, with variable, URL, static asset, settings, and model references later.
+Find references works for templates used by `{% extends %}` and `{% include %}` and for definite block definitions across template inheritance. Variable, URL, static asset, settings, and model references remain.
 
 #### Document symbols
 
@@ -217,7 +217,7 @@ Execute commands may be useful for hierarchy views, project-status inspection, o
 ## Priority Order
 
 1. Template-name completion for `{% extends %}` and `{% include %}`.
-2. Block references and block-name completion.
+2. Block-name completion.
 3. Code actions for existing diagnostics.
 4. URL/static completions and diagnostics.
 5. Settings hover and typo diagnostics.

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -1295,6 +1295,7 @@ mod invalidation_tests {
                 SemanticOffsetContext::TemplateReference { name, .. } => Some(name),
                 SemanticOffsetContext::LoadLibrary { .. }
                 | SemanticOffsetContext::LoadSymbol { .. }
+                | SemanticOffsetContext::TemplateBlock { .. }
                 | SemanticOffsetContext::Tag { .. }
                 | SemanticOffsetContext::Filter { .. }
                 | SemanticOffsetContext::Variable { .. }
@@ -1312,6 +1313,7 @@ mod invalidation_tests {
             SemanticOffsetContext::TemplateReference { name, .. } => Some(name),
             SemanticOffsetContext::LoadLibrary { .. }
             | SemanticOffsetContext::LoadSymbol { .. }
+            | SemanticOffsetContext::TemplateBlock { .. }
             | SemanticOffsetContext::Tag { .. }
             | SemanticOffsetContext::Filter { .. }
             | SemanticOffsetContext::Variable { .. }

--- a/crates/djls-ide/src/ext.rs
+++ b/crates/djls-ide/src/ext.rs
@@ -134,29 +134,23 @@ impl DefinitionTargetExt for DefinitionTarget {
         db: &dyn djls_semantic::Db,
         encoding: PositionEncoding,
     ) -> Option<(ls_types::Uri, ls_types::Range, ls_types::Range)> {
-        match self {
+        let (file, definition_span, name_span) = match self {
+            DefinitionTarget::Block(site) => (site.file, site.full_span, site.name_span),
             DefinitionTarget::File(file) => {
                 let uri = file.path(db).to_lsp_uri()?;
                 let range = ls_types::Range::default();
-                Some((uri, range, range))
+                return Some((uri, range, range));
             }
             DefinitionTarget::Symbol(source) => {
-                let file = source.file();
-                let text = file.try_source(db).ok()?;
-                let line_index = file.line_index(db);
-                let range = source.definition_span().to_lsp_range_with_encoding(
-                    text.as_str(),
-                    line_index,
-                    encoding,
-                );
-                let selection_range = source.name_span().to_lsp_range_with_encoding(
-                    text.as_str(),
-                    line_index,
-                    encoding,
-                );
-                Some((file.path(db).to_lsp_uri()?, range, selection_range))
+                (source.file(), source.definition_span(), source.name_span())
             }
-        }
+        };
+        let text = file.try_source(db).ok()?;
+        let line_index = file.line_index(db);
+        let range = definition_span.to_lsp_range_with_encoding(text.as_str(), line_index, encoding);
+        let selection_range =
+            name_span.to_lsp_range_with_encoding(text.as_str(), line_index, encoding);
+        Some((file.path(db).to_lsp_uri()?, range, selection_range))
     }
 }
 

--- a/crates/djls-ide/src/hover.rs
+++ b/crates/djls-ide/src/hover.rs
@@ -81,7 +81,9 @@ pub fn hover(db: &dyn SemanticDb, file: File, offset: Offset) -> Option<ls_types
             )?,
             span,
         )),
-        SemanticOffsetContext::Variable { .. } | SemanticOffsetContext::None => None,
+        SemanticOffsetContext::TemplateBlock { .. }
+        | SemanticOffsetContext::Variable { .. }
+        | SemanticOffsetContext::None => None,
     }?;
 
     Some(ls_types::Hover {

--- a/crates/djls-ide/src/navigation.rs
+++ b/crates/djls-ide/src/navigation.rs
@@ -5,9 +5,11 @@ use djls_project::TemplateSymbolKind;
 use djls_project::TemplateSymbolSource;
 use djls_project::template_resolution;
 use djls_project::template_symbol_source;
+use djls_semantic::BlockSite;
 use djls_semantic::SemanticOffsetContext;
 use djls_semantic::TemplateReferenceKind;
 use djls_semantic::effective_symbol_candidate_at;
+use djls_semantic::parent_block;
 use djls_semantic::references_to_template_name;
 use djls_semantic::resolve_reference_for_file;
 use djls_semantic::resolve_reference_origins;
@@ -26,6 +28,7 @@ use crate::ext::Utf8PathExt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DefinitionTarget {
+    Block(BlockSite),
     File(File),
     Symbol(TemplateSymbolSource),
 }
@@ -257,6 +260,17 @@ pub fn goto_definition(
                 position_encoding,
             )
         }
+        SemanticOffsetContext::TemplateBlock { name, span } => {
+            let project = db.project()?;
+            let target = parent_block(db, project, file, &name)?;
+            exact_definition_response(
+                db,
+                encoded_range(db, file, span, position_encoding)?,
+                vec![DefinitionTarget::Block(target)],
+                supports_location_links,
+                position_encoding,
+            )
+        }
         SemanticOffsetContext::Tag { name, span, .. } => symbol_occurrence_response(
             db,
             file,
@@ -349,6 +363,7 @@ pub fn find_references(
         }
         SemanticOffsetContext::LoadLibrary { .. }
         | SemanticOffsetContext::LoadSymbol { .. }
+        | SemanticOffsetContext::TemplateBlock { .. }
         | SemanticOffsetContext::Tag { .. }
         | SemanticOffsetContext::Filter { .. }
         | SemanticOffsetContext::Variable { .. }

--- a/crates/djls-ide/src/navigation.rs
+++ b/crates/djls-ide/src/navigation.rs
@@ -8,6 +8,9 @@ use djls_project::template_symbol_source;
 use djls_semantic::BlockSite;
 use djls_semantic::SemanticOffsetContext;
 use djls_semantic::TemplateReferenceKind;
+use djls_semantic::ancestor_blocks;
+use djls_semantic::block_definition_at;
+use djls_semantic::block_overrides;
 use djls_semantic::effective_symbol_candidate_at;
 use djls_semantic::parent_block;
 use djls_semantic::references_to_template_name;
@@ -261,8 +264,11 @@ pub fn goto_definition(
             )
         }
         SemanticOffsetContext::TemplateBlock { name, span } => {
-            let project = db.project()?;
-            let target = parent_block(db, project, file, &name)?;
+            let local = block_definition_at(db, file, span)?;
+            let target = db
+                .project()
+                .and_then(|project| parent_block(db, project, file, &name))
+                .unwrap_or(local);
             exact_definition_response(
                 db,
                 encoded_range(db, file, span, position_encoding)?,
@@ -297,8 +303,43 @@ pub fn find_references(
     db: &dyn djls_semantic::Db,
     file: File,
     offset: Offset,
+    position_encoding: PositionEncoding,
+    include_declaration: bool,
 ) -> Option<Vec<ls_types::Location>> {
     match SemanticOffsetContext::from_offset(db, file, offset) {
+        SemanticOffsetContext::TemplateBlock { name, span } => {
+            let local = block_definition_at(db, file, span)?;
+            let sites = if let Some(project) = db.project() {
+                let root = ancestor_blocks(db, project, file, &name)
+                    .last()
+                    .copied()
+                    .unwrap_or(local);
+                let mut sites = block_overrides(db, project, root.file, &name);
+                if local != root && !sites.contains(&local) {
+                    sites.push(local);
+                }
+                if include_declaration {
+                    sites.insert(0, root);
+                }
+                sites
+            } else if include_declaration {
+                vec![local]
+            } else {
+                Vec::new()
+            };
+            let locations = sites
+                .into_iter()
+                .filter_map(|site| {
+                    let (uri, _definition_range, name_range) =
+                        DefinitionTarget::Block(site).to_lsp_parts(db, position_encoding)?;
+                    Some(ls_types::Location {
+                        uri,
+                        range: name_range,
+                    })
+                })
+                .collect::<Vec<_>>();
+            (!locations.is_empty()).then_some(locations)
+        }
         SemanticOffsetContext::TemplateReference {
             name: template_name,
             kind,
@@ -347,7 +388,7 @@ pub fn find_references(
                     };
                     let location = ls_types::Location {
                         uri,
-                        range: reference.span(db).to_lsp_range(ref_file.line_index(db)),
+                        range: encoded_range(db, ref_file, reference.span(db), position_encoding)?,
                     };
                     if !locations.contains(&location) {
                         locations.push(location);
@@ -363,7 +404,6 @@ pub fn find_references(
         }
         SemanticOffsetContext::LoadLibrary { .. }
         | SemanticOffsetContext::LoadSymbol { .. }
-        | SemanticOffsetContext::TemplateBlock { .. }
         | SemanticOffsetContext::Tag { .. }
         | SemanticOffsetContext::Filter { .. }
         | SemanticOffsetContext::Variable { .. }

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -455,9 +455,78 @@ fn goto_definition_resolves_template_block_to_nearest_parent() {
             ),
         }])
     );
-    assert!(
-        goto_definition(&db, parent, offset_of(parent_source, "title"), true).is_none(),
-        "a root Template Block has no parent definition"
+    let root_response = goto_definition(&db, parent, offset_of(parent_source, "title"), true)
+        .expect("a root Template Block should resolve to itself");
+    let ls_types::GotoDefinitionResponse::Link(root_links) = root_response else {
+        panic!("LocationLink client should receive a root Template Block link")
+    };
+    assert_eq!(
+        root_links[0].target_uri.as_str(),
+        "file:///test/project/templates/base.html"
+    );
+    assert_eq!(
+        root_links[0].target_selection_range,
+        ls_types::Range::new(
+            ls_types::Position::new(0, 9),
+            ls_types::Position::new(0, 14),
+        )
+    );
+
+    let references = find_references(
+        &db,
+        child,
+        offset_of(child_source, "title"),
+        PositionEncoding::Utf8,
+        true,
+    )
+    .expect("Template Block references should include the root and override");
+    assert_eq!(
+        references,
+        vec![
+            ls_types::Location {
+                uri: "file:///test/project/templates/base.html"
+                    .parse()
+                    .expect("test URI should parse"),
+                range: ls_types::Range::new(
+                    ls_types::Position::new(0, 9),
+                    ls_types::Position::new(0, 14),
+                ),
+            },
+            ls_types::Location {
+                uri: "file:///test/project/templates/child.html"
+                    .parse()
+                    .expect("test URI should parse"),
+                range: ls_types::Range::new(
+                    ls_types::Position::new(1, 9),
+                    ls_types::Position::new(1, 14),
+                ),
+            },
+        ]
+    );
+}
+
+#[test]
+fn goto_definition_resolves_a_projectless_root_block_to_itself() {
+    let db = TestDatabase::new();
+    let source = "{% block title %}Root{% endblock %}";
+    db.add_file("/projectless.html", source)
+        .expect("projectless Template fixture should load");
+    let file = db
+        .file(Utf8Path::new("/projectless.html"))
+        .expect("projectless Template fixture should exist");
+
+    let response = goto_definition(&db, file, offset_of(source, "title"), true)
+        .expect("projectless root Template Block should resolve to itself");
+    let ls_types::GotoDefinitionResponse::Link(links) = response else {
+        panic!("LocationLink client should receive a projectless Template Block link")
+    };
+    assert_eq!(links[0].target_uri.as_str(), "file:///projectless.html");
+    assert_eq!(
+        links[0].target_selection_range,
+        ls_types::Range::new(
+            ls_types::Position::new(0, 9),
+            ls_types::Position::new(0, 14),
+        )
     );
 }
 
@@ -514,11 +583,31 @@ fn goto_definition_encodes_template_block_targets_for_link_and_plain_clients() {
             .expect("test URI should parse")
     );
     assert_eq!(location.range.start, ls_types::Position::new(0, 2));
+
+    let references = find_references(&db, child, offset, PositionEncoding::Utf16, true)
+        .expect("encoded Template Block references should resolve");
+    assert_eq!(
+        references
+            .iter()
+            .map(|location| location.range)
+            .collect::<Vec<_>>(),
+        vec![
+            ls_types::Range::new(
+                ls_types::Position::new(0, 11),
+                ls_types::Position::new(0, 16),
+            ),
+            ls_types::Range::new(
+                ls_types::Position::new(1, 11),
+                ls_types::Position::new(1, 16),
+            ),
+        ]
+    );
 }
 
 #[test]
 fn goto_definition_does_not_skip_an_uncertain_parent_block() {
     let mut db = TestDatabase::new();
+    let base_source = "{% block title %}Base{% endblock %}";
     let child_source = "{% extends \"layout.html\" %}\n{% block title %}Child{% endblock %}";
     ProjectFixture::new("/test/project")
         .django_settings_module("testproject.settings")
@@ -526,10 +615,7 @@ fn goto_definition_does_not_skip_an_uncertain_parent_block() {
             "/test/project/testproject/settings.py",
             "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {**UNKNOWN}}}]\n",
         )
-        .file(
-            "/test/project/templates/base.html",
-            "{% block title %}Base{% endblock %}",
-        )
+        .file("/test/project/templates/base.html", base_source)
         .file(
             "/test/project/templates/layout.html",
             "{% extends \"base.html\" %}\n{% load unknown_library %}\n{% block title %}Layout{% endblock %}",
@@ -540,10 +626,85 @@ fn goto_definition_does_not_skip_an_uncertain_parent_block() {
     let child = db
         .file(Utf8Path::new("/test/project/templates/child.html"))
         .expect("child Template fixture should exist");
+    let base = db
+        .file(Utf8Path::new("/test/project/templates/base.html"))
+        .expect("base Template fixture should exist");
 
+    let response = goto_definition(&db, child, offset_of(child_source, "title"), true)
+        .expect("an uncertain parent should leave the local Template Block as the target");
+    let ls_types::GotoDefinitionResponse::Link(links) = response else {
+        panic!("LocationLink client should receive the local Template Block link")
+    };
+    assert_eq!(
+        links[0].target_uri.as_str(),
+        "file:///test/project/templates/child.html"
+    );
+    assert_eq!(
+        links[0].target_selection_range,
+        ls_types::Range::new(
+            ls_types::Position::new(1, 9),
+            ls_types::Position::new(1, 14),
+        )
+    );
     assert!(
-        goto_definition(&db, child, offset_of(child_source, "title"), true).is_none(),
-        "an uncertain block in the nearest ancestor must not be skipped"
+        find_references(
+            &db,
+            base,
+            offset_of(base_source, "title"),
+            PositionEncoding::Utf8,
+            false,
+        )
+        .is_none(),
+        "reverse references must not cross an uncertain block"
+    );
+    let local_references = find_references(
+        &db,
+        child,
+        offset_of(child_source, "title"),
+        PositionEncoding::Utf8,
+        true,
+    )
+    .expect("the definite local block should remain a declaration");
+    assert_eq!(local_references.len(), 1);
+    assert_eq!(
+        local_references[0].uri.as_str(),
+        "file:///test/project/templates/child.html"
+    );
+}
+
+#[test]
+fn find_references_keeps_an_originless_local_override() {
+    let mut db = TestDatabase::new();
+    let source = "{% extends \"base.html\" %}\n{% block title %}Scratch{% endblock %}";
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .file(
+            "/test/project/templates/base.html",
+            "{% block title %}Base{% endblock %}",
+        )
+        .file("/test/project/scratch.html", source)
+        .install(&mut db)
+        .expect("originless block-reference fixture should install");
+    let scratch = db
+        .file(Utf8Path::new("/test/project/scratch.html"))
+        .expect("originless Template fixture should exist");
+
+    let references = find_references(
+        &db,
+        scratch,
+        offset_of(source, "title"),
+        PositionEncoding::Utf8,
+        false,
+    )
+    .expect("the originless local override should remain a reference");
+    assert_eq!(references.len(), 1);
+    assert_eq!(
+        references[0].uri.as_str(),
+        "file:///test/project/scratch.html"
     );
 }
 
@@ -1015,6 +1176,8 @@ fn find_references_resolves_extends_with_the_source_origin_skipped() {
             )
             .expect("test source offset should fit in u32"),
         ),
+        PositionEncoding::Utf8,
+        false,
     )
     .expect("the shadowing template should reference the next origin");
 
@@ -1067,6 +1230,8 @@ fn find_references_skips_the_source_file_across_template_name_aliases() {
             )
             .expect("test source offset should fit in u32"),
         ),
+        PositionEncoding::Utf8,
+        false,
     )
     .expect("every source alias should resolve the extends reference to the parent");
 
@@ -1110,6 +1275,8 @@ fn find_references_reports_template_name_interior_range() {
             )
             .expect("test source offset should fit in u32"),
         ),
+        PositionEncoding::Utf8,
+        false,
     )
     .expect("template reference should resolve to at least one reference");
 

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -407,6 +407,147 @@ fn goto_definition_returns_none_for_originless_inconclusive_search() {
 }
 
 #[test]
+fn goto_definition_resolves_template_block_to_nearest_parent() {
+    let mut db = TestDatabase::new();
+    let parent_source = "{% block title %}Parent{% endblock %}";
+    let child_source = "{% extends \"base.html\" %}\n{% block title %}Child{% endblock %}";
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .file("/test/project/templates/base.html", parent_source)
+        .file("/test/project/templates/child.html", child_source)
+        .install(&mut db)
+        .expect("Template Block navigation fixture should install");
+    let child = db
+        .file(Utf8Path::new("/test/project/templates/child.html"))
+        .expect("child Template fixture should exist");
+    let parent = db
+        .file(Utf8Path::new("/test/project/templates/base.html"))
+        .expect("parent Template fixture should exist");
+
+    let response = goto_definition(&db, child, offset_of(child_source, "title"), true)
+        .expect("overridden Template Block should resolve to its parent");
+
+    assert_eq!(
+        response,
+        ls_types::GotoDefinitionResponse::Link(vec![ls_types::LocationLink {
+            origin_selection_range: Some(ls_types::Range::new(
+                ls_types::Position::new(1, 9),
+                ls_types::Position::new(1, 14),
+            )),
+            target_uri: "file:///test/project/templates/base.html"
+                .parse()
+                .expect("test URI should parse"),
+            target_range: ls_types::Range::new(
+                ls_types::Position::new(0, 0),
+                ls_types::Position::new(
+                    0,
+                    u32::try_from(parent_source.len())
+                        .expect("parent Template length should fit in u32"),
+                ),
+            ),
+            target_selection_range: ls_types::Range::new(
+                ls_types::Position::new(0, 9),
+                ls_types::Position::new(0, 14),
+            ),
+        }])
+    );
+    assert!(
+        goto_definition(&db, parent, offset_of(parent_source, "title"), true).is_none(),
+        "a root Template Block has no parent definition"
+    );
+}
+
+#[test]
+fn goto_definition_encodes_template_block_targets_for_link_and_plain_clients() {
+    let mut db = TestDatabase::new();
+    let parent_source = "😀{% block title %}Parent{% endblock %}";
+    let child_source = "{% extends \"base.html\" %}\n😀{% block title %}Child{% endblock %}";
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .file("/test/project/templates/base.html", parent_source)
+        .file("/test/project/templates/child.html", child_source)
+        .install(&mut db)
+        .expect("encoded Template Block navigation fixture should install");
+    let child = db
+        .file(Utf8Path::new("/test/project/templates/child.html"))
+        .expect("encoded child Template fixture should exist");
+    let offset = offset_of(child_source, "title");
+
+    let linked = ide_goto_definition(&db, child, offset, true, PositionEncoding::Utf16)
+        .expect("encoded Template Block should resolve for a link client");
+    let ls_types::GotoDefinitionResponse::Link(links) = linked else {
+        panic!("LocationLink client should receive a Template Block link")
+    };
+    assert_eq!(
+        links[0].origin_selection_range,
+        Some(ls_types::Range::new(
+            ls_types::Position::new(1, 11),
+            ls_types::Position::new(1, 16),
+        ))
+    );
+    assert_eq!(links[0].target_range.start, ls_types::Position::new(0, 2));
+    assert_eq!(
+        links[0].target_selection_range,
+        ls_types::Range::new(
+            ls_types::Position::new(0, 11),
+            ls_types::Position::new(0, 16),
+        )
+    );
+
+    let plain = ide_goto_definition(&db, child, offset, false, PositionEncoding::Utf16)
+        .expect("encoded Template Block should resolve for a plain client");
+    let ls_types::GotoDefinitionResponse::Scalar(location) = plain else {
+        panic!("plain client should receive one Template Block location")
+    };
+    assert_eq!(
+        location.uri,
+        "file:///test/project/templates/base.html"
+            .parse()
+            .expect("test URI should parse")
+    );
+    assert_eq!(location.range.start, ls_types::Position::new(0, 2));
+}
+
+#[test]
+fn goto_definition_does_not_skip_an_uncertain_parent_block() {
+    let mut db = TestDatabase::new();
+    let child_source = "{% extends \"layout.html\" %}\n{% block title %}Child{% endblock %}";
+    ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {**UNKNOWN}}}]\n",
+        )
+        .file(
+            "/test/project/templates/base.html",
+            "{% block title %}Base{% endblock %}",
+        )
+        .file(
+            "/test/project/templates/layout.html",
+            "{% extends \"base.html\" %}\n{% load unknown_library %}\n{% block title %}Layout{% endblock %}",
+        )
+        .file("/test/project/templates/child.html", child_source)
+        .install(&mut db)
+        .expect("uncertain parent Template Block fixture should install");
+    let child = db
+        .file(Utf8Path::new("/test/project/templates/child.html"))
+        .expect("child Template fixture should exist");
+
+    assert!(
+        goto_definition(&db, child, offset_of(child_source, "title"), true).is_none(),
+        "an uncertain block in the nearest ancestor must not be skipped"
+    );
+}
+
+#[test]
 fn goto_definition_resolves_template_library_to_module_start() {
     let source = "{% load custom %}";
     let (db, file) = custom_symbol_navigation_fixture(source, CUSTOM_SYMBOL_LIBRARY)

--- a/crates/djls-semantic/src/inheritance.rs
+++ b/crates/djls-semantic/src/inheritance.rs
@@ -258,7 +258,7 @@ pub enum ChainEnd {
     Cycle,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BlockSite {
     pub file: File,
     pub name_span: Span,
@@ -267,10 +267,14 @@ pub struct BlockSite {
 
 /// Nearest ancestor definition of `name`.
 pub fn parent_block(db: &dyn Db, project: Project, file: File, name: &str) -> Option<BlockSite> {
-    template_inheritance(db, project, file)
-        .ancestors(db)
-        .iter()
-        .find_map(|origin| first_block_site_in_scope(db, origin.file(db), file, name))
+    for origin in template_inheritance(db, project, file).ancestors(db) {
+        match block_site_in_scope(db, origin.file(db), file, name) {
+            BlockSiteLookup::Found(site) => return Some(site),
+            BlockSiteLookup::Absent => {}
+            BlockSiteLookup::Inconclusive => return None,
+        }
+    }
+    None
 }
 
 /// Block names visible from ancestors, using the nearest definition site per name.
@@ -283,7 +287,11 @@ pub fn inherited_blocks(db: &dyn Db, project: Project, file: File) -> Vec<(Strin
         let TemplateParseResult::Parsed(nodelist) = parse_template(db, ancestor_file) else {
             continue;
         };
-        for block in template_symbols_in_scope(db, ancestor_file, nodelist, file).blocks() {
+        let symbols = template_symbols_in_scope(db, ancestor_file, nodelist, file);
+        for name in &symbols.uncertain_block_names {
+            seen.insert(name.as_str());
+        }
+        for block in symbols.blocks() {
             if seen.insert(block.name.as_str()) {
                 inherited.push((
                     block.name.clone(),
@@ -336,8 +344,8 @@ pub fn block_overrides(db: &dyn Db, project: Project, file: File, name: &str) ->
             // A physical descendant can be reached through several origin names. Keep traversing
             // each origin because its relative-name anchor and backend scope differ, but emit its
             // block definition only once.
-            if let Some(site) =
-                first_block_site_in_scope(db, descendant.file(db), descendant.file(db), name)
+            if let BlockSiteLookup::Found(site) =
+                block_site_in_scope(db, descendant.file(db), descendant.file(db), name)
                 && emitted_sites.insert((site.file, site.name_span, site.full_span))
             {
                 overrides.push(site);
@@ -377,23 +385,30 @@ fn origin_extends_exact_target<'db>(
     )
 }
 
-fn first_block_site_in_scope(
-    db: &dyn Db,
-    file: File,
-    scope_file: File,
-    name: &str,
-) -> Option<BlockSite> {
+enum BlockSiteLookup {
+    Found(BlockSite),
+    Absent,
+    Inconclusive,
+}
+
+fn block_site_in_scope(db: &dyn Db, file: File, scope_file: File, name: &str) -> BlockSiteLookup {
     let TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
-        return None;
+        return BlockSiteLookup::Absent;
     };
-    template_symbols_in_scope(db, file, nodelist, scope_file)
+    let symbols = template_symbols_in_scope(db, file, nodelist, scope_file);
+    if symbols.uncertain_block_names.contains(name) {
+        return BlockSiteLookup::Inconclusive;
+    }
+    symbols
         .blocks()
         .iter()
         .find(|block| block.name == name)
-        .map(|block| BlockSite {
-            file,
-            name_span: block.name_span,
-            full_span: block.full_span,
+        .map_or(BlockSiteLookup::Absent, |block| {
+            BlockSiteLookup::Found(BlockSite {
+                file,
+                name_span: block.name_span,
+                full_span: block.full_span,
+            })
         })
 }
 
@@ -420,6 +435,7 @@ fn template_symbols_in_scope<'db>(
         tag_facts: projection.scoped_tag_facts(db),
         regions,
         blocks: Vec::new(),
+        uncertain_block_names: FxHashSet::default(),
         partials: Vec::new(),
         extends: None,
     };
@@ -431,6 +447,7 @@ fn template_symbols_in_scope<'db>(
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TemplateSymbols {
     blocks: Vec<BlockDef>,
+    uncertain_block_names: FxHashSet<String>,
     partials: Vec<PartialDef>,
     extends: Option<ExtendsTarget>,
 }
@@ -476,6 +493,7 @@ struct SymbolBuilder<'a> {
     tag_facts: &'a ScopedTagFacts,
     regions: &'a Regions,
     blocks: Vec<BlockDef>,
+    uncertain_block_names: FxHashSet<String>,
     partials: Vec<PartialDef>,
     extends: Option<ExtendsTarget>,
 }
@@ -484,6 +502,7 @@ impl SymbolBuilder<'_> {
     fn finish(self) -> TemplateSymbols {
         TemplateSymbols {
             blocks: self.blocks,
+            uncertain_block_names: self.uncertain_block_names,
             partials: self.partials,
             extends: self.extends,
         }
@@ -522,6 +541,7 @@ impl SymbolBuilder<'_> {
                 bits,
                 full_span,
             } => {
+                self.collect_uncertain_block_name(*name_span, bits);
                 self.collect_extends(tag, *name_span, bits, *full_span);
             }
             TemplateNode::Opaque { .. }
@@ -557,6 +577,18 @@ impl SymbolBuilder<'_> {
             | TagRole::TemplateTag
             | TagRole::StaticAssetReference
             | TagRole::RouteReference => {}
+        }
+    }
+
+    fn collect_uncertain_block_name(&mut self, name_span: Span, bits: &[TagBit]) {
+        let Some(facts) = self.tag_facts.for_name_span(name_span) else {
+            return;
+        };
+        if facts.spec.is_some() || !facts.structure_accepts_spelling {
+            return;
+        }
+        if let Some(name) = bits.first() {
+            self.uncertain_block_names.insert(name.as_str().to_string());
         }
     }
 

--- a/crates/djls-semantic/src/inheritance.rs
+++ b/crates/djls-semantic/src/inheritance.rs
@@ -265,16 +265,38 @@ pub struct BlockSite {
     pub full_span: Span,
 }
 
-/// Nearest ancestor definition of `name`.
-pub fn parent_block(db: &dyn Db, project: Project, file: File, name: &str) -> Option<BlockSite> {
+/// Exact local block definition at `name_span`.
+pub fn block_definition_at(db: &dyn Db, file: File, name_span: Span) -> Option<BlockSite> {
+    let TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
+        return None;
+    };
+    template_symbols(db, file, nodelist)
+        .blocks()
+        .iter()
+        .find(|block| block.name_span == name_span)
+        .map(|block| BlockSite {
+            file,
+            name_span: block.name_span,
+            full_span: block.full_span,
+        })
+}
+
+/// Definite ancestor definitions of `name`, nearest first and stopping at uncertainty.
+pub fn ancestor_blocks(db: &dyn Db, project: Project, file: File, name: &str) -> Vec<BlockSite> {
+    let mut ancestors = Vec::new();
     for origin in template_inheritance(db, project, file).ancestors(db) {
         match block_site_in_scope(db, origin.file(db), file, name) {
-            BlockSiteLookup::Found(site) => return Some(site),
+            BlockSiteLookup::Found(site) => ancestors.push(site),
             BlockSiteLookup::Absent => {}
-            BlockSiteLookup::Inconclusive => return None,
+            BlockSiteLookup::Inconclusive => break,
         }
     }
-    None
+    ancestors
+}
+
+/// Nearest ancestor definition of `name`.
+pub fn parent_block(db: &dyn Db, project: Project, file: File, name: &str) -> Option<BlockSite> {
+    ancestor_blocks(db, project, file, name).into_iter().next()
 }
 
 /// Block names visible from ancestors, using the nearest definition site per name.
@@ -308,81 +330,53 @@ pub fn inherited_blocks(db: &dyn Db, project: Project, file: File) -> Vec<(Strin
     inherited
 }
 
-/// Descendant templates that define `name`, discovered through exact reverse extends edges.
+/// Descendant templates that define `name`, discovered through definite reverse extends edges.
 ///
-/// Each candidate reference is re-resolved from its source origin and backend scope. Traversal
-/// therefore follows the concrete origin selected by Django rather than every file sharing a
-/// template name.
+/// A physical descendant contributes an edge only when its feasible origins agree on the same
+/// parent file. This is the reverse of `template_inheritance`, not a union of backend-local chains.
 pub fn block_overrides(db: &dyn Db, project: Project, file: File, name: &str) -> Vec<BlockSite> {
     let resolution = template_resolution(db, project);
-    let roots = resolution
-        .template_names_for_file(db, file)
-        .iter()
-        .flat_map(|template_name| resolution.origins_for_name(db, *template_name))
-        .filter(|origin| origin.file(db) == file)
-        .copied()
-        .collect::<Vec<_>>();
-    if roots.is_empty() {
+    if resolution.template_names_for_file(db, file).is_empty() {
         return Vec::new();
     }
 
-    let mut queue = VecDeque::from(roots.clone());
-    let mut visited_origins = roots.into_iter().collect::<FxHashSet<_>>();
-    let mut emitted_sites = FxHashSet::default();
+    let mut candidate_files = Vec::new();
+    for origin in resolution.origins(db) {
+        let candidate = origin.file(db);
+        if !candidate_files.contains(&candidate) {
+            candidate_files.push(candidate);
+        }
+    }
+
+    let mut queue = VecDeque::from([file]);
+    let mut visited_files = FxHashSet::from_iter([file]);
     let mut overrides = Vec::new();
 
     while let Some(target) = queue.pop_front() {
-        for descendant in resolution.origins(db) {
-            if !origin_extends_exact_target(db, resolution, descendant, target) {
+        for descendant in &candidate_files {
+            if visited_files.contains(descendant) {
+                continue;
+            }
+            let inheritance = template_inheritance(db, project, *descendant);
+            let Some(parent) = inheritance.ancestors(db).first() else {
+                continue;
+            };
+            if parent.file(db) != target || !visited_files.insert(*descendant) {
                 continue;
             }
 
-            if !visited_origins.insert(descendant) {
-                continue;
+            match block_site_in_scope(db, *descendant, *descendant, name) {
+                BlockSiteLookup::Found(site) => {
+                    overrides.push(site);
+                    queue.push_back(*descendant);
+                }
+                BlockSiteLookup::Absent => queue.push_back(*descendant),
+                BlockSiteLookup::Inconclusive => {}
             }
-
-            // A physical descendant can be reached through several origin names. Keep traversing
-            // each origin because its relative-name anchor and backend scope differ, but emit its
-            // block definition only once.
-            if let BlockSiteLookup::Found(site) =
-                block_site_in_scope(db, descendant.file(db), descendant.file(db), name)
-                && emitted_sites.insert((site.file, site.name_span, site.full_span))
-            {
-                overrides.push(site);
-            }
-            queue.push_back(descendant);
         }
     }
 
     overrides
-}
-
-fn origin_extends_exact_target<'db>(
-    db: &'db dyn Db,
-    resolution: TemplateResolution<'db>,
-    source: TemplateOrigin<'db>,
-    target: TemplateOrigin<'db>,
-) -> bool {
-    let file = source.file(db);
-    let TemplateParseResult::Parsed(nodelist) = parse_template(db, file) else {
-        return false;
-    };
-    let Some(ExtendsTarget::Literal { name, .. }) =
-        template_symbols_in_scope(db, file, nodelist, file).extends()
-    else {
-        return false;
-    };
-    let Some(resolved_name) =
-        resolve_relative_name(Some(source.template_name(db).name(db)), name, false)
-    else {
-        return false;
-    };
-    let name = TemplateName::new(db, resolved_name.into_owned());
-    let scope = resolution.backend_scope_for_origin(db, source);
-    matches!(
-        resolution.resolve_excluding_origins_in_scope(db, name, &[source], &scope),
-        TemplateResolutionResult::Found(origin) if origin == target
-    )
 }
 
 enum BlockSiteLookup {

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -31,6 +31,8 @@ pub use inheritance::ExtendsTarget;
 pub use inheritance::PartialDef;
 pub use inheritance::TemplateInheritance;
 pub use inheritance::TemplateSymbols;
+pub use inheritance::ancestor_blocks;
+pub use inheritance::block_definition_at;
 pub use inheritance::block_overrides;
 pub use inheritance::inherited_blocks;
 pub use inheritance::parent_block;

--- a/crates/djls-semantic/src/offset.rs
+++ b/crates/djls-semantic/src/offset.rs
@@ -36,6 +36,10 @@ pub enum SemanticOffsetContext<'db> {
         library: String,
         span: Span,
     },
+    TemplateBlock {
+        name: String,
+        span: Span,
+    },
     Tag {
         name: String,
         loaded_libraries: Vec<String>,
@@ -175,6 +179,14 @@ impl<'db> SemanticOffsetContext<'db> {
                         })
                 }
             }
+        } else if spec.and_then(TagSpec::role) == Some(TagRole::TemplateBlock) {
+            tag.bits
+                .first()
+                .filter(|name| name.span.contains(offset))
+                .map_or(Self::None, |name| Self::TemplateBlock {
+                    name: name.as_str().to_string(),
+                    span: name.span,
+                })
         } else {
             spec.and_then(|spec| LiteralTemplateReference::from_spec(spec, tag.bits))
                 .filter(|reference| reference.bit_span.contains(offset))

--- a/crates/djls-semantic/tests/inheritance.rs
+++ b/crates/djls-semantic/tests/inheritance.rs
@@ -15,6 +15,7 @@ use djls_semantic::TemplateSymbols;
 use djls_semantic::block_overrides;
 use djls_semantic::builtin_tag_specs;
 use djls_semantic::inherited_blocks;
+use djls_semantic::parent_block;
 use djls_semantic::template_inheritance;
 use djls_semantic::template_symbols;
 use djls_source::ChangeEvent;
@@ -654,6 +655,55 @@ fn scoped_parent_miss_is_unresolved_when_name_exists_only_in_another_backend() {
                 name: "other.html".to_string(),
             },
         )
+    );
+}
+
+#[test]
+fn block_queries_stop_only_for_the_uncertain_name() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {**UNKNOWN}}}]\n",
+        )
+        .file(
+            "/test/project/templates/base.html",
+            "{% block title %}Base title{% endblock %}{% block sidebar %}Base sidebar{% endblock %}",
+        )
+        .file(
+            "/test/project/templates/layout.html",
+            "{% extends 'base.html' %}{% load unknown_library %}{% maybe_block sidebar %}",
+        )
+        .file(
+            "/test/project/templates/child.html",
+            "{% extends 'layout.html' %}{% block title %}Child title{% endblock %}{% block sidebar %}Child sidebar{% endblock %}",
+        )
+        .install(&mut db)
+        .expect("uncertain Inheritance Block fixture should install");
+    let child = db
+        .file(Utf8Path::new("/test/project/templates/child.html"))
+        .expect("child Template fixture should exist");
+    let base = db
+        .file(Utf8Path::new("/test/project/templates/base.html"))
+        .expect("base Template fixture should exist");
+
+    assert_eq!(
+        parent_block(&db, project, child, "title").map(|site| site.file),
+        Some(base),
+        "unrelated uncertainty must not hide a definite parent block"
+    );
+    assert!(
+        parent_block(&db, project, child, "sidebar").is_none(),
+        "a possible nearer block must hide the grandparent block"
+    );
+    let inherited = inherited_blocks(&db, project, child);
+    assert_eq!(
+        inherited
+            .iter()
+            .map(|(name, site)| (name.as_str(), site.file))
+            .collect::<Vec<_>>(),
+        vec![("title", base)]
     );
 }
 

--- a/crates/djls-semantic/tests/inheritance.rs
+++ b/crates/djls-semantic/tests/inheritance.rs
@@ -773,6 +773,38 @@ fn reverse_inheritance_follows_the_exact_backend_origin() {
 }
 
 #[test]
+fn reverse_inheritance_rejects_a_shared_child_with_backend_local_parents() {
+    let mut db = TestDatabase::new();
+    let settings = "INSTALLED_APPS = []\nTEMPLATES = [\n    {'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/shared', '/test/project/a'], 'APP_DIRS': False},\n    {'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/shared', '/test/project/b'], 'APP_DIRS': False},\n]\n";
+    let project = ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file("/test/project/testproject/settings.py", settings)
+        .file(
+            "/test/project/a/base.html",
+            "{% block content %}A{% endblock %}",
+        )
+        .file(
+            "/test/project/b/base.html",
+            "{% block content %}B{% endblock %}",
+        )
+        .file(
+            "/test/project/shared/child.html",
+            "{% extends 'base.html' %}{% block content %}Child{% endblock %}",
+        )
+        .install(&mut db)
+        .expect("shared-child backend fixture should install");
+    let a_base = db
+        .file(Utf8Path::new("/test/project/a/base.html"))
+        .expect("backend A base Template should exist");
+    let b_base = db
+        .file(Utf8Path::new("/test/project/b/base.html"))
+        .expect("backend B base Template should exist");
+
+    assert!(block_overrides(&db, project, a_base, "content").is_empty());
+    assert!(block_overrides(&db, project, b_base, "content").is_empty());
+}
+
+#[test]
 fn template_inheritance_reports_missing_parent_as_unresolved() {
     let db = TestDatabase::new();
     let project = project_with_templates(

--- a/crates/djls-semantic/tests/offset.rs
+++ b/crates/djls-semantic/tests/offset.rs
@@ -209,6 +209,27 @@ fn identifies_tag_name_context() {
 }
 
 #[test]
+fn identifies_template_block_name_context() {
+    let db = TestDatabase::new();
+    let source = "{% block content %}{% endblock %}";
+
+    let context = context_for_source(
+        &db,
+        source,
+        offset_of(source, "content").expect("fixture offset should resolve"),
+    )
+    .expect("Template Block context fixture should load");
+
+    assert_eq!(
+        context,
+        SemanticOffsetContext::TemplateBlock {
+            name: "content".to_string(),
+            span: Span::new(9, 7),
+        }
+    );
+}
+
+#[test]
 fn captured_intermediate_has_no_tag_definition_context() {
     let db = TestDatabase::new();
     let source = "{% if user %}{% else %}{% endif %}";

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -631,7 +631,13 @@ impl LanguageServer for DjangoLanguageServer {
                     return None;
                 }
 
-                djls_ide::find_references(db, file, offset)
+                djls_ide::find_references(
+                    db,
+                    file,
+                    offset,
+                    snapshot.client_info().position_encoding(),
+                    params.context.include_declaration,
+                )
             })
             .await;
 

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -49,7 +49,7 @@ Each layer has a different failure mode and a different fix:
 
 The same inventory powers editor navigation. Resolved `{% load %}` library names become document links and go-to-definition targets for their Python source files. Selective-load symbols and available Tag and Filter names jump to definite local Python declarations. Dynamic, imported, member, and ambiguous callables are skipped rather than guessed.
 
-Template directory discovery also powers go to definition for literal `{% extends %}` and `{% include %}` names. Editors that support definition links receive exact origin and declaration ranges.
+Template directory discovery also powers go to definition for literal `{% extends %}` and `{% include %}` names. An overridden `{% block %}` name resolves to the nearest parent block when the inheritance chain is known. Editors that support definition links receive exact origin and declaration ranges.
 
 This gives you diagnostics based on the same template tag inventory Django would use at runtime, while distinguishing "not installed or misspelled" from "installed but not activated".
 

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -49,7 +49,7 @@ Each layer has a different failure mode and a different fix:
 
 The same inventory powers editor navigation. Resolved `{% load %}` library names become document links and go-to-definition targets for their Python source files. Selective-load symbols and available Tag and Filter names jump to definite local Python declarations. Dynamic, imported, member, and ambiguous callables are skipped rather than guessed.
 
-Template directory discovery also powers go to definition for literal `{% extends %}` and `{% include %}` names. An overridden `{% block %}` name resolves to the nearest parent block when the inheritance chain is known. Editors that support definition links receive exact origin and declaration ranges.
+Template directory discovery also powers go to definition for literal `{% extends %}` and `{% include %}` names. An overridden `{% block %}` name resolves to the nearest definite parent block; a root block resolves to itself. Find references returns the root block and its definite overrides. Editors that support definition links receive exact origin and declaration ranges.
 
 This gives you diagnostics based on the same template tag inventory Django would use at runtime, while distinguishing "not installed or misspelled" from "installed but not activated".
 

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -115,6 +115,79 @@ async def test_goto_definition_for_parent_template_block(client: LanguageClient)
 
 
 @pytest.mark.asyncio
+async def test_goto_definition_for_root_template_block(client: LanguageClient):
+    client.text_document_did_open(
+        DidOpenTextDocumentParams(
+            text_document=TextDocumentItem(
+                uri=BASE_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=BASE_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    result = await client.text_document_definition_async(
+        DefinitionParams(
+            text_document=TextDocumentIdentifier(uri=BASE_TEMPLATE.as_uri()),
+            position=position_in(BASE_TEMPLATE, "title %}"),
+        )
+    )
+
+    assert result is not None
+    assert len(result) == 1
+    link = result[0]
+    parent_name = position_in(BASE_TEMPLATE, "title %}")
+    assert link.origin_selection_range == Range(
+        start=parent_name,
+        end=Position(
+            line=parent_name.line,
+            character=parent_name.character + len("title"),
+        ),
+    )
+    assert link.target_uri == BASE_TEMPLATE.as_uri()
+    assert link.target_range.start == position_in(BASE_TEMPLATE, "{% block title")
+    assert link.target_selection_range == link.origin_selection_range
+
+
+@pytest.mark.asyncio
+async def test_find_references_for_template_block(client: LanguageClient):
+    client.text_document_did_open(
+        DidOpenTextDocumentParams(
+            text_document=TextDocumentItem(
+                uri=HOME_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=HOME_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    result = await client.text_document_references_async(
+        ReferenceParams(
+            text_document=TextDocumentIdentifier(uri=HOME_TEMPLATE.as_uri()),
+            position=position_in(HOME_TEMPLATE, "title %}"),
+            context=ReferenceContext(include_declaration=True),
+        )
+    )
+
+    assert result is not None
+    assert {
+        (
+            location.uri,
+            location.range.start.line,
+            location.range.start.character,
+            location.range.end.line,
+            location.range.end.character,
+        )
+        for location in result
+    } == {
+        (BASE_TEMPLATE.as_uri(), 7, 15, 7, 20),
+        (HOME_TEMPLATE.as_uri(), 2, 9, 2, 14),
+    }
+
+
+@pytest.mark.asyncio
 async def test_goto_definition_for_include_template_reference(client: LanguageClient):
     client.text_document_did_open(
         DidOpenTextDocumentParams(

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -76,6 +76,45 @@ async def test_goto_definition_for_extends_template_reference(client: LanguageCl
 
 
 @pytest.mark.asyncio
+async def test_goto_definition_for_parent_template_block(client: LanguageClient):
+    client.text_document_did_open(
+        DidOpenTextDocumentParams(
+            text_document=TextDocumentItem(
+                uri=HOME_TEMPLATE.as_uri(),
+                language_id="htmldjango",
+                version=1,
+                text=HOME_TEMPLATE.read_text(encoding="utf-8"),
+            )
+        )
+    )
+
+    result = await client.text_document_definition_async(
+        DefinitionParams(
+            text_document=TextDocumentIdentifier(uri=HOME_TEMPLATE.as_uri()),
+            position=position_in(HOME_TEMPLATE, "title %}"),
+        )
+    )
+
+    assert result is not None
+    assert len(result) == 1
+    link = result[0]
+    assert link.origin_selection_range == Range(
+        start=Position(line=2, character=9),
+        end=Position(line=2, character=14),
+    )
+    assert link.target_uri == BASE_TEMPLATE.as_uri()
+    assert link.target_range.start == position_in(BASE_TEMPLATE, "{% block title")
+    parent_name = position_in(BASE_TEMPLATE, "title %}")
+    assert link.target_selection_range == Range(
+        start=parent_name,
+        end=Position(
+            line=parent_name.line,
+            character=parent_name.character + len("title"),
+        ),
+    )
+
+
+@pytest.mark.asyncio
 async def test_goto_definition_for_include_template_reference(client: LanguageClient):
     client.text_document_did_open(
         DidOpenTextDocumentParams(


### PR DESCRIPTION
## Summary

- resolve overridden `{% block %}` names to the nearest definite parent block
- resolve root and uncertain-parent block definitions to themselves instead of returning no location
- find definite block references across correlated inheritance chains
- honor `includeDeclaration` and negotiated position encodings
- stop navigation and reverse traversal at uncertain block definitions or backend disagreement
- update feature docs and roadmap state

## Tests

- `cargo test -q`
- `just e2e`
- `just clippy`
- `just fmt --check`
- `just lint`
- `just hawk`