### PR TITLE
docs: clarify color output option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Clarified the `djls check --color` help text.
 
 ## [6.1.0]
 

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -167,7 +167,7 @@ pub(crate) struct Check {
     #[arg(short = 'd', long)]
     max_depth: Option<usize>,
 
-    /// When to use colors.
+    /// Control when diagnostic output uses color.
     #[arg(long, value_enum, default_value_t = ColorMode::Auto)]
     color: ColorMode,
 }


### PR DESCRIPTION
## Summary

Clarify that `djls check --color` controls color in rendered diagnostic output.

## Verification

- inspected `djls check --help`
- `just fmt`
- `just clippy`
- `just lint`