### PR TITLE
docs: describe diagnostic selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Documented diagnostic prefix selectors for `djls check --select` and `--ignore`.
 
 ## [6.1.0]
 

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -137,11 +137,13 @@ pub(crate) struct Check {
     /// Django project.
     paths: Vec<Utf8PathBuf>,
 
-    /// Select specific diagnostic codes to enable (e.g. S100,S101).
+    /// Set matching diagnostics to error, overriding project settings. Accepts
+    /// codes or prefixes (for example, S100,S2,T).
     #[arg(long, value_delimiter = ',')]
     select: Vec<String>,
 
-    /// Ignore specific diagnostic codes (e.g. S108,S109).
+    /// Disable matching diagnostics, overriding project settings. Accepts codes
+    /// or prefixes (for example, S108,S1,T).
     #[arg(long, value_delimiter = ',')]
     ignore: Vec<String>,
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,8 +38,8 @@ printf '{{ value|default }}' | djls check -
 
 | Option | Meaning |
 |---|---|
-| `--select CODE,...` | Enable the named diagnostic codes, overriding project configuration |
-| `--ignore CODE,...` | Disable the named diagnostic codes |
+| `--select SELECTOR,...` | Set matching diagnostics to error, overriding project settings |
+| `--ignore SELECTOR,...` | Disable matching diagnostics, overriding project settings |
 | `-g, --glob PATTERN` | Include or exclude matching files; prefix exclusions with `!`; later patterns win |
 | `-., --hidden` | Include hidden files and directories |
 | `--no-ignore` | Do not read `.gitignore`, `.ignore`, and related ignore files |
@@ -47,6 +47,8 @@ printf '{{ value|default }}' | djls check -
 | `-d, --max-depth DEPTH` | Limit directory traversal depth |
 | `--color always\|auto\|never` | Control colored diagnostic output |
 | `-q, --quiet` | Suppress output and report the result through the exit status |
+
+A diagnostic selector may be a full code such as `S100` or a prefix such as `S1` or `S`. More specific selectors take precedence.
 
 `djls check` exits with status 0 when no enabled diagnostics are found and status 1 when diagnostics or a command error occur. Run `djls check --help` for the command's full help text.
 


### PR DESCRIPTION
## Summary

Document that `djls check --select` and `--ignore` accept diagnostic prefixes as well as full codes, override project settings, and use the most specific match.

## Verification

- inspected `djls check --help`
- `just fmt`
- `just clippy`
- `just lint`