### PR TITLE
Fix release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,39 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify release tag matches package version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python_version="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          cargo_version="$(python3 -c 'import tomllib; print(tomllib.load(open("crates/djls/Cargo.toml", "rb"))["package"]["version"])')"
+          normalized_cargo_version="${cargo_version/-a/a}"
+          normalized_cargo_version="${normalized_cargo_version/-b/b}"
+          normalized_cargo_version="${normalized_cargo_version/-rc/rc}"
+          expected_tag="v${python_version}"
+
+          printf 'Release tag: %s\n' "$RELEASE_TAG"
+          printf 'Python package version: %s\n' "$python_version"
+          printf 'Cargo package version: %s\n' "$cargo_version"
+
+          if [[ "$normalized_cargo_version" != "$python_version" ]]; then
+            printf 'Python package version %s does not match Cargo package version %s.\n' "$python_version" "$cargo_version" >&2
+            exit 1
+          fi
+
+          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+            printf 'Release tag must be %s, but got %s.\n' "$expected_tag" "$RELEASE_TAG" >&2
+            exit 1
+          fi
+
   lint:
     uses: ./.github/workflows/lint.yml
     permissions:
@@ -25,7 +58,7 @@ jobs:
 
   build:
     uses: ./.github/workflows/build.yml
-    needs: [lint, test]
+    needs: [preflight, lint, test]
     permissions:
       attestations: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Fixed LSP ranges for diagnostics, hover, document links, document symbols, and code actions when clients use UTF-16 or UTF-32 position encoding.
+- Fixed `djls check` returning success when an explicit path could not be read or indexed.
+- Fixed malformed env-file entries exposing their contents in server logs.
+- **Internal**: Added a release preflight check that requires the release tag to match the package version.
 - Fixed false unknown tag and filter diagnostics when a template library imports or dynamically mutates its Django registration object.
 - Fixed static path evaluation to follow imported helper aliases without mistaking shadowed `Path`, `str`, or `os` bindings for standard-library helpers.
 - Fixed static Django settings evaluation through ordinary and `from` imports, including dotted module chains, module attributes, named package children, and `__all__`-controlled star exports.

--- a/crates/djls-bench/benches/diagnostics.rs
+++ b/crates/djls-bench/benches/diagnostics.rs
@@ -24,6 +24,7 @@ use djls_source::DiagnosticRenderer;
 use djls_source::File;
 use djls_source::FileError;
 use djls_source::FileReadError;
+use djls_source::PositionEncoding;
 
 fn main() {
     divan::main();
@@ -81,7 +82,11 @@ fn render_synthetic(bencher: Bencher) {
 }
 
 fn benchmark_diagnostics(db: &Db, file: File, context: &str) -> usize {
-    require_some(context, collect_diagnostics(db, file)).len()
+    require_some(
+        context,
+        collect_diagnostics(db, file, PositionEncoding::Utf8),
+    )
+    .len()
 }
 
 fn verify_expected_diagnostics(
@@ -89,7 +94,7 @@ fn verify_expected_diagnostics(
     file: File,
     path: &Utf8PathBuf,
 ) -> Result<(), DiagnosticsSetupError> {
-    let diagnostics = collect_diagnostics(db, file)
+    let diagnostics = collect_diagnostics(db, file, PositionEncoding::Utf8)
         .ok_or_else(|| DiagnosticsSetupError::DiagnosticsUnavailable { path: path.clone() })?;
     if diagnostics.is_empty() {
         return Err(DiagnosticsSetupError::MissingDiagnostics { path: path.clone() });

--- a/crates/djls-bench/src/check.rs
+++ b/crates/djls-bench/src/check.rs
@@ -81,6 +81,7 @@ mod tests {
     use djls_semantic::validate_template_file;
     use djls_source::DiagnosticRenderer;
     use djls_source::File;
+    use djls_source::PositionEncoding;
     use djls_templates::parse_template;
     use insta::assert_yaml_snapshot;
     use salsa::Database as _;
@@ -502,7 +503,7 @@ mod tests {
                     .collect(),
             });
 
-            if let Some(diagnostics) = collect_diagnostics(db, file) {
+            if let Some(diagnostics) = collect_diagnostics(db, file, PositionEncoding::Utf8) {
                 ide_eligible_file_count += 1;
                 normalized_ide_diagnostics
                     .extend(normalize_lsp_diagnostics(path.as_str(), diagnostics));
@@ -676,7 +677,7 @@ mod tests {
         };
         let mut original_diagnostics = Vec::new();
         for _ in 0..DIAGNOSTICS_WARMUP_ITERS {
-            original_diagnostics = collect_diagnostics(&db, file)
+            original_diagnostics = collect_diagnostics(&db, file, PositionEncoding::Utf8)
                 .expect("incremental Template fixture should be eligible for diagnostics");
         }
         let original_diagnostics =
@@ -688,7 +689,7 @@ mod tests {
         drop(take_will_execute_names(&db, &events));
 
         db.set_file_contents(file, &modified);
-        let modified_diagnostics = collect_diagnostics(&db, file)
+        let modified_diagnostics = collect_diagnostics(&db, file, PositionEncoding::Utf8)
             .expect("modified Template fixture should be eligible for diagnostics");
         let modified_diagnostics =
             normalize_lsp_diagnostics(fixture.path.as_str(), modified_diagnostics);
@@ -696,14 +697,14 @@ mod tests {
         assert_execution_count(&modified_names, "validate_template_file", 1);
 
         db.set_file_contents(file, &original);
-        let restored_diagnostics = collect_diagnostics(&db, file)
+        let restored_diagnostics = collect_diagnostics(&db, file, PositionEncoding::Utf8)
             .expect("restored Template fixture should be eligible for diagnostics");
         let restored_diagnostics =
             normalize_lsp_diagnostics(fixture.path.as_str(), restored_diagnostics);
         let restored_names = take_will_execute_names(&db, &events);
         assert_execution_count(&restored_names, "validate_template_file", 1);
 
-        let repeated_diagnostics = collect_diagnostics(&db, file)
+        let repeated_diagnostics = collect_diagnostics(&db, file, PositionEncoding::Utf8)
             .expect("repeated Template fixture should be eligible for diagnostics");
         let repeated_diagnostics =
             normalize_lsp_diagnostics(fixture.path.as_str(), repeated_diagnostics);

--- a/crates/djls-ide/src/code_actions.rs
+++ b/crates/djls-ide/src/code_actions.rs
@@ -71,7 +71,9 @@ pub fn code_actions(
         match error {
             ValidationError::UnloadedTag { library, .. }
             | ValidationError::UnloadedFilter { library, .. } => {
-                let Some(diagnostic) = error.to_lsp_diagnostic(line_index, &config) else {
+                let Some(diagnostic) =
+                    error.to_lsp_diagnostic(source_text, line_index, encoding, &config)
+                else {
                     continue;
                 };
                 let insertion_offset =
@@ -87,7 +89,9 @@ pub fn code_actions(
             }
             ValidationError::AmbiguousUnloadedTag { libraries, .. }
             | ValidationError::AmbiguousUnloadedFilter { libraries, .. } => {
-                let Some(diagnostic) = error.to_lsp_diagnostic(line_index, &config) else {
+                let Some(diagnostic) =
+                    error.to_lsp_diagnostic(source_text, line_index, encoding, &config)
+                else {
                     continue;
                 };
                 let insertion_offset =
@@ -110,7 +114,9 @@ pub fn code_actions(
             ValidationError::UnmatchedBlockName {
                 expected, got_span, ..
             } => {
-                let Some(diagnostic) = error.to_lsp_diagnostic(line_index, &config) else {
+                let Some(diagnostic) =
+                    error.to_lsp_diagnostic(source_text, line_index, encoding, &config)
+                else {
                     continue;
                 };
                 let edit = ls_types::TextEdit::new(

--- a/crates/djls-ide/src/diagnostics.rs
+++ b/crates/djls-ide/src/diagnostics.rs
@@ -10,19 +10,11 @@ use crate::ext::DiagnosticExt;
 ///
 /// Returns `None` when `file` is not a diagnostics target. For template files,
 /// triggers parsing and validation via Salsa-tracked queries (cached across
-/// calls), then converts the accumulated errors to LSP types. Diagnostics are
-/// filtered and severity-adjusted per `diagnostics_config`.
+/// calls), then converts the accumulated errors to LSP types using the client's
+/// negotiated position encoding. Diagnostics are filtered and severity-adjusted
+/// per `diagnostics_config`.
 #[must_use]
 pub fn collect_diagnostics(
-    db: &dyn djls_semantic::Db,
-    file: File,
-) -> Option<Vec<ls_types::Diagnostic>> {
-    collect_diagnostics_with_encoding(db, file, PositionEncoding::Utf8)
-}
-
-/// Collect all LSP diagnostics using the client's negotiated position encoding.
-#[must_use]
-pub fn collect_diagnostics_with_encoding(
     db: &dyn djls_semantic::Db,
     file: File,
     encoding: PositionEncoding,

--- a/crates/djls-ide/src/diagnostics.rs
+++ b/crates/djls-ide/src/diagnostics.rs
@@ -1,6 +1,7 @@
 use djls_semantic::collect_template_diagnostics;
 use djls_source::File;
 use djls_source::FileKind;
+use djls_source::PositionEncoding;
 use tower_lsp_server::ls_types;
 
 use crate::ext::DiagnosticExt;
@@ -15,6 +16,16 @@ use crate::ext::DiagnosticExt;
 pub fn collect_diagnostics(
     db: &dyn djls_semantic::Db,
     file: File,
+) -> Option<Vec<ls_types::Diagnostic>> {
+    collect_diagnostics_with_encoding(db, file, PositionEncoding::Utf8)
+}
+
+/// Collect all LSP diagnostics using the client's negotiated position encoding.
+#[must_use]
+pub fn collect_diagnostics_with_encoding(
+    db: &dyn djls_semantic::Db,
+    file: File,
+    encoding: PositionEncoding,
 ) -> Option<Vec<ls_types::Diagnostic>> {
     let Ok(source) = file.try_source(db) else {
         return None;
@@ -31,13 +42,17 @@ pub fn collect_diagnostics(
     let line_index = file.line_index(db);
 
     for error in collected.template_errors {
-        if let Some(diagnostic) = error.to_lsp_diagnostic(line_index, &config) {
+        if let Some(diagnostic) =
+            error.to_lsp_diagnostic(source.as_str(), line_index, encoding, &config)
+        {
             diagnostics.push(diagnostic);
         }
     }
 
     for error in collected.validation_errors {
-        if let Some(diagnostic) = error.to_lsp_diagnostic(line_index, &config) {
+        if let Some(diagnostic) =
+            error.to_lsp_diagnostic(source.as_str(), line_index, encoding, &config)
+        {
             diagnostics.push(diagnostic);
         }
     }
@@ -67,7 +82,12 @@ mod tests {
         });
 
         let diagnostic = error
-            .to_lsp_diagnostic(&line_index, &djls_conf::DiagnosticsConfig::default())
+            .to_lsp_diagnostic(
+                source,
+                &line_index,
+                PositionEncoding::Utf8,
+                &djls_conf::DiagnosticsConfig::default(),
+            )
             .expect("default diagnostic severity should be enabled");
 
         assert_eq!(
@@ -76,6 +96,35 @@ mod tests {
         );
         assert_eq!(diagnostic.range.start, ls_types::Position::new(0, 6));
         assert_eq!(diagnostic.range.end, ls_types::Position::new(0, 8));
+    }
+
+    #[test]
+    fn diagnostic_ranges_follow_position_encoding() {
+        let source = "é😀 {{ value";
+        let line_index = LineIndex::from(source);
+        let error = TemplateError::from(ParseError::MalformedConstruct {
+            position: 7,
+            opener: "{{".to_string(),
+            closer: "}}".to_string(),
+            content: "value".to_string(),
+        });
+        let config = djls_conf::DiagnosticsConfig::default();
+
+        let utf16 = error
+            .to_lsp_diagnostic(source, &line_index, PositionEncoding::Utf16, &config)
+            .expect("UTF-16 diagnostic should be enabled");
+        let utf32 = error
+            .to_lsp_diagnostic(source, &line_index, PositionEncoding::Utf32, &config)
+            .expect("UTF-32 diagnostic should be enabled");
+
+        assert_eq!(
+            utf16.range,
+            ls_types::Range::new(ls_types::Position::new(0, 4), ls_types::Position::new(0, 6),)
+        );
+        assert_eq!(
+            utf32.range,
+            ls_types::Range::new(ls_types::Position::new(0, 3), ls_types::Position::new(0, 5),)
+        );
     }
 
     #[test]

--- a/crates/djls-ide/src/ext.rs
+++ b/crates/djls-ide/src/ext.rs
@@ -41,9 +41,7 @@ impl OutlineKindExt for djls_semantic::OutlineKind {
 }
 
 trait OffsetExt {
-    fn to_lsp_position(&self, line_index: &LineIndex) -> ls_types::Position;
-
-    fn to_lsp_position_with_encoding(
+    fn to_lsp_position(
         &self,
         source: &str,
         line_index: &LineIndex,
@@ -52,19 +50,15 @@ trait OffsetExt {
 }
 
 impl OffsetExt for Offset {
-    fn to_lsp_position(&self, line_index: &LineIndex) -> ls_types::Position {
-        let (line, character) = line_index.to_line_col(*self).into();
-        ls_types::Position { line, character }
-    }
-
-    fn to_lsp_position_with_encoding(
+    fn to_lsp_position(
         &self,
         source: &str,
         line_index: &LineIndex,
         encoding: PositionEncoding,
     ) -> ls_types::Position {
         let Some(source_line) = line_index.line_at_offset(source, *self) else {
-            return self.to_lsp_position(line_index);
+            let (line, character) = line_index.to_line_col(*self).into();
+            return ls_types::Position { line, character };
         };
         let byte_offset = source_line.byte_offset(*self);
         let line_prefix = &source_line.text()[..byte_offset];
@@ -87,8 +81,6 @@ impl OffsetExt for Offset {
 }
 
 pub(crate) trait SpanExt {
-    fn to_lsp_range(&self, line_index: &LineIndex) -> ls_types::Range;
-
     fn to_lsp_range_with_encoding(
         &self,
         source: &str,
@@ -98,12 +90,6 @@ pub(crate) trait SpanExt {
 }
 
 impl SpanExt for Span {
-    fn to_lsp_range(&self, line_index: &LineIndex) -> ls_types::Range {
-        let start = self.start_offset().to_lsp_position(line_index);
-        let end = self.end_offset().to_lsp_position(line_index);
-        ls_types::Range { start, end }
-    }
-
     fn to_lsp_range_with_encoding(
         &self,
         source: &str,
@@ -112,10 +98,10 @@ impl SpanExt for Span {
     ) -> ls_types::Range {
         let start = self
             .start_offset()
-            .to_lsp_position_with_encoding(source, line_index, encoding);
+            .to_lsp_position(source, line_index, encoding);
         let end = self
             .end_offset()
-            .to_lsp_position_with_encoding(source, line_index, encoding);
+            .to_lsp_position(source, line_index, encoding);
         ls_types::Range { start, end }
     }
 }
@@ -330,16 +316,17 @@ pub(crate) trait FoldSpanExt {
 
 impl FoldSpanExt for FoldSpan {
     fn to_lsp_folding_range(self, line_index: &LineIndex) -> Option<ls_types::FoldingRange> {
-        let range = self.span.to_lsp_range(line_index);
+        let (start_line, _) = line_index.to_line_col(self.span.start_offset()).into();
+        let (end_line, _) = line_index.to_line_col(self.span.end_offset()).into();
 
-        if range.start.line >= range.end.line {
+        if start_line >= end_line {
             return None;
         }
 
         Some(ls_types::FoldingRange {
-            start_line: range.start.line,
+            start_line,
             start_character: None,
-            end_line: range.end.line,
+            end_line,
             end_character: None,
             kind: Some(self.kind.to_lsp_kind()),
             collapsed_text: None,
@@ -375,14 +362,18 @@ pub(crate) trait DiagnosticExt: std::fmt::Display {
 
     fn to_lsp_diagnostic(
         &self,
+        source: &str,
         line_index: &LineIndex,
+        encoding: PositionEncoding,
         config: &djls_conf::DiagnosticsConfig,
     ) -> Option<ls_types::Diagnostic> {
         let code = self.diagnostic_code();
         let severity = config.get_severity(code).to_lsp_severity()?;
         let range = self
             .diagnostic_span()
-            .map(|(start, length)| Span::new(start, length).to_lsp_range(line_index))
+            .map(|(start, length)| {
+                Span::new(start, length).to_lsp_range_with_encoding(source, line_index, encoding)
+            })
             .unwrap_or_default();
 
         Some(ls_types::Diagnostic {

--- a/crates/djls-ide/src/hover.rs
+++ b/crates/djls-ide/src/hover.rs
@@ -18,11 +18,17 @@ use djls_semantic::resolve_reference_for_file;
 use djls_semantic::scoped_template_libraries_for_file;
 use djls_source::File;
 use djls_source::Offset;
+use djls_source::PositionEncoding;
 use tower_lsp_server::ls_types;
 
 use crate::ext::SpanExt;
 
-pub fn hover(db: &dyn SemanticDb, file: File, offset: Offset) -> Option<ls_types::Hover> {
+pub fn hover(
+    db: &dyn SemanticDb,
+    file: File,
+    offset: Offset,
+    encoding: PositionEncoding,
+) -> Option<ls_types::Hover> {
     let scoped_libraries = scoped_template_libraries_for_file(db, file);
     let (markdown, span) = match SemanticOffsetContext::from_offset(db, file, offset) {
         SemanticOffsetContext::TemplateReference {
@@ -86,12 +92,17 @@ pub fn hover(db: &dyn SemanticDb, file: File, offset: Offset) -> Option<ls_types
         | SemanticOffsetContext::None => None,
     }?;
 
+    let source = file.try_source(db).ok()?;
     Some(ls_types::Hover {
         contents: ls_types::HoverContents::Markup(ls_types::MarkupContent {
             kind: ls_types::MarkupKind::Markdown,
             value: markdown,
         }),
-        range: Some(span.to_lsp_range(file.line_index(db))),
+        range: Some(span.to_lsp_range_with_encoding(
+            source.as_str(),
+            file.line_index(db),
+            encoding,
+        )),
     })
 }
 

--- a/crates/djls-ide/src/lib.rs
+++ b/crates/djls-ide/src/lib.rs
@@ -16,7 +16,6 @@ mod warmup;
 pub use code_actions::code_actions;
 pub use completions::completion;
 pub use diagnostics::collect_diagnostics;
-pub use diagnostics::collect_diagnostics_with_encoding;
 pub use folding::collect_folding_ranges;
 pub use formatting::format_document;
 pub use hover::hover;

--- a/crates/djls-ide/src/lib.rs
+++ b/crates/djls-ide/src/lib.rs
@@ -16,6 +16,7 @@ mod warmup;
 pub use code_actions::code_actions;
 pub use completions::completion;
 pub use diagnostics::collect_diagnostics;
+pub use diagnostics::collect_diagnostics_with_encoding;
 pub use folding::collect_folding_ranges;
 pub use formatting::format_document;
 pub use hover::hover;

--- a/crates/djls-ide/src/links.rs
+++ b/crates/djls-ide/src/links.rs
@@ -5,12 +5,20 @@ use djls_semantic::scoped_template_libraries_for_file;
 use djls_semantic::template_library_references_in_file;
 use djls_semantic::template_references_in_file;
 use djls_source::File;
+use djls_source::PositionEncoding;
 use tower_lsp_server::ls_types;
 
 use crate::ext::SpanExt;
 use crate::ext::Utf8PathExt;
 
-pub fn document_links(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_types::DocumentLink> {
+pub fn document_links(
+    db: &dyn djls_semantic::Db,
+    file: File,
+    encoding: PositionEncoding,
+) -> Vec<ls_types::DocumentLink> {
+    let Ok(source) = file.try_source(db) else {
+        return Vec::new();
+    };
     let line_index = file.line_index(db);
     let scoped_libraries = scoped_template_libraries_for_file(db, file);
     let mut links = Vec::new();
@@ -30,7 +38,11 @@ pub fn document_links(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_types::D
                         reference.kind(),
                     )? {
                         TemplateResolutionResult::Found(origin) => Some(ls_types::DocumentLink {
-                            range: reference.span().to_lsp_range(line_index),
+                            range: reference.span().to_lsp_range_with_encoding(
+                                source.as_str(),
+                                line_index,
+                                encoding,
+                            ),
                             target: Some(origin.path_buf(db).to_lsp_uri()?),
                             tooltip: None,
                             data: None,
@@ -65,7 +77,11 @@ pub fn document_links(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_types::D
             .filter_map(|reference| {
                 let target = scoped_libraries.library_link(reference.load_name())?;
                 Some(ls_types::DocumentLink {
-                    range: reference.span().to_lsp_range(line_index),
+                    range: reference.span().to_lsp_range_with_encoding(
+                        source.as_str(),
+                        line_index,
+                        encoding,
+                    ),
                     target: Some(target.path(db).to_lsp_uri()?),
                     tooltip: None,
                     data: None,

--- a/crates/djls-ide/src/symbols.rs
+++ b/crates/djls-ide/src/symbols.rs
@@ -2,32 +2,45 @@ use djls_semantic::OutlineItem;
 use djls_semantic::build_template_outline_for_file;
 use djls_source::File;
 use djls_source::LineIndex;
+use djls_source::PositionEncoding;
 use tower_lsp_server::ls_types;
 
 use crate::ext::OutlineKindExt;
 use crate::ext::SpanExt;
 
 #[must_use]
-pub fn document_symbols(db: &dyn djls_semantic::Db, file: File) -> Vec<ls_types::DocumentSymbol> {
+pub fn document_symbols(
+    db: &dyn djls_semantic::Db,
+    file: File,
+    encoding: PositionEncoding,
+) -> Vec<ls_types::DocumentSymbol> {
     let djls_templates::TemplateParseResult::Parsed(nodelist) =
         djls_templates::parse_template(db, file)
     else {
         return Vec::new();
     };
 
+    let Ok(source) = file.try_source(db) else {
+        return Vec::new();
+    };
     let outline = build_template_outline_for_file(db, file, nodelist);
     let line_index = file.line_index(db);
     outline
         .iter()
-        .map(|item| item_to_document_symbol(item, line_index))
+        .map(|item| item_to_document_symbol(item, source.as_str(), line_index, encoding))
         .collect()
 }
 
-fn item_to_document_symbol(item: &OutlineItem, line_index: &LineIndex) -> ls_types::DocumentSymbol {
+fn item_to_document_symbol(
+    item: &OutlineItem,
+    source: &str,
+    line_index: &LineIndex,
+    encoding: PositionEncoding,
+) -> ls_types::DocumentSymbol {
     let children = (!item.children.is_empty()).then(|| {
         item.children
             .iter()
-            .map(|child| item_to_document_symbol(child, line_index))
+            .map(|child| item_to_document_symbol(child, source, line_index, encoding))
             .collect()
     });
 
@@ -41,8 +54,12 @@ fn item_to_document_symbol(item: &OutlineItem, line_index: &LineIndex) -> ls_typ
         // We set both to `None` because template outline items are not deprecated.
         #[allow(deprecated)]
         deprecated: None,
-        range: item.span.to_lsp_range(line_index),
-        selection_range: item.selection_span.to_lsp_range(line_index),
+        range: item
+            .span
+            .to_lsp_range_with_encoding(source, line_index, encoding),
+        selection_range: item
+            .selection_span
+            .to_lsp_range_with_encoding(source, line_index, encoding),
         children,
     }
 }
@@ -92,7 +109,7 @@ mod tests {
 
         let symbols = outline
             .iter()
-            .map(|item| item_to_document_symbol(item, &line_index))
+            .map(|item| item_to_document_symbol(item, source, &line_index, PositionEncoding::Utf16))
             .collect::<Vec<_>>();
 
         assert_eq!(symbols.len(), 1);
@@ -119,5 +136,40 @@ mod tests {
         let filters = children[1].children.as_ref().expect("filters should exist");
         assert_eq!(filters[0].name, "lower");
         assert_eq!(filters[0].kind, ls_types::SymbolKind::FUNCTION);
+    }
+
+    #[test]
+    fn outline_conversion_follows_position_encoding() {
+        let source = "é😀 {{ user }}";
+        let line_index = LineIndex::from(source);
+        let start = source
+            .find("user")
+            .expect("test source should contain user");
+        let item = OutlineItem {
+            label: "user".to_string(),
+            detail: None,
+            kind: djls_semantic::OutlineKind::Variable,
+            span: Span::saturating_from_bounds_usize(7, source.len()),
+            selection_span: Span::saturating_from_bounds_usize(start, start + "user".len()),
+            children: Vec::new(),
+        };
+
+        let utf16 = item_to_document_symbol(&item, source, &line_index, PositionEncoding::Utf16);
+        let utf32 = item_to_document_symbol(&item, source, &line_index, PositionEncoding::Utf32);
+
+        assert_eq!(
+            utf16.selection_range,
+            ls_types::Range::new(
+                ls_types::Position::new(0, 7),
+                ls_types::Position::new(0, 11),
+            )
+        );
+        assert_eq!(
+            utf32.selection_range,
+            ls_types::Range::new(
+                ls_types::Position::new(0, 6),
+                ls_types::Position::new(0, 10),
+            )
+        );
     }
 }

--- a/crates/djls-ide/tests/code_actions.rs
+++ b/crates/djls-ide/tests/code_actions.rs
@@ -117,7 +117,7 @@ fn apply_edit(source: &str, edit: &ls_types::TextEdit) -> String {
 
 fn diagnostic_codes(source: &str) -> TestResult<Vec<String>> {
     let db = db_with_source(source)?;
-    Ok(collect_diagnostics(&db, file(&db)?)
+    Ok(collect_diagnostics(&db, file(&db)?, PositionEncoding::Utf8)
         .ok_or_else(|| io::Error::other("template file should return diagnostics"))?
         .into_iter()
         .filter_map(|diagnostic| match diagnostic.code {
@@ -311,7 +311,8 @@ fn severity_off_suppresses_diagnostic_and_code_action() {
         .expect("validation fixture with custom diagnostics should build");
 
     let file = file(&db).expect("template fixture file should exist");
-    let diagnostics = collect_diagnostics(&db, file).expect("template should return diagnostics");
+    let diagnostics = collect_diagnostics(&db, file, PositionEncoding::Utf8)
+        .expect("template should return diagnostics");
     let actions = collect_actions(&db, request_at(source, "trans"))
         .expect("disabled diagnostic should return a code action response");
 

--- a/crates/djls-ide/tests/document_links.rs
+++ b/crates/djls-ide/tests/document_links.rs
@@ -3,10 +3,16 @@ use djls_conf::TagDef;
 use djls_conf::TagLibraryDef;
 use djls_conf::TagSpecDef;
 use djls_conf::TagTypeDef;
-use djls_ide::document_links;
+use djls_ide::document_links as ide_document_links;
+use djls_source::File;
+use djls_source::PositionEncoding;
 use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
+
+fn document_links(db: &TestDatabase, file: File) -> Vec<ls_types::DocumentLink> {
+    ide_document_links(db, file, PositionEncoding::Utf16)
+}
 
 #[test]
 fn document_links_do_not_leak_templates_from_another_backend() {
@@ -51,6 +57,46 @@ fn document_links_resolve_absolute_references_from_originless_files() {
     assert_eq!(
         links[0].target.as_ref().map(|uri| uri.as_str()),
         Some("file:///test/project/templates/card.html")
+    );
+}
+
+#[test]
+fn document_link_ranges_follow_position_encoding() {
+    let mut db = TestDatabase::new();
+    let template_path = "/test/project/templates/page.html";
+    let source = "é😀 {% include \"card.html\" %}";
+    ProjectFixture::new("/test/project")
+        .django_settings_module("project.settings")
+        .file(
+            "/test/project/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
+        )
+        .file(template_path, source)
+        .file("/test/project/templates/card.html", "card")
+        .install(&mut db)
+        .expect("document link range fixture should install");
+    let file = db
+        .file(Utf8Path::new(template_path))
+        .expect("template fixture should exist");
+
+    let utf16 = ide_document_links(&db, file, PositionEncoding::Utf16);
+    let utf32 = ide_document_links(&db, file, PositionEncoding::Utf32);
+
+    assert_eq!(utf16.len(), 1);
+    assert_eq!(utf32.len(), 1);
+    assert_eq!(
+        utf16[0].range,
+        ls_types::Range::new(
+            ls_types::Position::new(0, 16),
+            ls_types::Position::new(0, 25),
+        )
+    );
+    assert_eq!(
+        utf32[0].range,
+        ls_types::Range::new(
+            ls_types::Position::new(0, 15),
+            ls_types::Position::new(0, 24),
+        )
     );
 }
 

--- a/crates/djls-ide/tests/hover.rs
+++ b/crates/djls-ide/tests/hover.rs
@@ -1,10 +1,15 @@
 use camino::Utf8Path;
-use djls_ide::hover;
+use djls_ide::hover as ide_hover;
 use djls_source::File;
 use djls_source::Offset;
+use djls_source::PositionEncoding;
 use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
+
+fn hover(db: &TestDatabase, file: File, offset: Offset) -> Option<ls_types::Hover> {
+    ide_hover(db, file, offset, PositionEncoding::Utf16)
+}
 
 fn hover_markdown(hover: ls_types::Hover) -> Option<String> {
     match hover.contents {
@@ -40,6 +45,40 @@ fn collision_fixture(source: &str) -> Result<(TestDatabase, File), Box<dyn std::
         .install(&mut db)?;
     let file = db.file(Utf8Path::new("/test/project/templates/page.html"))?;
     Ok((db, file))
+}
+
+#[test]
+fn hover_ranges_follow_position_encoding() {
+    let source = "é😀 {% shared %}";
+    let (db, file) = collision_fixture(source).expect("hover range fixture should build");
+    let offset = Offset::new(
+        u32::try_from(
+            source
+                .find("shared")
+                .expect("test source should contain shared"),
+        )
+        .expect("test source offset should fit in u32"),
+    );
+
+    let utf16 = ide_hover(&db, file, offset, PositionEncoding::Utf16)
+        .expect("builtin tag should have a UTF-16 hover");
+    let utf32 = ide_hover(&db, file, offset, PositionEncoding::Utf32)
+        .expect("builtin tag should have a UTF-32 hover");
+
+    assert_eq!(
+        utf16.range,
+        Some(ls_types::Range::new(
+            ls_types::Position::new(0, 7),
+            ls_types::Position::new(0, 13),
+        ))
+    );
+    assert_eq!(
+        utf32.range,
+        Some(ls_types::Range::new(
+            ls_types::Position::new(0, 6),
+            ls_types::Position::new(0, 12),
+        ))
+    );
 }
 
 #[test]

--- a/crates/djls-project/src/project.rs
+++ b/crates/djls-project/src/project.rs
@@ -199,8 +199,8 @@ fn load_env_file(
                 tracing::debug!("Loaded env var from file: {}", key);
                 vars.push((key, value));
             }
-            Err(err) => {
-                tracing::warn!("Failed to parse env file entry: {}", err);
+            Err(_) => {
+                tracing::warn!("{}", env_file_parse_warning(&env_path));
             }
         }
     }
@@ -211,6 +211,10 @@ fn load_env_file(
         );
     }
     vars
+}
+
+fn env_file_parse_warning(env_path: &Utf8Path) -> String {
+    format!("Could not parse an entry in env file {env_path}; skipped the entry")
 }
 
 fn django_settings_module_name(
@@ -380,6 +384,26 @@ mod tests {
                 ("SECRET".to_string(), "my secret value".to_string())
             );
             assert_eq!(vars[1], ("OTHER".to_string(), "single quoted".to_string()));
+        }
+
+        #[test]
+        fn malformed_entry_warning_does_not_include_file_contents() {
+            const SENTINEL_SECRET: &str = "djls-sentinel-secret-do-not-log";
+            let env_path = Utf8Path::new("/project/.env");
+            let malformed = format!("SECRET=\"{SENTINEL_SECRET}");
+            let error = dotenvy::from_read_iter(malformed.as_bytes())
+                .next()
+                .expect("malformed env entry should produce a parser result")
+                .expect_err("unterminated quoted value should fail to parse");
+
+            let warning = env_file_parse_warning(env_path);
+
+            assert!(matches!(error, dotenvy::Error::LineParse(_, _)));
+            assert_eq!(
+                warning,
+                "Could not parse an entry in env file /project/.env; skipped the entry"
+            );
+            assert!(!warning.contains(SENTINEL_SECRET));
         }
     }
 }

--- a/crates/djls-server/src/reload.rs
+++ b/crates/djls-server/src/reload.rs
@@ -17,7 +17,7 @@ use djls_db::DjangoDatabase;
 use djls_ide::PrimedTemplateLibraries;
 use djls_ide::WarmCachePart;
 use djls_ide::WarmCachePhase;
-use djls_ide::collect_diagnostics_with_encoding;
+use djls_ide::collect_diagnostics;
 use djls_ide::prime_template_library_products;
 use djls_ide::warm_cache_phases;
 use djls_project::Db as ProjectDb;
@@ -999,7 +999,7 @@ async fn collect_snapshot_diagnostics(
         let joined = spawn_blocking(move || {
             Cancelled::catch(AssertUnwindSafe(|| {
                 let file = path_to_file(snapshot.db(), &path).ok()?;
-                collect_diagnostics_with_encoding(
+                collect_diagnostics(
                     snapshot.db(),
                     file,
                     snapshot.client_info().position_encoding(),

--- a/crates/djls-server/src/reload.rs
+++ b/crates/djls-server/src/reload.rs
@@ -17,7 +17,7 @@ use djls_db::DjangoDatabase;
 use djls_ide::PrimedTemplateLibraries;
 use djls_ide::WarmCachePart;
 use djls_ide::WarmCachePhase;
-use djls_ide::collect_diagnostics;
+use djls_ide::collect_diagnostics_with_encoding;
 use djls_ide::prime_template_library_products;
 use djls_ide::warm_cache_phases;
 use djls_project::Db as ProjectDb;
@@ -999,7 +999,11 @@ async fn collect_snapshot_diagnostics(
         let joined = spawn_blocking(move || {
             Cancelled::catch(AssertUnwindSafe(|| {
                 let file = path_to_file(snapshot.db(), &path).ok()?;
-                collect_diagnostics(snapshot.db(), file)
+                collect_diagnostics_with_encoding(
+                    snapshot.db(),
+                    file,
+                    snapshot.client_info().position_encoding(),
+                )
             }))
         })
         .await;

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -110,7 +110,7 @@ impl DjangoLanguageServer {
         let Some(diagnostics) = self
             .with_ready_snapshot(move |snapshot| {
                 let file = path_to_file(snapshot.db(), &path).ok()?;
-                djls_ide::collect_diagnostics_with_encoding(
+                djls_ide::collect_diagnostics(
                     snapshot.db(),
                     file,
                     snapshot.client_info().position_encoding(),
@@ -499,7 +499,7 @@ impl LanguageServer for DjangoLanguageServer {
                     return Vec::new();
                 };
 
-                djls_ide::collect_diagnostics_with_encoding(
+                djls_ide::collect_diagnostics(
                     snapshot.db(),
                     file,
                     snapshot.client_info().position_encoding(),

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -110,7 +110,11 @@ impl DjangoLanguageServer {
         let Some(diagnostics) = self
             .with_ready_snapshot(move |snapshot| {
                 let file = path_to_file(snapshot.db(), &path).ok()?;
-                djls_ide::collect_diagnostics(snapshot.db(), file)
+                djls_ide::collect_diagnostics_with_encoding(
+                    snapshot.db(),
+                    file,
+                    snapshot.client_info().position_encoding(),
+                )
             })
             .await
         else {
@@ -466,7 +470,12 @@ impl LanguageServer for DjangoLanguageServer {
                     return None;
                 }
 
-                djls_ide::hover(db, file, offset)
+                djls_ide::hover(
+                    db,
+                    file,
+                    offset,
+                    snapshot.client_info().position_encoding(),
+                )
             })
             .await;
 
@@ -490,7 +499,12 @@ impl LanguageServer for DjangoLanguageServer {
                     return Vec::new();
                 };
 
-                djls_ide::collect_diagnostics(snapshot.db(), file).unwrap_or_default()
+                djls_ide::collect_diagnostics_with_encoding(
+                    snapshot.db(),
+                    file,
+                    snapshot.client_info().position_encoding(),
+                )
+                .unwrap_or_default()
             })
             .await;
 
@@ -550,7 +564,11 @@ impl LanguageServer for DjangoLanguageServer {
                     return Vec::new();
                 }
 
-                djls_ide::document_symbols(db, file)
+                djls_ide::document_symbols(
+                    db,
+                    file,
+                    snapshot.client_info().position_encoding(),
+                )
             })
             .await;
 
@@ -575,7 +593,11 @@ impl LanguageServer for DjangoLanguageServer {
                     return Vec::new();
                 }
 
-                djls_ide::document_links(db, file)
+                djls_ide::document_links(
+                    db,
+                    file,
+                    snapshot.client_info().position_encoding(),
+                )
             })
             .await;
 

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io::Read as _;
 use std::io::Result as IoResult;
 use std::io::Write as _;
@@ -24,6 +25,7 @@ use djls_project::ProjectFactsData;
 use djls_project::run_django_discovery;
 use djls_source::CaseSensitivity;
 use djls_source::DiagnosticRenderer;
+use djls_source::FileError;
 use djls_source::FileSystem;
 use djls_source::OsFileSystem;
 use djls_source::RootWalk;
@@ -101,10 +103,15 @@ impl CheckInput {
         db: &DjangoDatabase,
         project_root: &Utf8Path,
         walk_options: &WalkOptions,
-    ) -> Vec<Utf8PathBuf> {
+    ) -> Result<Vec<Utf8PathBuf>> {
         match self {
-            Self::Files { .. } => discover_files(requested_paths, db, project_root, walk_options),
-            Self::Stdin { path, .. } => vec![path.clone()],
+            Self::Files { .. } => Ok(discover_files(
+                requested_paths,
+                db,
+                project_root,
+                walk_options,
+            )?),
+            Self::Stdin { path, .. } => Ok(vec![path.clone()]),
         }
     }
 
@@ -194,7 +201,7 @@ impl Command for Check {
             follow_links: self.follow,
             max_depth: self.max_depth,
         };
-        let files = input.files(&self.paths, &db, &project_root, &walk_options);
+        let files = input.files(&self.paths, &db, &project_root, &walk_options)?;
         if files.is_empty() {
             return Ok(Exit::success());
         }
@@ -263,6 +270,24 @@ fn report_results(
     Ok(Exit::error().with_message(message))
 }
 
+#[derive(Debug)]
+struct TemplateIndexError {
+    path: Utf8PathBuf,
+    source: FileError,
+}
+
+impl fmt::Display for TemplateIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cannot index Template path `{}`", self.path)
+    }
+}
+
+impl std::error::Error for TemplateIndexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 /// Validate paths with the same per-clone Rayon execution used by the batch CLI.
 fn check_files_parallel(
     db: DjangoDatabase,
@@ -277,23 +302,21 @@ fn check_files_parallel(
             let db = db.clone();
             let tx = tx.clone();
             scope.spawn(move |_| {
-                let Ok(file) = path_to_file(&db, &path) else {
-                    return;
-                };
-                match check_template(&db, file) {
-                    Ok(result) if result.has_diagnostics() => {
-                        drop(tx.send(Ok(result)));
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        drop(tx.send(Err(error.into())));
-                    }
-                }
+                let result = (|| -> Result<Option<CheckedTemplate>> {
+                    let file = path_to_file(&db, &path).map_err(|source| TemplateIndexError {
+                        path: path.clone(),
+                        source,
+                    })?;
+                    let checked = check_template(&db, file)?;
+                    Ok(checked.has_diagnostics().then_some(checked))
+                })();
+                drop(tx.send(result));
             });
         }
     });
 
-    rx.into_iter().collect()
+    let checked: Vec<Option<CheckedTemplate>> = rx.into_iter().collect::<Result<_>>()?;
+    Ok(checked.into_iter().flatten().collect())
 }
 
 struct SingleFileOverlay {
@@ -375,6 +398,7 @@ fn pick_renderer(color: ColorMode) -> DiagnosticRenderer {
 #[cfg(test)]
 mod tests {
     use djls_project::EnvironmentPhase;
+    use djls_source::InMemoryFileSystem;
 
     use super::*;
 
@@ -400,5 +424,27 @@ mod tests {
             .expect_err("check should require a configured Project");
 
         assert_eq!(error.to_string(), "No Project configured for check");
+    }
+
+    #[test]
+    fn indexing_failure_reaches_batch_check_caller() {
+        let db = DjangoDatabase::new(
+            Arc::new(InMemoryFileSystem::new()),
+            &Settings::default(),
+            None,
+        );
+        let path = Utf8PathBuf::from("/project/disappeared.html");
+
+        let error = check_files_parallel(db, vec![path.clone()])
+            .err()
+            .expect("a Template that disappeared before indexing should fail the check");
+
+        assert_eq!(
+            error.chain().map(ToString::to_string).collect::<Vec<_>>(),
+            [
+                format!("Cannot index Template path `{path}`"),
+                "Not found".to_owned(),
+            ]
+        );
     }
 }

--- a/crates/djls/src/commands/common.rs
+++ b/crates/djls/src/commands/common.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+use std::io;
 use std::io::IsTerminal;
 
 use anyhow::Context;
@@ -35,19 +37,59 @@ impl ColorMode {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum FileDiscoveryError {
+    Missing(Utf8PathBuf),
+    Inaccessible {
+        path: Utf8PathBuf,
+        kind: io::ErrorKind,
+    },
+}
+
+impl fmt::Display for FileDiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing(path) => write!(f, "Cannot check `{path}`: path does not exist"),
+            Self::Inaccessible { path, kind } => {
+                write!(f, "Cannot check `{path}`: {}", io::Error::from(*kind))
+            }
+        }
+    }
+}
+
+impl std::error::Error for FileDiscoveryError {}
+
 pub(crate) fn discover_files(
     paths: &[Utf8PathBuf],
     db: &DjangoDatabase,
     project_root: &Utf8Path,
     options: &WalkOptions,
-) -> Vec<Utf8PathBuf> {
+) -> std::result::Result<Vec<Utf8PathBuf>, FileDiscoveryError> {
     let roots = discovery_roots(paths, db, project_root);
+    let explicit = !paths.is_empty();
 
     let mut files = Vec::new();
     for path in &roots {
         let entries = match db.walk_root(path, options) {
             RootWalk::File(entry) => vec![entry],
-            RootWalk::Directory { entries, .. } => entries,
+            RootWalk::Directory { entries, issues } => {
+                if explicit && let Some(kind) = issues.into_iter().next() {
+                    return Err(FileDiscoveryError::Inaccessible {
+                        path: path.clone(),
+                        kind,
+                    });
+                }
+                entries
+            }
+            RootWalk::Missing if explicit => {
+                return Err(FileDiscoveryError::Missing(path.clone()));
+            }
+            RootWalk::Inaccessible(kind) if explicit => {
+                return Err(FileDiscoveryError::Inaccessible {
+                    path: path.clone(),
+                    kind,
+                });
+            }
             RootWalk::Missing | RootWalk::Inaccessible(_) => continue,
         };
         for entry in entries {
@@ -69,7 +111,7 @@ pub(crate) fn discover_files(
 
     files.sort();
     files.dedup();
-    files
+    Ok(files)
 }
 
 /// Selects the directories a batch command enumerates templates from.
@@ -127,9 +169,46 @@ mod tests {
     use std::sync::Arc;
 
     use djls_conf::Settings;
+    use djls_source::CaseSensitivity;
+    use djls_source::FileSystem;
     use djls_source::OsFileSystem;
 
     use super::*;
+
+    struct InaccessibleDirectoryFileSystem;
+
+    impl FileSystem for InaccessibleDirectoryFileSystem {
+        fn read_to_string(&self, _path: &Utf8Path) -> io::Result<String> {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        }
+
+        fn exists(&self, _path: &Utf8Path) -> bool {
+            true
+        }
+
+        fn is_file(&self, _path: &Utf8Path) -> bool {
+            false
+        }
+
+        fn is_dir(&self, _path: &Utf8Path) -> bool {
+            true
+        }
+
+        fn case_sensitivity(&self) -> CaseSensitivity {
+            CaseSensitivity::CaseSensitive
+        }
+
+        fn path_exists_case_sensitive(&self, _path: &Utf8Path, _prefix: &Utf8Path) -> bool {
+            true
+        }
+
+        fn walk_root(&self, _root: &Utf8Path, _options: &WalkOptions) -> RootWalk {
+            RootWalk::Directory {
+                entries: Vec::new(),
+                issues: vec![io::ErrorKind::PermissionDenied],
+            }
+        }
+    }
 
     fn project_database(project_root: &Utf8Path) -> anyhow::Result<DjangoDatabase> {
         let settings = Settings::new(project_root, None)?;
@@ -226,7 +305,8 @@ mod tests {
             &db,
             &dir_path,
             &WalkOptions::default(),
-        );
+        )
+        .expect("explicit Template directory should be discovered");
         let names: Vec<_> = files.iter().filter_map(|path| path.file_name()).collect();
 
         assert!(names.contains(&"page.html"));
@@ -253,7 +333,8 @@ mod tests {
             &db,
             &dir_path,
             &WalkOptions::default(),
-        );
+        )
+        .expect("explicit Template file should be discovered");
 
         let canonical = Utf8PathBuf::from_path_buf(
             file_path
@@ -285,9 +366,81 @@ mod tests {
             &db,
             &dir_path,
             &WalkOptions::default(),
-        );
+        )
+        .expect("explicit Template paths should be discovered");
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].file_name(), Some("page.html"));
+    }
+
+    #[test]
+    fn missing_explicit_path_is_an_error() {
+        let db = DjangoDatabase::new(
+            Arc::new(OsFileSystem::default()),
+            &Settings::default(),
+            None,
+        );
+        let dir = tempfile::tempdir().expect("temporary test directory should be created");
+        let project_root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
+            .expect("temporary test path should be valid UTF-8");
+        let missing = project_root.join("missing.html");
+
+        let error = discover_files(
+            std::slice::from_ref(&missing),
+            &db,
+            &project_root,
+            &WalkOptions::default(),
+        )
+        .expect_err("a missing explicit path should fail discovery");
+
+        assert_eq!(error, FileDiscoveryError::Missing(missing.clone()));
+        assert_eq!(
+            error.to_string(),
+            format!("Cannot check `{missing}`: path does not exist")
+        );
+    }
+
+    #[test]
+    fn inaccessible_explicit_directory_is_an_error() {
+        let db = DjangoDatabase::new(
+            Arc::new(InaccessibleDirectoryFileSystem),
+            &Settings::default(),
+            None,
+        );
+        let project_root = Utf8Path::new("/project");
+        let inaccessible = Utf8PathBuf::from("/project/templates");
+
+        let error = discover_files(
+            std::slice::from_ref(&inaccessible),
+            &db,
+            project_root,
+            &WalkOptions::default(),
+        )
+        .expect_err("an inaccessible explicit directory should fail discovery");
+
+        assert_eq!(
+            error,
+            FileDiscoveryError::Inaccessible {
+                path: inaccessible,
+                kind: io::ErrorKind::PermissionDenied,
+            }
+        );
+    }
+
+    #[test]
+    fn missing_implicit_root_produces_empty_discovery() {
+        let db = DjangoDatabase::new(
+            Arc::new(OsFileSystem::default()),
+            &Settings::default(),
+            None,
+        );
+        let dir = tempfile::tempdir().expect("temporary test directory should be created");
+        let project_root = Utf8PathBuf::from_path_buf(dir.path().join("missing-project"))
+            .expect("temporary test path should be valid UTF-8");
+
+        let files = discover_files(&[], &db, &project_root, &WalkOptions::default())
+            .expect("a missing implicit root should be an empty discovery");
+
+        assert!(files.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- honor negotiated LSP position encodings for all range-bearing IDE responses
- fail `djls check` when explicit inputs cannot be discovered or indexed
- redact malformed env-file contents from logs
- require release tags to match both Python and Cargo package versions

## Validation

- `cargo test -q`
- `just clippy`
- `just fmt --check`
- `just lint`
- release preflight shell check