### PR TITLE
fix: describe check findings as diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Described `djls check` findings as diagnostics instead of errors.
 
 ## [6.1.0]
 

--- a/crates/djls/src/commands.rs
+++ b/crates/djls/src/commands.rs
@@ -14,7 +14,7 @@ pub(crate) trait Command {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum DjlsCommand {
-    /// Check Django template files for errors
+    /// Check Django template files for diagnostics
     Check(self::check::Check),
     /// Start the LSP server
     Serve(self::serve::Serve),

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -225,7 +225,7 @@ fn report_results(
 ) -> Result<Exit> {
     results.sort_by(|left, right| left.path().cmp(right.path()));
 
-    let mut error_count = 0;
+    let mut diagnostic_count = 0;
     let mut file_count = 0;
     let stdout = stdout();
     let mut stdout = stdout.lock();
@@ -235,7 +235,7 @@ fn report_results(
             let count = result.renderable_diagnostic_count(config);
             if count > 0 {
                 file_count += 1;
-                error_count += count;
+                diagnostic_count += count;
             }
             continue;
         }
@@ -246,26 +246,30 @@ fn report_results(
         }
 
         file_count += 1;
-        error_count += rendered.len();
+        diagnostic_count += rendered.len();
         for output in rendered {
             writeln!(stdout, "{output}\n")?;
         }
     }
 
-    if error_count == 0 {
+    if diagnostic_count == 0 {
         return Ok(Exit::success());
     }
     if quiet {
         return Ok(Exit::error());
     }
 
-    let error_word = if error_count == 1 { "error" } else { "errors" };
+    let diagnostic_word = if diagnostic_count == 1 {
+        "diagnostic"
+    } else {
+        "diagnostics"
+    };
     let message = match summary_style {
         SummaryStyle::Files => {
             let file_word = if file_count == 1 { "file" } else { "files" };
-            format!("Found {error_count} {error_word} in {file_count} {file_word}.")
+            format!("Found {diagnostic_count} {diagnostic_word} in {file_count} {file_word}.")
         }
-        SummaryStyle::Stdin => format!("Found {error_count} {error_word}."),
+        SummaryStyle::Stdin => format!("Found {diagnostic_count} {diagnostic_word}."),
     };
     Ok(Exit::error().with_message(message))
 }

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -267,7 +267,7 @@ fn check_broken_template_exits_one() {
     );
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Found 1 error in 1 file.\n"
+        "Found 1 diagnostic in 1 file.\n"
     );
 }
 
@@ -292,7 +292,7 @@ fn check_plural_path_summary_reports_errors_and_files_exactly() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Found 2 errors in 2 files.\n"
+        "Found 2 diagnostics in 2 files.\n"
     );
 }
 
@@ -318,7 +318,7 @@ fn check_plural_errors_with_singular_file_summary_exactly() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
-        "Found 2 errors in 1 file.\n"
+        "Found 2 diagnostics in 1 file.\n"
     );
 }
 
@@ -420,7 +420,10 @@ fn check_stdin_detects_errors() {
         stdout.contains("S100"),
         "Expected S100 in stdin output:\n{stdout}"
     );
-    assert_eq!(String::from_utf8_lossy(&output.stderr), "Found 1 error.\n");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Found 1 diagnostic.\n"
+    );
 }
 
 #[test]
@@ -449,7 +452,10 @@ fn check_plural_stdin_summary_reports_errors_exactly() {
         .expect("djls check process should finish");
 
     assert_eq!(output.status.code(), Some(1));
-    assert_eq!(String::from_utf8_lossy(&output.stderr), "Found 2 errors.\n");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Found 2 diagnostics.\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Use “diagnostic” in `djls check` help and summaries because enabled findings may be configured as errors, warnings, info, or hints. Counts and exit behavior stay unchanged.

## Verification

- `cargo test -q -p djls --test check` (20 passed)
- `just fmt`
- `just clippy`
- `just lint`