### PR TITLE
fix: describe djls in CLI help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+
+### Fixed
+
+- Fixed `djls --help` to describe django-language-server instead of its CLI implementation.
 
 ## [6.1.0]
 

--- a/crates/djls/src/cli.rs
+++ b/crates/djls/src/cli.rs
@@ -6,7 +6,7 @@ use crate::commands::Command;
 use crate::commands::DjlsCommand;
 use crate::exit::Exit;
 
-/// Main CLI structure that defines the command-line interface
+/// A language server for the Django web framework.
 #[derive(Parser)]
 #[command(name = "djls")]
 #[command(version, about)]


### PR DESCRIPTION
## Summary

Replace the implementation-oriented `djls --help` description with the project tagline used by the README.

## Verification

- `cargo run -q -p djls -- --help`
- `just fmt`
- `just clippy`
- `just lint`