### PR TITLE
fix: reject invalid check globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
+- Changed `djls check --glob` to reject invalid patterns instead of ignoring them.
 
 ## [6.1.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "djls-source",
  "djls-templates",
  "dunce",
+ "ignore",
  "rayon",
  "tempfile",
 ]

--- a/crates/djls/Cargo.toml
+++ b/crates/djls/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true }
 dunce = { workspace = true }
+ignore = { workspace = true }
 rayon = { workspace = true }
 
 [dev-dependencies]

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -152,7 +152,7 @@ pub(crate) struct Check {
     /// Include or exclude files matching a glob pattern. Prefix with `!` to
     /// exclude. May be specified multiple times. Later patterns take
     /// precedence.
-    #[arg(short = 'g', long = "glob")]
+    #[arg(short = 'g', long = "glob", value_parser = parse_glob)]
     globs: Vec<String>,
 
     /// Don't respect ignore files (.gitignore, .ignore, etc.).
@@ -170,6 +170,12 @@ pub(crate) struct Check {
     /// When to use colors.
     #[arg(long, value_enum, default_value_t = ColorMode::Auto)]
     color: ColorMode,
+}
+
+fn parse_glob(value: &str) -> std::result::Result<String, String> {
+    let mut overrides = ignore::overrides::OverrideBuilder::new(".");
+    overrides.add(value).map_err(|error| error.to_string())?;
+    Ok(value.to_owned())
 }
 
 fn require_configured_discovery(

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -680,6 +680,20 @@ fn check_explicit_paths_take_precedence_over_known_roots() {
 }
 
 #[test]
+fn check_rejects_an_invalid_glob() {
+    let output = Command::new(djls_binary())
+        .args(["check", "--glob", "["])
+        .output()
+        .expect("djls check process should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid value '[' for '--glob <GLOBS>'"));
+    assert!(stderr.contains("unclosed character class"));
+}
+
+#[test]
 fn check_no_templates_exits_zero() {
     let dir = tempfile::tempdir().expect("temporary test directory should be created");
     setup_project(dir.path()).expect("test project fixture should be configured");


### PR DESCRIPTION
## Summary

Validate `djls check --glob` values during CLI parsing with the same override syntax used during traversal. Invalid patterns now exit 2 with the parser reason instead of being silently ignored.

## Verification

- CLI integration test for an unclosed character class
- `just fmt`
- `just clippy`
- `just lint`