### PR TITLE
docs: shorten terminal server warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Shortened the warning shown when `djls serve` runs directly in a terminal.
 
 ## [6.1.0]
 

--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -21,15 +21,9 @@ use crate::server::DjangoLanguageServer;
 /// Run the Django language server.
 pub fn run() -> Result<()> {
     if std::io::stdin().is_terminal() {
-        eprintln!("Django Language Server is running directly in a terminal.");
-        eprintln!(
-            "This server is designed to communicate over stdin/stdout with a language client."
-        );
-        eprintln!("It is not intended to be used directly in a terminal.");
-        eprintln!();
-        eprintln!("The server is now waiting for LSP messages, but no editor is connected.");
-        eprintln!("To exit: press ENTER to send invalid input and trigger an error exit.");
-        eprintln!("Ctrl+C may not work as expected due to LSP stdio communication.");
+        eprintln!("`djls serve` communicates with an editor over standard input and output.");
+        eprintln!("No editor is connected; waiting for LSP messages.");
+        eprintln!("Press Enter to stop the server. Ctrl+C may not work with LSP stdio.");
     }
 
     let runtime = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
## Summary

Reduce the direct-terminal `djls serve` warning from seven lines to three while retaining the transport explanation, waiting state, and exit guidance.

## Verification

- `cargo test -q -p djls-server` (77 passed)
- `just fmt`
- `just clippy`
- `just lint`