### PR TITLE
Add a "Why a language server?" docs page

### DIFF
--- a/.mkdocs.yml
+++ b/.mkdocs.yml
@@ -28,6 +28,7 @@ markdown_extensions:
       permalink: true
 nav:
   - Home: index.md
+  - "Why a language server?": why.md
   - Installation: installation.md
   - Command-line interface: cli.md
   - Pre-commit: pre-commit.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
-## Changed
+### Added
+
+- Added a "Why a language server?" docs page covering what a language server does and who needs one.
+
+### Changed
 
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
-- Added a "Why a language server?" docs page covering what a language server does and who needs one.
+- Added a "Why a language server?" docs page.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ cog.outl(f"![Django Version](https://img.shields.io/badge/django-{'%20%7C%20'.jo
 
 A language server for the Django web framework.
 
+New to language servers, or unsure whether you need one? Start with [Why a language server?](docs/why.md)
+
 > [!CAUTION]
 > This project is in early stages. ~~All~~ Most features are incomplete and missing.
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -2,7 +2,7 @@
 
 Open a Django template in most editors and you get HTML support at best. The editor highlights the angle brackets, but `{% block %}`, `{% url %}`, and `{{ value|date }}` are plain text to it. It cannot complete a tag name, flag a misspelled filter, or jump to the template behind an `{% extends %}`, because it knows nothing about Django.
 
-Django Language Server closes that gap, for every editor at once.
+Django Language Server adds that knowledge, in whichever editor you use.
 
 ## What a language server is
 
@@ -29,9 +29,9 @@ See [Template Validation](template-validation.md) for how the analysis works and
 
 If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs, or any other editor with LSP support: yes. Without a language server, these editors treat a Django template as HTML with unusual punctuation.
 
-If you use PyCharm Professional: probably not. JetBrains builds Django template support directly into the IDE, and it already covers most of what this project does. If you have used PyCharm's template tooling, it is a fair preview of what Django Language Server brings to other editors.
+If you use PyCharm Professional: probably not. JetBrains builds Django template support directly into the IDE, and it already covers most of what this project does. PyCharm's template tooling is a fair preview of what Django Language Server brings to other editors.
 
-If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) is available. No LSP client required.
+If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) is available.
 
 ## Next steps
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -45,6 +45,8 @@ If you use PyCharm Professional: probably not. JetBrains builds Django template 
 
 If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) runs it on staged templates before each commit.
 
+Templates are only the start. The goal is everything PyCharm knows about Django — settings, models, the ORM — in every editor with an LSP client.
+
 ## Next steps
 
 [Install the server](installation.md), then [set up your editor](clients/index.md). Most projects need no configuration; the [configuration guide](configuration/index.md) covers the exceptions.

--- a/docs/why.md
+++ b/docs/why.md
@@ -25,7 +25,7 @@ In the editor, that knowledge becomes:
 
 See [Template Validation](template-validation.md) for how the analysis works and where its limits are.
 
-## Other Django template servers
+## Related projects
 
 [django-template-lsp](https://github.com/fourdigits/django-template-lsp) is another language server for Django templates. The feature sets differ in both directions: it resolves `{% url %}` to views and suggests `{% static %}` paths; this server validates tag arguments, formats templates, and renames across files.
 
@@ -35,7 +35,7 @@ Django Language Server never executes project code. It reads the same sources â€
 
 Both servers need to find your project's Python environment to locate installed packages; neither needs you to activate it.
 
-Related: [django-lsp](https://github.com/patrick91/django-lsp) applies the same static approach to the ORM, following model relations in Python source without importing the project. It attaches to Python files rather than templates.
+Two separate projects are named django-lsp. [One](https://github.com/patrick91/django-lsp) applies the same static approach to the ORM: it follows model relations in Python source to complete relation paths in QuerySet calls and warn about repeated relation queries. It works on Python files, leaving templates to the servers above. [The other](https://github.com/adamghill/django-lsp) adds context-aware autocomplete and hover documentation for Django settings.py, including typo detection.
 
 ## Do I need it?
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -45,7 +45,7 @@ If you use PyCharm Professional: probably not. JetBrains builds Django template 
 
 If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) runs it on staged templates before each commit.
 
-Templates are only the start. The goal is everything PyCharm knows about Django — settings, models, the ORM — in every editor with an LSP client.
+Templates are only the start. The goal is everything PyCharm knows about Django — settings, models, the ORM — in every editor with an LSP client. The [roadmap](https://github.com/joshuadavidthomas/django-language-server/blob/main/ROADMAP.md) tracks what works, what comes next, and what is ruled out.
 
 ## Next steps
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -8,7 +8,7 @@ Django Language Server adds that knowledge, in whichever editor you use.
 
 A language server is a separate program that runs next to your editor and answers questions about your code. The two divide the work. The editor owns everything you see: squiggles, completion menus, jumping between files. The server owns the understanding: which template tags your project can use, whether a filter takes an argument, where `base.html` lives.
 
-They communicate over the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), a standard both sides agree on. Without it, Django support would mean a separately maintained plugin for VS Code, another for Neovim, another for Zed. With it, one server works in any editor that has an LSP client.
+They communicate over the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), a standard both sides agree on. Without it, Django support would mean a separately maintained plugin for VS Code, another for Neovim, another for Zed. With it, one server works in any editor with an LSP client.
 
 In practice you never interact with the server directly. Your editor starts `djls serve` in the background when you open a project and talks to it as you type.
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -35,6 +35,8 @@ Django Language Server never executes project code. It reads the same sources â€
 
 Both servers need to find your project's Python environment to locate installed packages; neither needs you to activate it.
 
+Related: [django-lsp](https://github.com/patrick91/django-lsp) applies the same static approach to the ORM, following model relations in Python source without importing the project. It attaches to Python files rather than templates.
+
 ## Do I need it?
 
 If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs, or any other editor with LSP support: yes. Without a language server, these editors treat a Django template as HTML with unusual punctuation.

--- a/docs/why.md
+++ b/docs/why.md
@@ -27,7 +27,7 @@ See [Template Validation](template-validation.md) for how the analysis works and
 
 ## Related projects
 
-[django-template-lsp](https://github.com/fourdigits/django-template-lsp) is another language server for Django templates. The feature sets differ in both directions: it resolves `{% url %}` to views and suggests `{% static %}` paths; this server validates tag arguments, formats templates, and renames across files.
+[django-template-lsp](https://github.com/fourdigits/django-template-lsp) is the closest project: a language server for Django templates too. Today it does things this server cannot, like URL-name and static-path completion and navigation from `{% url %}` to the view it names. This server does things it cannot, like validation of tag arguments and load scoping, whole-document formatting, and quick fixes for unloaded tags. Neither replaces the other yet.
 
 django-template-lsp runs a Python script inside your project's environment to learn what exists: it imports your settings and template tag libraries and asks Django for its tags, filters, and URLs. Because it executes inside the project, collection fails when the project has syntax errors or missing imports, as its own documentation notes.
 
@@ -35,7 +35,9 @@ Django Language Server never executes project code. It reads the same sources �
 
 Both servers need to find your project's Python environment to locate installed packages; neither needs you to activate it.
 
-Two separate projects are named django-lsp. [One](https://github.com/patrick91/django-lsp) applies the same static approach to the ORM: it follows model relations in Python source to complete relation paths in QuerySet calls and warn about repeated relation queries. It works on Python files, leaving templates to the servers above. [The other](https://github.com/adamghill/django-lsp) adds context-aware autocomplete and hover documentation for Django settings.py, including typo detection.
+Two separate projects are named django-lsp. [One](https://github.com/patrick91/django-lsp) works on Python files instead of templates: it follows model relations in source to complete relation paths in QuerySet calls and warn when a loop issues one relation query per row. [The other](https://github.com/adamghill/django-lsp) works on settings.py: context-aware autocomplete, hover documentation, and typo detection.
+
+The gaps above are all planned. The [roadmap](https://github.com/joshuadavidthomas/django-language-server/blob/main/ROADMAP.md) tracks the order: the remaining template features finish first, then the split between generic Python analysis and Django Project Facts, then URLs, settings, models, template context, and ORM queries. Current work is building the foundations that expansion needs.
 
 ## Do I need it?
 
@@ -45,7 +47,7 @@ If you use PyCharm Professional: probably not. JetBrains builds Django template 
 
 If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) runs it on staged templates before each commit.
 
-Templates are only the start. The goal is everything PyCharm knows about Django — settings, models, the ORM — in every editor with an LSP client. The [roadmap](https://github.com/joshuadavidthomas/django-language-server/blob/main/ROADMAP.md) tracks what works, what comes next, and what is ruled out.
+Templates are only the start. The goal is everything PyCharm knows about Django, in every editor with an LSP client.
 
 ## Next steps
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,38 @@
+# Why a language server?
+
+Open a Django template in most editors and you get HTML support at best. The editor highlights the angle brackets, but `{% block %}`, `{% url %}`, and `{{ value|date }}` are plain text to it. It cannot complete a tag name, flag a misspelled filter, or jump to the template behind an `{% extends %}`, because it knows nothing about Django.
+
+Django Language Server closes that gap, for every editor at once.
+
+## What a language server is
+
+A language server is a separate program that runs next to your editor and answers questions about your code. The two divide the work. The editor owns everything you see: squiggles, completion menus, jumping between files. The server owns the understanding: which template tags your project can use, whether a filter takes an argument, where `base.html` lives.
+
+They communicate over the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), a standard both sides agree on. The standard is what lets one server support many editors. Instead of a Django plugin for VS Code, another for Neovim, and another for Zed, each maintained separately, there is one server, and any editor with an LSP client can use it.
+
+In practice you never interact with the server directly. Your editor starts `djls serve` in the background when you open a project and talks to it as you type.
+
+## What it does for Django templates
+
+The server statically reads your project: the settings module, `INSTALLED_APPS`, template directories, and the Python source of the template tag libraries it discovers. It never imports or runs your code. From that it builds a picture of which tags and filters are available in each template, what arguments they accept, and how templates relate through `{% extends %}` and `{% include %}`.
+
+In the editor, that picture becomes:
+
+- Completions for template tags and filters, including third-party and project-local libraries
+- Validation as you type: unclosed blocks, unknown or unloaded tags, filters given the wrong arguments
+- Navigation: jump to the template behind an `{% extends %}` or `{% include %}`, the parent of a `{% block %}`, or the Python function that registers a tag or filter
+- Hover documentation, quick fixes for missing `{% load %}` lines, folding, and document outlines
+
+See [Template Validation](template-validation.md) for how the analysis works and where its limits are.
+
+## Do I need it?
+
+If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs, or any other editor with LSP support: yes. Without a language server, these editors treat a Django template as HTML with unusual punctuation.
+
+If you use PyCharm Professional: probably not. JetBrains builds Django template support directly into the IDE, and it already covers most of what this project does. If you have used PyCharm's template tooling, it is a fair preview of what Django Language Server brings to other editors.
+
+If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) is available. No LSP client required.
+
+## Next steps
+
+[Install the server](installation.md), then [set up your editor](clients/index.md). Most projects need no configuration; the [configuration guide](configuration/index.md) covers the exceptions.

--- a/docs/why.md
+++ b/docs/why.md
@@ -25,6 +25,16 @@ In the editor, that knowledge becomes:
 
 See [Template Validation](template-validation.md) for how the analysis works and where its limits are.
 
+## Other Django template servers
+
+[django-template-lsp](https://github.com/fourdigits/django-template-lsp) is another language server for Django templates. The feature sets differ in both directions: it resolves `{% url %}` to views and suggests `{% static %}` paths; this server validates tag arguments, formats templates, and renames across files.
+
+django-template-lsp runs a Python script inside your project's environment to learn what exists: it imports your settings and template tag libraries and asks Django for its tags, filters, and URLs. Because it executes inside the project, collection fails when the project has syntax errors or missing imports, as its own documentation notes.
+
+Django Language Server never executes project code. It reads the same sources — settings, installed packages, the Python source of template tag libraries — and derives tags, filters, and validation rules by parsing them statically. There is no Django runtime to boot, and the server keeps working on projects with syntax errors or broken imports. Never running anything has a cost: tags registered through dynamic imports or generated code are invisible to it.
+
+Both servers need to find your project's Python environment to locate installed packages; neither needs you to activate it.
+
 ## Do I need it?
 
 If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs, or any other editor with LSP support: yes. Without a language server, these editors treat a Django template as HTML with unusual punctuation.

--- a/docs/why.md
+++ b/docs/why.md
@@ -25,6 +25,16 @@ In the editor, that knowledge becomes:
 
 See [Template Validation](template-validation.md) for how the analysis works and where its limits are.
 
+## Do I need it?
+
+If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs, or any other editor with LSP support: yes. Without a language server, these editors treat a Django template as HTML with unusual punctuation.
+
+If you use PyCharm Professional: probably not. JetBrains builds Django template support directly into the IDE, and it already covers most of what this project does. PyCharm's template tooling is a fair preview of what Django Language Server brings to other editors.
+
+If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) runs it on staged templates before each commit.
+
+Templates are only the start. The goal is everything PyCharm knows about Django, in every editor with an LSP client.
+
 ## Related projects
 
 [django-template-lsp](https://github.com/fourdigits/django-template-lsp) is the closest project: a language server for Django templates too. Today it does things this server cannot, like URL-name and static-path completion and navigation from `{% url %}` to the view it names. This server does things it cannot, like validation of tag arguments and load scoping, whole-document formatting, and quick fixes for unloaded tags. Neither replaces the other yet.
@@ -38,16 +48,6 @@ Both servers need to find your project's Python environment to locate installed 
 Two separate projects are named django-lsp. [One](https://github.com/patrick91/django-lsp) works on Python files instead of templates: it follows model relations in source to complete relation paths in QuerySet calls and warn when a loop issues one relation query per row. [The other](https://github.com/adamghill/django-lsp) works on settings.py: context-aware autocomplete, hover documentation, and typo detection.
 
 The gaps above are all planned. The [roadmap](https://github.com/joshuadavidthomas/django-language-server/blob/main/ROADMAP.md) tracks the order: the remaining template features finish first, then the split between generic Python analysis and Django Project Facts, then URLs, settings, models, template context, and ORM queries. Current work is building the foundations that expansion needs.
-
-## Do I need it?
-
-If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs, or any other editor with LSP support: yes. Without a language server, these editors treat a Django template as HTML with unusual punctuation.
-
-If you use PyCharm Professional: probably not. JetBrains builds Django template support directly into the IDE, and it already covers most of what this project does. PyCharm's template tooling is a fair preview of what Django Language Server brings to other editors.
-
-If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) runs it on staged templates before each commit.
-
-Templates are only the start. The goal is everything PyCharm knows about Django, in every editor with an LSP client.
 
 ## Next steps
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -8,15 +8,15 @@ Django Language Server adds that knowledge, in whichever editor you use.
 
 A language server is a separate program that runs next to your editor and answers questions about your code. The two divide the work. The editor owns everything you see: squiggles, completion menus, jumping between files. The server owns the understanding: which template tags your project can use, whether a filter takes an argument, where `base.html` lives.
 
-They communicate over the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), a standard both sides agree on. The standard is what lets one server support many editors. Instead of a Django plugin for VS Code, another for Neovim, and another for Zed, each maintained separately, there is one server, and any editor with an LSP client can use it.
+They communicate over the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), a standard both sides agree on. Without it, Django support would mean a separately maintained plugin for VS Code, another for Neovim, another for Zed. With it, one server works in any editor that has an LSP client.
 
 In practice you never interact with the server directly. Your editor starts `djls serve` in the background when you open a project and talks to it as you type.
 
 ## What it does for Django templates
 
-The server statically reads your project: the settings module, `INSTALLED_APPS`, template directories, and the Python source of the template tag libraries it discovers. It never imports or runs your code. From that it builds a picture of which tags and filters are available in each template, what arguments they accept, and how templates relate through `{% extends %}` and `{% include %}`.
+The server reads your project: the settings module, `INSTALLED_APPS`, template directories, and the Python source of the template tag libraries it discovers. It never imports or runs your code. From that it knows which tags and filters are available in each template, what arguments they accept, and how templates relate through `{% extends %}` and `{% include %}`.
 
-In the editor, that picture becomes:
+In the editor, that knowledge becomes:
 
 - Completions for template tags and filters, including third-party and project-local libraries
 - Validation as you type: unclosed blocks, unknown or unloaded tags, filters given the wrong arguments
@@ -31,7 +31,7 @@ If you edit Django templates in Neovim, VS Code, Zed, Sublime Text, Helix, Emacs
 
 If you use PyCharm Professional: probably not. JetBrains builds Django template support directly into the IDE, and it already covers most of what this project does. PyCharm's template tooling is a fair preview of what Django Language Server brings to other editors.
 
-If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) is available.
+If you want template checking without any editor integration, the [`djls check`](cli.md#djls-check) command runs the same validation in a terminal, and a [pre-commit hook](pre-commit.md) runs it on staged templates before each commit.
 
 ## Next steps
 


### PR DESCRIPTION
## What

Adds a short explainer page to the docs answering the questions that came up at DjangoCon sprints: what a language server is, what this one does for Django templates, and who actually needs it.

- New `docs/why.md` with four sections: what a language server is (the editor/server split and why LSP means one server for every editor), what the server does for Django templates, "Do I need it?", and next steps.
- The "Do I need it?" section answers the PyCharm question directly: PyCharm Professional users already have this built in and probably don't need it. It also points people who want no editor integration at `djls check` and the pre-commit hook.
- Nav entry after Home, and a one-line pointer in the README intro.

## Why

The docs currently assume the reader already knows what a language server is. The home page leads with a feature checklist of LSP capability names, which doesn't help someone deciding whether the project is for them.

## Notes

- Follow-ups planned: a getting-started guide and a contributor-facing "How it works" page. Once those land, this page and they should cross-link; each PR avoids linking to pages that don't exist on main yet.