### PR TITLE
Document CLI and move the pre-commit hook

### DIFF
--- a/.mkdocs.yml
+++ b/.mkdocs.yml
@@ -29,6 +29,8 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Installation: installation.md
+  - Command-line interface: cli.md
+  - Pre-commit: pre-commit.md
   - Configuration:
       - configuration/index.md
   - Template Validation: template-validation.md

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,0 @@
-- id: djls-check
-  name: djls check
-  entry: djls check
-  language: system
-  require_serial: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
+- Changed the `djls-check` pre-commit hook to install the matching django-language-server release from `djls-pre-commit`.
 - Changed Django settings analysis to keep mutually exclusive configuration branches separate instead of combining their values into one partial result.
 - Changed Django settings analysis to treat closed unsupported Python literals as malformed rather than unresolved.
 - Changed template semantics and IDE features to use each file's feasible backends and the Template Library definitions active at each source position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
-- Changed the `djls-check` pre-commit hook to install the matching django-language-server release from `djls-pre-commit`.
+- Moved the `djls-check` pre-commit hook to the dedicated `djls-pre-commit` repository, where each hook revision installs the matching django-language-server release.
 - Changed Django settings analysis to keep mutually exclusive configuration branches separate instead of combining their values into one partial result.
 - Changed Django settings analysis to treat closed unsupported Python literals as malformed rather than unresolved.
 - Changed template semantics and IDE features to use each file's feasible backends and the Template Library definitions active at each source position.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ A language server for the Django web framework.
   ![Completions](docs/assets/autocomplete.png)
 - [x] **Diagnostics** - Real-time error checking and validation
   ![Diagnostics](docs/assets/diagnostics.png)
-- [ ] **Go to definition** - Jump to template, block, or variable definitions
+- [x] **Command-line checks** - Validate template files and directories with `djls check`
+- [x] **Go to definition** - Jump to template, block, and registered Python definitions
     - [x] Template navigation for `{% extends %}` and `{% include %}`
     - [x] Template Library, Tag, Filter, and selective-load symbol navigation
     - [x] Exact source highlighting in editors that support definition links
     - [x] Block definitions across template inheritance
     - [ ] Variable definitions
-- [ ] **Find references** - See where templates, blocks, and variables are used
+- [x] **Find references** - See where templates and inherited blocks are used
     - [x] Template references for `{% extends %}` and `{% include %}`
     - [x] Block references across template inheritance
     - [ ] Variable references
@@ -49,8 +50,8 @@ A language server for the Django web framework.
   ![Hover tag](docs/assets/hover-tag.png)
   ![Hover filter](docs/assets/hover-filter.png)
   ![Hover template](docs/assets/hover-template.png)
-- [x] **Code actions** - Quick fixes for unloaded template libraries and mismatched closing block names
-- [x] **Formatting** - Opt-in whole-document Django template formatting through `djangofmt`
+- [x] **Code actions** - Quick fixes for unloaded tags or filters and mismatched closing block names
+- [x] **Formatting** - Opt-in LSP document formatting through `djangofmt`
 - [ ] **Rename** - Refactor names across files
 - [x] **Document symbols** - Outline view of template structure
 - [ ] **Workspace symbols** - Search across all project templates
@@ -74,7 +75,7 @@ uv tool install django-language-server
 # or: pipx install django-language-server
 ```
 
-See the [Installation](docs/installation.md) guide for more options including pip, standalone binaries, and building from source.
+See the [Installation](docs/installation.md) guide for Homebrew, pip, standalone binaries, and source builds. The [`djls` CLI](docs/cli.md) can also check templates without an editor.
 
 Once configured, open any Django template file in your project to get:
 
@@ -87,7 +88,7 @@ Once configured, open any Django template file in your project to get:
 - Quick fixes for unloaded template tags/filters and mismatched `{% endblock %}` names
 - Folding for Django template regions
 - Outline symbols for template structure
-- Opt-in whole-document formatting through `djangofmt`
+- Opt-in LSP document formatting through `djangofmt`
 
 ## Documentation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,67 @@
+# Command-line interface
+
+Installing django-language-server adds the `djls` executable. It can check templates in a terminal or start the language server.
+
+## `djls check`
+
+Check Django templates without an editor:
+
+```console
+$ djls check [OPTIONS] [PATH]...
+```
+
+Run the command from the Django project root so it can load `djls.toml`, `.djls.toml`, or `pyproject.toml` and discover the project environment.
+
+### Input
+
+| Input | Behavior |
+|---|---|
+| No path | Check templates in the directories discovered from Django settings |
+| File paths | Check the named template files |
+| Directory paths | Recursively check supported template files below those directories |
+| `-` | Read one template from standard input; cannot be combined with paths |
+
+File and directory scans recognize `.html`, `.htm`, and `.djhtml` files.
+
+```bash
+# Check all discovered template directories
+djls check
+
+# Check explicit files or directories
+djls check templates/ app/templates/page.html
+
+# Check standard input
+printf '{{ value|default }}' | djls check -
+```
+
+### Options
+
+| Option | Meaning |
+|---|---|
+| `--select CODE,...` | Enable the named diagnostic codes, overriding project configuration |
+| `--ignore CODE,...` | Disable the named diagnostic codes |
+| `-g, --glob PATTERN` | Include or exclude matching files; prefix exclusions with `!`; later patterns win |
+| `-., --hidden` | Include hidden files and directories |
+| `--no-ignore` | Do not read `.gitignore`, `.ignore`, and related ignore files |
+| `-L, --follow` | Follow symbolic links |
+| `-d, --max-depth DEPTH` | Limit directory traversal depth |
+| `--color always\|auto\|never` | Control colored diagnostic output |
+| `-q, --quiet` | Suppress output and report the result through the exit status |
+
+`djls check` exits with status 0 when no enabled diagnostics are found and status 1 when diagnostics or a command error occur. Run `djls check --help` for the command's full help text.
+
+The [pre-commit hook](pre-commit.md) runs this command on staged templates.
+
+## `djls serve`
+
+Start the Language Server Protocol server over standard input and output:
+
+```console
+$ djls serve
+```
+
+Editors normally start this command through their [LSP client configuration](clients/index.md). TCP transport is not supported.
+
+## Formatting
+
+Django template formatting is an editor feature. Enable it in [format configuration](configuration/index.md#format), then use the editor's format-document command. There is no `djls format` command.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-A client that supports the Language Server Protocol (LSP) is required, along with a supported version of Python and Django. See [Versioning](versioning.md) for the full list of supported versions and the version support policy.
+Django Language Server needs a discoverable project environment with a supported Python and Django version. An LSP client is required only for editor features through `djls serve`; [`djls check`](cli.md#djls-check) runs in a terminal. See [Versioning](versioning.md) for supported versions and the version support policy.
 
 ## Try it out
 
@@ -25,7 +25,15 @@ The language server is published to PyPI with pre-built wheels for the following
 - **Windows**: x64
 - **Source distribution**: Available for other platforms
 
-Installing it adds the `djls` command-line tool to your environment.
+Installing it adds the `djls` command-line tool to your environment. See the [command-line reference](cli.md) for `djls check` and `djls serve`.
+
+### Homebrew
+
+Install the standalone macOS binary from the personal Homebrew tap:
+
+```bash
+brew install joshuadavidthomas/homebrew/django-language-server
+```
 
 ### System-wide tool installation
 
@@ -60,30 +68,33 @@ Standalone binaries are available for macOS, Linux, and Windows from [GitHub Rel
 === "Linux/macOS"
 
     ```bash
-    # Download the latest release for your platform
-    # Example for Linux x64:
-    curl -LO https://github.com/joshuadavidthomas/django-language-server/releases/latest/download/django-language-server-VERSION-linux-x64.tar.gz
+    # Set the release and platform: linux-x64, linux-arm64,
+    # darwin-x64, or darwin-arm64.
+    VERSION="6.0.3"
+    PLATFORM="linux-x64"
+    ARCHIVE="django-language-server-v${VERSION}-${PLATFORM}"
 
-    # Extract the archive
-    tar -xzf django-language-server-VERSION-linux-x64.tar.gz
+    curl -LO "https://github.com/joshuadavidthomas/django-language-server/releases/download/v${VERSION}/${ARCHIVE}.tar.gz"
+    tar -xzf "${ARCHIVE}.tar.gz"
 
-    # Move the binary to a location in your PATH
-    sudo mv django-language-server-VERSION-linux-x64/djls /usr/local/bin/
+    # Move the binary to a location in your PATH.
+    sudo mv "${ARCHIVE}/djls" /usr/local/bin/
     ```
 
 === "Windows"
 
     ```powershell
-    # Download the latest release for your platform
-    # Example for Windows x64:
-    Invoke-WebRequest -Uri "https://github.com/joshuadavidthomas/django-language-server/releases/latest/download/django-language-server-VERSION-windows-x64.zip" -OutFile "django-language-server-VERSION-windows-x64.zip"
+    # Set this to the release you want to install.
+    $Version = "6.0.3"
+    $Archive = "django-language-server-v$Version-windows-x64.zip"
 
-    # Extract the archive
-    Expand-Archive -Path "django-language-server-VERSION-windows-x64.zip" -DestinationPath .
+    # Download and extract the Windows x64 archive.
+    Invoke-WebRequest -Uri "https://github.com/joshuadavidthomas/django-language-server/releases/download/v$Version/$Archive" -OutFile $Archive
+    Expand-Archive -Path $Archive -DestinationPath .
 
-    # Move the binary to a location in your PATH (requires admin)
-    # Or add the directory containing djls.exe to your PATH
-    Move-Item -Path "django-language-server-VERSION-windows-x64\djls.exe" -Destination "$env:LOCALAPPDATA\Programs\djls.exe"
+    # Move the binary to a location in your PATH (requires admin),
+    # or add its extracted directory to your PATH.
+    Move-Item -Path "django-language-server-v$Version-windows-x64\djls.exe" -Destination "$env:LOCALAPPDATA\Programs\djls.exe"
     ```
 
 ## Building from source

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,40 +1,34 @@
 # pre-commit
 
-django-language-server provides a [pre-commit](https://pre-commit.com/) hook for running `djls check` on Django template files. This also works with [prek](https://github.com/j178/prek), a drop-in replacement for pre-commit written in Rust.
-
-## Prerequisites
-
-The hook uses `language: system`, which means `djls` must be installed and available on your `PATH` before running the hook. See [Installation](installation.md) for installation options.
+The dedicated [djls-pre-commit](https://github.com/joshuadavidthomas/djls-pre-commit) repository provides a hook for checking staged Django templates with [`djls check`](cli.md#djls-check). It works with [pre-commit](https://pre-commit.com/) and [prek](https://prek.j178.dev/).
 
 ## Usage
 
-Add the following to your `.pre-commit-config.yaml`:
+Add the hook to `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-  - repo: https://github.com/joshuadavidthomas/django-language-server
+  - repo: https://github.com/joshuadavidthomas/djls-pre-commit
     rev: v6.0.3  # use the latest release tag
     hooks:
       - id: djls-check
 ```
 
-Currently, `djls check` recognizes `.html`, `.htm`, and `.djhtml` files as templates. Files with other extensions are silently skipped.
+The hook tag pins and installs the matching django-language-server release. You do not need a separate system installation of `djls`, but your Django project still needs a supported Python environment that the checker can discover.
 
-!!! note
-
-    Broader template extension support is planned. See [#465](https://github.com/joshuadavidthomas/django-language-server/issues/465) for details.
+The hook runs once with all staged `.html`, `.htm`, and `.djhtml` files. It checks templates and does not format or rewrite them.
 
 ## Configuration
 
-Pass additional arguments to `djls check` via the `args` option:
+Pass [`djls check` options](cli.md#options) through `args`:
 
 ```yaml
 repos:
-  - repo: https://github.com/joshuadavidthomas/django-language-server
+  - repo: https://github.com/joshuadavidthomas/djls-pre-commit
     rev: v6.0.3
     hooks:
       - id: djls-check
         args: [--select, "S100,S117", --color, never]
 ```
 
-See `djls check --help` for all available options.
+Project settings in `djls.toml`, `.djls.toml`, or `pyproject.toml` apply to hook runs in the same way as direct CLI runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ classifiers = [
 ]
 
 [project.urls]
-Documentation = "https://django-language-server.readthedocs.io/"
+Documentation = "https://djls.joshthomas.dev"
 Issues = "https://github.com/joshuadavidthomas/django-language-server/issues"
 Source = "https://github.com/joshuadavidthomas/django-language-server"
 
@@ -104,6 +104,10 @@ version_pattern = "MAJOR.MINOR.PATCH[-TAG[.NUM]]"
 ]
 "docs/pre-commit.md" = [
   '    rev: v{version}',
+]
+"docs/installation.md" = [
+  '    VERSION="{version}"',
+  '    \$Version = "{version}"',
 ]
 
 [tool.djlint]


### PR DESCRIPTION
## Summary

- move `djls-check` installation to the dedicated `djls-pre-commit` mirror
- add a CLI reference for `djls check` and `djls serve`, including the LSP-only formatting boundary
- refresh feature, installation, standalone archive, Homebrew, and documentation metadata

The companion repositories are ready:

- https://github.com/joshuadavidthomas/djls-pre-commit
- https://github.com/joshuadavidthomas/homebrew-homebrew

No package version or release tag changes in this PR.

## Verification

- `cargo run -q -p djls -- check --help`
- `just docs build`
- `just clippy`
- `just fmt --check`
- `just lint`
- `djls-pre-commit`: manifest validation, `pre-commit try-repo`, test workflow, and no-op mirror workflow passed
- Homebrew tap: formula style, audit, native install, and formula test passed on Apple Silicon and Intel macOS runners
- PR test matrix and E2E checks passed

Fixes #460
