### PR TITLE
feat: wire CLI verbosity levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added debug and trace logging through `djls -v` and `djls -vv`.
+
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "dunce",
  "rayon",
  "tempfile",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -18,8 +18,20 @@ use tower_lsp_server::Server;
 
 use crate::server::DjangoLanguageServer;
 
+/// Requested server log detail.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LogVerbosity {
+    /// Use `RUST_LOG`, defaulting to info.
+    #[default]
+    Default,
+    /// Include debug events.
+    Debug,
+    /// Include trace events in the server log file.
+    Trace,
+}
+
 /// Run the Django language server.
-pub fn run() -> Result<()> {
+pub fn run(verbosity: LogVerbosity) -> Result<()> {
     if std::io::stdin().is_terminal() {
         eprintln!("Django Language Server is running directly in a terminal.");
         eprintln!(
@@ -41,15 +53,18 @@ pub fn run() -> Result<()> {
         let stdout = tokio::io::stdout();
 
         let (service, socket) = LspService::build(|client| {
-            let logging = logging::init_tracing({
-                let client = client.clone();
-                move |message_type, message| {
+            let logging = logging::init_tracing(
+                {
                     let client = client.clone();
-                    tokio::spawn(async move {
-                        client.log_message(message_type, message).await;
-                    });
-                }
-            });
+                    move |message_type, message| {
+                        let client = client.clone();
+                        tokio::spawn(async move {
+                            client.log_message(message_type, message).await;
+                        });
+                    }
+                },
+                verbosity,
+            );
 
             DjangoLanguageServer::new(client, logging)
         })

--- a/crates/djls-server/src/logging.rs
+++ b/crates/djls-server/src/logging.rs
@@ -24,9 +24,12 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::LogVerbosity;
 
 /// A tracing Layer that forwards events to the LSP client.
 ///
@@ -136,11 +139,17 @@ impl LoggingGuard {
 /// - `EnvFilter`: respects `RUST_LOG` env var, defaults to "info"
 ///
 /// Returns a [`LoggingGuard`] that must be kept alive for the logging to work.
-pub(crate) fn init_tracing<F>(send_message: F) -> LoggingGuard
+pub(crate) fn init_tracing<F>(send_message: F, verbosity: LogVerbosity) -> LoggingGuard
 where
     F: Fn(ls_types::MessageType, String) + Send + Sync + 'static,
 {
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = match verbosity {
+        LogVerbosity::Default => {
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+        }
+        LogVerbosity::Debug => EnvFilter::new("debug"),
+        LogVerbosity::Trace => EnvFilter::new("trace"),
+    };
 
     let (non_blocking, guard) = match djls_conf::log_dir() {
         Ok(log_dir) => {
@@ -166,7 +175,11 @@ where
 
     let lsp_layer = LspLayer::new(send_message);
     let lsp_disabled = Arc::clone(&lsp_layer.disabled);
-    let lsp_layer = lsp_layer.with_filter(tracing_subscriber::filter::LevelFilter::INFO);
+    let lsp_level = match verbosity {
+        LogVerbosity::Default => LevelFilter::INFO,
+        LogVerbosity::Debug | LogVerbosity::Trace => LevelFilter::DEBUG,
+    };
+    let lsp_layer = lsp_layer.with_filter(lsp_level);
 
     Registry::default().with(log_layer).with(lsp_layer).init();
 

--- a/crates/djls/Cargo.toml
+++ b/crates/djls/Cargo.toml
@@ -18,6 +18,7 @@ camino = { workspace = true }
 clap = { workspace = true }
 dunce = { workspace = true }
 rayon = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/djls/src/args.rs
+++ b/crates/djls/src/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use djls_server::LogVerbosity;
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct Args {
@@ -6,7 +7,17 @@ pub(crate) struct Args {
     #[arg(global = true, long, short, conflicts_with = "verbose")]
     pub quiet: bool,
 
-    /// Use verbose output.
+    /// Increase log verbosity. Use `-v` for debug and `-vv` for trace.
     #[arg(global = true, action = clap::ArgAction::Count, long, short, conflicts_with = "quiet")]
-    pub verbose: u8,
+    verbose: u8,
+}
+
+impl Args {
+    pub(crate) fn log_verbosity(&self) -> LogVerbosity {
+        match self.verbose {
+            0 => LogVerbosity::Default,
+            1 => LogVerbosity::Debug,
+            2.. => LogVerbosity::Trace,
+        }
+    }
 }

--- a/crates/djls/src/commands/check.rs
+++ b/crates/djls/src/commands/check.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io::Read as _;
 use std::io::Result as IoResult;
 use std::io::Write as _;
+use std::io::stderr;
 use std::io::stdin;
 use std::io::stdout;
 use std::sync::Arc;
@@ -23,6 +24,7 @@ use djls_ide::prepare_project_template_analysis;
 use djls_project::EnvironmentAssemblyError;
 use djls_project::ProjectFactsData;
 use djls_project::run_django_discovery;
+use djls_server::LogVerbosity;
 use djls_source::CaseSensitivity;
 use djls_source::DiagnosticRenderer;
 use djls_source::FileError;
@@ -32,6 +34,7 @@ use djls_source::RootWalk;
 use djls_source::WalkOptions;
 use djls_source::path_to_file;
 use rayon::scope;
+use tracing_subscriber::EnvFilter;
 
 use crate::args::Args;
 use crate::commands::Command;
@@ -172,6 +175,19 @@ pub(crate) struct Check {
     color: ColorMode,
 }
 
+fn init_tracing(verbosity: LogVerbosity) -> Result<()> {
+    let filter = match verbosity {
+        LogVerbosity::Default => return Ok(()),
+        LogVerbosity::Debug => EnvFilter::new("debug"),
+        LogVerbosity::Trace => EnvFilter::new("trace"),
+    };
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(stderr)
+        .try_init()
+        .map_err(|error| anyhow::anyhow!("Failed to initialize tracing: {error}"))
+}
+
 fn require_configured_discovery(
     outcome: std::result::Result<Option<ProjectFactsData>, EnvironmentAssemblyError>,
 ) -> Result<ProjectFactsData> {
@@ -182,6 +198,7 @@ fn require_configured_discovery(
 
 impl Command for Check {
     fn execute(&self, args: &Args) -> Result<Exit> {
+        init_tracing(args.log_verbosity())?;
         let project_root = resolve_project_root()?;
         let settings = Settings::new(&project_root, None).context("Failed to load settings")?;
         let input = CheckInput::collect(&self.paths)?;

--- a/crates/djls/src/commands/serve.rs
+++ b/crates/djls/src/commands/serve.rs
@@ -20,10 +20,10 @@ enum ConnectionType {
 }
 
 impl Command for Serve {
-    fn execute(&self, _args: &Args) -> Result<Exit> {
+    fn execute(&self, args: &Args) -> Result<Exit> {
         match self.connection_type {
             ConnectionType::Stdio => {
-                djls_server::run()?;
+                djls_server::run(args.log_verbosity())?;
                 Ok(Exit::success())
             }
             ConnectionType::Tcp => bail!("`djls serve --connection-type tcp` is not supported yet"),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,7 @@ printf '{{ value|default }}' | djls check -
 | `-d, --max-depth DEPTH` | Limit directory traversal depth |
 | `--color always\|auto\|never` | Control colored diagnostic output |
 | `-q, --quiet` | Suppress output and report the result through the exit status |
+| `-v, --verbose` | Include debug logs; repeat as `-vv` to include trace logs |
 
 `djls check` exits with status 0 when no enabled diagnostics are found and status 1 when diagnostics or a command error occur. Run `djls check --help` for the command's full help text.
 


### PR DESCRIPTION
## Summary

Implement the existing repeatable `-v/--verbose` option.

- `-v` enables debug logging
- `-vv` and above enable trace logging
- `djls check` writes logs to stderr
- `djls serve` raises file logging and forwards debug events to the LSP client; trace remains file-only
- no flag preserves current behavior, including `RUST_LOG` for the server

## Verification

- `cargo test -q -p djls -p djls-server` (109 passed, 1 ignored)
- manually inspected `djls check -v` output and root help
- `just fmt`
- `just clippy`
- `just lint`