### PR TITLE
Follow cross-module Template Tag registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Added
 
 - Added support for Django 6.1.
+- Added static discovery and navigation for Template Tags and Filters registered with imported module constants and functions.
 - Added env-file-aware static evaluation for `os.getenv()` and `os.environ.get()` in Django settings.
 - Added quick-fix code actions for loading missing Django template tag libraries.
 - Added quick-fix code actions for choosing among ambiguous unloaded Django template tag libraries.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,7 +102,7 @@ Hover is supported for template tags, filters, libraries, selectively loaded sym
 
 **Status:** 🚧 Partially supported
 
-Go to definition works for literal template references in `{% extends %}` and `{% include %}`, block names, Template Library arguments in `{% load %}`, selective-load symbols, and available Template Tags and Filters with definite local Python declarations. Block overrides resolve to the nearest definite parent; root or uncertain-parent blocks resolve to themselves. Clients that support definition links receive exact origin and declaration ranges; older clients receive plain locations. Ambiguous definitions and dynamic, imported, or member callables do not produce guessed targets.
+Go to definition works for literal template references in `{% extends %}` and `{% include %}`, block names, Template Library arguments in `{% load %}`, selective-load symbols, and available Template Tags and Filters with definite local or imported module-level Python declarations. Block overrides resolve to the nearest definite parent; root or uncertain-parent blocks resolve to themselves. Clients that support definition links receive exact origin and declaration ranges; older clients receive plain locations. Ambiguous definitions and dynamic, transformed, recovered, or member callables do not produce guessed targets.
 
 #### Find references
 

--- a/crates/djls-ide/src/warmup.rs
+++ b/crates/djls-ide/src/warmup.rs
@@ -5,6 +5,7 @@ use djls_project::ScopedTemplateLibraries;
 use djls_project::template_directories;
 use djls_project::template_library_catalog;
 use djls_project::template_library_definition_facts;
+use djls_project::template_library_registration_dependencies;
 use djls_project::template_resolution;
 use djls_semantic::Db as SemanticDb;
 use djls_semantic::library_filter_specs;
@@ -82,6 +83,11 @@ pub fn prime_template_library_products(db: &dyn SemanticDb) -> Option<PrimedTemp
             && !reprime_files.contains(&file)
         {
             reprime_files.push(file);
+        }
+        for &file in template_library_registration_dependencies(db, key) {
+            if !reprime_files.contains(&file) {
+                reprime_files.push(file);
+            }
         }
     }
 
@@ -342,6 +348,44 @@ mod tests {
                 execution_count(&names, intrinsic),
                 0,
                 "repeated prime ran {intrinsic}"
+            );
+        }
+    }
+
+    #[test]
+    fn priming_covers_imported_registration_sources() {
+        let mut db = TestDatabase::new();
+        ProjectFixture::new("/project")
+            .django_settings_module("settings")
+            .file(
+                "/project/settings.py",
+                "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'OPTIONS': {'builtins': ['app.templatetags.tags']}}]\n",
+            )
+            .file("/project/app/__init__.py", "")
+            .file("/project/app/templatetags/__init__.py", "")
+            .file(
+                "/project/app/templatetags/tags.py",
+                "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+            )
+            .file(
+                "/project/app/templatetags/implementation.py",
+                "TAG = 'imported'\ndef compile_tag(parser, token): pass\n",
+            )
+            .install(&mut db)
+            .expect("imported registration warmup fixture should install");
+
+        let primed = prime_template_library_products(&db).expect("fixture has a Project");
+        for path in [
+            "/project/app/__init__.py",
+            "/project/app/templatetags/__init__.py",
+            "/project/app/templatetags/implementation.py",
+        ] {
+            assert!(
+                primed
+                    .reprime_files()
+                    .iter()
+                    .any(|file| file.path(&db) == Utf8Path::new(path)),
+                "priming coverage should include {path}",
             );
         }
     }

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -900,6 +900,59 @@ fn goto_definition_resolves_loaded_tag_and_filter_to_local_functions() {
 }
 
 #[test]
+fn goto_definition_resolves_imported_registration_callable() {
+    let source = "{% load bird %}\n{% bird component %}";
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/test/project")
+        .django_settings_module("settings")
+        .file(
+            "/test/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'OPTIONS': {'libraries': {'bird': 'app.templatetags.bird_tags'}}}]\n",
+        )
+        .file("/test/project/app/__init__.py", "")
+        .file("/test/project/app/templatetags/__init__.py", "")
+        .file(
+            "/test/project/app/templatetags/bird_tags.py",
+            "from django import template\nfrom . import bird\nregister = template.Library()\nregister.tag(bird.TAG, bird.do_bird)\n",
+        )
+        .file(
+            "/test/project/app/templatetags/bird.py",
+            "TAG = 'bird'\n\ndef do_bird(parser, token):\n    return None\n",
+        )
+        .file("/test/project/templates/page.html", source)
+        .install(&mut db)
+        .expect("imported registration navigation fixture should install");
+    let file = db
+        .file(Utf8Path::new("/test/project/templates/page.html"))
+        .expect("Template fixture should exist");
+
+    let response = goto_definition(&db, file, offset_of(source, "bird component"), true)
+        .expect("imported Tag callable should resolve");
+    let ls_types::GotoDefinitionResponse::Link(links) = response else {
+        panic!("LocationLink client should receive an imported Tag link")
+    };
+    assert_eq!(links.len(), 1);
+    assert_eq!(
+        links[0].target_uri.as_str(),
+        "file:///test/project/app/templatetags/bird.py"
+    );
+    assert_eq!(
+        links[0].target_range,
+        ls_types::Range::new(
+            ls_types::Position::new(2, 0),
+            ls_types::Position::new(3, 15),
+        )
+    );
+    assert_eq!(
+        links[0].target_selection_range,
+        ls_types::Range::new(
+            ls_types::Position::new(2, 4),
+            ls_types::Position::new(2, 11),
+        )
+    );
+}
+
+#[test]
 fn goto_definition_follows_source_order_shadowing() {
     let source = "{% shared %}{% load alpha %}{% shared %}{% load beta %}{% shared %}";
     let mut db = TestDatabase::new();

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -98,6 +98,7 @@ pub use templates::template_directories;
 pub use templates::template_library_catalog;
 pub use templates::template_library_definition_facts;
 pub use templates::template_library_filter_facts;
+pub use templates::template_library_registration_dependencies;
 pub use templates::template_library_tag_facts;
 pub use templates::template_resolution;
 pub use templates::template_symbol_source;

--- a/crates/djls-project/src/python.rs
+++ b/crates/djls-project/src/python.rs
@@ -7,6 +7,7 @@ mod name;
 mod parse;
 mod path_eval;
 mod search_paths;
+mod source_occurrences;
 
 pub use interpreter::Interpreter;
 pub(crate) use intrinsic::PythonIntrinsic;
@@ -35,3 +36,5 @@ pub(crate) use parse::python_syntax_errors;
 pub(crate) use path_eval::PythonPath;
 pub use search_paths::SearchPath;
 pub use search_paths::SearchPaths;
+pub(crate) use source_occurrences::PythonFunctionDefinition;
+pub(crate) use source_occurrences::PythonSourceLookup;

--- a/crates/djls-project/src/python/source_occurrences.rs
+++ b/crates/djls-project/src/python/source_occurrences.rs
@@ -1,0 +1,1056 @@
+use std::collections::BTreeMap;
+
+use djls_source::File;
+use djls_source::Span;
+use ruff_python_ast::Expr;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtClassDef;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::visitor;
+use ruff_python_ast::visitor::Visitor;
+
+use crate::ast::ExprExt;
+use crate::ast::RangedExt;
+use crate::db::Db as ProjectDb;
+use crate::project::Project;
+use crate::python::PythonModule;
+use crate::python::PythonModuleName;
+use crate::python::PythonSourceModule;
+use crate::python::RecoveredPythonModule;
+use crate::python::import::DirectImportClause;
+use crate::python::import::FromImportSyntax;
+use crate::python::module::PythonImportChainResolution;
+use crate::python::module::PythonImportRequest;
+
+const MAX_REEXPORT_DEPTH: usize = 8;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LazyFromImport {
+    level: u32,
+    module: Option<String>,
+    member: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Binding {
+    Module(PythonModule),
+    ModuleMember(PythonModule, Box<Binding>),
+    LazyFromImport(LazyFromImport),
+    String(String),
+    Function(PythonFunctionDefinition),
+    Unknown,
+}
+
+#[derive(Clone, Debug)]
+enum ResolvedValue {
+    Module(PythonModule),
+    String(String),
+    Function(PythonFunctionDefinition),
+}
+
+#[derive(Clone, Debug)]
+enum MemberLookup {
+    Found(ResolvedValue),
+    Absent,
+    Uncertain,
+}
+
+/// Stable source identity for an undecorated module-level Python function.
+///
+/// The definition span, together with the file, distinguishes definitions that
+/// reuse a name. Python owns the AST lookup so consumers never repeat that
+/// identity check against a recovered parse.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PythonFunctionDefinition {
+    file: File,
+    definition_span: Span,
+    name: String,
+}
+
+impl PythonFunctionDefinition {
+    #[must_use]
+    pub(crate) fn file(&self) -> File {
+        self.file
+    }
+
+    #[must_use]
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub(crate) fn statement<'db>(&self, db: &'db dyn ProjectDb) -> Option<&'db StmtFunctionDef> {
+        let module = RecoveredPythonModule::from_file(db, self.file)
+            .ok()
+            .flatten()?;
+        module.body(db).iter().find_map(|statement| {
+            let Stmt::FunctionDef(function) = statement else {
+                return None;
+            };
+            (function.span() == self.definition_span).then_some(function)
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PythonOccurrenceValue {
+    String(String),
+    Function(PythonFunctionDefinition),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct PythonSourceOccurrence {
+    value: Option<PythonOccurrenceValue>,
+    consulted_files: Vec<File>,
+    recovered_source: bool,
+}
+
+/// On-demand access to exact Python facts at selected source occurrences.
+///
+/// Each lookup scans only as far as its target statement. The facade merges
+/// evidence from the operands its consumer actually asks about.
+pub(crate) struct PythonSourceLookup<'db> {
+    db: &'db dyn ProjectDb,
+    project: Option<Project>,
+    module: Option<PythonSourceModule>,
+    file: File,
+    consulted_files: Vec<File>,
+    recovered_source: bool,
+}
+
+impl<'db> PythonSourceLookup<'db> {
+    pub(crate) fn for_file(db: &'db dyn ProjectDb, file: File) -> Self {
+        Self {
+            db,
+            project: None,
+            module: None,
+            file,
+            consulted_files: Vec::new(),
+            recovered_source: false,
+        }
+    }
+
+    pub(crate) fn for_module(
+        db: &'db dyn ProjectDb,
+        project: Project,
+        module: PythonSourceModule,
+    ) -> Self {
+        Self {
+            db,
+            project: Some(project),
+            file: module.file(),
+            module: Some(module),
+            consulted_files: Vec::new(),
+            recovered_source: false,
+        }
+    }
+
+    pub(crate) fn exact_string(&mut self, expression: &Expr) -> Option<String> {
+        if let Some(value) = expression.string_literal() {
+            return Some(value.to_string());
+        }
+        match self.lookup(expression) {
+            Some(PythonOccurrenceValue::String(value)) => Some(value),
+            Some(PythonOccurrenceValue::Function(_)) | None => None,
+        }
+    }
+
+    pub(crate) fn function(&mut self, expression: &Expr) -> Option<PythonFunctionDefinition> {
+        match self.lookup(expression) {
+            Some(PythonOccurrenceValue::Function(definition)) => Some(definition),
+            Some(PythonOccurrenceValue::String(_)) | None => None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn consulted_files(&self) -> &[File] {
+        &self.consulted_files
+    }
+
+    #[must_use]
+    pub(crate) fn has_recovered_source(&self) -> bool {
+        self.recovered_source
+    }
+
+    fn lookup(&mut self, expression: &Expr) -> Option<PythonOccurrenceValue> {
+        let occurrence = python_source_occurrence(
+            self.db,
+            self.project,
+            self.module.clone(),
+            self.file,
+            expression.span(),
+        );
+        self.recovered_source |= occurrence.recovered_source;
+        for file in &occurrence.consulted_files {
+            if !self.consulted_files.contains(file) {
+                self.consulted_files.push(*file);
+            }
+        }
+        occurrence.value.clone()
+    }
+}
+
+#[salsa::tracked(returns(ref))]
+fn python_source_occurrence(
+    db: &dyn ProjectDb,
+    project: Option<Project>,
+    module: Option<PythonSourceModule>,
+    file: File,
+    target: Span,
+) -> PythonSourceOccurrence {
+    let Ok(Some(parsed)) = RecoveredPythonModule::from_file(db, file) else {
+        return PythonSourceOccurrence::default();
+    };
+    let mut analysis = SourceOccurrenceAnalysis::new(db, project, module, file);
+    analysis.recovered_source = parsed.has_ordinary_syntax_errors(db);
+    for statement in parsed.body(db) {
+        if span_contains(statement.span(), target) {
+            if statement_contains_named_binding(statement) {
+                return analysis.finish(None);
+            }
+            let expression = find_expression(statement, target);
+            let value = expression
+                .and_then(|expression| analysis.resolve_expression(expression, 0))
+                .and_then(occurrence_value);
+            return analysis.finish(value);
+        }
+        if statement_contains_named_binding(statement) {
+            analysis.bindings.clear();
+        } else {
+            analysis.apply_statement_effects(statement);
+        }
+    }
+    analysis.finish(None)
+}
+
+struct SourceOccurrenceAnalysis<'db> {
+    db: &'db dyn ProjectDb,
+    project: Option<Project>,
+    importer: Option<PythonSourceModule>,
+    file: File,
+    bindings: BTreeMap<String, Binding>,
+    consulted_files: Vec<File>,
+    recovered_source: bool,
+}
+
+impl<'db> SourceOccurrenceAnalysis<'db> {
+    fn new(
+        db: &'db dyn ProjectDb,
+        project: Option<Project>,
+        importer: Option<PythonSourceModule>,
+        file: File,
+    ) -> Self {
+        Self {
+            db,
+            project,
+            importer,
+            file,
+            bindings: BTreeMap::new(),
+            consulted_files: Vec::new(),
+            recovered_source: false,
+        }
+    }
+
+    fn finish(mut self, value: Option<PythonOccurrenceValue>) -> PythonSourceOccurrence {
+        self.consulted_files
+            .sort_by(|left, right| left.path(self.db).cmp(right.path(self.db)));
+        self.consulted_files.dedup();
+        PythonSourceOccurrence {
+            value,
+            consulted_files: self.consulted_files,
+            recovered_source: self.recovered_source,
+        }
+    }
+
+    fn apply_statement_effects(&mut self, statement: &Stmt) {
+        match statement {
+            Stmt::Import(import) => {
+                for clause in DirectImportClause::lower(import) {
+                    let binding = if clause.binds_root() && clause.requested() != clause.target() {
+                        Binding::Unknown
+                    } else {
+                        self.resolve_import(0, Some(clause.target()))
+                            .map_or(Binding::Unknown, Binding::Module)
+                    };
+                    self.bindings.insert(clause.bound().to_string(), binding);
+                }
+            }
+            Stmt::ImportFrom(import) => {
+                let syntax = FromImportSyntax::lower(import);
+                if syntax.has_star() {
+                    self.bindings.clear();
+                }
+                for member in syntax.named_members() {
+                    let binding = if self.project.is_some() && self.importer.is_some() {
+                        Binding::LazyFromImport(LazyFromImport {
+                            level: syntax.level(),
+                            module: syntax.module().map(str::to_string),
+                            member: member.imported().to_string(),
+                        })
+                    } else {
+                        Binding::Unknown
+                    };
+                    self.bindings.insert(member.bound().to_string(), binding);
+                }
+            }
+            Stmt::Assign(assign) => {
+                self.invalidate_escaped_modules(&assign.value);
+                let value = self.resolve_local_expr(&assign.value);
+                for target in &assign.targets {
+                    self.bind_target(target, value.clone());
+                }
+            }
+            Stmt::AnnAssign(assign) => {
+                if let Some(value) = assign.value.as_deref() {
+                    self.invalidate_escaped_modules(value);
+                }
+                let value = assign
+                    .value
+                    .as_deref()
+                    .and_then(|value| self.resolve_local_expr(value));
+                self.bind_target(&assign.target, value);
+            }
+            Stmt::FunctionDef(function) => {
+                let binding = if function.decorator_list.is_empty() {
+                    Binding::Function(function_definition(self.file, function))
+                } else {
+                    Binding::Unknown
+                };
+                self.bindings.insert(function.name.to_string(), binding);
+            }
+            Stmt::ClassDef(class) => {
+                self.bindings
+                    .insert(class.name.to_string(), Binding::Unknown);
+            }
+            Stmt::AugAssign(assign) => self.bind_target(&assign.target, None),
+            Stmt::Delete(delete) => {
+                for target in &delete.targets {
+                    self.bind_target(target, None);
+                }
+            }
+            Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Try(_)
+            | Stmt::TypeAlias(_) => self.bindings.clear(),
+            Stmt::Expr(expression) => self.invalidate_escaped_modules(&expression.value),
+            Stmt::Return(_)
+            | Stmt::Raise(_)
+            | Stmt::Assert(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => {}
+        }
+    }
+
+    fn bind_target(&mut self, target: &Expr, value: Option<Binding>) {
+        if let Some(name) = target.name_target() {
+            self.bindings
+                .insert(name.to_string(), value.unwrap_or(Binding::Unknown));
+        } else if let Some(root) = mutation_root(target) {
+            if let Some(binding) = self.bindings.get(root).cloned() {
+                self.invalidate_binding(binding);
+            }
+        } else {
+            self.bindings.clear();
+        }
+    }
+
+    fn invalidate_escaped_modules(&mut self, expression: &Expr) {
+        if expression.name_target().is_some() || expression.string_literal().is_some() {
+            return;
+        }
+        let escaped = self
+            .bindings
+            .iter()
+            .filter(|(name, _)| expression_escapes_name(expression, name))
+            .map(|(_, binding)| binding.clone())
+            .collect::<Vec<_>>();
+        for binding in escaped {
+            self.invalidate_binding(binding);
+        }
+    }
+
+    fn invalidate_binding(&mut self, binding: Binding) {
+        match binding {
+            Binding::Module(module) | Binding::ModuleMember(module, _) => {
+                self.invalidate_module(&module);
+            }
+            Binding::LazyFromImport(lazy) => {
+                if let Some(materialized) =
+                    self.materialize_binding(Binding::LazyFromImport(lazy.clone()), 0)
+                {
+                    self.invalidate_binding(materialized);
+                } else {
+                    for binding in self.bindings.values_mut() {
+                        if matches!(binding, Binding::LazyFromImport(bound) if bound == &lazy) {
+                            *binding = Binding::Unknown;
+                        }
+                    }
+                }
+            }
+            Binding::String(_) | Binding::Function(_) | Binding::Unknown => {}
+        }
+    }
+
+    fn invalidate_module(&mut self, module: &PythonModule) {
+        for binding in self.bindings.values_mut() {
+            if matches!(binding, Binding::Module(bound) | Binding::ModuleMember(bound, _) if bound == module)
+            {
+                *binding = Binding::Unknown;
+            }
+        }
+    }
+
+    fn resolve_local_expr(&mut self, expression: &Expr) -> Option<Binding> {
+        if let Some(value) = expression.string_literal() {
+            return Some(Binding::String(value.to_string()));
+        }
+        if let Some(name) = expression.name_target() {
+            return self.bindings.get(name).cloned();
+        }
+        let path = expression.path_segments()?;
+        let (root, tail) = path.split_first()?;
+        let binding = self.bindings.get(root).cloned()?;
+        let module = match self.materialize_binding(binding, 0)? {
+            Binding::Module(module) => module,
+            Binding::ModuleMember(_, _)
+            | Binding::LazyFromImport(_)
+            | Binding::String(_)
+            | Binding::Function(_)
+            | Binding::Unknown => return None,
+        };
+        let value = self.resolve_module_path(&module, tail, 1)?;
+        Some(Binding::ModuleMember(
+            module,
+            Box::new(binding_from_value(value)),
+        ))
+    }
+
+    fn resolve_expression(&mut self, expression: &Expr, depth: usize) -> Option<ResolvedValue> {
+        if depth >= MAX_REEXPORT_DEPTH {
+            return None;
+        }
+        if let Some(value) = expression.string_literal() {
+            return Some(ResolvedValue::String(value.to_string()));
+        }
+        let path = expression.path_segments()?;
+        let (root, tail) = path.split_first()?;
+        let binding = self.bindings.get(root).cloned()?;
+        self.resolve_binding(binding, tail, depth + 1)
+    }
+
+    fn resolve_binding(
+        &mut self,
+        binding: Binding,
+        tail: &[String],
+        depth: usize,
+    ) -> Option<ResolvedValue> {
+        match self.materialize_binding(binding, depth)? {
+            Binding::Module(module) => {
+                if tail.is_empty() {
+                    Some(ResolvedValue::Module(module))
+                } else {
+                    self.resolve_module_path(&module, tail, depth)
+                }
+            }
+            Binding::ModuleMember(_, value) => self.resolve_binding(*value, tail, depth),
+            Binding::String(value) if tail.is_empty() => Some(ResolvedValue::String(value)),
+            Binding::Function(function) if tail.is_empty() => {
+                Some(ResolvedValue::Function(function))
+            }
+            Binding::LazyFromImport(_)
+            | Binding::String(_)
+            | Binding::Function(_)
+            | Binding::Unknown => None,
+        }
+    }
+
+    fn materialize_binding(&mut self, binding: Binding, depth: usize) -> Option<Binding> {
+        let Binding::LazyFromImport(lazy) = binding else {
+            return Some(binding);
+        };
+        let materialized = self.materialize_lazy_import(&lazy, depth)?;
+        for binding in self.bindings.values_mut() {
+            if matches!(binding, Binding::LazyFromImport(bound) if bound == &lazy) {
+                *binding = materialized.clone();
+            }
+        }
+        Some(materialized)
+    }
+
+    fn materialize_lazy_import(&mut self, lazy: &LazyFromImport, depth: usize) -> Option<Binding> {
+        let source = self.resolve_import(lazy.level, lazy.module.as_deref())?;
+        match self.lookup_member(&source, &lazy.member, depth + 1) {
+            MemberLookup::Found(value) => Some(Binding::ModuleMember(
+                source,
+                Box::new(binding_from_value(value)),
+            )),
+            MemberLookup::Absent if source.is_package() => self
+                .resolve_child(&source, &lazy.member)
+                .map(Binding::Module),
+            MemberLookup::Absent | MemberLookup::Uncertain => None,
+        }
+    }
+
+    fn lookup_member(&mut self, module: &PythonModule, member: &str, depth: usize) -> MemberLookup {
+        let PythonModule::Source(source) = module else {
+            return MemberLookup::Absent;
+        };
+        if let Some(value) = self.resolve_module_path(module, &[member.to_string()], depth) {
+            return MemberLookup::Found(value);
+        }
+        self.follow(source.file());
+        let Ok(Some(parsed)) = RecoveredPythonModule::from_file(self.db, source.file()) else {
+            return MemberLookup::Uncertain;
+        };
+        if parsed.has_ordinary_syntax_errors(self.db) {
+            self.recovered_source = true;
+            return MemberLookup::Uncertain;
+        }
+        if member_absence_is_proven(parsed.body(self.db), member) {
+            MemberLookup::Absent
+        } else {
+            MemberLookup::Uncertain
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn resolve_module_path(
+        &mut self,
+        module: &PythonModule,
+        path: &[String],
+        depth: usize,
+    ) -> Option<ResolvedValue> {
+        if depth >= MAX_REEXPORT_DEPTH || path.is_empty() {
+            return None;
+        }
+        let PythonModule::Source(source) = module else {
+            let child = self.resolve_child(module, &path[0])?;
+            return if path.len() == 1 {
+                Some(ResolvedValue::Module(child))
+            } else {
+                self.resolve_module_path(&child, &path[1..], depth + 1)
+            };
+        };
+        self.follow(source.file());
+        let parsed = RecoveredPythonModule::from_file(self.db, source.file()).ok()??;
+        let parse_is_exact = !parsed.has_ordinary_syntax_errors(self.db);
+        self.recovered_source |= !parse_is_exact;
+        let root = &path[0];
+        let mut value = None;
+        let mut enum_bindings = BTreeMap::new();
+
+        for statement in parsed.body(self.db) {
+            match statement {
+                Stmt::Import(import) => {
+                    for clause in DirectImportClause::lower(import) {
+                        enum_bindings.remove(clause.bound());
+                        if clause.bound() == root {
+                            value = if clause.binds_root() && clause.requested() != clause.target()
+                            {
+                                None
+                            } else {
+                                self.resolve_import_from(source, 0, Some(clause.target()))
+                                    .map(ResolvedValue::Module)
+                            };
+                        }
+                        if clause.bound() == "enum" && clause.target() == "enum" {
+                            enum_bindings.insert("enum".to_string(), "module".to_string());
+                        }
+                    }
+                }
+                Stmt::ImportFrom(import) => {
+                    let syntax = FromImportSyntax::lower(import);
+                    if syntax.has_star() {
+                        value = None;
+                        enum_bindings.clear();
+                    }
+                    for member in syntax.named_members() {
+                        enum_bindings.remove(member.bound());
+                        if syntax.level() == 0
+                            && syntax.module() == Some("enum")
+                            && member.imported() == "Enum"
+                        {
+                            enum_bindings.insert(member.bound().to_string(), "enum".to_string());
+                        }
+                        if member.bound() == root {
+                            let imported =
+                                self.resolve_import_from(source, syntax.level(), syntax.module());
+                            value = imported.and_then(|imported| {
+                                match self.lookup_member(&imported, member.imported(), depth + 1) {
+                                    MemberLookup::Found(value) => Some(value),
+                                    MemberLookup::Absent if imported.is_package() => self
+                                        .resolve_child(&imported, member.imported())
+                                        .map(ResolvedValue::Module),
+                                    MemberLookup::Absent | MemberLookup::Uncertain => None,
+                                }
+                            });
+                        }
+                    }
+                }
+                Stmt::Assign(assign) => {
+                    let mut complex_target = false;
+                    for target in &assign.targets {
+                        if let Some(name) = target.name_target() {
+                            enum_bindings.remove(name);
+                        } else {
+                            complex_target = true;
+                        }
+                    }
+                    if complex_target {
+                        value = None;
+                    } else if assign
+                        .targets
+                        .iter()
+                        .any(|target| target.name_target().is_some_and(|name| name == root))
+                    {
+                        value = if path.len() == 1 {
+                            assign
+                                .value
+                                .string_literal()
+                                .map(|value| ResolvedValue::String(value.to_string()))
+                        } else {
+                            None
+                        };
+                    }
+                }
+                Stmt::AnnAssign(assign) => {
+                    if let Some(name) = assign.target.name_target() {
+                        enum_bindings.remove(name);
+                    }
+                    if assign.target.name_target() == Some(root) {
+                        value = if path.len() == 1 {
+                            assign
+                                .value
+                                .as_deref()
+                                .and_then(ExprExt::string_literal)
+                                .map(|value| ResolvedValue::String(value.to_string()))
+                        } else {
+                            None
+                        };
+                    }
+                }
+                Stmt::FunctionDef(function) => {
+                    enum_bindings.remove(function.name.as_str());
+                    if function.name.as_str() == root {
+                        value = if path.len() == 1 && function.decorator_list.is_empty() {
+                            Some(ResolvedValue::Function(function_definition(
+                                source.file(),
+                                function,
+                            )))
+                        } else {
+                            None
+                        };
+                    }
+                }
+                Stmt::ClassDef(class) => {
+                    enum_bindings.remove(class.name.as_str());
+                    if class.name.as_str() == root {
+                        value = Self::resolve_enum_member(class, &path[1..], &enum_bindings);
+                    }
+                }
+                Stmt::AugAssign(assign)
+                    if assign.target.name_target() == Some(root)
+                        || assign.target.name_target().is_none() =>
+                {
+                    value = None;
+                }
+                Stmt::Delete(delete)
+                    if delete.targets.iter().any(|target| {
+                        target.name_target() == Some(root) || target.name_target().is_none()
+                    }) =>
+                {
+                    value = None;
+                }
+                Stmt::For(_)
+                | Stmt::While(_)
+                | Stmt::If(_)
+                | Stmt::With(_)
+                | Stmt::Match(_)
+                | Stmt::Try(_)
+                | Stmt::TypeAlias(_)
+                | Stmt::Return(_)
+                | Stmt::Raise(_)
+                | Stmt::Assert(_) => value = None,
+                Stmt::Expr(expression) if expression.value.string_literal().is_none() => {
+                    value = None;
+                }
+                Stmt::AugAssign(_)
+                | Stmt::Delete(_)
+                | Stmt::Expr(_)
+                | Stmt::Global(_)
+                | Stmt::Nonlocal(_)
+                | Stmt::Pass(_)
+                | Stmt::Break(_)
+                | Stmt::Continue(_)
+                | Stmt::IpyEscapeCommand(_) => {}
+            }
+        }
+
+        match value? {
+            ResolvedValue::Module(module) if path.len() > 1 => {
+                self.resolve_module_path(&module, &path[1..], depth + 1)
+            }
+            resolved @ ResolvedValue::String(_) => Some(resolved),
+            resolved @ (ResolvedValue::Module(_) | ResolvedValue::Function(_))
+                if path.len() == 1 =>
+            {
+                Some(resolved)
+            }
+            ResolvedValue::Module(_) | ResolvedValue::Function(_) => None,
+        }
+    }
+
+    fn resolve_enum_member(
+        class: &StmtClassDef,
+        path: &[String],
+        enum_bindings: &BTreeMap<String, String>,
+    ) -> Option<ResolvedValue> {
+        let [member, value] = path else {
+            return None;
+        };
+        let arguments = class.arguments.as_deref()?;
+        let [base] = arguments.args.as_ref() else {
+            return None;
+        };
+        if value != "value"
+            || !class.decorator_list.is_empty()
+            || !arguments.keywords.is_empty()
+            || !base.path_segments().is_some_and(|segments| {
+                matches!(segments.as_slice(), [module, enum_name]
+                    if enum_bindings.get(module).is_some_and(|kind| kind == "module")
+                        && enum_name == "Enum")
+                    || matches!(segments.as_slice(), [enum_name]
+                        if enum_bindings.get(enum_name).is_some_and(|kind| kind == "enum"))
+            })
+        {
+            return None;
+        }
+
+        let mut result = None;
+        for statement in &class.body {
+            match statement {
+                Stmt::Assign(assign) => {
+                    let [target] = assign.targets.as_slice() else {
+                        return None;
+                    };
+                    let name = target.name_target()?;
+                    let literal = assign.value.string_literal()?;
+                    if name == member {
+                        result = Some(literal.to_string());
+                    }
+                }
+                Stmt::AnnAssign(assign) => {
+                    let name = assign.target.name_target()?;
+                    let literal = assign.value.as_deref().and_then(ExprExt::string_literal)?;
+                    if name == member {
+                        result = Some(literal.to_string());
+                    }
+                }
+                Stmt::Expr(expression) if expression.value.string_literal().is_some() => {}
+                Stmt::Pass(_) => {}
+                Stmt::Import(_)
+                | Stmt::ImportFrom(_)
+                | Stmt::FunctionDef(_)
+                | Stmt::ClassDef(_)
+                | Stmt::AugAssign(_)
+                | Stmt::Delete(_)
+                | Stmt::For(_)
+                | Stmt::While(_)
+                | Stmt::If(_)
+                | Stmt::With(_)
+                | Stmt::Match(_)
+                | Stmt::Try(_)
+                | Stmt::TypeAlias(_)
+                | Stmt::Expr(_)
+                | Stmt::Return(_)
+                | Stmt::Raise(_)
+                | Stmt::Assert(_)
+                | Stmt::Global(_)
+                | Stmt::Nonlocal(_)
+                | Stmt::Break(_)
+                | Stmt::Continue(_)
+                | Stmt::IpyEscapeCommand(_) => return None,
+            }
+        }
+        result.map(ResolvedValue::String)
+    }
+
+    fn resolve_import(&mut self, level: u32, module: Option<&str>) -> Option<PythonModule> {
+        let importer = self.importer.clone()?;
+        self.resolve_import_from(&importer, level, module)
+    }
+
+    fn resolve_import_from(
+        &mut self,
+        importer: &PythonSourceModule,
+        level: u32,
+        module: Option<&str>,
+    ) -> Option<PythonModule> {
+        let (_, resolution) = PythonSourceModule::resolve_import_chain(
+            self.db,
+            self.project?,
+            PythonImportRequest {
+                level,
+                module,
+                importer,
+            },
+        )
+        .ok()?;
+        let chain = match resolution {
+            PythonImportChainResolution::Resolved(chain) => chain,
+            PythonImportChainResolution::Failed { prefix, .. } => {
+                self.follow_chain(prefix.into_components());
+                return None;
+            }
+        };
+        let components = chain.into_components();
+        let module = components.last().cloned();
+        self.follow_chain(components);
+        module
+    }
+
+    fn resolve_child(&mut self, module: &PythonModule, member: &str) -> Option<PythonModule> {
+        let name =
+            PythonModuleName::parse(&format!("{}.{}", module.name().as_str(), member)).ok()?;
+        let name_string = name.as_str().to_string();
+        let importer = self.importer.clone()?;
+        self.resolve_import_from(&importer, 0, Some(&name_string))
+    }
+
+    fn follow_chain(&mut self, components: Vec<PythonModule>) {
+        for component in components {
+            if let PythonModule::Source(source) = component {
+                self.follow(source.file());
+            }
+        }
+    }
+
+    fn follow(&mut self, file: File) {
+        if file != self.file && !self.consulted_files.contains(&file) {
+            self.consulted_files.push(file);
+        }
+    }
+}
+
+struct ExpressionFinder<'a> {
+    target: Span,
+    found: Option<&'a Expr>,
+}
+
+impl<'a> Visitor<'a> for ExpressionFinder<'a> {
+    fn visit_expr(&mut self, expression: &'a Expr) {
+        if expression.span() == self.target {
+            self.found = Some(expression);
+            return;
+        }
+        visitor::walk_expr(self, expression);
+    }
+}
+
+fn find_expression(statement: &Stmt, target: Span) -> Option<&Expr> {
+    let mut finder = ExpressionFinder {
+        target,
+        found: None,
+    };
+    finder.visit_stmt(statement);
+    finder.found
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.start() <= inner.start() && inner.end() <= outer.end()
+}
+
+fn occurrence_value(value: ResolvedValue) -> Option<PythonOccurrenceValue> {
+    match value {
+        ResolvedValue::String(value) => Some(PythonOccurrenceValue::String(value)),
+        ResolvedValue::Function(function) => Some(PythonOccurrenceValue::Function(function)),
+        ResolvedValue::Module(_) => None,
+    }
+}
+
+struct NamedBindingVisitor {
+    found: bool,
+}
+
+impl<'a> Visitor<'a> for NamedBindingVisitor {
+    fn visit_expr(&mut self, expression: &'a Expr) {
+        if matches!(expression, Expr::Named(_)) {
+            self.found = true;
+            return;
+        }
+        visitor::walk_expr(self, expression);
+    }
+}
+
+fn statement_contains_named_binding(statement: &Stmt) -> bool {
+    let mut visitor = NamedBindingVisitor { found: false };
+    visitor.visit_stmt(statement);
+    visitor.found
+}
+
+fn binding_from_value(value: ResolvedValue) -> Binding {
+    match value {
+        ResolvedValue::Module(module) => Binding::Module(module),
+        ResolvedValue::String(value) => Binding::String(value),
+        ResolvedValue::Function(function) => Binding::Function(function),
+    }
+}
+
+fn function_definition(file: File, function: &StmtFunctionDef) -> PythonFunctionDefinition {
+    PythonFunctionDefinition {
+        file,
+        definition_span: function.span(),
+        name: function.name.to_string(),
+    }
+}
+
+fn expression_escapes_name(expression: &Expr, name: &str) -> bool {
+    let mut visitor = ModuleEscapeVisitor { name, found: false };
+    visitor.visit_expr(expression);
+    visitor.found
+}
+
+struct ModuleEscapeVisitor<'a> {
+    name: &'a str,
+    found: bool,
+}
+
+impl<'a> Visitor<'a> for ModuleEscapeVisitor<'_> {
+    fn visit_expr(&mut self, expression: &'a Expr) {
+        if expression.name_target() == Some(self.name) {
+            self.found = true;
+            return;
+        }
+        if let Expr::Attribute(attribute) = expression
+            && attribute
+                .value
+                .path_segments()
+                .is_some_and(|path| path.first().is_some_and(|root| root == self.name))
+        {
+            return;
+        }
+        if let Expr::Call(call) = expression
+            && (mutation_root(&call.func) == Some(self.name)
+                || expression_contains_module_member(&call.func, self.name))
+        {
+            self.found = true;
+            return;
+        }
+        visitor::walk_expr(self, expression);
+    }
+}
+
+fn expression_contains_module_member(expression: &Expr, name: &str) -> bool {
+    struct ModuleMemberVisitor<'a> {
+        name: &'a str,
+        found: bool,
+    }
+
+    impl<'a> Visitor<'a> for ModuleMemberVisitor<'a> {
+        fn visit_expr(&mut self, expression: &'a Expr) {
+            if let Expr::Attribute(attribute) = expression
+                && mutation_root(&attribute.value) == Some(self.name)
+            {
+                self.found = true;
+                return;
+            }
+            visitor::walk_expr(self, expression);
+        }
+    }
+
+    let mut visitor = ModuleMemberVisitor { name, found: false };
+    visitor.visit_expr(expression);
+    visitor.found
+}
+
+fn mutation_root(expression: &Expr) -> Option<&str> {
+    match expression {
+        Expr::Name(_) => expression.name_target(),
+        Expr::Attribute(attribute) => mutation_root(&attribute.value),
+        Expr::Subscript(subscript) => mutation_root(&subscript.value),
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Compare(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Starred(_)
+        | Expr::List(_)
+        | Expr::Tuple(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => None,
+    }
+}
+
+fn member_absence_is_proven(body: &[Stmt], member: &str) -> bool {
+    body.iter().all(|statement| match statement {
+        Stmt::Import(import) => DirectImportClause::lower(import)
+            .iter()
+            .all(|clause| clause.bound() != member),
+        Stmt::ImportFrom(import) => {
+            let syntax = FromImportSyntax::lower(import);
+            !syntax.has_star()
+                && syntax
+                    .named_members()
+                    .iter()
+                    .all(|clause| clause.bound() != member)
+        }
+        Stmt::Assign(assign) => assign
+            .targets
+            .iter()
+            .all(|target| target.name_target() != Some(member)),
+        Stmt::AnnAssign(assign) => assign.target.name_target() != Some(member),
+        Stmt::AugAssign(assign) => assign.target.name_target() != Some(member),
+        Stmt::Delete(delete) => delete
+            .targets
+            .iter()
+            .all(|target| target.name_target() != Some(member)),
+        Stmt::FunctionDef(function) => {
+            function.name.as_str() != "__getattr__" && function.name.as_str() != member
+        }
+        Stmt::ClassDef(class) => class.name.as_str() != member,
+        Stmt::Expr(expression) => expression.value.string_literal().is_some(),
+        Stmt::Pass(_) => true,
+        Stmt::For(_)
+        | Stmt::While(_)
+        | Stmt::If(_)
+        | Stmt::With(_)
+        | Stmt::Match(_)
+        | Stmt::Try(_)
+        | Stmt::TypeAlias(_)
+        | Stmt::Return(_)
+        | Stmt::Raise(_)
+        | Stmt::Assert(_)
+        | Stmt::Global(_)
+        | Stmt::Nonlocal(_)
+        | Stmt::Break(_)
+        | Stmt::Continue(_)
+        | Stmt::IpyEscapeCommand(_) => false,
+    })
+}

--- a/crates/djls-project/src/templates.rs
+++ b/crates/djls-project/src/templates.rs
@@ -37,6 +37,7 @@ pub use registrations::TemplateLibraryFilterFacts;
 pub use registrations::TemplateLibraryTagFacts;
 pub use registrations::template_library_definition_facts;
 pub use registrations::template_library_filter_facts;
+pub use registrations::template_library_registration_dependencies;
 pub use registrations::template_library_tag_facts;
 pub use registrations::template_symbol_source;
 pub use resolution::InconclusiveTemplateResolution;

--- a/crates/djls-project/src/templates/registrations.rs
+++ b/crates/djls-project/src/templates/registrations.rs
@@ -25,6 +25,9 @@ use super::tags::blocks::EndTagEvidence;
 use crate::ast::ExprExt;
 use crate::ast::RangedExt;
 use crate::db::Db as ProjectDb;
+use crate::python::PythonFunctionDefinition;
+use crate::python::PythonSourceLookup;
+use crate::python::PythonSourceModule;
 use crate::python::RecoveredPythonModule;
 use crate::python::import::DirectImportClause;
 use crate::python::import::FromImportSyntax;
@@ -37,8 +40,36 @@ const FILTER_DECORATORS: &[&str] = &["filter"];
 pub(crate) struct RegistrationInfo {
     name: String,
     kind: RegistrationKind,
-    func_name: Option<String>,
-    local_source: Option<LocalFunctionSource>,
+    callable: RegistrationCallable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RegistrationCallable {
+    DecoratedLocal {
+        function_name: String,
+        navigation: Option<LocalFunctionSource>,
+    },
+    ResolvedFunction(PythonFunctionDefinition),
+    Unresolved(Option<String>),
+}
+
+impl RegistrationInfo {
+    #[cfg(test)]
+    fn func_name(&self) -> Option<&str> {
+        match &self.callable {
+            RegistrationCallable::DecoratedLocal { function_name, .. } => Some(function_name),
+            RegistrationCallable::ResolvedFunction(_) => None,
+            RegistrationCallable::Unresolved(function_name) => function_name.as_deref(),
+        }
+    }
+
+    #[cfg(test)]
+    fn local_source(&self) -> Option<LocalFunctionSource> {
+        match self.callable {
+            RegistrationCallable::DecoratedLocal { navigation, .. } => navigation,
+            RegistrationCallable::ResolvedFunction(_) | RegistrationCallable::Unresolved(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -254,16 +285,14 @@ fn is_canonical_library_import(syntax: &FromImportSyntax, module_name: &str) -> 
             && module_name.starts_with("django.template."))
 }
 
-fn invalidate_local_function_target(
-    local_functions: &mut BTreeMap<String, LocalFunctionSource>,
+fn invalidate_transparent_decorator_target(
+    functions: &mut BTreeMap<String, LocalFunctionSource>,
     target: &Expr,
 ) {
     if let Some(name) = target.name_target() {
-        local_functions.remove(name);
+        functions.remove(name);
     } else if !matches!(target, Expr::Attribute(_) | Expr::Subscript(_)) {
-        // Destructuring and other complex targets are uncommon in Template Library modules.
-        // Clearing the map keeps navigation conservative without duplicating Python binding logic.
-        local_functions.clear();
+        functions.clear();
     }
 }
 
@@ -271,15 +300,16 @@ fn invalidate_local_function_target(
 fn analyze_registrations_from_body_in_module(
     body: &[Stmt],
     module_name: &str,
+    mut python_facts: Option<&mut PythonSourceLookup<'_>>,
 ) -> RegistrationSourceAnalysis {
     let mut analysis = RegistrationSourceAnalysis::default();
-    let mut local_functions = BTreeMap::new();
+    let mut transparent_decorated_functions = BTreeMap::new();
     let mut template_is_django = false;
     let mut library_constructor = None;
 
     for stmt in body {
         if statement_contains_named_binding(stmt) {
-            local_functions.clear();
+            transparent_decorated_functions.clear();
         }
         match stmt {
             Stmt::Import(import) => {
@@ -294,7 +324,7 @@ fn analyze_registrations_from_body_in_module(
                         analysis.registrations.clear();
                         analysis.open_inventory();
                     }
-                    local_functions.remove(clause.bound());
+                    transparent_decorated_functions.remove(clause.bound());
                 }
             }
             Stmt::ImportFrom(import) => {
@@ -302,7 +332,7 @@ fn analyze_registrations_from_body_in_module(
                 if syntax.has_star() {
                     template_is_django = false;
                     library_constructor = None;
-                    local_functions.clear();
+                    transparent_decorated_functions.clear();
                 }
                 let canonical_library_import = is_canonical_library_import(&syntax, module_name);
                 for member in syntax.named_members() {
@@ -321,7 +351,7 @@ fn analyze_registrations_from_body_in_module(
                         analysis.registrations.clear();
                         analysis.open_inventory();
                     }
-                    local_functions.remove(member.bound());
+                    transparent_decorated_functions.remove(member.bound());
                 }
             }
             Stmt::Assign(assign) => {
@@ -365,7 +395,10 @@ fn analyze_registrations_from_body_in_module(
                     template_is_django = false;
                 }
                 for target in &assign.targets {
-                    invalidate_local_function_target(&mut local_functions, target);
+                    invalidate_transparent_decorator_target(
+                        &mut transparent_decorated_functions,
+                        target,
+                    );
                 }
             }
             Stmt::AnnAssign(assign) => {
@@ -388,7 +421,10 @@ fn analyze_registrations_from_body_in_module(
                 {
                     library_constructor = None;
                 }
-                invalidate_local_function_target(&mut local_functions, &assign.target);
+                invalidate_transparent_decorator_target(
+                    &mut transparent_decorated_functions,
+                    &assign.target,
+                );
             }
             Stmt::AugAssign(assign) => {
                 if assign.target.name_target() == Some("register")
@@ -407,7 +443,10 @@ fn analyze_registrations_from_body_in_module(
                 {
                     library_constructor = None;
                 }
-                invalidate_local_function_target(&mut local_functions, &assign.target);
+                invalidate_transparent_decorator_target(
+                    &mut transparent_decorated_functions,
+                    &assign.target,
+                );
             }
             Stmt::Delete(delete) => {
                 if delete.targets.iter().any(|target| {
@@ -432,7 +471,10 @@ fn analyze_registrations_from_body_in_module(
                     library_constructor = None;
                 }
                 for target in &delete.targets {
-                    invalidate_local_function_target(&mut local_functions, target);
+                    invalidate_transparent_decorator_target(
+                        &mut transparent_decorated_functions,
+                        target,
+                    );
                 }
             }
             Stmt::FunctionDef(function) => {
@@ -451,12 +493,14 @@ fn analyze_registrations_from_body_in_module(
                 if body_contains_register(&function.body) {
                     analysis.open_inventory();
                 }
-                if function.decorator_list.iter().all(|decorator| {
-                    registration_decorator_rooted_at_register(&decorator.expression)
-                }) {
-                    local_functions.insert(function.name.to_string(), local_source);
+                if !function.decorator_list.is_empty()
+                    && function.decorator_list.iter().all(|decorator| {
+                        registration_decorator_rooted_at_register(&decorator.expression)
+                    })
+                {
+                    transparent_decorated_functions.insert(function.name.to_string(), local_source);
                 } else {
-                    local_functions.remove(function.name.as_str());
+                    transparent_decorated_functions.remove(function.name.as_str());
                 }
             }
             Stmt::ClassDef(class) => {
@@ -474,11 +518,16 @@ fn analyze_registrations_from_body_in_module(
                 if statement_contains_register(stmt) {
                     analysis.open_inventory();
                 }
-                local_functions.remove(class.name.as_str());
+                transparent_decorated_functions.remove(class.name.as_str());
             }
             Stmt::Expr(StmtExpr { value, .. }) => {
                 if let Expr::Call(call) = value.as_ref() {
-                    collect_from_call_statement(call, &local_functions, &mut analysis);
+                    collect_from_call_statement(
+                        call,
+                        &transparent_decorated_functions,
+                        python_facts.as_deref_mut(),
+                        &mut analysis,
+                    );
                 } else if contains_register(value) {
                     analysis.open_inventory();
                 }
@@ -491,13 +540,13 @@ fn analyze_registrations_from_body_in_module(
             | Stmt::Try(_) => {
                 template_is_django = false;
                 library_constructor = None;
-                local_functions.clear();
+                transparent_decorated_functions.clear();
                 if statement_contains_register(stmt) {
                     analysis.open_inventory();
                 }
             }
             Stmt::TypeAlias(_) => {
-                local_functions.clear();
+                transparent_decorated_functions.clear();
                 if statement_contains_register(stmt) {
                     analysis.open_inventory();
                 }
@@ -523,7 +572,7 @@ fn analyze_registrations_from_body_in_module(
 
 #[cfg(test)]
 fn analyze_registrations_from_body(body: &[Stmt]) -> RegistrationSourceAnalysis {
-    analyze_registrations_from_body_in_module(body, "")
+    analyze_registrations_from_body_in_module(body, "", None)
 }
 
 /// Collect registrations from a pre-parsed module body.
@@ -535,21 +584,41 @@ pub(crate) fn collect_registrations_from_body(body: &[Stmt]) -> Vec<Registration
     analyze_registrations_from_body(body).registrations
 }
 
-fn for_each_registration(
+fn for_each_registration<'db>(
+    db: &'db dyn ProjectDb,
     analysis: &RegistrationSourceAnalysis,
-    body: &[Stmt],
+    body: &'db [Stmt],
+    registration_file: djls_source::File,
     module_name: &str,
-    mut f: impl FnMut(&RegistrationInfo, Option<&StmtFunctionDef>, SymbolKey),
+    mut f: impl FnMut(
+        &RegistrationInfo,
+        Option<(&'db StmtFunctionDef, djls_source::File, bool)>,
+        SymbolKey,
+    ),
 ) {
     let func_defs = collect_func_defs(body);
 
     for reg in &analysis.registrations {
-        let func = reg.func_name.as_deref().and_then(|name| {
-            func_defs
+        let func = match &reg.callable {
+            RegistrationCallable::DecoratedLocal {
+                function_name,
+                navigation,
+            } => func_defs
                 .iter()
-                .find(|func| func.name.as_str() == name)
+                .find(|function| {
+                    function.name.as_str() == function_name
+                        && navigation.is_none_or(|source| function.span() == source.definition_span)
+                })
                 .copied()
-        });
+                .map(|function| (function, registration_file, false)),
+            RegistrationCallable::ResolvedFunction(definition) => {
+                definition.statement(db).map(|function| {
+                    let file = definition.file();
+                    (function, file, file != registration_file)
+                })
+            }
+            RegistrationCallable::Unresolved(_) => None,
+        };
 
         let kind = reg.kind;
         let key = SymbolKey {
@@ -615,8 +684,10 @@ fn collect_from_decorated_function(
             analysis.registrations.push(RegistrationInfo {
                 name,
                 kind,
-                func_name: Some(func_name.to_string()),
-                local_source: registration_source,
+                callable: RegistrationCallable::DecoratedLocal {
+                    function_name: func_name.to_string(),
+                    navigation: registration_source,
+                },
             });
             continue;
         }
@@ -625,8 +696,10 @@ fn collect_from_decorated_function(
             analysis.registrations.push(RegistrationInfo {
                 name,
                 kind: RegistrationKind::Filter,
-                func_name: Some(func_name.to_string()),
-                local_source: registration_source,
+                callable: RegistrationCallable::DecoratedLocal {
+                    function_name: func_name.to_string(),
+                    navigation: registration_source,
+                },
             });
         } else {
             analysis.open_inventory();
@@ -713,6 +786,48 @@ fn registration_decorator_has_dynamic_name(expr: &Expr) -> bool {
             _ => true,
         }
     })
+}
+
+fn registration_call_has_conflicting_arguments(helper: &str, call: &ExprCall) -> bool {
+    let has_keyword = |names: &[&str]| {
+        call.arguments.keywords.iter().any(|keyword| {
+            keyword
+                .arg
+                .as_ref()
+                .is_some_and(|name| names.contains(&name.as_str()))
+        })
+    };
+    let positional_callable = match helper {
+        "tag" | "filter" | "inclusion_tag" => call.arguments.args.len() >= 2,
+        "simple_tag" | "simple_block_tag" => !call.arguments.args.is_empty(),
+        _ => false,
+    };
+    let callable_keywords = match helper {
+        "tag" => &["compile_function", "func"][..],
+        "filter" => &["filter_func", "func"][..],
+        "simple_tag" | "simple_block_tag" | "inclusion_tag" => &["func"][..],
+        _ => &[][..],
+    };
+    (matches!(helper, "tag" | "filter") && call.arguments.args.len() >= 2 && has_keyword(&["name"]))
+        || (positional_callable && has_keyword(callable_keywords))
+}
+
+fn registration_name_requires_callable(helper: &str, call: &ExprCall) -> bool {
+    let has_name = call.arguments.keywords.iter().any(|keyword| {
+        keyword
+            .arg
+            .as_ref()
+            .is_some_and(|name| name.as_str() == "name")
+    });
+    match helper {
+        "tag" | "filter" => match &call.arguments.args[..] {
+            [argument] => !has_name && argument.string_literal().is_none(),
+            [] => !has_name,
+            [_, _] | [_, _, ..] => false,
+        },
+        "simple_tag" | "simple_block_tag" | "inclusion_tag" => !has_name,
+        _ => false,
+    }
 }
 
 fn registration_call_has_dynamic_name(call: &ExprCall) -> bool {
@@ -802,7 +917,8 @@ fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
 /// - `register.simple_tag(func, name="alias")`
 fn collect_from_call_statement(
     call: &ExprCall,
-    local_functions: &BTreeMap<String, LocalFunctionSource>,
+    transparent_decorated_functions: &BTreeMap<String, LocalFunctionSource>,
+    python_facts: Option<&mut PythonSourceLookup<'_>>,
     analysis: &mut RegistrationSourceAnalysis,
 ) {
     if !call_rooted_at_register(call) {
@@ -821,21 +937,46 @@ fn collect_from_call_statement(
         analysis.open_inventory();
         return;
     }
+    if registration_arguments_are_unsupported(helper, call)
+        || registration_call_has_conflicting_arguments(helper, call)
+    {
+        analysis.open_inventory();
+        return;
+    }
+    if let Some(python_facts) = python_facts
+        && let Some(registration) = resolved_python_registration(call, helper, python_facts)
+    {
+        analysis.registrations.push(registration);
+        return;
+    }
     if registration_call_has_dynamic_name(call) {
         analysis.open_inventory();
         return;
     }
+    let needs_callable_name = registration_name_requires_callable(helper, call);
 
     if let Some((name, kind, func_name)) = tag_registration_from_call(call) {
         let local_source = func_name
             .as_deref()
-            .and_then(|name| local_functions.get(name))
+            .and_then(|name| transparent_decorated_functions.get(name))
             .copied();
+        if needs_callable_name && local_source.is_none() {
+            analysis.open_inventory();
+            return;
+        }
         analysis.registrations.push(RegistrationInfo {
             name,
             kind,
-            func_name,
-            local_source,
+            callable: func_name.map_or(RegistrationCallable::Unresolved(None), |function_name| {
+                if let Some(navigation) = local_source {
+                    RegistrationCallable::DecoratedLocal {
+                        function_name,
+                        navigation: Some(navigation),
+                    }
+                } else {
+                    RegistrationCallable::Unresolved(Some(function_name))
+                }
+            }),
         });
         return;
     }
@@ -843,17 +984,116 @@ fn collect_from_call_statement(
     if let Some((name, func_name)) = filter_registration_from_call(call) {
         let local_source = func_name
             .as_deref()
-            .and_then(|name| local_functions.get(name))
+            .and_then(|name| transparent_decorated_functions.get(name))
             .copied();
+        if needs_callable_name && local_source.is_none() {
+            analysis.open_inventory();
+            return;
+        }
         analysis.registrations.push(RegistrationInfo {
             name,
             kind: RegistrationKind::Filter,
-            func_name,
-            local_source,
+            callable: func_name.map_or(RegistrationCallable::Unresolved(None), |function_name| {
+                if let Some(navigation) = local_source {
+                    RegistrationCallable::DecoratedLocal {
+                        function_name,
+                        navigation: Some(navigation),
+                    }
+                } else {
+                    RegistrationCallable::Unresolved(Some(function_name))
+                }
+            }),
         });
     } else {
         analysis.open_inventory();
     }
+}
+
+fn resolved_python_registration(
+    call: &ExprCall,
+    helper: &str,
+    python_facts: &mut PythonSourceLookup<'_>,
+) -> Option<RegistrationInfo> {
+    let args = &call.arguments.args;
+    let keyword = |names: &[&str]| {
+        call.arguments.keywords.iter().find_map(|keyword| {
+            keyword
+                .arg
+                .as_ref()
+                .is_some_and(|name| names.contains(&name.as_str()))
+                .then_some(&keyword.value)
+        })
+    };
+
+    let (kind, name_expression, callable_expression) = match helper {
+        "tag" => match &args[..] {
+            [name, callable] => (RegistrationKind::Tag, Some(name), Some(callable)),
+            [name] if name.string_literal().is_some() => (
+                RegistrationKind::Tag,
+                Some(name),
+                keyword(&["compile_function", "func"]),
+            ),
+            [callable] if keyword(&["name"]).is_none() => {
+                (RegistrationKind::Tag, None, Some(callable))
+            }
+            [] => (
+                RegistrationKind::Tag,
+                keyword(&["name"]),
+                keyword(&["compile_function", "func"]),
+            ),
+            _ => return None,
+        },
+        "simple_tag" | "simple_block_tag" => {
+            let kind = if helper == "simple_tag" {
+                RegistrationKind::SimpleTag
+            } else {
+                RegistrationKind::SimpleBlockTag
+            };
+            let callable = match &args[..] {
+                [callable] => Some(callable),
+                [] => keyword(&["func"]),
+                _ => return None,
+            };
+            (kind, keyword(&["name"]), callable)
+        }
+        "inclusion_tag" => {
+            let callable = match &args[..] {
+                [_template, callable] => Some(callable),
+                [_] | [] => keyword(&["func"]),
+                _ => return None,
+            };
+            (RegistrationKind::InclusionTag, keyword(&["name"]), callable)
+        }
+        "filter" => match &args[..] {
+            [name, callable] => (RegistrationKind::Filter, Some(name), Some(callable)),
+            [name] if name.string_literal().is_some() => (
+                RegistrationKind::Filter,
+                Some(name),
+                keyword(&["filter_func", "func"]),
+            ),
+            [callable] if keyword(&["name"]).is_none() => {
+                (RegistrationKind::Filter, None, Some(callable))
+            }
+            [] => (
+                RegistrationKind::Filter,
+                keyword(&["name"]),
+                keyword(&["filter_func", "func"]),
+            ),
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    let function = python_facts.function(callable_expression?)?;
+    let name = name_expression.map_or_else(
+        || Some(function.name().to_string()),
+        |expression| python_facts.exact_string(expression),
+    )?;
+    Some(RegistrationInfo {
+        name,
+        kind,
+        callable: RegistrationCallable::ResolvedFunction(function),
+    })
 }
 
 /// Extract tag registration info from a call expression.
@@ -878,31 +1118,27 @@ fn tag_registration_from_call(
                 Some((name, kind, func_name))
             }
             [name] if name.string_literal().is_some() => {
-                let name = name.string_literal()?.to_string();
-                let func_name = keyword_func?;
-                Some((name, kind, Some(func_name)))
+                Some((name.string_literal()?.to_string(), kind, keyword_func))
             }
             [callable] if name_override.is_none() => {
                 let func_name = callable_name(callable)?;
                 Some((func_name.clone(), kind, Some(func_name)))
             }
             [] => {
-                let func_name = keyword_func?;
-                let name = name_override.unwrap_or_else(|| func_name.clone());
-                Some((name, kind, Some(func_name)))
+                let name = name_override.or_else(|| keyword_func.clone())?;
+                Some((name, kind, keyword_func))
             }
             _ => None,
         },
         "simple_tag" | "simple_block_tag" => match &args[..] {
             [callable] => {
-                let func_name = callable_name(callable).or(keyword_func)?;
-                let name = name_override.unwrap_or_else(|| func_name.clone());
-                Some((name, kind, Some(func_name)))
+                let func_name = callable_name(callable).or(keyword_func);
+                let name = name_override.or_else(|| func_name.clone())?;
+                Some((name, kind, func_name))
             }
             [] => {
-                let func_name = keyword_func?;
-                let name = name_override.unwrap_or_else(|| func_name.clone());
-                Some((name, kind, Some(func_name)))
+                let name = name_override.or_else(|| keyword_func.clone())?;
+                Some((name, kind, keyword_func))
             }
             _ => None,
         },
@@ -911,9 +1147,9 @@ fn tag_registration_from_call(
                 [_template, callable] => callable_name(callable).or(keyword_func),
                 [_] | [] => keyword_func,
                 _ => None,
-            }?;
-            let name = name_override.unwrap_or_else(|| func_name.clone());
-            Some((name, kind, Some(func_name)))
+            };
+            let name = name_override.or_else(|| func_name.clone())?;
+            Some((name, kind, func_name))
         }
         _ => None,
     }
@@ -938,18 +1174,15 @@ fn filter_registration_from_call(call: &ExprCall) -> Option<(String, Option<Stri
             Some((name, callable_name(callable).or(keyword_func)))
         }
         [name] if name.string_literal().is_some() => {
-            let name = name.string_literal()?.to_string();
-            let func_name = keyword_func?;
-            Some((name, Some(func_name)))
+            Some((name.string_literal()?.to_string(), keyword_func))
         }
         [callable] if name_override.is_none() => {
             let func_name = callable_name(callable)?;
             Some((func_name.clone(), Some(func_name)))
         }
         [] => {
-            let func_name = keyword_func?;
-            let name = name_override.unwrap_or_else(|| func_name.clone());
-            Some((name, Some(func_name)))
+            let name = name_override.or_else(|| keyword_func.clone())?;
+            Some((name, keyword_func))
         }
         _ => None,
     }
@@ -1173,6 +1406,7 @@ impl TemplateLibrarySymbolSources {
 struct TemplateLibrarySourceAnalysis {
     definitions: TemplateLibraryDefinitionFacts,
     symbol_sources: TemplateLibrarySymbolSources,
+    registration_dependencies: Vec<djls_source::File>,
     tag_rules: TagRuleMap,
     block_specs: BlockSpecs,
     filter_arities: FilterArityMap,
@@ -1187,6 +1421,7 @@ impl TemplateLibrarySourceAnalysis {
                 filters: BTreeMap::new(),
             },
             symbol_sources: TemplateLibrarySymbolSources::default(),
+            registration_dependencies: Vec::new(),
             tag_rules: TagRuleMap::default(),
             block_specs: BlockSpecs::default(),
             filter_arities: FilterArityMap::default(),
@@ -1219,14 +1454,31 @@ fn template_library_source_analysis(
     let mut block_specs = BlockSpecs::default();
     let mut filter_arities = FilterArityMap::default();
     let registration_module = key.module(db).as_str();
-    let registration_analysis =
-        analyze_registrations_from_body_in_module(module.body(db), registration_module);
+    let project_module = db.project().and_then(|project| {
+        PythonSourceModule::resolve(db, project, key.module(db).clone())
+            .filter(|source| source.file() == file)
+            .map(|source| (project, source))
+    });
+    let mut python_facts = project_module.map_or_else(
+        || PythonSourceLookup::for_file(db, file),
+        |(project, module)| PythonSourceLookup::for_module(db, project, module),
+    );
+    let registration_analysis = analyze_registrations_from_body_in_module(
+        module.body(db),
+        registration_module,
+        Some(&mut python_facts),
+    );
+    let used_recovered_source = python_facts.has_recovered_source();
+    let registration_dependencies = python_facts.consulted_files().to_vec();
     let mut symbols_unobserved = parse_quality == TemplateLibraryParseQuality::Recovered
+        || used_recovered_source
         || registration_analysis.inventory_is_open();
 
     for_each_registration(
+        db,
         &registration_analysis,
         module.body(db),
+        file,
         registration_module,
         |registration, func, symbol_key| {
             if let Ok(name) = TemplateSymbolName::parse(&registration.name) {
@@ -1247,25 +1499,49 @@ fn template_library_source_analysis(
                     }
                 }
                 let source = (parse_quality == TemplateLibraryParseQuality::Exact
+                    && !used_recovered_source
                     && !registration_analysis.inventory_is_open())
-                .then_some(registration.local_source)
-                .flatten()
-                .map(|local_source| {
-                    TemplateSymbolSource::new(
+                .then(|| match &registration.callable {
+                    RegistrationCallable::ResolvedFunction(_) => {
+                        func.map(|(function, implementation_file, _)| {
+                            TemplateSymbolSource::new(
+                                implementation_file,
+                                function.span(),
+                                function.name.span(),
+                            )
+                        })
+                    }
+                    RegistrationCallable::DecoratedLocal {
+                        navigation: Some(local_source),
+                        ..
+                    } => Some(TemplateSymbolSource::new(
                         file,
                         local_source.definition_span,
                         local_source.name_span,
-                    )
-                });
+                    )),
+                    RegistrationCallable::DecoratedLocal {
+                        navigation: None, ..
+                    }
+                    | RegistrationCallable::Unresolved(_) => None,
+                })
+                .flatten();
                 symbol_sources.set(kind, symbol_name, source);
             } else {
                 symbols_unobserved = true;
             }
 
-            let Some(func) = func else {
+            tag_rules.remove(&symbol_key);
+            block_specs.0.remove(&symbol_key);
+            filter_arities.remove(&symbol_key);
+
+            let Some((func, implementation_file, imported)) = func else {
                 return;
             };
-            if let Some(rule) = registration.kind.extract_tag_rule(func) {
+            if let Some(rule) = registration.kind.extract_tag_rule(
+                db,
+                imported.then_some(implementation_file),
+                func,
+            ) {
                 tag_rules.insert(symbol_key.clone(), rule.into());
             }
             if let Some(block_spec) = registration.kind.extract_block_spec(func) {
@@ -1310,6 +1586,7 @@ fn template_library_source_analysis(
             filters,
         },
         symbol_sources,
+        registration_dependencies,
         tag_rules,
         block_specs,
         filter_arities,
@@ -1365,6 +1642,17 @@ fn template_library_symbol_sources(
 ) -> TemplateLibrarySymbolSources {
     template_library_source_analysis(db, key)
         .symbol_sources
+        .clone()
+}
+
+/// Python source dependencies followed while resolving one Template Library's registrations.
+#[salsa::tracked(returns(ref))]
+pub fn template_library_registration_dependencies(
+    db: &dyn ProjectDb,
+    key: TemplateLibraryId,
+) -> Vec<djls_source::File> {
+    template_library_source_analysis(db, key)
+        .registration_dependencies
         .clone()
 }
 
@@ -1429,7 +1717,7 @@ mod tests {
     }
 
     fn registered_source<'a>(source: &'a str, registration: &RegistrationInfo) -> Option<&'a str> {
-        let span = registration.local_source?.definition_span;
+        let span = registration.local_source()?.definition_span;
         source.get(span.start_usize()..span.end_usize())
     }
 
@@ -1444,7 +1732,7 @@ mod tests {
                 .all(|registration| registration.name != "stale")
         );
         assert_eq!(
-            find_reg(&registrations, "current").func_name.as_deref(),
+            find_reg(&registrations, "current").func_name(),
             Some("current")
         );
     }
@@ -1460,7 +1748,7 @@ mod tests {
             Some("@register.tag('shown')\ndef implementation(parser, token):\n    pass")
         );
         let local_source = registration
-            .local_source
+            .local_source()
             .expect("decorated registration should retain its local source");
         assert_eq!(
             source.get(local_source.name_span.start_usize()..local_source.name_span.end_usize()),
@@ -1473,7 +1761,7 @@ mod tests {
         let source = "from django import template\nregister = template.Library()\ndef swap(function): return replacement\n@register.tag('shown')\n@swap\ndef original(parser, token): pass\n";
         let registrations = collect_registrations(source);
 
-        assert_eq!(find_reg(&registrations, "shown").local_source, None);
+        assert_eq!(find_reg(&registrations, "shown").local_source(), None);
     }
 
     #[test]
@@ -1481,8 +1769,8 @@ mod tests {
         let source = "from django import template\nregister = template.Library()\ndef swap(function): return replacement\n@swap\n@register.tag('shown')\ndef original(parser, token): pass\nregister.tag('later', original)\n";
         let registrations = collect_registrations(source);
 
-        assert!(find_reg(&registrations, "shown").local_source.is_some());
-        assert_eq!(find_reg(&registrations, "later").local_source, None);
+        assert!(find_reg(&registrations, "shown").local_source().is_some());
+        assert_eq!(find_reg(&registrations, "later").local_source(), None);
     }
 
     #[test]
@@ -1495,17 +1783,18 @@ mod tests {
             .find(|registration| registration.name == "shown")
             .expect("final shown registration should be collected");
 
-        assert_eq!(final_registration.local_source, None);
+        assert_eq!(final_registration.local_source(), None);
     }
 
     #[test]
-    fn direct_registration_uses_the_active_preceding_function_binding() {
+    fn body_only_analysis_defers_plain_function_identity_to_python_facts() {
         let source = "from django import template\nregister = template.Library()\ndef implementation(parser, token):\n    pass\nregister.tag('shown', implementation)\n";
         let registrations = collect_registrations(source);
 
         assert_eq!(
             registered_source(source, find_reg(&registrations, "shown")),
-            Some("def implementation(parser, token):\n    pass")
+            None,
+            "the body-only Django test seam has no Python occurrence product",
         );
     }
 
@@ -1515,7 +1804,7 @@ mod tests {
         let registrations = collect_registrations(source);
 
         for name in ["imported", "forward", "member"] {
-            assert_eq!(find_reg(&registrations, name).local_source, None);
+            assert_eq!(find_reg(&registrations, name).local_source(), None);
         }
     }
 
@@ -1524,11 +1813,11 @@ mod tests {
         let source = "from django import template\nregister = template.Library()\ndef implementation(parser, token):\n    pass\n(implementation := replacement)\nregister.tag('shown', implementation)\n";
         let registrations = collect_registrations(source);
 
-        assert_eq!(find_reg(&registrations, "shown").local_source, None);
+        assert_eq!(find_reg(&registrations, "shown").local_source(), None);
     }
 
     #[test]
-    fn final_registration_keeps_the_final_definite_source() {
+    fn body_only_analysis_does_not_guess_between_plain_function_definitions() {
         let source = "from django import template\nregister = template.Library()\ndef first(parser, token):\n    pass\ndef second(parser, token):\n    pass\nregister.tag('shown', first)\nregister.tag('shown', second)\n";
         let registrations = collect_registrations(source);
         let registration = registrations
@@ -1539,7 +1828,8 @@ mod tests {
 
         assert_eq!(
             registered_source(source, registration),
-            Some("def second(parser, token):\n    pass")
+            None,
+            "the body-only Django test seam has no Python occurrence product",
         );
     }
 
@@ -1550,7 +1840,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "autoescape");
         assert_eq!(reg.kind, RegistrationKind::Tag);
-        assert_eq!(reg.func_name.as_deref(), Some("autoescape"));
+        assert_eq!(reg.func_name(), Some("autoescape"));
     }
 
     // Corpus: `querystring` in django/template/defaulttags.py uses
@@ -1561,7 +1851,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "querystring");
         assert_eq!(reg.kind, RegistrationKind::SimpleTag);
-        assert_eq!(reg.func_name.as_deref(), Some("querystring"));
+        assert_eq!(reg.func_name(), Some("querystring"));
     }
 
     // Corpus: `inclusion_no_params` in tests/template_tests/templatetags/inclusion.py uses
@@ -1591,7 +1881,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "escapejs");
         assert_eq!(reg.kind, RegistrationKind::Filter);
-        assert_eq!(reg.func_name.as_deref(), Some("escapejs_filter"));
+        assert_eq!(reg.func_name(), Some("escapejs_filter"));
     }
 
     // Corpus: `other_echo` in tests/template_tests/templatetags/testtags.py uses
@@ -1602,7 +1892,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "other_echo");
         assert_eq!(reg.kind, RegistrationKind::Tag);
-        assert_eq!(reg.func_name.as_deref(), Some("echo"));
+        assert_eq!(reg.func_name(), Some("echo"));
     }
 
     // Corpus: `intcomma` in wagtail/admin/templatetags/wagtailadmin_tags.py uses
@@ -1613,7 +1903,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "intcomma");
         assert_eq!(reg.kind, RegistrationKind::Filter);
-        assert_eq!(reg.func_name.as_deref(), Some("intcomma"));
+        assert_eq!(reg.func_name(), Some("intcomma"));
     }
 
     // Corpus: `for` in django/template/defaulttags.py uses `@register.tag("for")`
@@ -1624,7 +1914,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "for");
         assert_eq!(reg.kind, RegistrationKind::Tag);
-        assert_eq!(reg.func_name.as_deref(), Some("do_for"));
+        assert_eq!(reg.func_name(), Some("do_for"));
     }
 
     // Corpus: `addslashes` in django/template/defaultfilters.py uses
@@ -1635,7 +1925,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "addslashes");
         assert_eq!(reg.kind, RegistrationKind::Filter);
-        assert_eq!(reg.func_name.as_deref(), Some("addslashes"));
+        assert_eq!(reg.func_name(), Some("addslashes"));
     }
 
     // Corpus: `partialdef` in django/template/defaulttags.py uses
@@ -1646,7 +1936,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "partialdef");
         assert_eq!(reg.kind, RegistrationKind::Tag);
-        assert_eq!(reg.func_name.as_deref(), Some("partialdef_func"));
+        assert_eq!(reg.func_name(), Some("partialdef_func"));
     }
 
     // Corpus: `dialog` in wagtail/admin/templatetags/wagtailadmin_tags.py uses
@@ -1657,7 +1947,7 @@ mod tests {
         let regs = collect_registrations(source);
         let reg = find_reg(&regs, "dialog");
         assert_eq!(reg.kind, RegistrationKind::Tag);
-        assert_eq!(reg.func_name.as_deref(), Some("DialogNode.handle"));
+        assert_eq!(reg.func_name(), Some("DialogNode.handle"));
     }
 
     // Corpus: `div` in tests/template_tests/templatetags/custom.py uses
@@ -1741,7 +2031,7 @@ register.simple_tag(my_func, name="alias")
         assert_eq!(regs.len(), 1);
         assert_eq!(regs[0].name, "alias");
         assert_eq!(regs[0].kind, RegistrationKind::SimpleTag);
-        assert_eq!(regs[0].func_name.as_deref(), Some("my_func"));
+        assert_eq!(regs[0].func_name(), Some("my_func"));
     }
 
     #[test]
@@ -1767,33 +2057,31 @@ class MyClass:
     // Edge case: register.tag(do_something) — single func arg, no name string.
     // Valid Django API but rare. Not found cleanly in corpus.
     #[test]
-    fn call_style_single_func_no_name() {
+    fn unresolved_callable_derived_tag_name_stays_unknown() {
         let source = r"
 from django import template
 register = template.Library()
 
 register.tag(do_something)
 ";
-        let regs = collect_registrations(source);
-        assert_eq!(regs.len(), 1);
-        assert_eq!(regs[0].name, "do_something");
-        assert_eq!(regs[0].kind, RegistrationKind::Tag);
+        let analysis = analyze_registrations(source);
+        assert!(analysis.registrations.is_empty());
+        assert!(analysis.inventory_is_open());
     }
 
     // Edge case: register.filter(my_filter_func) — single func arg, no name string.
     // Valid Django API but rare. Not found cleanly in corpus.
     #[test]
-    fn call_style_filter_single_func_no_name() {
+    fn unresolved_callable_derived_filter_name_stays_unknown() {
         let source = r"
 from django import template
 register = template.Library()
 
 register.filter(my_filter_func)
 ";
-        let regs = collect_registrations(source);
-        assert_eq!(regs.len(), 1);
-        assert_eq!(regs[0].name, "my_filter_func");
-        assert_eq!(regs[0].kind, RegistrationKind::Filter);
+        let analysis = analyze_registrations(source);
+        assert!(analysis.registrations.is_empty());
+        assert!(analysis.inventory_is_open());
     }
 
     // Edge case: name kwarg overrides positional string arg.

--- a/crates/djls-project/src/templates/tags/analysis.rs
+++ b/crates/djls-project/src/templates/tags/analysis.rs
@@ -133,15 +133,28 @@ impl<'a> CompileFunction<'a> {
 /// (no database), helper calls evaluate to `Unknown`.
 #[must_use]
 pub(crate) fn analyze_compile_function(func: &StmtFunctionDef) -> TagRule {
+    analyze_compile_function_with_context(func, None, None)
+}
+
+pub(crate) fn analyze_compile_function_in_file(
+    db: &dyn djls_source::Db,
+    file: File,
+    func: &StmtFunctionDef,
+) -> TagRule {
+    analyze_compile_function_with_context(func, Some(db), Some(file))
+}
+
+fn analyze_compile_function_with_context(
+    func: &StmtFunctionDef,
+    db: Option<&dyn djls_source::Db>,
+    file: Option<File>,
+) -> TagRule {
     let Some(compile_fn) = CompileFunction::from_ast(func) else {
         return TagRule::default();
     };
 
     let mut env = state::Env::for_compile_function(compile_fn.parser_param, compile_fn.token_param);
-    let mut ctx = CallContext {
-        db: None,
-        file: None,
-    };
+    let mut ctx = CallContext { db, file };
 
     let result = statements::process_statements(compile_fn.body, &mut env, &mut ctx);
 

--- a/crates/djls-project/src/templates/tags/registry.rs
+++ b/crates/djls-project/src/templates/tags/registry.rs
@@ -1,3 +1,4 @@
+use djls_source::File;
 use ruff_python_ast::StmtFunctionDef;
 
 use crate::templates::FilterArity;
@@ -34,7 +35,12 @@ impl RegistrationKind {
         }
     }
 
-    pub(crate) fn extract_tag_rule(self, func: &StmtFunctionDef) -> Option<Box<TagRule>> {
+    pub(crate) fn extract_tag_rule(
+        self,
+        db: &dyn djls_source::Db,
+        implementation_file: Option<File>,
+        func: &StmtFunctionDef,
+    ) -> Option<Box<TagRule>> {
         match self {
             Self::Filter => None,
             Self::SimpleTag | Self::InclusionTag => {
@@ -42,7 +48,10 @@ impl RegistrationKind {
                 rule.has_content().then(|| Box::new(rule))
             }
             Self::Tag | Self::SimpleBlockTag => {
-                let mut rule = analysis::analyze_compile_function(func);
+                let mut rule = implementation_file.map_or_else(
+                    || analysis::analyze_compile_function(func),
+                    |file| analysis::analyze_compile_function_in_file(db, file, func),
+                );
                 if self.var_assignment().strips_suffix() {
                     rule.as_var = self.var_assignment();
                 }

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -6,6 +6,7 @@ use djls_project::TemplateLibraryId;
 use djls_project::TemplateSymbolKind;
 use djls_project::template_library_definition_facts;
 use djls_project::template_library_filter_facts;
+use djls_project::template_library_registration_dependencies;
 use djls_project::template_library_tag_facts;
 use djls_project::template_symbol_source;
 use djls_project::testing::PythonSyntaxErrorClass;
@@ -14,6 +15,7 @@ use djls_source::ChangeEvent;
 use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_testing::ExtractionBundle;
+use djls_testing::ProjectFixture;
 use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
 use djls_testing::extract_bundle;
@@ -365,6 +367,60 @@ fn template_symbol_source_rejects_open_registration_inventory() {
 }
 
 #[test]
+fn template_symbol_source_resolves_a_preceding_plain_function() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/test/templatetags/direct.py");
+    let source = "from django import template\nregister = template.Library()\ndef implementation(parser, token):\n    pass\nregister.tag('direct', implementation)\n";
+    db.add_file(path.as_str(), source)
+        .expect("direct-registration fixture should be added to the test database");
+    let file = db
+        .file(path)
+        .expect("direct-registration fixture should exist in the test database");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(file),
+        PythonModuleName::parse("test.templatetags.direct")
+            .expect("test Python module name should be valid"),
+    );
+    let symbol = template_library_definition_facts(&db, key)
+        .symbol(TemplateSymbolKind::Tag, "direct")
+        .expect("direct registration should be extracted");
+    let location = template_symbol_source(&db, symbol)
+        .expect("the preceding plain function should be navigable");
+
+    assert_eq!(location.file(), file);
+    assert_eq!(
+        &source[location.name_span().start_usize()..location.name_span().end_usize()],
+        "implementation"
+    );
+}
+
+#[test]
+fn named_expression_rebinding_invalidates_later_python_function_facts() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/test/templatetags/named.py");
+    let source = "from django import template\nregister = template.Library()\ndef first(parser, token): pass\ndef second(parser, token): pass\n(first := second)\nregister.tag(first)\n";
+    db.add_file(path.as_str(), source)
+        .expect("named-expression fixture should be added to the test database");
+    let file = db
+        .file(path)
+        .expect("named-expression fixture should exist in the test database");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(file),
+        PythonModuleName::parse("test.templatetags.named")
+            .expect("test Python module name should be valid"),
+    );
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "first")
+            .is_none(),
+        "a callable-derived name must not fall back to source spelling"
+    );
+    assert!(template_library_tag_facts(&db, key).tag_rules().is_empty());
+}
+
+#[test]
 fn template_symbol_source_rejects_member_callable() {
     let db = TestDatabase::new();
     let path = Utf8Path::new("/test/templatetags/member.py");
@@ -385,6 +441,59 @@ fn template_symbol_source_rejects_member_callable() {
         .expect("member registration should remain a known Tag Definition");
 
     assert_eq!(template_symbol_source(&db, symbol), None);
+}
+
+#[test]
+fn later_unresolved_callable_clears_an_overwritten_tag_rule() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/test/templatetags/overwritten.py");
+    let source = "from django import template\nregister = template.Library()\ndef first(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 2: raise ValueError()\nclass Node:\n    def handle(self, parser, token): pass\nregister.tag('shown', first)\nregister.tag('shown', Node.handle)\n";
+    db.add_file(path.as_str(), source)
+        .expect("overwritten-registration fixture should be added");
+    let file = db
+        .file(path)
+        .expect("overwritten-registration fixture should exist");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(file),
+        PythonModuleName::parse("test.templatetags.overwritten")
+            .expect("test Python module name should be valid"),
+    );
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "shown")
+            .is_some()
+    );
+    assert!(
+        !template_library_tag_facts(&db, key)
+            .tag_rules()
+            .contains_key(&SymbolKey::tag("test.templatetags.overwritten", "shown"))
+    );
+}
+
+#[test]
+fn explicit_names_survive_keyword_member_callables() {
+    let db = TestDatabase::new();
+    let path = Utf8Path::new("/test/templatetags/keyword_member.py");
+    let source = "from django import template\nregister = template.Library()\nclass Node:\n    def handle(self, parser, token): pass\nregister.tag('known_tag', compile_function=Node.handle)\nregister.filter('known_filter', filter_func=Node.handle)\n";
+    db.add_file(path.as_str(), source)
+        .expect("keyword-member fixture should be added");
+    let file = db.file(path).expect("keyword-member fixture should exist");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(file),
+        PythonModuleName::parse("test.templatetags.keyword_member")
+            .expect("test Python module name should be valid"),
+    );
+    let facts = template_library_definition_facts(&db, key);
+
+    assert!(facts.symbol(TemplateSymbolKind::Tag, "known_tag").is_some());
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Filter, "known_filter")
+            .is_some()
+    );
 }
 
 #[test]
@@ -518,6 +627,681 @@ fn template_library_extraction_products_execute_once_and_share_parsing() {
         0,
         "same-revision extraction should be memoized",
     );
+}
+
+fn imported_registration_fixture(
+    package_init: &str,
+    registration_source: &str,
+    implementation_source: &str,
+) -> Result<(TestDatabase, TemplateLibraryId), String> {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/test/project")
+        .django_settings_module("settings")
+        .file("/test/project/settings.py", "INSTALLED_APPS = []\n")
+        .file("/test/project/pkg/__init__.py", package_init)
+        .file("/test/project/pkg/tags.py", registration_source)
+        .file("/test/project/pkg/implementation.py", implementation_source)
+        .install(&mut db)
+        .map_err(|error| error.to_string())?;
+    let file = db
+        .file(Utf8Path::new("/test/project/pkg/tags.py"))
+        .map_err(|error| error.to_string())?;
+    let module = PythonModuleName::parse("pkg.tags").map_err(|error| error.to_string())?;
+    let key = TemplateLibraryId::new(&db, Some(file), module);
+    Ok((db, key))
+}
+
+#[test]
+fn from_import_prefers_an_exact_package_member_over_a_same_named_child() {
+    let (db, key) = imported_registration_fixture(
+        "implementation = 'not the child module'\n",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'child_tag'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("member-precedence fixture should install");
+
+    let facts = template_library_definition_facts(&db, key);
+    assert!(facts.symbol(TemplateSymbolKind::Tag, "child_tag").is_none());
+}
+
+#[test]
+fn from_import_does_not_bypass_package_getattr() {
+    let (db, key) = imported_registration_fixture(
+        "def __getattr__(name): return dynamic_member\n",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'child_tag'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("package-getattr fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "child_tag")
+            .is_none()
+    );
+}
+
+#[test]
+fn from_import_resolves_a_namespace_package_sibling() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/test/project")
+        .django_settings_module("settings")
+        .file("/test/project/settings.py", "INSTALLED_APPS = []\n")
+        .file(
+            "/test/project/pkg/tags.py",
+            "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        )
+        .file(
+            "/test/project/pkg/implementation.py",
+            "TAG = 'namespace_tag'\ndef compile_tag(parser, token): pass\n",
+        )
+        .install(&mut db)
+        .expect("namespace-package fixture should install");
+    let file = db
+        .file(Utf8Path::new("/test/project/pkg/tags.py"))
+        .expect("namespace registration source should exist");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(file),
+        PythonModuleName::parse("pkg.tags").expect("namespace module name should be valid"),
+    );
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "namespace_tag")
+            .is_some()
+    );
+}
+
+#[test]
+fn reading_imported_module_members_through_an_unrelated_call_keeps_resolution_exact() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nconsume([implementation.TAG, implementation.compile_tag])\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'member_reads'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("module-member-read fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "member_reads")
+            .is_some()
+    );
+}
+
+#[test]
+fn unused_lazy_from_import_does_not_open_registration_evidence() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/test/project")
+        .django_settings_module("settings")
+        .file("/test/project/settings.py", "INSTALLED_APPS = []\n")
+        .file("/test/project/pkg/__init__.py", "")
+        .file(
+            "/test/project/pkg/tags.py",
+            "from django import template\nfrom . import implementation\nfrom .unrelated import UNUSED\nregister = template.Library()\nignored = UNUSED\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        )
+        .file(
+            "/test/project/pkg/implementation.py",
+            "TAG = 'focused'\ndef compile_tag(parser, token): pass\n",
+        )
+        .file(
+            "/test/project/pkg/unrelated.py",
+            "UNUSED = 'ignored'\ndef broken(\n",
+        )
+        .install(&mut db)
+        .expect("focused-occurrence fixture should install");
+    let file = db
+        .file(Utf8Path::new("/test/project/pkg/tags.py"))
+        .expect("focused-occurrence registration source should exist");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(file),
+        PythonModuleName::parse("pkg.tags").expect("fixture module name should be valid"),
+    );
+    let symbol = template_library_definition_facts(&db, key)
+        .symbol(TemplateSymbolKind::Tag, "focused")
+        .expect("the exact registration should survive the unrelated recovered read");
+
+    assert!(template_symbol_source(&db, symbol).is_some());
+}
+
+#[test]
+fn invoking_an_imported_module_member_invalidates_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nimplementation.configure()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'member_call'\ndef configure(): pass\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("module-member-call fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "member_call")
+            .is_none()
+    );
+}
+
+#[test]
+fn invoking_an_alias_of_an_imported_module_member_invalidates_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nhook = implementation.configure\nhook()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'aliased_member_call'\ndef configure(): pass\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("aliased module-member-call fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "aliased_member_call")
+            .is_none()
+    );
+}
+
+#[test]
+fn invoking_an_indirect_imported_module_callee_invalidates_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nimplementation.HOOKS[0]()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'indirect_member_call'\nHOOKS = []\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("indirect module-callee fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "indirect_member_call")
+            .is_none()
+    );
+}
+
+#[test]
+fn invoking_a_wrapped_imported_module_member_invalidates_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\n(implementation.configure if enabled else noop)()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'wrapped_member_call'\ndef configure(): pass\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("wrapped module-member-call fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "wrapped_member_call")
+            .is_none()
+    );
+}
+
+#[test]
+fn passing_an_imported_module_object_to_a_call_invalidates_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nconsume(implementation)\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'escaped_call'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("module-call-escape fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "escaped_call")
+            .is_none()
+    );
+}
+
+#[test]
+fn escaped_imported_module_invalidates_aliased_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nbox = [implementation]\nbox[0].TAG = dynamic_name\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'escaped'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("module-escape fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "escaped")
+            .is_none()
+    );
+}
+
+#[test]
+fn unconditional_import_failure_discards_prior_module_values() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'never_imported'\ndef compile_tag(parser, token): pass\nraise RuntimeError()\n",
+    )
+    .expect("import-failure fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "never_imported")
+            .is_none()
+    );
+}
+
+#[test]
+fn imported_duplicate_function_uses_the_resolved_definition_span() {
+    let implementation = "TAG = 'duplicate'\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 2: raise ValueError()\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 3: raise ValueError()\n";
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        implementation,
+    )
+    .expect("duplicate-function fixture should install");
+
+    let rule =
+        &template_library_tag_facts(&db, key).tag_rules()[&SymbolKey::tag("pkg.tags", "duplicate")];
+    assert_eq!(
+        rule.arg_constraints,
+        vec![ArgumentCountConstraint::Exact(3)]
+    );
+    let symbol = template_library_definition_facts(&db, key)
+        .symbol(TemplateSymbolKind::Tag, "duplicate")
+        .expect("duplicate function registration should resolve");
+    let source =
+        template_symbol_source(&db, symbol).expect("exact final definition should navigate");
+    assert!(
+        source.definition_span().start_usize()
+            > implementation
+                .find("def compile_tag")
+                .expect("fixture should contain the first definition")
+    );
+}
+
+#[test]
+fn imported_source_edits_invalidate_registration_products() {
+    let (mut db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'before'\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 2: raise ValueError()\n",
+    )
+    .expect("imported-edit fixture should install");
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "before")
+            .is_some()
+    );
+
+    let implementation_path = Utf8Path::new("/test/project/pkg/implementation.py");
+    db.add_file(
+        implementation_path.as_str(),
+        "TAG = 'after'\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 3: raise ValueError()\n",
+    )
+    .expect("updated imported implementation should be written");
+    SourceChanges::new([ChangeEvent::ContentChanged(
+        implementation_path.to_path_buf(),
+    )])
+    .apply(&mut db);
+
+    let definitions = template_library_definition_facts(&db, key);
+    assert!(
+        definitions
+            .symbol(TemplateSymbolKind::Tag, "before")
+            .is_none()
+    );
+    assert!(
+        definitions
+            .symbol(TemplateSymbolKind::Tag, "after")
+            .is_some()
+    );
+    assert_eq!(
+        template_library_tag_facts(&db, key).tag_rules()[&SymbolKey::tag("pkg.tags", "after")]
+            .arg_constraints,
+        vec![ArgumentCountConstraint::Exact(3)]
+    );
+}
+
+#[test]
+fn same_length_imported_function_rename_invalidates_callable_only_name() {
+    let (mut db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom .implementation import alpha\nregister = template.Library()\nregister.tag(alpha)\n",
+        "def alpha(parser, token): pass\n",
+    )
+    .expect("function-rename fixture should install");
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "alpha")
+            .is_some()
+    );
+
+    let registration_path = Utf8Path::new("/test/project/pkg/tags.py");
+    let implementation_path = Utf8Path::new("/test/project/pkg/implementation.py");
+    db.add_file(
+        registration_path.as_str(),
+        "from django import template\nfrom .implementation import bravo\nregister = template.Library()\nregister.tag(bravo)\n",
+    )
+    .expect("renamed registration source should be written");
+    db.add_file(
+        implementation_path.as_str(),
+        "def bravo(parser, token): pass\n",
+    )
+    .expect("renamed implementation source should be written");
+    SourceChanges::new([
+        ChangeEvent::ContentChanged(registration_path.to_path_buf()),
+        ChangeEvent::ContentChanged(implementation_path.to_path_buf()),
+    ])
+    .apply(&mut db);
+
+    let definitions = template_library_definition_facts(&db, key);
+    assert!(
+        definitions
+            .symbol(TemplateSymbolKind::Tag, "alpha")
+            .is_none()
+    );
+    assert!(
+        definitions
+            .symbol(TemplateSymbolKind::Tag, "bravo")
+            .is_some()
+    );
+}
+
+#[test]
+fn malformed_imported_registration_keywords_fail_closed() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\n@register.simple_tag\ndef retained(): pass\nregister.tag(implementation.TAG, implementation.compile_tag, nonsense=True)\n",
+        "TAG = 'malformed'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("malformed-registration fixture should install");
+    let facts = template_library_definition_facts(&db, key);
+    assert!(facts.symbol(TemplateSymbolKind::Tag, "malformed").is_none());
+    let retained = facts
+        .symbol(TemplateSymbolKind::Tag, "retained")
+        .expect("prior exact registration should survive");
+    assert_eq!(template_symbol_source(&db, retained), None);
+}
+
+#[test]
+fn imported_module_attribute_mutation_invalidates_later_resolution() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\nimplementation.TAG = dynamic_name\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'mutated'\ndef compile_tag(parser, token): pass\n",
+    )
+    .expect("attribute-mutation fixture should install");
+
+    assert!(
+        template_library_definition_facts(&db, key)
+            .symbol(TemplateSymbolKind::Tag, "mutated")
+            .is_none()
+    );
+}
+
+#[test]
+fn recovered_import_retains_positive_facts_but_opens_inventory_and_navigation() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\n@register.simple_tag\ndef retained(): pass\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
+        "TAG = 'recovered'\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 1: raise ValueError()\ndef broken(\n",
+    )
+    .expect("recovered-import fixture should install");
+    let facts = template_library_definition_facts(&db, key);
+    let imported = facts
+        .symbol(TemplateSymbolKind::Tag, "recovered")
+        .expect("recovered imported positive fact should survive");
+    let retained = facts
+        .symbol(TemplateSymbolKind::Tag, "retained")
+        .expect("other exact registrations should survive");
+    assert_eq!(template_symbol_source(&db, imported), None);
+    assert_eq!(template_symbol_source(&db, retained), None);
+    assert!(
+        template_library_tag_facts(&db, key)
+            .tag_rules()
+            .contains_key(&SymbolKey::tag("pkg.tags", "recovered"))
+    );
+}
+
+#[test]
+fn literal_name_with_unresolved_imported_callable_keeps_only_the_name_fact() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom missing import implementation\nregister = template.Library()\nregister.tag('literal', implementation.compile_tag)\n",
+        "",
+    )
+    .expect("unresolved-callable fixture should install");
+    let facts = template_library_definition_facts(&db, key);
+    let symbol = facts
+        .symbol(TemplateSymbolKind::Tag, "literal")
+        .expect("existing literal-name behavior should remain");
+    assert_eq!(template_symbol_source(&db, symbol), None);
+    assert!(template_library_tag_facts(&db, key).tag_rules().is_empty());
+}
+
+#[test]
+fn imported_callable_only_registration_uses_the_function_name() {
+    let (db, key) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom .implementation import compile_tag as tag_callable, imported_filter as filter_callable\nregister = template.Library()\nregister.tag(tag_callable)\nregister.filter(filter_callable)\n",
+        "def compile_tag(parser, token): pass\ndef imported_filter(value): return value\n",
+    )
+    .expect("callable-only fixture should install");
+
+    let facts = template_library_definition_facts(&db, key);
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Tag, "compile_tag")
+            .is_some()
+    );
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Filter, "imported_filter")
+            .is_some()
+    );
+}
+
+// The fixture deliberately keeps all released django-bird registration shapes together so the
+// cross-module name, callable, rule, block, arity, source, and dependency contracts stay visible.
+#[allow(clippy::too_many_lines)]
+#[test]
+fn imported_registration_resolution_extracts_django_bird_shapes_and_coverage() {
+    let registration_source = r#"from django import template
+from . import asset, bird, load, prop, slot, var
+from .filters import imported_filter
+
+register = template.Library()
+register.tag(asset.AssetTag.CSS.value, asset.do_asset)
+register.tag(asset.AssetTag.JS.value, asset.do_asset)
+register.tag(bird.TAG, bird.do_bird)
+register.tag(load.TAG, load.do_load)
+register.tag(prop.TAG, prop.do_prop)
+register.tag(slot.TAG, slot.do_slot)
+register.tag(var.TAG, var.do_var)
+register.tag(var.END_TAG, var.do_end_var)
+register.filter("bird_filter", imported_filter)
+"#;
+    let bird_source = r#"TAG = "bird"
+
+def split_bits(token):
+    return token.split_contents()
+
+def do_bird(parser, token):
+    bits = split_bits(token)
+    if len(bits) != 2:
+        raise ValueError("bird takes one argument")
+    nodelist = parser.parse(("endbird",))
+    parser.delete_first_token()
+    return nodelist
+"#;
+    let asset_source = r#"from enum import Enum
+
+class AssetTag(Enum):
+    CSS = "bird:css"
+    JS = "bird:js"
+
+def do_asset(parser, token):
+    bits = token.split_contents()
+    if len(bits) != 1:
+        raise ValueError("asset takes no arguments")
+"#;
+    let filter_source = "def imported_filter(value, argument):\n    return value\n";
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/test/project")
+        .django_settings_module("settings")
+        .file("/test/project/settings.py", "INSTALLED_APPS = []\n")
+        .file("/test/project/app/__init__.py", "")
+        .file("/test/project/app/templatetags/__init__.py", "")
+        .file(
+            "/test/project/app/templatetags/bird_tags.py",
+            registration_source,
+        )
+        .file("/test/project/app/templatetags/bird.py", bird_source)
+        .file("/test/project/app/templatetags/asset.py", asset_source)
+        .file(
+            "/test/project/app/templatetags/load.py",
+            "TAG = 'bird:load'\ndef do_load(parser, token): pass\n",
+        )
+        .file(
+            "/test/project/app/templatetags/prop.py",
+            "TAG = 'bird:prop'\ndef do_prop(parser, token): pass\n",
+        )
+        .file(
+            "/test/project/app/templatetags/slot.py",
+            "TAG = 'bird:slot'\ndef do_slot(parser, token):\n    nodelist = parser.parse(('endbird:slot',))\n    parser.delete_first_token()\n",
+        )
+        .file(
+            "/test/project/app/templatetags/var.py",
+            "TAG = 'bird:var'\nEND_TAG = 'endbird:var'\ndef do_var(parser, token): pass\ndef do_end_var(parser, token): pass\n",
+        )
+        .file("/test/project/app/templatetags/filters.py", filter_source)
+        .install(&mut db)
+        .expect("multi-file registration fixture should install");
+
+    let registration_file = db
+        .file(Utf8Path::new("/test/project/app/templatetags/bird_tags.py"))
+        .expect("registration source should exist");
+    let key = TemplateLibraryId::new(
+        &db,
+        Some(registration_file),
+        PythonModuleName::parse("app.templatetags.bird_tags")
+            .expect("fixture module name should be valid"),
+    );
+    let definitions = template_library_definition_facts(&db, key);
+    for name in [
+        "bird",
+        "bird:css",
+        "bird:js",
+        "bird:load",
+        "bird:prop",
+        "bird:slot",
+        "bird:var",
+        "endbird:var",
+    ] {
+        assert!(
+            definitions.symbol(TemplateSymbolKind::Tag, name).is_some(),
+            "imported Tag `{name}` should be registered"
+        );
+    }
+    assert!(
+        definitions
+            .symbol(TemplateSymbolKind::Filter, "bird_filter")
+            .is_some()
+    );
+
+    let tag_facts = template_library_tag_facts(&db, key);
+    let bird_key = SymbolKey::tag("app.templatetags.bird_tags", "bird");
+    assert_eq!(
+        tag_facts.tag_rules()[&bird_key].arg_constraints,
+        vec![ArgumentCountConstraint::Exact(2)]
+    );
+    assert_eq!(
+        tag_facts.block_specs().as_map()[&bird_key]
+            .end_tag
+            .as_deref(),
+        Some("endbird")
+    );
+    assert_eq!(
+        tag_facts.block_specs().as_map()
+            [&SymbolKey::tag("app.templatetags.bird_tags", "bird:slot")]
+            .end_tag
+            .as_deref(),
+        Some("endbird:slot")
+    );
+    let filter_key = SymbolKey::filter("app.templatetags.bird_tags", "bird_filter");
+    let filter_arity = &template_library_filter_facts(&db, key).filter_arities()[&filter_key];
+    assert!(filter_arity.expects_arg);
+    assert!(!filter_arity.arg_optional);
+
+    let bird_symbol = definitions
+        .symbol(TemplateSymbolKind::Tag, "bird")
+        .expect("imported bird Tag should exist");
+    let source = template_symbol_source(&db, bird_symbol)
+        .expect("exact imported callable should have a source");
+    assert_eq!(
+        source.file().path(&db),
+        Utf8Path::new("/test/project/app/templatetags/bird.py")
+    );
+    assert_eq!(
+        &bird_source[source.name_span().start_usize()..source.name_span().end_usize()],
+        "do_bird"
+    );
+    assert_eq!(
+        &bird_source[source.definition_span().start_usize()..source.definition_span().end_usize()],
+        "def do_bird(parser, token):\n    bits = split_bits(token)\n    if len(bits) != 2:\n        raise ValueError(\"bird takes one argument\")\n    nodelist = parser.parse((\"endbird\",))\n    parser.delete_first_token()\n    return nodelist"
+    );
+
+    let covered_paths = template_library_registration_dependencies(&db, key)
+        .iter()
+        .map(|file| file.path(&db).as_str())
+        .collect::<Vec<_>>();
+    for path in [
+        "/test/project/app/__init__.py",
+        "/test/project/app/templatetags/__init__.py",
+        "/test/project/app/templatetags/asset.py",
+        "/test/project/app/templatetags/bird.py",
+        "/test/project/app/templatetags/filters.py",
+        "/test/project/app/templatetags/load.py",
+        "/test/project/app/templatetags/prop.py",
+        "/test/project/app/templatetags/slot.py",
+        "/test/project/app/templatetags/var.py",
+    ] {
+        assert!(
+            covered_paths.contains(&path),
+            "coverage should include {path}"
+        );
+    }
+}
+
+#[test]
+fn unresolved_imported_registration_opens_only_its_library_inventory() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/test/project")
+        .django_settings_module("settings")
+        .file("/test/project/settings.py", "INSTALLED_APPS = []\n")
+        .file("/test/project/known.py", "from django import template\nregister = template.Library()\n@register.simple_tag\ndef retained(): pass\n")
+        .file("/test/project/dynamic.py", "from django import template\nfrom missing import names, functions\nregister = template.Library()\n@register.simple_tag\ndef retained(): pass\nregister.tag(names.TAG, functions.compile_tag)\n")
+        .install(&mut db)
+        .expect("uncertain registration fixture should install");
+
+    let dynamic_file = db
+        .file(Utf8Path::new("/test/project/dynamic.py"))
+        .expect("dynamic library should exist");
+    let dynamic = TemplateLibraryId::new(
+        &db,
+        Some(dynamic_file),
+        PythonModuleName::parse("dynamic").expect("fixture module should be valid"),
+    );
+    let dynamic_facts = template_library_definition_facts(&db, dynamic);
+    let dynamic_retained = dynamic_facts
+        .symbol(TemplateSymbolKind::Tag, "retained")
+        .expect("exact registration should survive uncertainty");
+    assert_eq!(template_symbol_source(&db, dynamic_retained), None);
+    assert!(
+        dynamic_facts
+            .symbol(TemplateSymbolKind::Tag, "TAG")
+            .is_none()
+    );
+
+    let known_file = db
+        .file(Utf8Path::new("/test/project/known.py"))
+        .expect("known library should exist");
+    let known = TemplateLibraryId::new(
+        &db,
+        Some(known_file),
+        PythonModuleName::parse("known").expect("fixture module should be valid"),
+    );
+    let known_facts = template_library_definition_facts(&db, known);
+    let known_retained = known_facts
+        .symbol(TemplateSymbolKind::Tag, "retained")
+        .expect("closed library should retain its exact registration");
+    assert!(template_symbol_source(&db, known_retained).is_some());
 }
 
 // (b) Edge case — valid Python with no registrations

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -649,7 +649,7 @@ fn configured_same_name_specs_remain_keyed_by_library() {
 }
 
 #[test]
-fn configured_dynamic_registration_is_available_through_its_library_catalog() {
+fn configured_source_registration_is_available_through_its_library_catalog() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
         .django_settings_module("myproject.settings")
@@ -682,7 +682,7 @@ fn configured_dynamic_registration_is_available_through_its_library_catalog() {
     let symbol = dynamic
         .symbol(TemplateSymbolKind::Tag, "dynamic_panel")
         .expect("configured-only definition should enter the keyed catalog");
-    assert!(matches!(symbol.definition, SymbolDefinition::Unknown));
+    assert!(matches!(symbol.definition, SymbolDefinition::Exact { .. }));
     assert!(matches!(
         dynamic
             .symbol(TemplateSymbolKind::Tag, "sourced_tag")

--- a/docs/template-validation.md
+++ b/docs/template-validation.md
@@ -47,7 +47,7 @@ Each layer has a different failure mode and a different fix:
 
 `{% load %}` library names are checked against the active static inventory first. If the library exists on the project's Python search paths but its app is not in `INSTALLED_APPS`, djls reports S121. If no inactive-library evidence exists, djls reports S120.
 
-The same inventory powers editor navigation. Resolved `{% load %}` library names become document links and go-to-definition targets for their Python source files. Selective-load symbols and available Tag and Filter names jump to definite local Python declarations. Dynamic, imported, member, and ambiguous callables are skipped rather than guessed.
+The same inventory powers editor navigation. Resolved `{% load %}` library names become document links and go-to-definition targets for their Python source files. Selective-load symbols and available Tag and Filter names jump to definite local or imported module-level Python declarations. Dynamic, transformed, recovered, member, and ambiguous callables are skipped rather than guessed.
 
 Template directory discovery also powers go to definition for literal `{% extends %}` and `{% include %}` names. An overridden `{% block %}` name resolves to the nearest definite parent block; a root block resolves to itself. Find references returns the root block and its definite overrides. Editors that support definition links receive exact origin and declaration ranges.
 


### PR DESCRIPTION
## Summary

- resolve Template Tag and Filter registrations that use imported module constants, string-valued Enum members, and module-level callables
- keep generic Python source-order binding, import, function identity, uncertainty, and dependency semantics behind the Python substrate while Django owns registration policy
- extract rules, block structure, filter arity, and navigation targets from imported implementation files and include followed sources in intrinsic priming coverage
- add django-bird-shaped and conservative mutation, recovery, rebinding, package, and invalidation regressions

## Validation

- `cargo test -q`
- `just e2e` (44 passed)
- `just clippy`
- `just fmt --check`
- `just lint`
- `just hawk`