### PR TITLE
feat: support TCP language-server connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added TCP transport through `djls serve --connection-type tcp --address IP:PORT`.
+
 ## Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.

--- a/crates/djls-server/src/lib.rs
+++ b/crates/djls-server/src/lib.rs
@@ -11,16 +11,30 @@ mod session;
 mod workspace;
 
 use std::io::IsTerminal;
+use std::net::SocketAddr;
 
+use anyhow::Context as _;
 use anyhow::Result;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::net::TcpListener;
 use tower_lsp_server::LspService;
 use tower_lsp_server::Server;
 
 use crate::server::DjangoLanguageServer;
 
+/// Transport used by the language server.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Connection {
+    /// Communicate over standard input and output.
+    Stdio,
+    /// Listen for one client at the given address.
+    Tcp(SocketAddr),
+}
+
 /// Run the Django language server.
-pub fn run() -> Result<()> {
-    if std::io::stdin().is_terminal() {
+pub fn run(connection: Connection) -> Result<()> {
+    if connection == Connection::Stdio && std::io::stdin().is_terminal() {
         eprintln!("Django Language Server is running directly in a terminal.");
         eprintln!(
             "This server is designed to communicate over stdin/stdout with a language client."
@@ -36,27 +50,48 @@ pub fn run() -> Result<()> {
         .enable_all()
         .build()?;
 
-    runtime.block_on(async {
-        let stdin = tokio::io::stdin();
-        let stdout = tokio::io::stdout();
-
-        let (service, socket) = LspService::build(|client| {
-            let logging = logging::init_tracing({
-                let client = client.clone();
-                move |message_type, message| {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        client.log_message(message_type, message).await;
-                    });
-                }
-            });
-
-            DjangoLanguageServer::new(client, logging)
-        })
-        .finish();
-
-        Server::new(stdin, stdout, socket).serve(service).await;
-
-        Ok(())
+    runtime.block_on(async move {
+        match connection {
+            Connection::Stdio => serve(tokio::io::stdin(), tokio::io::stdout()).await,
+            Connection::Tcp(address) => {
+                let listener = TcpListener::bind(address)
+                    .await
+                    .with_context(|| format!("Failed to bind TCP listener at {address}"))?;
+                let local_address = listener
+                    .local_addr()
+                    .context("Failed to read TCP listener address")?;
+                eprintln!("Listening for an LSP client at {local_address}");
+                let (stream, _) = listener
+                    .accept()
+                    .await
+                    .context("Failed to accept TCP client")?;
+                let (reader, writer) = tokio::io::split(stream);
+                serve(reader, writer).await
+            }
+        }
     })
+}
+
+async fn serve<R, W>(reader: R, writer: W) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite,
+{
+    let (service, socket) = LspService::build(|client| {
+        let logging = logging::init_tracing({
+            let client = client.clone();
+            move |message_type, message| {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    client.log_message(message_type, message).await;
+                });
+            }
+        });
+
+        DjangoLanguageServer::new(client, logging)
+    })
+    .finish();
+
+    Server::new(reader, writer, socket).serve(service).await;
+    Ok(())
 }

--- a/crates/djls/src/commands/serve.rs
+++ b/crates/djls/src/commands/serve.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use anyhow::Result;
 use anyhow::bail;
 use clap::Parser;
@@ -9,8 +11,13 @@ use crate::exit::Exit;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Serve {
+    /// How the language server communicates with its client.
     #[arg(short, long, default_value_t = ConnectionType::Stdio, value_enum)]
     connection_type: ConnectionType,
+
+    /// IP address and port to listen on for TCP connections.
+    #[arg(long, required_if_eq("connection_type", "tcp"))]
+    address: Option<SocketAddr>,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -21,12 +28,17 @@ enum ConnectionType {
 
 impl Command for Serve {
     fn execute(&self, _args: &Args) -> Result<Exit> {
-        match self.connection_type {
-            ConnectionType::Stdio => {
-                djls_server::run()?;
-                Ok(Exit::success())
+        let connection = match (self.connection_type, self.address) {
+            (ConnectionType::Stdio, None) => djls_server::Connection::Stdio,
+            (ConnectionType::Stdio, Some(_)) => {
+                bail!("`--address` can only be used with `--connection-type tcp`");
             }
-            ConnectionType::Tcp => bail!("`djls serve --connection-type tcp` is not supported yet"),
-        }
+            (ConnectionType::Tcp, Some(address)) => djls_server::Connection::Tcp(address),
+            (ConnectionType::Tcp, None) => {
+                bail!("`--address` is required with `--connection-type tcp`");
+            }
+        };
+        djls_server::run(connection)?;
+        Ok(Exit::success())
     }
 }

--- a/crates/djls/tests/serve.rs
+++ b/crates/djls/tests/serve.rs
@@ -1,21 +1,88 @@
+use std::net::TcpListener;
+use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 fn djls_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_djls"))
 }
 
 #[test]
-fn serve_tcp_reports_unsupported_connection_type() {
+fn serve_tcp_requires_an_address() {
     let output = Command::new(djls_binary())
         .args(["serve", "--connection-type", "tcp"])
+        .output()
+        .expect("djls serve process should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--address <ADDRESS>"), "{stderr}");
+    assert!(stderr.contains("required"), "{stderr}");
+}
+
+#[test]
+fn serve_address_requires_tcp() {
+    let output = Command::new(djls_binary())
+        .args(["serve", "--address", "127.0.0.1:9257"])
         .output()
         .expect("djls serve process should run");
 
     assert_eq!(output.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("`djls serve --connection-type tcp` is not supported yet"),
-        "Expected unsupported connection-type message, got:\n{stderr}"
+        stderr.contains("`--address` can only be used with `--connection-type tcp`"),
+        "{stderr}"
     );
+}
+
+#[test]
+fn serve_tcp_accepts_a_client() {
+    let probe = TcpListener::bind("127.0.0.1:0").expect("test port should be allocated");
+    let address = probe
+        .local_addr()
+        .expect("test address should be available");
+    drop(probe);
+
+    let mut child = Command::new(djls_binary())
+        .args([
+            "serve",
+            "--connection-type",
+            "tcp",
+            "--address",
+            &address.to_string(),
+        ])
+        .spawn()
+        .expect("djls serve process should start");
+
+    let stream = (0..100)
+        .find_map(|_| {
+            if let Ok(stream) = TcpStream::connect(address) {
+                Some(stream)
+            } else {
+                thread::sleep(Duration::from_millis(10));
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            child.kill().expect("TCP test server should be stopped");
+            panic!("djls serve did not accept a TCP connection at {address}");
+        });
+    drop(stream);
+
+    let status = (0..100)
+        .find_map(|_| {
+            let status = child.try_wait().expect("TCP test server should be polled");
+            if status.is_none() {
+                thread::sleep(Duration::from_millis(10));
+            }
+            status
+        })
+        .unwrap_or_else(|| {
+            child.kill().expect("TCP test server should be stopped");
+            panic!("djls serve did not exit after its TCP client disconnected");
+        });
+
+    assert!(status.success(), "TCP server exited with {status}");
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,7 +60,15 @@ Start the Language Server Protocol server over standard input and output:
 $ djls serve
 ```
 
-Editors normally start this command through their [LSP client configuration](clients/index.md). TCP transport is not supported.
+Editors normally start this command through their [LSP client configuration](clients/index.md).
+
+To listen for one LSP client over TCP, provide an explicit address:
+
+```console
+$ djls serve --connection-type tcp --address 127.0.0.1:9257
+```
+
+The server exits when that client disconnects. DJLS does not choose a default TCP port.
 
 ## Formatting
 


### PR DESCRIPTION
## Summary

Implement the existing TCP server mode.

- require an explicit numeric `--address IP:PORT` with `--connection-type tcp`
- listen for one LSP client and exit when it disconnects
- keep stdio as the default transport
- reject `--address` with stdio
- document the TCP lifecycle and lack of a default port

## Verification

- `cargo test -q -p djls --test serve` (3 passed)
- inspected `djls serve --help`
- `just fmt`
- `just clippy`
- `just lint`