### PR TITLE
docs: clarify check input help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Clarified how `djls check -` selects template libraries for standard input.
 
 ## [6.1.0]
 

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -132,9 +132,9 @@ enum SummaryStyle {
 #[derive(Debug, Parser)]
 pub(crate) struct Check {
     /// Template files or directories to check. Pass `-` to read stdin; stdin is
-    /// analyzed as a generic Template in the current Project; stdin cannot be
-    /// combined with paths. If omitted, discovers Template directories from the
-    /// Django project.
+    /// checked using template libraries from the whole Django project and cannot
+    /// be combined with paths. If omitted, checks the template directories found
+    /// in Django settings.
     paths: Vec<Utf8PathBuf>,
 
     /// Select specific diagnostic codes to enable (e.g. S100,S101).

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -509,7 +509,7 @@ fn check_multi_backend_stdin_uses_inventory_while_concrete_path_uses_backend() {
 }
 
 #[test]
-fn check_help_describes_generic_stdin_template() {
+fn check_help_describes_stdin_project_context() {
     let output = Command::new(djls_binary())
         .args(["check", "--help"])
         .output()
@@ -519,11 +519,12 @@ fn check_help_describes_generic_stdin_template() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let normalized = stdout.split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
-        normalized.contains("stdin is analyzed as a generic Template in the current Project"),
+        normalized
+            .contains("stdin is checked using template libraries from the whole Django project"),
         "{stdout}"
     );
     assert!(
-        normalized.contains("stdin cannot be combined with paths"),
+        normalized.contains("cannot be combined with paths"),
         "{stdout}"
     );
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,7 @@ Run the command from the Django project root so it can load `djls.toml`, `.djls.
 | No path | Check templates in the directories discovered from Django settings |
 | File paths | Check the named template files |
 | Directory paths | Recursively check supported template files below those directories |
-| `-` | Read one template from standard input; cannot be combined with paths |
+| `-` | Read one template from standard input using template libraries from the whole Django project; cannot be combined with paths |
 
 File and directory scans recognize `.html`, `.htm`, and `.djhtml` files.
 


### PR DESCRIPTION
## Summary

Describe standard-input checking in user terms. The help now explains that stdin uses template libraries from the whole Django project without exposing the internal synthetic Template model.

## Verification

- targeted `check --help` integration test
- inspected `djls check --help`
- `just fmt`
- `just clippy`
- `just lint`