### PR TITLE
fix: scope quiet output to checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Scoped `--quiet` output suppression to `djls check`.
 
 ## [6.1.0]
 

--- a/crates/djls/src/args.rs
+++ b/crates/djls/src/args.rs
@@ -2,11 +2,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct Args {
-    /// Do not print any output.
-    #[arg(global = true, long, short, conflicts_with = "verbose")]
-    pub quiet: bool,
-
     /// Use verbose output.
-    #[arg(global = true, action = clap::ArgAction::Count, long, short, conflicts_with = "quiet")]
+    #[arg(global = true, action = clap::ArgAction::Count, long, short)]
     pub verbose: u8,
 }

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -130,7 +130,15 @@ enum SummaryStyle {
 }
 
 #[derive(Debug, Parser)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "these booleans represent independent CLI flags"
+)]
 pub(crate) struct Check {
+    /// Do not print diagnostics or a summary.
+    #[arg(long, short, conflicts_with = "verbose")]
+    quiet: bool,
+
     /// Template files or directories to check. Pass `-` to read stdin; stdin is
     /// analyzed as a generic Template in the current Project; stdin cannot be
     /// combined with paths. If omitted, discovers Template directories from the
@@ -181,14 +189,14 @@ fn require_configured_discovery(
 }
 
 impl Command for Check {
-    fn execute(&self, args: &Args) -> Result<Exit> {
+    fn execute(&self, _args: &Args) -> Result<Exit> {
         let project_root = resolve_project_root()?;
         let settings = Settings::new(&project_root, None).context("Failed to load settings")?;
         let input = CheckInput::collect(&self.paths)?;
 
         let config = build_diagnostics_config(&settings, &self.select, &self.ignore);
         let fmt = pick_renderer(self.color);
-        let quiet = args.quiet;
+        let quiet = self.quiet;
 
         let mut db = DjangoDatabase::new(input.file_system(), &settings, Some(&project_root));
         db.apply_project_settings(settings);


### PR DESCRIPTION
## Summary

Move `--quiet` from the global CLI arguments to `djls check`, the command that implements output suppression. `djls serve --help` no longer advertises an option it ignores.

## Verification

- `cargo test -q -p djls --test check check_quiet`
- inspected root, check, and serve help output
- `just fmt`
- `just clippy`
- `just lint`