### PR TITLE
fix: reject unsupported check files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Changed `djls check` to reject explicit files with unsupported extensions.
 
 ## [6.1.0]
 

--- a/crates/djls/src/commands/common.rs
+++ b/crates/djls/src/commands/common.rs
@@ -40,6 +40,7 @@ impl ColorMode {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum FileDiscoveryError {
     Missing(Utf8PathBuf),
+    UnsupportedFile(Utf8PathBuf),
     Inaccessible {
         path: Utf8PathBuf,
         kind: io::ErrorKind,
@@ -50,6 +51,10 @@ impl fmt::Display for FileDiscoveryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Missing(path) => write!(f, "Cannot check `{path}`: path does not exist"),
+            Self::UnsupportedFile(path) => write!(
+                f,
+                "Cannot check `{path}`: expected a .html, .htm, or .djhtml file"
+            ),
             Self::Inaccessible { path, kind } => {
                 write!(f, "Cannot check `{path}`: {}", io::Error::from(*kind))
             }
@@ -71,7 +76,12 @@ pub(crate) fn discover_files(
     let mut files = Vec::new();
     for path in &roots {
         let entries = match db.walk_root(path, options) {
-            RootWalk::File(entry) => vec![entry],
+            RootWalk::File(entry) => {
+                if explicit && !is_template(&entry.path) {
+                    return Err(FileDiscoveryError::UnsupportedFile(entry.path));
+                }
+                vec![entry]
+            }
             RootWalk::Directory { entries, issues } => {
                 if explicit && let Some(kind) = issues.into_iter().next() {
                     return Err(FileDiscoveryError::Inaccessible {
@@ -344,6 +354,38 @@ mod tests {
         )
         .expect("canonical test fixture path should be valid UTF-8");
         assert_eq!(files, vec![canonical]);
+    }
+
+    #[test]
+    fn rejects_explicit_files_with_unsupported_types() {
+        let dir = tempfile::tempdir().expect("temporary test directory should be created");
+        let project_root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
+            .expect("temporary test path should be valid UTF-8");
+        let db = DjangoDatabase::new(
+            Arc::new(OsFileSystem::default()),
+            &Settings::default(),
+            None,
+        );
+
+        for name in ["style.css", "README"] {
+            let path = project_root.join(name);
+            std::fs::write(path.as_std_path(), "not a Template")
+                .expect("unsupported test file should be written");
+
+            let error = discover_files(
+                std::slice::from_ref(&path),
+                &db,
+                &project_root,
+                &WalkOptions::default(),
+            )
+            .expect_err("an explicit non-Template file should fail discovery");
+
+            assert_eq!(error, FileDiscoveryError::UnsupportedFile(path.clone()));
+            assert_eq!(
+                error.to_string(),
+                format!("Cannot check `{path}`: expected a .html, .htm, or .djhtml file")
+            );
+        }
     }
 
     #[test]

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -680,6 +680,30 @@ fn check_explicit_paths_take_precedence_over_known_roots() {
 }
 
 #[test]
+fn check_rejects_an_explicit_file_with_an_unsupported_type() {
+    let dir = tempfile::tempdir().expect("temporary test directory should be created");
+    setup_project(dir.path()).expect("test project fixture should be configured");
+    std::fs::write(dir.path().join("style.css"), "body {}")
+        .expect("unsupported test file should be written");
+
+    let output = Command::new(djls_binary())
+        .args(["check", "style.css"])
+        .current_dir(dir.path())
+        .output()
+        .expect("djls check process should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Cannot check `{}`: expected a .html, .htm, or .djhtml file\n",
+            dir.path().join("style.css").display()
+        )
+    );
+}
+
+#[test]
 fn check_no_templates_exits_zero() {
     let dir = tempfile::tempdir().expect("temporary test directory should be created");
     setup_project(dir.path()).expect("test project fixture should be configured");


### PR DESCRIPTION
## Summary

Reject explicit files that `djls check` cannot classify as Django templates instead of silently filtering them and returning a clean result. Empty directories remain successful.

## Verification

- unit coverage for extension and extensionless files
- CLI integration test for the error and exit status
- `just fmt`
- `just clippy`
- `just lint`