### PR TITLE
Represent filter arity with three explicit states

### DIFF
--- a/crates/djls-bench/src/specs.rs
+++ b/crates/djls-bench/src/specs.rs
@@ -62,29 +62,23 @@ fn build_filter_arities(
         specs.merge_filter_arities(filter_arities);
     }
 
-    let known: &[(&str, bool, bool)] = &[
-        ("title", false, false),
-        ("lower", false, false),
-        ("upper", false, false),
-        ("default", true, false),
-        ("date", true, true),
-        ("truncatewords", true, false),
-        ("floatformat", true, true),
-        ("join", true, false),
-        ("cut", true, false),
-        ("yesno", true, true),
-        ("pluralize", true, true),
-        ("center", true, false),
+    let known = [
+        ("title", FilterArity::NoArgument),
+        ("lower", FilterArity::NoArgument),
+        ("upper", FilterArity::NoArgument),
+        ("default", FilterArity::RequiredArgument),
+        ("date", FilterArity::OptionalArgument),
+        ("truncatewords", FilterArity::RequiredArgument),
+        ("floatformat", FilterArity::OptionalArgument),
+        ("join", FilterArity::RequiredArgument),
+        ("cut", FilterArity::RequiredArgument),
+        ("yesno", FilterArity::OptionalArgument),
+        ("pluralize", FilterArity::OptionalArgument),
+        ("center", FilterArity::RequiredArgument),
     ];
 
-    for &(name, expects_arg, arg_optional) in known {
-        specs.insert(
-            SymbolKey::filter(defaultfilters, name),
-            FilterArity {
-                expects_arg,
-                arg_optional,
-            },
-        );
+    for (name, arity) in known {
+        specs.insert(SymbolKey::filter(defaultfilters, name), arity);
     }
 
     specs

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -212,6 +212,7 @@ mod invalidation_tests {
     use djls_conf::TagTypeDef;
     use djls_ide::prime_template_library_products;
     use djls_project::Db as ProjectDb;
+    use djls_project::FilterArity;
     use djls_project::LibraryName;
     use djls_project::LoadableLibraryLookup;
     use djls_project::Project;
@@ -2056,11 +2057,9 @@ env_file = ".env.local"
                 .len(),
             1
         );
-        assert!(
-            alpha_filters
-                .get("alpha_filter")
-                .expect("expected test fixture entry should exist")
-                .expects_arg
+        assert_eq!(
+            alpha_filters.get("alpha_filter"),
+            Some(&FilterArity::RequiredArgument)
         );
         for (file, module) in identities
             .iter()
@@ -2104,11 +2103,9 @@ env_file = ".env.local"
                 .len(),
             2
         );
-        assert!(
-            alpha_filters
-                .get("alpha_filter")
-                .expect("expected test fixture entry should exist")
-                .expects_arg
+        assert_eq!(
+            alpha_filters.get("alpha_filter"),
+            Some(&FilterArity::RequiredArgument)
         );
         for (file, module) in identities
             .iter()
@@ -2250,7 +2247,10 @@ def my_filter(value, arg):
             result.filter_arities().contains_key(&key),
             "should extract filter from file content"
         );
-        assert!(result.filter_arities()[&key].expects_arg);
+        assert_eq!(
+            result.filter_arities().get(&key),
+            Some(&FilterArity::RequiredArgument)
+        );
 
         let other_library = TemplateLibraryId::new(
             &db,

--- a/crates/djls-project/src/templates/filters.rs
+++ b/crates/djls-project/src/templates/filters.rs
@@ -10,12 +10,12 @@ pub type FilterArityMap = FxHashMap<SymbolKey, FilterArity>;
 ///
 /// Django filters receive the value being filtered as their first argument.
 /// Some filters accept an additional argument (e.g., `{{ value|default:"nothing" }}`).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct FilterArity {
-    /// Whether the filter expects an argument after the colon.
-    pub expects_arg: bool,
-    /// Whether the argument is optional (has a default value).
-    pub arg_optional: bool,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterArity {
+    NoArgument,
+    RequiredArgument,
+    OptionalArgument,
 }
 
 /// Extract filter argument arity from a filter function's signature.
@@ -43,10 +43,7 @@ pub(crate) fn extract_filter_arity(func: &StmtFunctionDef) -> FilterArity {
         .collect();
 
     if all_positional.is_empty() {
-        return FilterArity {
-            expects_arg: false,
-            arg_optional: false,
-        };
+        return FilterArity::NoArgument;
     }
 
     // Skip `self` if present (method-style filter)
@@ -62,20 +59,16 @@ pub(crate) fn extract_filter_arity(func: &StmtFunctionDef) -> FilterArity {
 
     if after_self.len() <= 1 {
         // Only the value parameter (or no params beyond self)
-        return FilterArity {
-            expects_arg: false,
-            arg_optional: false,
-        };
+        return FilterArity::NoArgument;
     }
 
     // There's at least one additional parameter beyond the value.
     // Check if the extra parameter(s) have defaults.
     let extra_params = &after_self[1..];
-    let all_have_defaults = extra_params.iter().all(|p| p.default.is_some());
-
-    FilterArity {
-        expects_arg: true,
-        arg_optional: all_have_defaults,
+    if extra_params.iter().all(|p| p.default.is_some()) {
+        FilterArity::OptionalArgument
+    } else {
+        FilterArity::RequiredArgument
     }
 }
 
@@ -93,8 +86,7 @@ mod tests {
         let func = django_function("django/template/defaultfilters.py", "title")
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
-        assert!(!arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::NoArgument);
     }
 
     // Corpus: `upper` in defaultfilters.py — `def upper(value):`
@@ -103,8 +95,7 @@ mod tests {
         let func = django_function("django/template/defaultfilters.py", "upper")
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
-        assert!(!arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::NoArgument);
     }
 
     // Required-arg filters
@@ -115,8 +106,7 @@ mod tests {
         let func = django_function("django/template/defaultfilters.py", "cut")
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::RequiredArgument);
     }
 
     // Corpus: `add` in defaultfilters.py — `def add(value, arg):`
@@ -125,8 +115,7 @@ mod tests {
         let func = django_function("django/template/defaultfilters.py", "add")
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::RequiredArgument);
     }
 
     // Optional-arg filters
@@ -137,8 +126,7 @@ mod tests {
         let func = django_function("django/template/defaultfilters.py", "floatformat")
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(arity.arg_optional);
+        assert_eq!(arity, FilterArity::OptionalArgument);
     }
 
     // Corpus: `date` in defaultfilters.py — `def date(value, arg=None):`
@@ -147,8 +135,7 @@ mod tests {
         let func = django_function("django/template/defaultfilters.py", "date")
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(arity.arg_optional);
+        assert_eq!(arity, FilterArity::OptionalArgument);
     }
 
     // Method-style filters (with self)
@@ -161,8 +148,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(!arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::NoArgument);
     }
 
     #[test]
@@ -171,8 +157,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::RequiredArgument);
     }
 
     #[test]
@@ -181,8 +166,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(arity.arg_optional);
+        assert_eq!(arity, FilterArity::OptionalArgument);
     }
 
     // Edge cases — no real filter has zero params or self-only.
@@ -194,8 +178,7 @@ mod tests {
         let func = find_function_in_source(source, "weird_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(!arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::NoArgument);
     }
 
     #[test]
@@ -204,8 +187,7 @@ mod tests {
         let func = find_function_in_source(source, "weird_method")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(!arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::NoArgument);
     }
 
     // Python 3.8+ positional-only parameters — no Django filter uses these
@@ -217,8 +199,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::RequiredArgument);
     }
 
     #[test]
@@ -227,8 +208,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(arity.arg_optional);
+        assert_eq!(arity, FilterArity::OptionalArgument);
     }
 
     // Unusual multi-param signatures — no real Django filter has 3+ positional
@@ -240,8 +220,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(arity.arg_optional);
+        assert_eq!(arity, FilterArity::OptionalArgument);
     }
 
     #[test]
@@ -250,8 +229,7 @@ mod tests {
         let func = find_function_in_source(source, "my_filter")
             .expect("expected function should exist in test source");
         let arity = extract_filter_arity(&func);
-        assert!(arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::RequiredArgument);
     }
 
     // Arity doesn't change with decorator kwargs
@@ -267,8 +245,7 @@ mod tests {
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
         // floatformat has is_safe=True on decorator; arity should reflect signature only
-        assert!(arity.expects_arg);
-        assert!(arity.arg_optional);
+        assert_eq!(arity, FilterArity::OptionalArgument);
     }
 
     // Corpus: `title` in defaultfilters.py — decorated with both
@@ -279,7 +256,6 @@ mod tests {
             .expect("expected Django fixture function should exist");
         let arity = extract_filter_arity(&func);
         // title has @stringfilter decorator; arity should reflect signature only (value-only)
-        assert!(!arity.expects_arg);
-        assert!(!arity.arg_optional);
+        assert_eq!(arity, FilterArity::NoArgument);
     }
 }

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -1,5 +1,6 @@
 use camino::Utf8Path;
 use djls_project::ArgumentCountConstraint;
+use djls_project::FilterArity;
 use djls_project::PythonModuleName;
 use djls_project::SymbolKey;
 use djls_project::TemplateLibraryId;
@@ -95,9 +96,10 @@ fn extract_bundle_filter() {
     let result = extract_source(DEFAULTFILTERS_SOURCE, "django.template.defaultfilters")
         .expect("filter extraction fixture should build");
     let key = SymbolKey::filter("django.template.defaultfilters", "lower");
-    assert!(result.filter_arities.contains_key(&key));
-    let arity = &result.filter_arities[&key];
-    assert!(!arity.expects_arg);
+    assert_eq!(
+        result.filter_arities.get(&key),
+        Some(&FilterArity::NoArgument)
+    );
 }
 
 // Corpus: `default` in django/template/defaultfilters.py — filter with
@@ -107,10 +109,10 @@ fn extract_bundle_filter_with_arg() {
     let result = extract_source(DEFAULTFILTERS_SOURCE, "django.template.defaultfilters")
         .expect("filter-with-argument extraction fixture should build");
     let key = SymbolKey::filter("django.template.defaultfilters", "default");
-    assert!(result.filter_arities.contains_key(&key));
-    let arity = &result.filter_arities[&key];
-    assert!(arity.expects_arg);
-    assert!(!arity.arg_optional);
+    assert_eq!(
+        result.filter_arities.get(&key),
+        Some(&FilterArity::RequiredArgument)
+    );
 }
 
 // Corpus: `block` in django/template/loader_tags.py — `@register.tag("block")`
@@ -1245,9 +1247,12 @@ def do_asset(parser, token):
         Some("endbird:slot")
     );
     let filter_key = SymbolKey::filter("app.templatetags.bird_tags", "bird_filter");
-    let filter_arity = &template_library_filter_facts(&db, key).filter_arities()[&filter_key];
-    assert!(filter_arity.expects_arg);
-    assert!(!filter_arity.arg_optional);
+    assert_eq!(
+        template_library_filter_facts(&db, key)
+            .filter_arities()
+            .get(&filter_key),
+        Some(&FilterArity::RequiredArgument)
+    );
 
     let bird_symbol = definitions
         .symbol(TemplateSymbolKind::Tag, "bird")
@@ -1900,9 +1905,10 @@ fn corpus_filter_no_arg() {
     let result = extract_source(DEFAULTFILTERS_SOURCE, "django.template.defaultfilters")
         .expect("no-argument filter extraction fixture should build");
     let key = SymbolKey::filter("django.template.defaultfilters", "title");
-    assert!(result.filter_arities.contains_key(&key));
-    let arity = &result.filter_arities[&key];
-    assert!(!arity.expects_arg);
+    assert_eq!(
+        result.filter_arities.get(&key),
+        Some(&FilterArity::NoArgument)
+    );
 }
 
 // Corpus: `default` in defaultfilters.py — filter with required arg.
@@ -1911,10 +1917,10 @@ fn corpus_filter_required_arg() {
     let result = extract_source(DEFAULTFILTERS_SOURCE, "django.template.defaultfilters")
         .expect("required-argument filter extraction fixture should build");
     let key = SymbolKey::filter("django.template.defaultfilters", "default");
-    assert!(result.filter_arities.contains_key(&key));
-    let arity = &result.filter_arities[&key];
-    assert!(arity.expects_arg);
-    assert!(!arity.arg_optional);
+    assert_eq!(
+        result.filter_arities.get(&key),
+        Some(&FilterArity::RequiredArgument)
+    );
 }
 
 // Corpus: `date` in defaultfilters.py — filter with optional arg (arg=None).
@@ -1923,10 +1929,10 @@ fn corpus_filter_optional_arg() {
     let result = extract_source(DEFAULTFILTERS_SOURCE, "django.template.defaultfilters")
         .expect("optional-argument filter extraction fixture should build");
     let key = SymbolKey::filter("django.template.defaultfilters", "date");
-    assert!(result.filter_arities.contains_key(&key));
-    let arity = &result.filter_arities[&key];
-    assert!(arity.expects_arg);
-    assert!(arity.arg_optional);
+    assert_eq!(
+        result.filter_arities.get(&key),
+        Some(&FilterArity::OptionalArgument)
+    );
 }
 
 // Corpus: `escapejs` in defaultfilters.py — @register.filter("escapejs")

--- a/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__core_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__core_tags.py.snap
@@ -97,16 +97,8 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "archivebox.core.templatetags.core_tags::filter::file_size":
-    expects_arg: false
-    arg_optional: false
-  "archivebox.core.templatetags.core_tags::filter::plugin_display_name":
-    expects_arg: false
-    arg_optional: false
-  "archivebox.core.templatetags.core_tags::filter::plugin_name":
-    expects_arg: false
-    arg_optional: false
-  "archivebox.core.templatetags.core_tags::filter::split":
-    expects_arg: true
-    arg_optional: true
+  "archivebox.core.templatetags.core_tags::filter::file_size": no_argument
+  "archivebox.core.templatetags.core_tags::filter::plugin_display_name": no_argument
+  "archivebox.core.templatetags.core_tags::filter::plugin_name": no_argument
+  "archivebox.core.templatetags.core_tags::filter::split": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__bootstrap.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__bootstrap.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "core.templatetags.bootstrap::filter::bool_icon":
-    expects_arg: false
-    arg_optional: false
+  "core.templatetags.bootstrap::filter::bool_icon": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__datetime.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__datetime.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "core.templatetags.datetime::filter::datetime_short":
-    expects_arg: false
-    arg_optional: false
+  "core.templatetags.datetime::filter::datetime_short": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__duration.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__duration.py.snap
@@ -4,25 +4,11 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "core.templatetags.duration::filter::child_age_string":
-    expects_arg: false
-    arg_optional: false
-  "core.templatetags.duration::filter::dayssince":
-    expects_arg: true
-    arg_optional: true
-  "core.templatetags.duration::filter::deltasince":
-    expects_arg: true
-    arg_optional: true
-  "core.templatetags.duration::filter::duration_string":
-    expects_arg: true
-    arg_optional: true
-  "core.templatetags.duration::filter::hours":
-    expects_arg: false
-    arg_optional: false
-  "core.templatetags.duration::filter::minutes":
-    expects_arg: false
-    arg_optional: false
-  "core.templatetags.duration::filter::seconds":
-    expects_arg: false
-    arg_optional: false
+  "core.templatetags.duration::filter::child_age_string": no_argument
+  "core.templatetags.duration::filter::dayssince": optional_argument
+  "core.templatetags.duration::filter::deltasince": optional_argument
+  "core.templatetags.duration::filter::duration_string": optional_argument
+  "core.templatetags.duration::filter::hours": no_argument
+  "core.templatetags.duration::filter::minutes": no_argument
+  "core.templatetags.duration::filter::seconds": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__misc.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__misc.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "core.templatetags.misc::filter::next":
-    expects_arg: true
-    arg_optional: false
-  "core.templatetags.misc::filter::prev":
-    expects_arg: true
-    arg_optional: false
+  "core.templatetags.misc::filter::next": required_argument
+  "core.templatetags.misc::filter::prev": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__contrib__admin__templatetags__admin_modify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__contrib__admin__templatetags__admin_modify.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.admin.templatetags.admin_modify::filter::cell_count":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_modify::filter::cell_count": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -25,10 +25,6 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname":
-    expects_arg: true
-    arg_optional: false
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__contrib__humanize__templatetags__humanize.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__contrib__humanize__templatetags__humanize.py.snap
@@ -4,22 +4,10 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.humanize.templatetags.humanize::filter::apnumber":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::intcomma":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::intword":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::naturalday":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::naturaltime":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::ordinal":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::apnumber": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intcomma": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intword": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturalday": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturaltime": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::ordinal": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__defaultfilters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__defaultfilters.py.snap
@@ -4,175 +4,61 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.template.defaultfilters::filter::add":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::addslashes":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::capfirst":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::center":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::cut":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::date":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::default":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::default_if_none":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsort":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsortreversed":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::divisibleby":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapejs":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::filesizeformat":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::first":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::floatformat":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::force_escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::get_digit":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::iriencode":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::join":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::json_script":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::last":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::length":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::length_is":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::linebreaks":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linebreaksbr":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linenumbers":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::ljust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::lower":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::make_list":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::phone2numeric":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::pluralize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::pprint":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::random":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::rjust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::safe":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::safeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::slice":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::slugify":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::stringformat":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::striptags":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::time":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timesince":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timeuntil":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::title":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::unordered_list":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::upper":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::urlencode":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlizetrunc":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordcount":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordwrap":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::yesno":
-    expects_arg: true
-    arg_optional: true
+  "django.template.defaultfilters::filter::add": required_argument
+  "django.template.defaultfilters::filter::addslashes": no_argument
+  "django.template.defaultfilters::filter::capfirst": no_argument
+  "django.template.defaultfilters::filter::center": required_argument
+  "django.template.defaultfilters::filter::cut": required_argument
+  "django.template.defaultfilters::filter::date": optional_argument
+  "django.template.defaultfilters::filter::default": required_argument
+  "django.template.defaultfilters::filter::default_if_none": required_argument
+  "django.template.defaultfilters::filter::dictsort": required_argument
+  "django.template.defaultfilters::filter::dictsortreversed": required_argument
+  "django.template.defaultfilters::filter::divisibleby": required_argument
+  "django.template.defaultfilters::filter::escape": no_argument
+  "django.template.defaultfilters::filter::escapejs": no_argument
+  "django.template.defaultfilters::filter::filesizeformat": no_argument
+  "django.template.defaultfilters::filter::first": no_argument
+  "django.template.defaultfilters::filter::floatformat": optional_argument
+  "django.template.defaultfilters::filter::force_escape": no_argument
+  "django.template.defaultfilters::filter::get_digit": required_argument
+  "django.template.defaultfilters::filter::iriencode": no_argument
+  "django.template.defaultfilters::filter::join": required_argument
+  "django.template.defaultfilters::filter::json_script": optional_argument
+  "django.template.defaultfilters::filter::last": no_argument
+  "django.template.defaultfilters::filter::length": no_argument
+  "django.template.defaultfilters::filter::length_is": required_argument
+  "django.template.defaultfilters::filter::linebreaks": optional_argument
+  "django.template.defaultfilters::filter::linebreaksbr": optional_argument
+  "django.template.defaultfilters::filter::linenumbers": optional_argument
+  "django.template.defaultfilters::filter::ljust": required_argument
+  "django.template.defaultfilters::filter::lower": no_argument
+  "django.template.defaultfilters::filter::make_list": no_argument
+  "django.template.defaultfilters::filter::phone2numeric": no_argument
+  "django.template.defaultfilters::filter::pluralize": optional_argument
+  "django.template.defaultfilters::filter::pprint": no_argument
+  "django.template.defaultfilters::filter::random": no_argument
+  "django.template.defaultfilters::filter::rjust": required_argument
+  "django.template.defaultfilters::filter::safe": no_argument
+  "django.template.defaultfilters::filter::safeseq": no_argument
+  "django.template.defaultfilters::filter::slice": required_argument
+  "django.template.defaultfilters::filter::slugify": no_argument
+  "django.template.defaultfilters::filter::stringformat": required_argument
+  "django.template.defaultfilters::filter::striptags": no_argument
+  "django.template.defaultfilters::filter::time": optional_argument
+  "django.template.defaultfilters::filter::timesince": optional_argument
+  "django.template.defaultfilters::filter::timeuntil": optional_argument
+  "django.template.defaultfilters::filter::title": no_argument
+  "django.template.defaultfilters::filter::truncatechars": required_argument
+  "django.template.defaultfilters::filter::truncatechars_html": required_argument
+  "django.template.defaultfilters::filter::truncatewords": required_argument
+  "django.template.defaultfilters::filter::truncatewords_html": required_argument
+  "django.template.defaultfilters::filter::unordered_list": optional_argument
+  "django.template.defaultfilters::filter::upper": no_argument
+  "django.template.defaultfilters::filter::urlencode": optional_argument
+  "django.template.defaultfilters::filter::urlize": optional_argument
+  "django.template.defaultfilters::filter::urlizetrunc": required_argument
+  "django.template.defaultfilters::filter::wordcount": no_argument
+  "django.template.defaultfilters::filter::wordwrap": required_argument
+  "django.template.defaultfilters::filter::yesno": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
@@ -236,18 +236,10 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.i18n::filter::language_bidi":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_local":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_translated":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.i18n::filter::language_bidi": no_argument
+  "django.templatetags.i18n::filter::language_name": no_argument
+  "django.templatetags.i18n::filter::language_name_local": no_argument
+  "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
     end_tag: endblocktrans

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__l10n.py.snap
@@ -44,12 +44,8 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.l10n::filter::localize":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.l10n::filter::unlocalize":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.l10n::filter::localize": no_argument
+  "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
     end_tag: endlocalize

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__tz.py.snap
@@ -86,15 +86,9 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.tz::filter::localtime":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.tz::filter::timezone":
-    expects_arg: true
-    arg_optional: false
-  "django.templatetags.tz::filter::utc":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.tz::filter::localtime": no_argument
+  "django.templatetags.tz::filter::timezone": required_argument
+  "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
     end_tag: endlocaltime

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__tests__template_tests__templatetags__custom.py.snap
@@ -245,13 +245,7 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "tests.template_tests.templatetags.custom::filter::make_data_div":
-    expects_arg: false
-    arg_optional: false
-  "tests.template_tests.templatetags.custom::filter::noop":
-    expects_arg: true
-    arg_optional: true
-  "tests.template_tests.templatetags.custom::filter::trim":
-    expects_arg: true
-    arg_optional: false
+  "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
+  "tests.template_tests.templatetags.custom::filter::noop": optional_argument
+  "tests.template_tests.templatetags.custom::filter::trim": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__tests__template_tests__templatetags__testtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__tests__template_tests__templatetags__testtags.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "tests.template_tests.templatetags.testtags::filter::upper":
-    expects_arg: false
-    arg_optional: false
+  "tests.template_tests.templatetags.testtags::filter::upper": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_modify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_modify.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.admin.templatetags.admin_modify::filter::cell_count":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_modify::filter::cell_count": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -25,10 +25,6 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname":
-    expects_arg: true
-    arg_optional: false
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__humanize__templatetags__humanize.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__humanize__templatetags__humanize.py.snap
@@ -4,22 +4,10 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.humanize.templatetags.humanize::filter::apnumber":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::intcomma":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::intword":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::naturalday":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::naturaltime":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::ordinal":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::apnumber": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intcomma": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intword": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturalday": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturaltime": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::ordinal": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaultfilters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaultfilters.py.snap
@@ -4,175 +4,61 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.template.defaultfilters::filter::add":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::addslashes":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::capfirst":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::center":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::cut":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::date":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::default":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::default_if_none":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsort":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsortreversed":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::divisibleby":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapejs":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::filesizeformat":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::first":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::floatformat":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::force_escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::get_digit":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::iriencode":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::join":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::json_script":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::last":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::length":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::linebreaks":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linebreaksbr":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linenumbers":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::ljust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::lower":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::make_list":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::phone2numeric":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::pluralize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::pprint":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::random":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::rjust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::safe":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::safeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::slice":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::slugify":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::stringformat":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::striptags":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::time":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timesince":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timeuntil":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::title":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::unordered_list":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::upper":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::urlencode":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlizetrunc":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordcount":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordwrap":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::yesno":
-    expects_arg: true
-    arg_optional: true
+  "django.template.defaultfilters::filter::add": required_argument
+  "django.template.defaultfilters::filter::addslashes": no_argument
+  "django.template.defaultfilters::filter::capfirst": no_argument
+  "django.template.defaultfilters::filter::center": required_argument
+  "django.template.defaultfilters::filter::cut": required_argument
+  "django.template.defaultfilters::filter::date": optional_argument
+  "django.template.defaultfilters::filter::default": required_argument
+  "django.template.defaultfilters::filter::default_if_none": required_argument
+  "django.template.defaultfilters::filter::dictsort": required_argument
+  "django.template.defaultfilters::filter::dictsortreversed": required_argument
+  "django.template.defaultfilters::filter::divisibleby": required_argument
+  "django.template.defaultfilters::filter::escape": no_argument
+  "django.template.defaultfilters::filter::escapejs": no_argument
+  "django.template.defaultfilters::filter::escapeseq": no_argument
+  "django.template.defaultfilters::filter::filesizeformat": no_argument
+  "django.template.defaultfilters::filter::first": no_argument
+  "django.template.defaultfilters::filter::floatformat": optional_argument
+  "django.template.defaultfilters::filter::force_escape": no_argument
+  "django.template.defaultfilters::filter::get_digit": required_argument
+  "django.template.defaultfilters::filter::iriencode": no_argument
+  "django.template.defaultfilters::filter::join": required_argument
+  "django.template.defaultfilters::filter::json_script": optional_argument
+  "django.template.defaultfilters::filter::last": no_argument
+  "django.template.defaultfilters::filter::length": no_argument
+  "django.template.defaultfilters::filter::linebreaks": optional_argument
+  "django.template.defaultfilters::filter::linebreaksbr": optional_argument
+  "django.template.defaultfilters::filter::linenumbers": optional_argument
+  "django.template.defaultfilters::filter::ljust": required_argument
+  "django.template.defaultfilters::filter::lower": no_argument
+  "django.template.defaultfilters::filter::make_list": no_argument
+  "django.template.defaultfilters::filter::phone2numeric": no_argument
+  "django.template.defaultfilters::filter::pluralize": optional_argument
+  "django.template.defaultfilters::filter::pprint": no_argument
+  "django.template.defaultfilters::filter::random": no_argument
+  "django.template.defaultfilters::filter::rjust": required_argument
+  "django.template.defaultfilters::filter::safe": no_argument
+  "django.template.defaultfilters::filter::safeseq": no_argument
+  "django.template.defaultfilters::filter::slice": required_argument
+  "django.template.defaultfilters::filter::slugify": no_argument
+  "django.template.defaultfilters::filter::stringformat": required_argument
+  "django.template.defaultfilters::filter::striptags": no_argument
+  "django.template.defaultfilters::filter::time": optional_argument
+  "django.template.defaultfilters::filter::timesince": optional_argument
+  "django.template.defaultfilters::filter::timeuntil": optional_argument
+  "django.template.defaultfilters::filter::title": no_argument
+  "django.template.defaultfilters::filter::truncatechars": required_argument
+  "django.template.defaultfilters::filter::truncatechars_html": required_argument
+  "django.template.defaultfilters::filter::truncatewords": required_argument
+  "django.template.defaultfilters::filter::truncatewords_html": required_argument
+  "django.template.defaultfilters::filter::unordered_list": optional_argument
+  "django.template.defaultfilters::filter::upper": no_argument
+  "django.template.defaultfilters::filter::urlencode": optional_argument
+  "django.template.defaultfilters::filter::urlize": optional_argument
+  "django.template.defaultfilters::filter::urlizetrunc": required_argument
+  "django.template.defaultfilters::filter::wordcount": no_argument
+  "django.template.defaultfilters::filter::wordwrap": required_argument
+  "django.template.defaultfilters::filter::yesno": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -236,18 +236,10 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.i18n::filter::language_bidi":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_local":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_translated":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.i18n::filter::language_bidi": no_argument
+  "django.templatetags.i18n::filter::language_name": no_argument
+  "django.templatetags.i18n::filter::language_name_local": no_argument
+  "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
     end_tag: endblocktrans

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__l10n.py.snap
@@ -44,12 +44,8 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.l10n::filter::localize":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.l10n::filter::unlocalize":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.l10n::filter::localize": no_argument
+  "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
     end_tag: endlocalize

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__tz.py.snap
@@ -86,15 +86,9 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.tz::filter::localtime":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.tz::filter::timezone":
-    expects_arg: true
-    arg_optional: false
-  "django.templatetags.tz::filter::utc":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.tz::filter::localtime": no_argument
+  "django.templatetags.tz::filter::timezone": required_argument
+  "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
     end_tag: endlocaltime

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
@@ -245,13 +245,7 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "tests.template_tests.templatetags.custom::filter::make_data_div":
-    expects_arg: false
-    arg_optional: false
-  "tests.template_tests.templatetags.custom::filter::noop":
-    expects_arg: true
-    arg_optional: true
-  "tests.template_tests.templatetags.custom::filter::trim":
-    expects_arg: true
-    arg_optional: false
+  "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
+  "tests.template_tests.templatetags.custom::filter::noop": optional_argument
+  "tests.template_tests.templatetags.custom::filter::trim": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__testtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__testtags.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "tests.template_tests.templatetags.testtags::filter::upper":
-    expects_arg: false
-    arg_optional: false
+  "tests.template_tests.templatetags.testtags::filter::upper": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_modify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_modify.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.admin.templatetags.admin_modify::filter::cell_count":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_modify::filter::cell_count": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -25,10 +25,6 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname":
-    expects_arg: true
-    arg_optional: false
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__humanize__templatetags__humanize.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__humanize__templatetags__humanize.py.snap
@@ -4,22 +4,10 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.humanize.templatetags.humanize::filter::apnumber":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::intcomma":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::intword":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::naturalday":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::naturaltime":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::ordinal":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::apnumber": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intcomma": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intword": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturalday": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturaltime": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::ordinal": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaultfilters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaultfilters.py.snap
@@ -4,175 +4,61 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.template.defaultfilters::filter::add":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::addslashes":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::capfirst":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::center":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::cut":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::date":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::default":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::default_if_none":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsort":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsortreversed":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::divisibleby":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapejs":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::filesizeformat":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::first":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::floatformat":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::force_escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::get_digit":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::iriencode":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::join":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::json_script":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::last":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::length":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::linebreaks":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linebreaksbr":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linenumbers":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::ljust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::lower":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::make_list":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::phone2numeric":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::pluralize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::pprint":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::random":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::rjust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::safe":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::safeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::slice":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::slugify":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::stringformat":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::striptags":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::time":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timesince":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timeuntil":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::title":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::unordered_list":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::upper":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::urlencode":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlizetrunc":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordcount":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordwrap":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::yesno":
-    expects_arg: true
-    arg_optional: true
+  "django.template.defaultfilters::filter::add": required_argument
+  "django.template.defaultfilters::filter::addslashes": no_argument
+  "django.template.defaultfilters::filter::capfirst": no_argument
+  "django.template.defaultfilters::filter::center": required_argument
+  "django.template.defaultfilters::filter::cut": required_argument
+  "django.template.defaultfilters::filter::date": optional_argument
+  "django.template.defaultfilters::filter::default": required_argument
+  "django.template.defaultfilters::filter::default_if_none": required_argument
+  "django.template.defaultfilters::filter::dictsort": required_argument
+  "django.template.defaultfilters::filter::dictsortreversed": required_argument
+  "django.template.defaultfilters::filter::divisibleby": required_argument
+  "django.template.defaultfilters::filter::escape": no_argument
+  "django.template.defaultfilters::filter::escapejs": no_argument
+  "django.template.defaultfilters::filter::escapeseq": no_argument
+  "django.template.defaultfilters::filter::filesizeformat": no_argument
+  "django.template.defaultfilters::filter::first": no_argument
+  "django.template.defaultfilters::filter::floatformat": optional_argument
+  "django.template.defaultfilters::filter::force_escape": no_argument
+  "django.template.defaultfilters::filter::get_digit": required_argument
+  "django.template.defaultfilters::filter::iriencode": no_argument
+  "django.template.defaultfilters::filter::join": required_argument
+  "django.template.defaultfilters::filter::json_script": optional_argument
+  "django.template.defaultfilters::filter::last": no_argument
+  "django.template.defaultfilters::filter::length": no_argument
+  "django.template.defaultfilters::filter::linebreaks": optional_argument
+  "django.template.defaultfilters::filter::linebreaksbr": optional_argument
+  "django.template.defaultfilters::filter::linenumbers": optional_argument
+  "django.template.defaultfilters::filter::ljust": required_argument
+  "django.template.defaultfilters::filter::lower": no_argument
+  "django.template.defaultfilters::filter::make_list": no_argument
+  "django.template.defaultfilters::filter::phone2numeric": no_argument
+  "django.template.defaultfilters::filter::pluralize": optional_argument
+  "django.template.defaultfilters::filter::pprint": no_argument
+  "django.template.defaultfilters::filter::random": no_argument
+  "django.template.defaultfilters::filter::rjust": required_argument
+  "django.template.defaultfilters::filter::safe": no_argument
+  "django.template.defaultfilters::filter::safeseq": no_argument
+  "django.template.defaultfilters::filter::slice": required_argument
+  "django.template.defaultfilters::filter::slugify": no_argument
+  "django.template.defaultfilters::filter::stringformat": required_argument
+  "django.template.defaultfilters::filter::striptags": no_argument
+  "django.template.defaultfilters::filter::time": optional_argument
+  "django.template.defaultfilters::filter::timesince": optional_argument
+  "django.template.defaultfilters::filter::timeuntil": optional_argument
+  "django.template.defaultfilters::filter::title": no_argument
+  "django.template.defaultfilters::filter::truncatechars": required_argument
+  "django.template.defaultfilters::filter::truncatechars_html": required_argument
+  "django.template.defaultfilters::filter::truncatewords": required_argument
+  "django.template.defaultfilters::filter::truncatewords_html": required_argument
+  "django.template.defaultfilters::filter::unordered_list": optional_argument
+  "django.template.defaultfilters::filter::upper": no_argument
+  "django.template.defaultfilters::filter::urlencode": optional_argument
+  "django.template.defaultfilters::filter::urlize": optional_argument
+  "django.template.defaultfilters::filter::urlizetrunc": required_argument
+  "django.template.defaultfilters::filter::wordcount": no_argument
+  "django.template.defaultfilters::filter::wordwrap": required_argument
+  "django.template.defaultfilters::filter::yesno": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -236,18 +236,10 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.i18n::filter::language_bidi":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_local":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_translated":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.i18n::filter::language_bidi": no_argument
+  "django.templatetags.i18n::filter::language_name": no_argument
+  "django.templatetags.i18n::filter::language_name_local": no_argument
+  "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
     end_tag: endblocktrans

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__l10n.py.snap
@@ -44,12 +44,8 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.l10n::filter::localize":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.l10n::filter::unlocalize":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.l10n::filter::localize": no_argument
+  "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
     end_tag: endlocalize

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__tz.py.snap
@@ -86,15 +86,9 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.tz::filter::localtime":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.tz::filter::timezone":
-    expects_arg: true
-    arg_optional: false
-  "django.templatetags.tz::filter::utc":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.tz::filter::localtime": no_argument
+  "django.templatetags.tz::filter::timezone": required_argument
+  "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
     end_tag: endlocaltime

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
@@ -245,13 +245,7 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "tests.template_tests.templatetags.custom::filter::make_data_div":
-    expects_arg: false
-    arg_optional: false
-  "tests.template_tests.templatetags.custom::filter::noop":
-    expects_arg: true
-    arg_optional: true
-  "tests.template_tests.templatetags.custom::filter::trim":
-    expects_arg: true
-    arg_optional: false
+  "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
+  "tests.template_tests.templatetags.custom::filter::noop": optional_argument
+  "tests.template_tests.templatetags.custom::filter::trim": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__testtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__testtags.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "tests.template_tests.templatetags.testtags::filter::upper":
-    expects_arg: false
-    arg_optional: false
+  "tests.template_tests.templatetags.testtags::filter::upper": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_filters.py.snap
@@ -4,10 +4,6 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.admin.templatetags.admin_filters::filter::to_object_display_value":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.admin.templatetags.admin_filters::filter::truncated_unordered_list":
-    expects_arg: true
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_filters::filter::to_object_display_value": no_argument
+  "django.contrib.admin.templatetags.admin_filters::filter::truncated_unordered_list": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_modify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_modify.py.snap
@@ -4,7 +4,5 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.admin.templatetags.admin_modify::filter::cell_count":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_modify::filter::cell_count": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -25,10 +25,6 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname":
-    expects_arg: true
-    arg_optional: false
-  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument
+  "django.contrib.admin.templatetags.admin_urls::filter::admin_urlquote": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__humanize__templatetags__humanize.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__humanize__templatetags__humanize.py.snap
@@ -4,22 +4,10 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules: {}
 filter_arities:
-  "django.contrib.humanize.templatetags.humanize::filter::apnumber":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::intcomma":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::intword":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::naturalday":
-    expects_arg: true
-    arg_optional: true
-  "django.contrib.humanize.templatetags.humanize::filter::naturaltime":
-    expects_arg: false
-    arg_optional: false
-  "django.contrib.humanize.templatetags.humanize::filter::ordinal":
-    expects_arg: false
-    arg_optional: false
+  "django.contrib.humanize.templatetags.humanize::filter::apnumber": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intcomma": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::intword": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturalday": optional_argument
+  "django.contrib.humanize.templatetags.humanize::filter::naturaltime": no_argument
+  "django.contrib.humanize.templatetags.humanize::filter::ordinal": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaultfilters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaultfilters.py.snap
@@ -4,175 +4,61 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules: {}
 filter_arities:
-  "django.template.defaultfilters::filter::add":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::addslashes":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::capfirst":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::center":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::cut":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::date":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::default":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::default_if_none":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsort":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::dictsortreversed":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::divisibleby":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapejs":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::filesizeformat":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::first":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::floatformat":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::force_escape":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::get_digit":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::iriencode":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::join":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::json_script":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::last":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::length":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::linebreaks":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linebreaksbr":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::linenumbers":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::ljust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::lower":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::make_list":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::phone2numeric":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::pluralize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::pprint":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::random":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::rjust":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::safe":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::safeseq":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::slice":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::slugify":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::stringformat":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::striptags":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::time":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timesince":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::timeuntil":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::title":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatechars_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::truncatewords_html":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::unordered_list":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::upper":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::urlencode":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlize":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::urlizetrunc":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordcount":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::wordwrap":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::yesno":
-    expects_arg: true
-    arg_optional: true
+  "django.template.defaultfilters::filter::add": required_argument
+  "django.template.defaultfilters::filter::addslashes": no_argument
+  "django.template.defaultfilters::filter::capfirst": no_argument
+  "django.template.defaultfilters::filter::center": required_argument
+  "django.template.defaultfilters::filter::cut": required_argument
+  "django.template.defaultfilters::filter::date": optional_argument
+  "django.template.defaultfilters::filter::default": required_argument
+  "django.template.defaultfilters::filter::default_if_none": required_argument
+  "django.template.defaultfilters::filter::dictsort": required_argument
+  "django.template.defaultfilters::filter::dictsortreversed": required_argument
+  "django.template.defaultfilters::filter::divisibleby": required_argument
+  "django.template.defaultfilters::filter::escape": no_argument
+  "django.template.defaultfilters::filter::escapejs": no_argument
+  "django.template.defaultfilters::filter::escapeseq": no_argument
+  "django.template.defaultfilters::filter::filesizeformat": no_argument
+  "django.template.defaultfilters::filter::first": no_argument
+  "django.template.defaultfilters::filter::floatformat": optional_argument
+  "django.template.defaultfilters::filter::force_escape": no_argument
+  "django.template.defaultfilters::filter::get_digit": required_argument
+  "django.template.defaultfilters::filter::iriencode": no_argument
+  "django.template.defaultfilters::filter::join": required_argument
+  "django.template.defaultfilters::filter::json_script": optional_argument
+  "django.template.defaultfilters::filter::last": no_argument
+  "django.template.defaultfilters::filter::length": no_argument
+  "django.template.defaultfilters::filter::linebreaks": optional_argument
+  "django.template.defaultfilters::filter::linebreaksbr": optional_argument
+  "django.template.defaultfilters::filter::linenumbers": optional_argument
+  "django.template.defaultfilters::filter::ljust": required_argument
+  "django.template.defaultfilters::filter::lower": no_argument
+  "django.template.defaultfilters::filter::make_list": no_argument
+  "django.template.defaultfilters::filter::phone2numeric": no_argument
+  "django.template.defaultfilters::filter::pluralize": optional_argument
+  "django.template.defaultfilters::filter::pprint": no_argument
+  "django.template.defaultfilters::filter::random": no_argument
+  "django.template.defaultfilters::filter::rjust": required_argument
+  "django.template.defaultfilters::filter::safe": no_argument
+  "django.template.defaultfilters::filter::safeseq": no_argument
+  "django.template.defaultfilters::filter::slice": required_argument
+  "django.template.defaultfilters::filter::slugify": no_argument
+  "django.template.defaultfilters::filter::stringformat": required_argument
+  "django.template.defaultfilters::filter::striptags": no_argument
+  "django.template.defaultfilters::filter::time": optional_argument
+  "django.template.defaultfilters::filter::timesince": optional_argument
+  "django.template.defaultfilters::filter::timeuntil": optional_argument
+  "django.template.defaultfilters::filter::title": no_argument
+  "django.template.defaultfilters::filter::truncatechars": required_argument
+  "django.template.defaultfilters::filter::truncatechars_html": required_argument
+  "django.template.defaultfilters::filter::truncatewords": required_argument
+  "django.template.defaultfilters::filter::truncatewords_html": required_argument
+  "django.template.defaultfilters::filter::unordered_list": optional_argument
+  "django.template.defaultfilters::filter::upper": no_argument
+  "django.template.defaultfilters::filter::urlencode": optional_argument
+  "django.template.defaultfilters::filter::urlize": optional_argument
+  "django.template.defaultfilters::filter::urlizetrunc": required_argument
+  "django.template.defaultfilters::filter::wordcount": no_argument
+  "django.template.defaultfilters::filter::wordwrap": required_argument
+  "django.template.defaultfilters::filter::yesno": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
@@ -236,18 +236,10 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.i18n::filter::language_bidi":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_local":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.i18n::filter::language_name_translated":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.i18n::filter::language_bidi": no_argument
+  "django.templatetags.i18n::filter::language_name": no_argument
+  "django.templatetags.i18n::filter::language_name_local": no_argument
+  "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
     end_tag: endblocktrans

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
@@ -44,12 +44,8 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.l10n::filter::localize":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.l10n::filter::unlocalize":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.l10n::filter::localize": no_argument
+  "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
     end_tag: endlocalize

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
@@ -86,15 +86,9 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "django.templatetags.tz::filter::localtime":
-    expects_arg: false
-    arg_optional: false
-  "django.templatetags.tz::filter::timezone":
-    expects_arg: true
-    arg_optional: false
-  "django.templatetags.tz::filter::utc":
-    expects_arg: false
-    arg_optional: false
+  "django.templatetags.tz::filter::localtime": no_argument
+  "django.templatetags.tz::filter::timezone": required_argument
+  "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
     end_tag: endlocaltime

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
@@ -229,13 +229,7 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "tests.template_tests.templatetags.custom::filter::make_data_div":
-    expects_arg: false
-    arg_optional: false
-  "tests.template_tests.templatetags.custom::filter::noop":
-    expects_arg: true
-    arg_optional: true
-  "tests.template_tests.templatetags.custom::filter::trim":
-    expects_arg: true
-    arg_optional: false
+  "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
+  "tests.template_tests.templatetags.custom::filter::noop": optional_argument
+  "tests.template_tests.templatetags.custom::filter::trim": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__testtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__testtags.py.snap
@@ -4,7 +4,5 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules: {}
 filter_arities:
-  "tests.template_tests.templatetags.testtags::filter::upper":
-    expects_arg: false
-    arg_optional: false
+  "tests.template_tests.templatetags.testtags::filter::upper": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
@@ -66,10 +66,6 @@ tag_rules:
         position: 1
     as_var: keep
 filter_arities:
-  "actstream.templatetags.activity_tags::filter::activity_stream":
-    expects_arg: true
-    arg_optional: false
-  "actstream.templatetags.activity_tags::filter::is_following":
-    expects_arg: true
-    arg_optional: false
+  "actstream.templatetags.activity_tags::filter::activity_stream": required_argument
+  "actstream.templatetags.activity_tags::filter::is_following": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-avatar__avatar__templatetags__avatar_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-avatar__avatar__templatetags__avatar_tags.py.snap
@@ -87,7 +87,5 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "avatar.templatetags.avatar_tags::filter::has_avatar":
-    expects_arg: false
-    arg_optional: false
+  "avatar.templatetags.avatar_tags::filter::has_avatar": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-baton__baton__templatetags__baton_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-baton__baton__templatetags__baton_tags.py.snap
@@ -49,7 +49,5 @@ tag_rules:
     extracted_args: []
     as_var: keep
 filter_arities:
-  "baton.templatetags.baton_tags::filter::to_json":
-    expects_arg: false
-    arg_optional: false
+  "baton.templatetags.baton_tags::filter::to_json": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
@@ -210,12 +210,8 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_message_classes":
-    expects_arg: false
-    arg_optional: false
-  "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_setting":
-    expects_arg: false
-    arg_optional: false
+  "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_message_classes": no_argument
+  "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_setting": no_argument
 block_specs:
   "src.bootstrap3.templatetags.bootstrap3::tag::buttons":
     end_tag: endbuttons

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_admin.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_admin.py.snap
@@ -67,10 +67,6 @@ tag_rules:
     extracted_args: []
     as_var: keep
 filter_arities:
-  "cms.templatetags.cms_admin::filter::boolean_icon":
-    expects_arg: false
-    arg_optional: false
-  "cms.templatetags.cms_admin::filter::placeholder_is_immutable":
-    expects_arg: true
-    arg_optional: false
+  "cms.templatetags.cms_admin::filter::boolean_icon": no_argument
+  "cms.templatetags.cms_admin::filter::placeholder_is_immutable": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_js_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_js_tags.py.snap
@@ -34,10 +34,6 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "cms.templatetags.cms_js_tags::filter::bool":
-    expects_arg: false
-    arg_optional: false
-  "cms.templatetags.cms_js_tags::filter::json":
-    expects_arg: false
-    arg_optional: false
+  "cms.templatetags.cms_js_tags::filter::bool": no_argument
+  "cms.templatetags.cms_js_tags::filter::json": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_field.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_field.py.snap
@@ -29,34 +29,14 @@ tag_rules:
         position: 3
     as_var: strip
 filter_arities:
-  "crispy_forms.templatetags.crispy_forms_field::filter::classes":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::css_class":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_checkbox":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_checkboxselectmultiple":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_clearable_file":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_file":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_multivalue":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_password":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_radioselect":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_field::filter::is_select":
-    expects_arg: false
-    arg_optional: false
+  "crispy_forms.templatetags.crispy_forms_field::filter::classes": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::css_class": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_checkbox": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_checkboxselectmultiple": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_clearable_file": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_file": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_multivalue": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_password": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_radioselect": no_argument
+  "crispy_forms.templatetags.crispy_forms_field::filter::is_select": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_filters.py.snap
@@ -4,19 +4,9 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "crispy_forms.templatetags.crispy_forms_filters::filter::as_crispy_errors":
-    expects_arg: true
-    arg_optional: true
-  "crispy_forms.templatetags.crispy_forms_filters::filter::as_crispy_field":
-    expects_arg: true
-    arg_optional: true
-  "crispy_forms.templatetags.crispy_forms_filters::filter::crispy":
-    expects_arg: true
-    arg_optional: true
-  "crispy_forms.templatetags.crispy_forms_filters::filter::flatatt":
-    expects_arg: false
-    arg_optional: false
-  "crispy_forms.templatetags.crispy_forms_filters::filter::optgroups":
-    expects_arg: false
-    arg_optional: false
+  "crispy_forms.templatetags.crispy_forms_filters::filter::as_crispy_errors": optional_argument
+  "crispy_forms.templatetags.crispy_forms_filters::filter::as_crispy_field": optional_argument
+  "crispy_forms.templatetags.crispy_forms_filters::filter::crispy": optional_argument
+  "crispy_forms.templatetags.crispy_forms_filters::filter::flatatt": no_argument
+  "crispy_forms.templatetags.crispy_forms_filters::filter::optgroups": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crm__common__templatetags__util.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crm__common__templatetags__util.py.snap
@@ -4,31 +4,13 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "common.templatetags.util::filter::crmadmin_urlname":
-    expects_arg: true
-    arg_optional: false
-  "common.templatetags.util::filter::get_url":
-    expects_arg: false
-    arg_optional: false
-  "common.templatetags.util::filter::param":
-    expects_arg: true
-    arg_optional: false
-  "common.templatetags.util::filter::priority":
-    expects_arg: false
-    arg_optional: false
-  "common.templatetags.util::filter::replace_lang":
-    expects_arg: true
-    arg_optional: false
-  "common.templatetags.util::filter::responsible_list":
-    expects_arg: false
-    arg_optional: false
-  "common.templatetags.util::filter::stage":
-    expects_arg: false
-    arg_optional: false
-  "common.templatetags.util::filter::task_completed_button":
-    expects_arg: true
-    arg_optional: false
-  "common.templatetags.util::filter::verbose_name":
-    expects_arg: false
-    arg_optional: false
+  "common.templatetags.util::filter::crmadmin_urlname": required_argument
+  "common.templatetags.util::filter::get_url": no_argument
+  "common.templatetags.util::filter::param": required_argument
+  "common.templatetags.util::filter::priority": no_argument
+  "common.templatetags.util::filter::replace_lang": required_argument
+  "common.templatetags.util::filter::responsible_list": no_argument
+  "common.templatetags.util::filter::stage": no_argument
+  "common.templatetags.util::filter::task_completed_button": required_argument
+  "common.templatetags.util::filter::verbose_name": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-forms-bootstrap__django_forms_bootstrap__templatetags__bootstrap_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-forms-bootstrap__django_forms_bootstrap__templatetags__bootstrap_tags.py.snap
@@ -4,16 +4,8 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::as_bootstrap":
-    expects_arg: false
-    arg_optional: false
-  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::as_bootstrap_horizontal":
-    expects_arg: true
-    arg_optional: true
-  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::as_bootstrap_inline":
-    expects_arg: false
-    arg_optional: false
-  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::css_class":
-    expects_arg: false
-    arg_optional: false
+  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::as_bootstrap": no_argument
+  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::as_bootstrap_horizontal": optional_argument
+  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::as_bootstrap_inline": no_argument
+  "django_forms_bootstrap.templatetags.bootstrap_tags::filter::css_class": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-grappelli__grappelli__templatetags__grp_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-grappelli__grappelli__templatetags__grp_tags.py.snap
@@ -101,16 +101,8 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "grappelli.templatetags.grp_tags::filter::classname":
-    expects_arg: true
-    arg_optional: true
-  "grappelli.templatetags.grp_tags::filter::classpath":
-    expects_arg: false
-    arg_optional: false
-  "grappelli.templatetags.grp_tags::filter::formsetsort":
-    expects_arg: true
-    arg_optional: false
-  "grappelli.templatetags.grp_tags::filter::prettylabel":
-    expects_arg: false
-    arg_optional: false
+  "grappelli.templatetags.grp_tags::filter::classname": optional_argument
+  "grappelli.templatetags.grp_tags::filter::classpath": no_argument
+  "grappelli.templatetags.grp_tags::filter::formsetsort": required_argument
+  "grappelli.templatetags.grp_tags::filter::prettylabel": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-htmx__example__example__templatetags__example_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-htmx__example__example__templatetags__example_tags.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "example.example.templatetags.example_tags::filter::json_dumps":
-    expects_arg: false
-    arg_optional: false
+  "example.example.templatetags.example_tags::filter::json_dumps": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-jazzmin__jazzmin__templatetags__jazzmin.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-jazzmin__jazzmin__templatetags__jazzmin.py.snap
@@ -229,31 +229,13 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "jazzmin.templatetags.jazzmin::filter::app_is_installed":
-    expects_arg: false
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::as_json":
-    expects_arg: false
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::can_view_self":
-    expects_arg: false
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::debug":
-    expects_arg: false
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::has_fieldsets":
-    expects_arg: false
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::has_jazzmin_setting":
-    expects_arg: true
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::remove_lang":
-    expects_arg: true
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::style_bold_first_word":
-    expects_arg: false
-    arg_optional: false
-  "jazzmin.templatetags.jazzmin::filter::unicode_slugify":
-    expects_arg: false
-    arg_optional: false
+  "jazzmin.templatetags.jazzmin::filter::app_is_installed": no_argument
+  "jazzmin.templatetags.jazzmin::filter::as_json": no_argument
+  "jazzmin.templatetags.jazzmin::filter::can_view_self": no_argument
+  "jazzmin.templatetags.jazzmin::filter::debug": no_argument
+  "jazzmin.templatetags.jazzmin::filter::has_fieldsets": no_argument
+  "jazzmin.templatetags.jazzmin::filter::has_jazzmin_setting": required_argument
+  "jazzmin.templatetags.jazzmin::filter::remove_lang": required_argument
+  "jazzmin.templatetags.jazzmin::filter::style_bold_first_word": no_argument
+  "jazzmin.templatetags.jazzmin::filter::unicode_slugify": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-markdownify__markdownify__templatetags__markdownify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-markdownify__markdownify__templatetags__markdownify.py.snap
@@ -4,9 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "markdownify.templatetags.markdownify::filter::markdownify":
-    expects_arg: true
-    arg_optional: true
+  "markdownify.templatetags.markdownify::filter::markdownify": optional_argument
 block_specs:
   "markdownify.templatetags.markdownify::tag::markdownify":
     end_tag: endmarkdownify

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__currency_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__currency_filters.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.oscar.templatetags.currency_filters::filter::currency":
-    expects_arg: true
-    arg_optional: true
+  "src.oscar.templatetags.currency_filters::filter::currency": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__datetime_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__datetime_filters.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.oscar.templatetags.datetime_filters::filter::timedelta":
-    expects_arg: false
-    arg_optional: false
+  "src.oscar.templatetags.datetime_filters::filter::timedelta": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__reviews_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__reviews_tags.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.oscar.templatetags.reviews_tags::filter::as_stars":
-    expects_arg: false
-    arg_optional: false
-  "src.oscar.templatetags.reviews_tags::filter::is_review_permitted":
-    expects_arg: true
-    arg_optional: false
-  "src.oscar.templatetags.reviews_tags::filter::may_vote":
-    expects_arg: true
-    arg_optional: false
+  "src.oscar.templatetags.reviews_tags::filter::as_stars": no_argument
+  "src.oscar.templatetags.reviews_tags::filter::is_review_permitted": required_argument
+  "src.oscar.templatetags.reviews_tags::filter::may_vote": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__string_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__string_filters.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.oscar.templatetags.string_filters::filter::split":
-    expects_arg: true
-    arg_optional: true
+  "src.oscar.templatetags.string_filters::filter::split": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-simple-history__simple_history__templatetags__getattributes.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-simple-history__simple_history__templatetags__getattributes.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "simple_history.templatetags.getattributes::filter::getattribute":
-    expects_arg: true
-    arg_optional: false
+  "simple_history.templatetags.getattributes::filter::getattribute": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-tables2__django_tables2__templatetags__django_tables2.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-tables2__django_tables2__templatetags__django_tables2.py.snap
@@ -33,7 +33,5 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "django_tables2.templatetags.django_tables2::filter::table_page_range":
-    expects_arg: true
-    arg_optional: false
+  "django_tables2.templatetags.django_tables2::filter::table_page_range": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-typogrify__typogrify__templatetags__typogrify_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-typogrify__typogrify__templatetags__typogrify_tags.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "typogrify.templatetags.typogrify_tags::filter::fuzzydate":
-    expects_arg: true
-    arg_optional: true
-  "typogrify.templatetags.typogrify_tags::filter::super_fuzzydate":
-    expects_arg: false
-    arg_optional: false
-  "typogrify.templatetags.typogrify_tags::filter::text_whole_number":
-    expects_arg: false
-    arg_optional: false
+  "typogrify.templatetags.typogrify_tags::filter::fuzzydate": optional_argument
+  "typogrify.templatetags.typogrify_tags::filter::super_fuzzydate": no_argument
+  "typogrify.templatetags.typogrify_tags::filter::text_whole_number": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
@@ -282,36 +282,16 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "src.unfold.templatetags.unfold::filter::add_css_class":
-    expects_arg: true
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::changeform_condition":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::changeform_data":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::class_name":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::has_active_item":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::index":
-    expects_arg: true
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::is_list":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::tabs":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::tabs_active":
-    expects_arg: false
-    arg_optional: false
-  "src.unfold.templatetags.unfold::filter::tabs_errors_count":
-    expects_arg: false
-    arg_optional: false
+  "src.unfold.templatetags.unfold::filter::add_css_class": required_argument
+  "src.unfold.templatetags.unfold::filter::changeform_condition": no_argument
+  "src.unfold.templatetags.unfold::filter::changeform_data": no_argument
+  "src.unfold.templatetags.unfold::filter::class_name": no_argument
+  "src.unfold.templatetags.unfold::filter::has_active_item": no_argument
+  "src.unfold.templatetags.unfold::filter::index": required_argument
+  "src.unfold.templatetags.unfold::filter::is_list": no_argument
+  "src.unfold.templatetags.unfold::filter::tabs": no_argument
+  "src.unfold.templatetags.unfold::filter::tabs_active": no_argument
+  "src.unfold.templatetags.unfold::filter::tabs_errors_count": no_argument
 block_specs:
   "src.unfold.templatetags.unfold::tag::capture":
     end_tag: endcapture

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-widget-tweaks__widget_tweaks__templatetags__widget_tweaks.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-widget-tweaks__widget_tweaks__templatetags__widget_tweaks.py.snap
@@ -4,37 +4,15 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "widget_tweaks.templatetags.widget_tweaks::filter::add_class":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::add_error_attr":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::add_error_class":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::add_label_class":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::add_required_class":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::append_attr":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::attr":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::field_type":
-    expects_arg: false
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::remove_attr":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::set_data":
-    expects_arg: true
-    arg_optional: false
-  "widget_tweaks.templatetags.widget_tweaks::filter::widget_type":
-    expects_arg: false
-    arg_optional: false
+  "widget_tweaks.templatetags.widget_tweaks::filter::add_class": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::add_error_attr": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::add_error_class": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::add_label_class": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::add_required_class": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::append_attr": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::attr": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::field_type": no_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::remove_attr": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::set_data": required_argument
+  "widget_tweaks.templatetags.widget_tweaks::filter::widget_type": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__core__templatetags__markdown_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__core__templatetags__markdown_tags.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "core.templatetags.markdown_tags::filter::markdown":
-    expects_arg: false
-    arg_optional: false
+  "core.templatetags.markdown_tags::filter::markdown": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__grid__templatetags__grid_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__grid__templatetags__grid_tags.py.snap
@@ -4,16 +4,8 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "grid.templatetags.grid_tags::filter::get_item":
-    expects_arg: true
-    arg_optional: false
-  "grid.templatetags.grid_tags::filter::hash":
-    expects_arg: true
-    arg_optional: false
-  "grid.templatetags.grid_tags::filter::multiply":
-    expects_arg: true
-    arg_optional: false
-  "grid.templatetags.grid_tags::filter::style_element":
-    expects_arg: false
-    arg_optional: false
+  "grid.templatetags.grid_tags::filter::get_item": required_argument
+  "grid.templatetags.grid_tags::filter::hash": required_argument
+  "grid.templatetags.grid_tags::filter::multiply": required_argument
+  "grid.templatetags.grid_tags::filter::style_element": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__package__templatetags__package_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__package__templatetags__package_tags.py.snap
@@ -19,13 +19,7 @@ tag_rules:
         position: 1
     as_var: keep
 filter_arities:
-  "package.templatetags.package_tags::filter::emojify":
-    expects_arg: false
-    arg_optional: false
-  "package.templatetags.package_tags::filter::is_in":
-    expects_arg: true
-    arg_optional: false
-  "package.templatetags.package_tags::filter::package_dev_status_badge":
-    expects_arg: true
-    arg_optional: true
+  "package.templatetags.package_tags::filter::emojify": no_argument
+  "package.templatetags.package_tags::filter::is_in": required_argument
+  "package.templatetags.package_tags::filter::package_dev_status_badge": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__checklists__templatetags__checklist_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__checklists__templatetags__checklist_extras.py.snap
@@ -4,46 +4,18 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "checklists.templatetags.checklist_extras::filter::enumerate_cves":
-    expects_arg: true
-    arg_optional: true
-  "checklists.templatetags.checklist_extras::filter::enumerate_items":
-    expects_arg: true
-    arg_optional: true
-  "checklists.templatetags.checklist_extras::filter::format_release_for_cve":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::format_releases_for_cves":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::format_version_for_blogpost":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::format_version_tuple":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::format_versions_for_blogpost":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::next_feature_version":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::next_release_date":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::next_version":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::next_version_tuple":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::rst_backticks":
-    expects_arg: false
-    arg_optional: false
-  "checklists.templatetags.checklist_extras::filter::rst_underline_for_headline":
-    expects_arg: true
-    arg_optional: true
-  "checklists.templatetags.checklist_extras::filter::stub_release_notes_title":
-    expects_arg: false
-    arg_optional: false
+  "checklists.templatetags.checklist_extras::filter::enumerate_cves": optional_argument
+  "checklists.templatetags.checklist_extras::filter::enumerate_items": optional_argument
+  "checklists.templatetags.checklist_extras::filter::format_release_for_cve": no_argument
+  "checklists.templatetags.checklist_extras::filter::format_releases_for_cves": no_argument
+  "checklists.templatetags.checklist_extras::filter::format_version_for_blogpost": no_argument
+  "checklists.templatetags.checklist_extras::filter::format_version_tuple": no_argument
+  "checklists.templatetags.checklist_extras::filter::format_versions_for_blogpost": no_argument
+  "checklists.templatetags.checklist_extras::filter::next_feature_version": no_argument
+  "checklists.templatetags.checklist_extras::filter::next_release_date": no_argument
+  "checklists.templatetags.checklist_extras::filter::next_version": no_argument
+  "checklists.templatetags.checklist_extras::filter::next_version_tuple": no_argument
+  "checklists.templatetags.checklist_extras::filter::rst_backticks": no_argument
+  "checklists.templatetags.checklist_extras::filter::rst_underline_for_headline": optional_argument
+  "checklists.templatetags.checklist_extras::filter::stub_release_notes_title": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
@@ -41,9 +41,7 @@ tag_rules:
     extracted_args: []
     as_var: keep
 filter_arities:
-  "docs.templatetags.docs::filter::fragment":
-    expects_arg: false
-    arg_optional: false
+  "docs.templatetags.docs::filter::fragment": no_argument
 block_specs:
   "docs.templatetags.docs::tag::pygment":
     end_tag: endpygment

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__fundraising__templatetags__fundraising_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__fundraising__templatetags__fundraising_extras.py.snap
@@ -43,7 +43,5 @@ tag_rules:
         position: 1
     as_var: keep
 filter_arities:
-  "fundraising.templatetags.fundraising_extras::filter::as_percentage":
-    expects_arg: true
-    arg_optional: false
+  "fundraising.templatetags.fundraising_extras::filter::as_percentage": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__base_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__base_tags.py.snap
@@ -122,10 +122,6 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "geonode.base.templatetags.base_tags::filter::get_item":
-    expects_arg: true
-    arg_optional: false
-  "geonode.base.templatetags.base_tags::filter::template_trans":
-    expects_arg: false
-    arg_optional: false
+  "geonode.base.templatetags.base_tags::filter::get_item": required_argument
+  "geonode.base.templatetags.base_tags::filter::template_trans": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__thesaurus.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__thesaurus.py.snap
@@ -4,25 +4,11 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "geonode.base.templatetags.thesaurus::filter::get_name_translation":
-    expects_arg: false
-    arg_optional: false
-  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_date":
-    expects_arg: false
-    arg_optional: false
-  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_localized_label":
-    expects_arg: false
-    arg_optional: false
-  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_title":
-    expects_arg: false
-    arg_optional: false
-  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_translation_by_id":
-    expects_arg: false
-    arg_optional: false
-  "geonode.base.templatetags.thesaurus::filter::get_unique_thesaurus_set":
-    expects_arg: false
-    arg_optional: false
-  "geonode.base.templatetags.thesaurus::filter::with_localized_labels":
-    expects_arg: false
-    arg_optional: false
+  "geonode.base.templatetags.thesaurus::filter::get_name_translation": no_argument
+  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_date": no_argument
+  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_localized_label": no_argument
+  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_title": no_argument
+  "geonode.base.templatetags.thesaurus::filter::get_thesaurus_translation_by_id": no_argument
+  "geonode.base.templatetags.thesaurus::filter::get_unique_thesaurus_set": no_argument
+  "geonode.base.templatetags.thesaurus::filter::with_localized_labels": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__contact_roles.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__contact_roles.py.snap
@@ -21,13 +21,7 @@ tag_rules:
         position: 1
     as_var: strip
 filter_arities:
-  "geonode.layers.templatetags.contact_roles::filter::get_contact_role_id":
-    expects_arg: true
-    arg_optional: false
-  "geonode.layers.templatetags.contact_roles::filter::get_contact_role_label":
-    expects_arg: true
-    arg_optional: false
-  "geonode.layers.templatetags.contact_roles::filter::get_contact_role_value":
-    expects_arg: true
-    arg_optional: false
+  "geonode.layers.templatetags.contact_roles::filter::get_contact_role_id": required_argument
+  "geonode.layers.templatetags.contact_roles::filter::get_contact_role_label": required_argument
+  "geonode.layers.templatetags.contact_roles::filter::get_contact_role_value": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__dataset_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__dataset_tags.py.snap
@@ -43,13 +43,7 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "geonode.layers.templatetags.dataset_tags::filter::camelize":
-    expects_arg: false
-    arg_optional: false
-  "geonode.layers.templatetags.dataset_tags::filter::crs_labels":
-    expects_arg: false
-    arg_optional: false
-  "geonode.layers.templatetags.dataset_tags::filter::lower":
-    expects_arg: false
-    arg_optional: false
+  "geonode.layers.templatetags.dataset_tags::filter::camelize": no_argument
+  "geonode.layers.templatetags.dataset_tags::filter::crs_labels": no_argument
+  "geonode.layers.templatetags.dataset_tags::filter::lower": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__hc_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__hc_extras.py.snap
@@ -81,73 +81,27 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "hc.front.templatetags.hc_extras::filter::add6days":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::break_underscore":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::decode":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::down_title":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::first5":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::format_headers":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::format_ping_endpoint":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::guess_schedule":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::hc_approx_duration":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::hc_duration":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::hms":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::mangle_link":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::mask_key":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::mask_phone":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::mask_ro_key":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::mask_rw_key":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::num_down_title":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::pct":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::sortbydowntime":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::sortchecks":
-    expects_arg: true
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::timestamp":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::underline":
-    expects_arg: false
-    arg_optional: false
-  "hc.front.templatetags.hc_extras::filter::uppercase_if_down":
-    expects_arg: false
-    arg_optional: false
+  "hc.front.templatetags.hc_extras::filter::add6days": no_argument
+  "hc.front.templatetags.hc_extras::filter::break_underscore": no_argument
+  "hc.front.templatetags.hc_extras::filter::decode": no_argument
+  "hc.front.templatetags.hc_extras::filter::down_title": no_argument
+  "hc.front.templatetags.hc_extras::filter::first5": no_argument
+  "hc.front.templatetags.hc_extras::filter::format_headers": no_argument
+  "hc.front.templatetags.hc_extras::filter::format_ping_endpoint": no_argument
+  "hc.front.templatetags.hc_extras::filter::guess_schedule": no_argument
+  "hc.front.templatetags.hc_extras::filter::hc_approx_duration": no_argument
+  "hc.front.templatetags.hc_extras::filter::hc_duration": no_argument
+  "hc.front.templatetags.hc_extras::filter::hms": no_argument
+  "hc.front.templatetags.hc_extras::filter::mangle_link": no_argument
+  "hc.front.templatetags.hc_extras::filter::mask_key": no_argument
+  "hc.front.templatetags.hc_extras::filter::mask_phone": no_argument
+  "hc.front.templatetags.hc_extras::filter::mask_ro_key": no_argument
+  "hc.front.templatetags.hc_extras::filter::mask_rw_key": no_argument
+  "hc.front.templatetags.hc_extras::filter::num_down_title": no_argument
+  "hc.front.templatetags.hc_extras::filter::pct": no_argument
+  "hc.front.templatetags.hc_extras::filter::sortbydowntime": no_argument
+  "hc.front.templatetags.hc_extras::filter::sortchecks": required_argument
+  "hc.front.templatetags.hc_extras::filter::timestamp": no_argument
+  "hc.front.templatetags.hc_extras::filter::underline": no_argument
+  "hc.front.templatetags.hc_extras::filter::uppercase_if_down": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__angular.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__angular.py.snap
@@ -12,7 +12,5 @@ tag_rules:
     extracted_args: []
     as_var: keep
 filter_arities:
-  "horizon.templatetags.angular::filter::angular_escapes":
-    expects_arg: false
-    arg_optional: false
+  "horizon.templatetags.angular::filter::angular_escapes": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__form_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__form_helpers.py.snap
@@ -4,34 +4,14 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "horizon.templatetags.form_helpers::filter::add_bootstrap_class":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::add_item_url":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::autocomplete":
-    expects_arg: true
-    arg_optional: true
-  "horizon.templatetags.form_helpers::filter::get_range":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::is_checkbox":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::is_file":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::is_multiple_checkbox":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::is_number":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::is_radio":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.form_helpers::filter::wrapper_classes":
-    expects_arg: false
-    arg_optional: false
+  "horizon.templatetags.form_helpers::filter::add_bootstrap_class": no_argument
+  "horizon.templatetags.form_helpers::filter::add_item_url": no_argument
+  "horizon.templatetags.form_helpers::filter::autocomplete": optional_argument
+  "horizon.templatetags.form_helpers::filter::get_range": no_argument
+  "horizon.templatetags.form_helpers::filter::is_checkbox": no_argument
+  "horizon.templatetags.form_helpers::filter::is_file": no_argument
+  "horizon.templatetags.form_helpers::filter::is_multiple_checkbox": no_argument
+  "horizon.templatetags.form_helpers::filter::is_number": no_argument
+  "horizon.templatetags.form_helpers::filter::is_radio": no_argument
+  "horizon.templatetags.form_helpers::filter::wrapper_classes": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
@@ -69,18 +69,10 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "horizon.templatetags.horizon::filter::has_permissions":
-    expects_arg: true
-    arg_optional: false
-  "horizon.templatetags.horizon::filter::has_permissions_on_list":
-    expects_arg: true
-    arg_optional: false
-  "horizon.templatetags.horizon::filter::quota":
-    expects_arg: true
-    arg_optional: true
-  "horizon.templatetags.horizon::filter::quotainf":
-    expects_arg: true
-    arg_optional: true
+  "horizon.templatetags.horizon::filter::has_permissions": required_argument
+  "horizon.templatetags.horizon::filter::has_permissions_on_list": required_argument
+  "horizon.templatetags.horizon::filter::quota": optional_argument
+  "horizon.templatetags.horizon::filter::quotainf": optional_argument
 block_specs:
   "horizon.templatetags.horizon::tag::jstemplate":
     end_tag: endjstemplate

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__parse_date.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__parse_date.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "horizon.templatetags.parse_date::filter::parse_date":
-    expects_arg: false
-    arg_optional: false
+  "horizon.templatetags.parse_date::filter::parse_date": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__shellfilter.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__shellfilter.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "horizon.templatetags.shellfilter::filter::shellfilter":
-    expects_arg: false
-    arg_optional: false
+  "horizon.templatetags.shellfilter::filter::shellfilter": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__sizeformat.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__sizeformat.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "horizon.templatetags.sizeformat::filter::diskgbformat":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.sizeformat::filter::mb_float_format":
-    expects_arg: false
-    arg_optional: false
-  "horizon.templatetags.sizeformat::filter::mbformat":
-    expects_arg: false
-    arg_optional: false
+  "horizon.templatetags.sizeformat::filter::diskgbformat": no_argument
+  "horizon.templatetags.sizeformat::filter::mb_float_format": no_argument
+  "horizon.templatetags.sizeformat::filter::mbformat": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__splitfilter.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__splitfilter.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "horizon.templatetags.splitfilter::filter::split_message":
-    expects_arg: false
-    arg_optional: false
+  "horizon.templatetags.splitfilter::filter::split_message": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__truncate_filter.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__truncate_filter.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "horizon.templatetags.truncate_filter::filter::truncate":
-    expects_arg: true
-    arg_optional: false
+  "horizon.templatetags.truncate_filter::filter::truncate": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__decorate.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__decorate.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "hyperkitty.templatetags.decorate::filter::render":
-    expects_arg: true
-    arg_optional: false
+  "hyperkitty.templatetags.decorate::filter::render": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_generic.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_generic.py.snap
@@ -53,55 +53,21 @@ tag_rules:
         position: 1
     as_var: strip
 filter_arities:
-  "hyperkitty.templatetags.hk_generic::filter::date_with_senders_timezone":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::escapeemail":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::escapeemaillinks":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::get_item":
-    expects_arg: true
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::is_unread_by":
-    expects_arg: true
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::monthtodate":
-    expects_arg: true
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::multiply":
-    expects_arg: true
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::num_comments":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::reply_subject":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::snip_pgp":
-    expects_arg: true
-    arg_optional: true
-  "hyperkitty.templatetags.hk_generic::filter::snip_quoted":
-    expects_arg: true
-    arg_optional: true
-  "hyperkitty.templatetags.hk_generic::filter::sort":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::sort_by_name":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::strip_subject":
-    expects_arg: true
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::to_json":
-    expects_arg: false
-    arg_optional: false
-  "hyperkitty.templatetags.hk_generic::filter::truncatesmart":
-    expects_arg: true
-    arg_optional: true
-  "hyperkitty.templatetags.hk_generic::filter::until":
-    expects_arg: true
-    arg_optional: false
+  "hyperkitty.templatetags.hk_generic::filter::date_with_senders_timezone": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::escapeemail": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::escapeemaillinks": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::get_item": required_argument
+  "hyperkitty.templatetags.hk_generic::filter::is_unread_by": required_argument
+  "hyperkitty.templatetags.hk_generic::filter::monthtodate": required_argument
+  "hyperkitty.templatetags.hk_generic::filter::multiply": required_argument
+  "hyperkitty.templatetags.hk_generic::filter::num_comments": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::reply_subject": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::snip_pgp": optional_argument
+  "hyperkitty.templatetags.hk_generic::filter::snip_quoted": optional_argument
+  "hyperkitty.templatetags.hk_generic::filter::sort": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::sort_by_name": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::strip_subject": required_argument
+  "hyperkitty.templatetags.hk_generic::filter::to_json": no_argument
+  "hyperkitty.templatetags.hk_generic::filter::truncatesmart": optional_argument
+  "hyperkitty.templatetags.hk_generic::filter::until": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_haystack.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_haystack.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "hyperkitty.templatetags.hk_haystack::filter::nolongterms":
-    expects_arg: false
-    arg_optional: false
+  "hyperkitty.templatetags.hk_haystack::filter::nolongterms": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__InvenTree__templatetags__inventree_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__InvenTree__templatetags__inventree_extras.py.snap
@@ -194,7 +194,5 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::filter::keyvalue":
-    expects_arg: true
-    arg_optional: false
+  "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::filter::keyvalue": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
@@ -57,21 +57,11 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "bookmarks.templatetags.shared::filter::first_char":
-    expects_arg: false
-    arg_optional: false
-  "bookmarks.templatetags.shared::filter::humanize_absolute_date":
-    expects_arg: false
-    arg_optional: false
-  "bookmarks.templatetags.shared::filter::humanize_relative_date":
-    expects_arg: false
-    arg_optional: false
-  "bookmarks.templatetags.shared::filter::model_to_dict":
-    expects_arg: false
-    arg_optional: false
-  "bookmarks.templatetags.shared::filter::remaining_chars":
-    expects_arg: true
-    arg_optional: false
+  "bookmarks.templatetags.shared::filter::first_char": no_argument
+  "bookmarks.templatetags.shared::filter::humanize_absolute_date": no_argument
+  "bookmarks.templatetags.shared::filter::humanize_relative_date": no_argument
+  "bookmarks.templatetags.shared::filter::model_to_dict": no_argument
+  "bookmarks.templatetags.shared::filter::remaining_chars": required_argument
 block_specs:
   "bookmarks.templatetags.shared::tag::formhelp":
     end_tag: endformhelp

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__admin__templatetags__misago_admin_form.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__admin__templatetags__misago_admin_form.py.snap
@@ -151,22 +151,10 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "misago.admin.templatetags.misago_admin_form::filter::get_options":
-    expects_arg: false
-    arg_optional: false
-  "misago.admin.templatetags.misago_admin_form::filter::is_multiple_choice_field":
-    expects_arg: false
-    arg_optional: false
-  "misago.admin.templatetags.misago_admin_form::filter::is_radio_select_field":
-    expects_arg: false
-    arg_optional: false
-  "misago.admin.templatetags.misago_admin_form::filter::is_select_field":
-    expects_arg: false
-    arg_optional: false
-  "misago.admin.templatetags.misago_admin_form::filter::is_textarea_field":
-    expects_arg: false
-    arg_optional: false
-  "misago.admin.templatetags.misago_admin_form::filter::is_yesno_switch_field":
-    expects_arg: false
-    arg_optional: false
+  "misago.admin.templatetags.misago_admin_form::filter::get_options": no_argument
+  "misago.admin.templatetags.misago_admin_form::filter::is_multiple_choice_field": no_argument
+  "misago.admin.templatetags.misago_admin_form::filter::is_radio_select_field": no_argument
+  "misago.admin.templatetags.misago_admin_form::filter::is_select_field": no_argument
+  "misago.admin.templatetags.misago_admin_form::filter::is_textarea_field": no_argument
+  "misago.admin.templatetags.misago_admin_form::filter::is_yesno_switch_field": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_batch.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_batch.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.core.templatetags.misago_batch::filter::batch":
-    expects_arg: true
-    arg_optional: false
-  "misago.core.templatetags.misago_batch::filter::batchnonefilled":
-    expects_arg: true
-    arg_optional: false
+  "misago.core.templatetags.misago_batch::filter::batch": required_argument
+  "misago.core.templatetags.misago_batch::filter::batchnonefilled": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_json.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_json.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.core.templatetags.misago_json::filter::as_json":
-    expects_arg: false
-    arg_optional: false
+  "misago.core.templatetags.misago_json::filter::as_json": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_shorthands.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_shorthands.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.core.templatetags.misago_shorthands::filter::iffalse":
-    expects_arg: true
-    arg_optional: false
-  "misago.core.templatetags.misago_shorthands::filter::iftrue":
-    expects_arg: true
-    arg_optional: false
+  "misago.core.templatetags.misago_shorthands::filter::iffalse": required_argument
+  "misago.core.templatetags.misago_shorthands::filter::iftrue": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_stringutils.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_stringutils.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.core.templatetags.misago_stringutils::filter::isdescriptionshort":
-    expects_arg: false
-    arg_optional: false
+  "misago.core.templatetags.misago_stringutils::filter::isdescriptionshort": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__forms__templatetags__misago_forms.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__forms__templatetags__misago_forms.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.forms.templatetags.misago_forms::filter::checkedhtml":
-    expects_arg: false
-    arg_optional: false
-  "misago.forms.templatetags.misago_forms::filter::requiredhtml":
-    expects_arg: false
-    arg_optional: false
-  "misago.forms.templatetags.misago_forms::filter::selectedhtml":
-    expects_arg: false
-    arg_optional: false
+  "misago.forms.templatetags.misago_forms::filter::checkedhtml": no_argument
+  "misago.forms.templatetags.misago_forms::filter::requiredhtml": no_argument
+  "misago.forms.templatetags.misago_forms::filter::selectedhtml": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__profile__templatetags__misago_profile_fields.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__profile__templatetags__misago_profile_fields.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.profile.templatetags.misago_profile_fields::filter::profilefieldwidget":
-    expects_arg: false
-    arg_optional: false
+  "misago.profile.templatetags.misago_profile_fields::filter::profilefieldwidget": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__users__templatetags__misago_avatars.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__users__templatetags__misago_avatars.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "misago.users.templatetags.misago_avatars::filter::avatar":
-    expects_arg: true
-    arg_optional: true
+  "misago.users.templatetags.misago_avatars::filter::avatar": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__builtins__filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__builtins__filters.py.snap
@@ -4,55 +4,21 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "netbox.utilities.templatetags.builtins.filters::filter::bettertitle":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::content_type":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::content_type_id":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::fgcolor":
-    expects_arg: true
-    arg_optional: true
-  "netbox.utilities.templatetags.builtins.filters::filter::getattr":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::isodate":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::isodatetime":
-    expects_arg: true
-    arg_optional: true
-  "netbox.utilities.templatetags.builtins.filters::filter::isotime":
-    expects_arg: true
-    arg_optional: true
-  "netbox.utilities.templatetags.builtins.filters::filter::json":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::linkify":
-    expects_arg: true
-    arg_optional: true
-  "netbox.utilities.templatetags.builtins.filters::filter::markdown":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::meta":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::placeholder":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::split":
-    expects_arg: true
-    arg_optional: true
-  "netbox.utilities.templatetags.builtins.filters::filter::truncate_middle":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::tzoffset":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.builtins.filters::filter::yaml":
-    expects_arg: false
-    arg_optional: false
+  "netbox.utilities.templatetags.builtins.filters::filter::bettertitle": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::content_type": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::content_type_id": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::fgcolor": optional_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::getattr": required_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::isodate": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::isodatetime": optional_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::isotime": optional_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::json": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::linkify": optional_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::markdown": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::meta": required_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::placeholder": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::split": optional_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::truncate_middle": required_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::tzoffset": no_argument
+  "netbox.utilities.templatetags.builtins.filters::filter::yaml": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__form_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__form_helpers.py.snap
@@ -81,10 +81,6 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "netbox.utilities.templatetags.form_helpers::filter::getfield":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.form_helpers::filter::widget_type":
-    expects_arg: false
-    arg_optional: false
+  "netbox.utilities.templatetags.form_helpers::filter::getfield": required_argument
+  "netbox.utilities.templatetags.form_helpers::filter::widget_type": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__helpers.py.snap
@@ -91,49 +91,19 @@ tag_rules:
         position: 2
     as_var: keep
 filter_arities:
-  "netbox.utilities.templatetags.helpers::filter::as_range":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::divide":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::get_item":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::get_key":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::humanize_disk_megabytes":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::humanize_ram_megabytes":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::humanize_speed":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::icon_from_status":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::kg_to_pounds":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::meters_to_feet":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::percentage":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::startswith":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::status_from_tag":
-    expects_arg: false
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::validated_viewname":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.helpers::filter::viewname":
-    expects_arg: true
-    arg_optional: false
+  "netbox.utilities.templatetags.helpers::filter::as_range": no_argument
+  "netbox.utilities.templatetags.helpers::filter::divide": required_argument
+  "netbox.utilities.templatetags.helpers::filter::get_item": required_argument
+  "netbox.utilities.templatetags.helpers::filter::get_key": required_argument
+  "netbox.utilities.templatetags.helpers::filter::humanize_disk_megabytes": no_argument
+  "netbox.utilities.templatetags.helpers::filter::humanize_ram_megabytes": no_argument
+  "netbox.utilities.templatetags.helpers::filter::humanize_speed": no_argument
+  "netbox.utilities.templatetags.helpers::filter::icon_from_status": no_argument
+  "netbox.utilities.templatetags.helpers::filter::kg_to_pounds": no_argument
+  "netbox.utilities.templatetags.helpers::filter::meters_to_feet": no_argument
+  "netbox.utilities.templatetags.helpers::filter::percentage": required_argument
+  "netbox.utilities.templatetags.helpers::filter::startswith": required_argument
+  "netbox.utilities.templatetags.helpers::filter::status_from_tag": no_argument
+  "netbox.utilities.templatetags.helpers::filter::validated_viewname": required_argument
+  "netbox.utilities.templatetags.helpers::filter::viewname": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__perms.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__perms.py.snap
@@ -4,22 +4,10 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "netbox.utilities.templatetags.perms::filter::can_add":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.perms::filter::can_change":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.perms::filter::can_delete":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.perms::filter::can_run":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.perms::filter::can_sync":
-    expects_arg: true
-    arg_optional: false
-  "netbox.utilities.templatetags.perms::filter::can_view":
-    expects_arg: true
-    arg_optional: false
+  "netbox.utilities.templatetags.perms::filter::can_add": required_argument
+  "netbox.utilities.templatetags.perms::filter::can_change": required_argument
+  "netbox.utilities.templatetags.perms::filter::can_delete": required_argument
+  "netbox.utilities.templatetags.perms::filter::can_run": required_argument
+  "netbox.utilities.templatetags.perms::filter::can_sync": required_argument
+  "netbox.utilities.templatetags.perms::filter::can_view": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__nomnom__src__nomnom__advise__templatetags__advise_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__nomnom__src__nomnom__advise__templatetags__advise_filters.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.nomnom.advise.templatetags.advise_filters::filter::proposal_is_open_for":
-    expects_arg: true
-    arg_optional: false
+  "src.nomnom.advise.templatetags.advise_filters::filter::proposal_is_open_for": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__nomnom__src__nomnom__nominate__templatetags__nomnom_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__nomnom__src__nomnom__nominate__templatetags__nomnom_filters.py.snap
@@ -4,16 +4,8 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.nomnom.nominate.templatetags.nomnom_filters::filter::get_item":
-    expects_arg: true
-    arg_optional: false
-  "src.nomnom.nominate.templatetags.nomnom_filters::filter::place":
-    expects_arg: false
-    arg_optional: false
-  "src.nomnom.nominate.templatetags.nomnom_filters::filter::strip_html_tags":
-    expects_arg: false
-    arg_optional: false
-  "src.nomnom.nominate.templatetags.nomnom_filters::filter::user_display_name":
-    expects_arg: false
-    arg_optional: false
+  "src.nomnom.nominate.templatetags.nomnom_filters::filter::get_item": required_argument
+  "src.nomnom.nominate.templatetags.nomnom_filters::filter::place": no_argument
+  "src.nomnom.nominate.templatetags.nomnom_filters::filter::strip_html_tags": no_argument
+  "src.nomnom.nominate.templatetags.nomnom_filters::filter::user_display_name": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__calendarhead.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__calendarhead.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.calendarhead::filter::iter_weekdays":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.calendarhead::filter::iter_weekdays": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__classname.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__classname.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.classname::filter::classname":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.classname::filter::classname": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__daterange.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__daterange.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.daterange::filter::datetimerange":
-    expects_arg: true
-    arg_optional: false
+  "src.pretix.base.templatetags.daterange::filter::datetimerange": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__escapejson.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__escapejson.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.escapejson::filter::attr_escapejson_dumps":
-    expects_arg: false
-    arg_optional: false
-  "src.pretix.base.templatetags.escapejson::filter::escapejson":
-    expects_arg: false
-    arg_optional: false
-  "src.pretix.base.templatetags.escapejson::filter::escapejson_dumps":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.escapejson::filter::attr_escapejson_dumps": no_argument
+  "src.pretix.base.templatetags.escapejson::filter::escapejson": no_argument
+  "src.pretix.base.templatetags.escapejson::filter::escapejson_dumps": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__lists.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__lists.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.lists::filter::joinlines":
-    expects_arg: false
-    arg_optional: false
-  "src.pretix.base.templatetags.lists::filter::splitlines":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.lists::filter::joinlines": no_argument
+  "src.pretix.base.templatetags.lists::filter::splitlines": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__money.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__money.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.money::filter::money":
-    expects_arg: true
-    arg_optional: true
-  "src.pretix.base.templatetags.money::filter::money_numberfield":
-    expects_arg: true
-    arg_optional: true
+  "src.pretix.base.templatetags.money::filter::money": optional_argument
+  "src.pretix.base.templatetags.money::filter::money_numberfield": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__oneline.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__oneline.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.oneline::filter::oneline":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.oneline::filter::oneline": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__phone_format.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__phone_format.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.phone_format::filter::phone_format":
-    expects_arg: true
-    arg_optional: true
+  "src.pretix.base.templatetags.phone_format::filter::phone_format": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__rich_text.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__rich_text.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.rich_text::filter::rich_text":
-    expects_arg: false
-    arg_optional: false
-  "src.pretix.base.templatetags.rich_text::filter::rich_text_snippet":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.rich_text::filter::rich_text": no_argument
+  "src.pretix.base.templatetags.rich_text::filter::rich_text_snippet": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__unidecode.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__unidecode.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.base.templatetags.unidecode::filter::unidecode":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.base.templatetags.unidecode::filter::unidecode": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__getitem.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__getitem.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.control.templatetags.getitem::filter::getitem":
-    expects_arg: true
-    arg_optional: false
+  "src.pretix.control.templatetags.getitem::filter::getitem": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__mail_settings_preview.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__mail_settings_preview.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.control.templatetags.mail_settings_preview::filter::getattr":
-    expects_arg: true
-    arg_optional: false
-  "src.pretix.control.templatetags.mail_settings_preview::filter::hasattr":
-    expects_arg: true
-    arg_optional: false
-  "src.pretix.control.templatetags.mail_settings_preview::filter::split":
-    expects_arg: true
-    arg_optional: true
+  "src.pretix.control.templatetags.mail_settings_preview::filter::getattr": required_argument
+  "src.pretix.control.templatetags.mail_settings_preview::filter::hasattr": required_argument
+  "src.pretix.control.templatetags.mail_settings_preview::filter::split": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__order_overview.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__order_overview.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.control.templatetags.order_overview::filter::togglesum":
-    expects_arg: true
-    arg_optional: true
+  "src.pretix.control.templatetags.order_overview::filter::togglesum": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__date_fast.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__date_fast.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.helpers.templatetags.date_fast::filter::date_fast":
-    expects_arg: true
-    arg_optional: true
+  "src.pretix.helpers.templatetags.date_fast::filter::date_fast": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__expiresformat.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__expiresformat.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.helpers.templatetags.expiresformat::filter::format_expires":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.helpers.templatetags.expiresformat::filter::format_expires": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__thumb.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__thumb.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.helpers.templatetags.thumb::filter::thumb":
-    expects_arg: true
-    arg_optional: false
+  "src.pretix.helpers.templatetags.thumb::filter::thumb": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__plugins__banktransfer__templatetags__commadecimal.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__plugins__banktransfer__templatetags__commadecimal.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.plugins.banktransfer.templatetags.commadecimal::filter::commadecimal":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.plugins.banktransfer.templatetags.commadecimal::filter::commadecimal": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__plugins__banktransfer__templatetags__dotdecimal.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__plugins__banktransfer__templatetags__dotdecimal.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.plugins.banktransfer.templatetags.dotdecimal::filter::dotdecimal":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.plugins.banktransfer.templatetags.dotdecimal::filter::dotdecimal": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__plugins__banktransfer__templatetags__ibanformat.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__plugins__banktransfer__templatetags__ibanformat.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.pretix.plugins.banktransfer.templatetags.ibanformat::filter::ibanformat":
-    expects_arg: false
-    arg_optional: false
+  "src.pretix.plugins.banktransfer.templatetags.ibanformat::filter::ibanformat": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__news__templatetags__news_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__news__templatetags__news_extra.py.snap
@@ -54,7 +54,5 @@ tag_rules:
         position: 1
     as_var: strip
 filter_arities:
-  "news.templatetags.news_extra::filter::comment_markdown":
-    expects_arg: false
-    arg_optional: false
+  "news.templatetags.news_extra::filter::comment_markdown": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__core_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__core_tags.py.snap
@@ -57,22 +57,10 @@ tag_rules:
         position: 2
     as_var: strip
 filter_arities:
-  "readthedocs.core.templatetags.core_tags::filter::escapejson":
-    expects_arg: true
-    arg_optional: true
-  "readthedocs.core.templatetags.core_tags::filter::get_key_or_none":
-    expects_arg: true
-    arg_optional: false
-  "readthedocs.core.templatetags.core_tags::filter::get_project":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.core.templatetags.core_tags::filter::get_version":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.core.templatetags.core_tags::filter::is_rich_select":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.core.templatetags.core_tags::filter::key":
-    expects_arg: true
-    arg_optional: false
+  "readthedocs.core.templatetags.core_tags::filter::escapejson": optional_argument
+  "readthedocs.core.templatetags.core_tags::filter::get_key_or_none": required_argument
+  "readthedocs.core.templatetags.core_tags::filter::get_project": no_argument
+  "readthedocs.core.templatetags.core_tags::filter::get_version": no_argument
+  "readthedocs.core.templatetags.core_tags::filter::is_rich_select": no_argument
+  "readthedocs.core.templatetags.core_tags::filter::key": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__privacy_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__privacy_tags.py.snap
@@ -17,10 +17,6 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "readthedocs.core.templatetags.privacy_tags::filter::is_admin":
-    expects_arg: true
-    arg_optional: false
-  "readthedocs.core.templatetags.privacy_tags::filter::is_member":
-    expects_arg: true
-    arg_optional: false
+  "readthedocs.core.templatetags.privacy_tags::filter::is_admin": required_argument
+  "readthedocs.core.templatetags.privacy_tags::filter::is_member": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__readthedocs__socialaccounts.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__readthedocs__socialaccounts.py.snap
@@ -4,13 +4,7 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "readthedocs.core.templatetags.readthedocs.socialaccounts::filter::can_be_disconnected":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.core.templatetags.readthedocs.socialaccounts::filter::has_github_app_account":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.core.templatetags.readthedocs.socialaccounts::filter::is_access_revoked":
-    expects_arg: false
-    arg_optional: false
+  "readthedocs.core.templatetags.readthedocs.socialaccounts::filter::can_be_disconnected": no_argument
+  "readthedocs.core.templatetags.readthedocs.socialaccounts::filter::has_github_app_account": no_argument
+  "readthedocs.core.templatetags.readthedocs.socialaccounts::filter::is_access_revoked": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__invitations__templatetags__invitations.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__invitations__templatetags__invitations.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "readthedocs.invitations.templatetags.invitations::filter::can_revoke_invitation":
-    expects_arg: true
-    arg_optional: false
+  "readthedocs.invitations.templatetags.invitations::filter::can_revoke_invitation": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__notifications__templatetags__notifications_filters.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__notifications__templatetags__notifications_filters.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "readthedocs.notifications.templatetags.notifications_filters::filter::to_class_name":
-    expects_arg: false
-    arg_optional: false
+  "readthedocs.notifications.templatetags.notifications_filters::filter::to_class_name": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__organizations__templatetags__organizations.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__organizations__templatetags__organizations.py.snap
@@ -4,22 +4,10 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "readthedocs.organizations.templatetags.organizations::filter::admin_teams":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.organizations.templatetags.organizations::filter::has_sso_enabled":
-    expects_arg: true
-    arg_optional: true
-  "readthedocs.organizations.templatetags.organizations::filter::org_owner":
-    expects_arg: true
-    arg_optional: false
-  "readthedocs.organizations.templatetags.organizations::filter::organization":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.organizations.templatetags.organizations::filter::owner_organizations":
-    expects_arg: false
-    arg_optional: false
-  "readthedocs.organizations.templatetags.organizations::filter::teams":
-    expects_arg: false
-    arg_optional: false
+  "readthedocs.organizations.templatetags.organizations::filter::admin_teams": no_argument
+  "readthedocs.organizations.templatetags.organizations::filter::has_sso_enabled": optional_argument
+  "readthedocs.organizations.templatetags.organizations::filter::org_owner": required_argument
+  "readthedocs.organizations.templatetags.organizations::filter::organization": no_argument
+  "readthedocs.organizations.templatetags.organizations::filter::owner_organizations": no_argument
+  "readthedocs.organizations.templatetags.organizations::filter::teams": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__projects__templatetags__projects_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__projects__templatetags__projects_tags.py.snap
@@ -4,10 +4,6 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "readthedocs.projects.templatetags.projects_tags::filter::is_project_user":
-    expects_arg: true
-    arg_optional: false
-  "readthedocs.projects.templatetags.projects_tags::filter::sort_version_aware":
-    expects_arg: false
-    arg_optional: false
+  "readthedocs.projects.templatetags.projects_tags::filter::is_project_user": required_argument
+  "readthedocs.projects.templatetags.projects_tags::filter::sort_version_aware": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_admin_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_admin_helpers.py.snap
@@ -4,7 +4,5 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "src.sentry.templatetags.sentry_admin_helpers::filter::with_event_counts":
-    expects_arg: false
-    arg_optional: false
+  "src.sentry.templatetags.sentry_admin_helpers::filter::with_event_counts": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_helpers.py.snap
@@ -112,55 +112,21 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "src.sentry.templatetags.sentry_helpers::filter::absolute_value":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::as_sorted":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::as_tag_alias":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::basename":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::date":
-    expects_arg: true
-    arg_optional: true
-  "src.sentry.templatetags.sentry_helpers::filter::duration":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::get_item":
-    expects_arg: true
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::is_url":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::multiply":
-    expects_arg: true
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::sanitize_periods":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::small_count":
-    expects_arg: true
-    arg_optional: true
-  "src.sentry.templatetags.sentry_helpers::filter::soft_break":
-    expects_arg: true
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::split":
-    expects_arg: true
-    arg_optional: true
-  "src.sentry.templatetags.sentry_helpers::filter::timesince":
-    expects_arg: true
-    arg_optional: true
-  "src.sentry.templatetags.sentry_helpers::filter::titleize":
-    expects_arg: false
-    arg_optional: false
-  "src.sentry.templatetags.sentry_helpers::filter::to_json":
-    expects_arg: true
-    arg_optional: true
-  "src.sentry.templatetags.sentry_helpers::filter::urlquote":
-    expects_arg: true
-    arg_optional: true
+  "src.sentry.templatetags.sentry_helpers::filter::absolute_value": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::as_sorted": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::as_tag_alias": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::basename": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::date": optional_argument
+  "src.sentry.templatetags.sentry_helpers::filter::duration": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::get_item": required_argument
+  "src.sentry.templatetags.sentry_helpers::filter::is_url": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::multiply": required_argument
+  "src.sentry.templatetags.sentry_helpers::filter::sanitize_periods": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::small_count": optional_argument
+  "src.sentry.templatetags.sentry_helpers::filter::soft_break": required_argument
+  "src.sentry.templatetags.sentry_helpers::filter::split": optional_argument
+  "src.sentry.templatetags.sentry_helpers::filter::timesince": optional_argument
+  "src.sentry.templatetags.sentry_helpers::filter::titleize": no_argument
+  "src.sentry.templatetags.sentry_helpers::filter::to_json": optional_argument
+  "src.sentry.templatetags.sentry_helpers::filter::urlquote": optional_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_tags.py.snap
@@ -140,7 +140,5 @@ tag_rules:
         position: 1
     as_var: strip
 filter_arities:
-  "blog.templatetags.blog_tags::filter::markdownify":
-    expects_arg: false
-    arg_optional: false
+  "blog.templatetags.blog_tags::filter::markdownify": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__entry_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__entry_tags.py.snap
@@ -30,43 +30,17 @@ tag_rules:
         position: 0
     as_var: keep
 filter_arities:
-  "blog.templatetags.entry_tags::filter::break_up_long_words":
-    expects_arg: true
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::ends_with_punctuation":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::first_paragraph":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::openid_to_url":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::remove_context_paragraph":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::resize_images_to_fit_width":
-    expects_arg: true
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::split_cutoff":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::strip_p_ids":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::strip_wrapping_p":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::text_ago":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::typography":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::xhtml":
-    expects_arg: false
-    arg_optional: false
-  "blog.templatetags.entry_tags::filter::xhtml2html":
-    expects_arg: false
-    arg_optional: false
+  "blog.templatetags.entry_tags::filter::break_up_long_words": required_argument
+  "blog.templatetags.entry_tags::filter::ends_with_punctuation": no_argument
+  "blog.templatetags.entry_tags::filter::first_paragraph": no_argument
+  "blog.templatetags.entry_tags::filter::openid_to_url": no_argument
+  "blog.templatetags.entry_tags::filter::remove_context_paragraph": no_argument
+  "blog.templatetags.entry_tags::filter::resize_images_to_fit_width": required_argument
+  "blog.templatetags.entry_tags::filter::split_cutoff": no_argument
+  "blog.templatetags.entry_tags::filter::strip_p_ids": no_argument
+  "blog.templatetags.entry_tags::filter::strip_wrapping_p": no_argument
+  "blog.templatetags.entry_tags::filter::text_ago": no_argument
+  "blog.templatetags.entry_tags::filter::typography": no_argument
+  "blog.templatetags.entry_tags::filter::xhtml": no_argument
+  "blog.templatetags.entry_tags::filter::xhtml2html": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sorl-thumbnail__sorl__thumbnail__templatetags__thumbnail.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sorl-thumbnail__sorl__thumbnail__templatetags__thumbnail.py.snap
@@ -4,22 +4,10 @@ expression: snapshot(result)
 ---
 tag_rules: {}
 filter_arities:
-  "sorl.thumbnail.templatetags.thumbnail::filter::background_margin":
-    expects_arg: true
-    arg_optional: false
-  "sorl.thumbnail.templatetags.thumbnail::filter::html_thumbnails":
-    expects_arg: false
-    arg_optional: false
-  "sorl.thumbnail.templatetags.thumbnail::filter::is_portrait":
-    expects_arg: false
-    arg_optional: false
-  "sorl.thumbnail.templatetags.thumbnail::filter::margin":
-    expects_arg: true
-    arg_optional: false
-  "sorl.thumbnail.templatetags.thumbnail::filter::markdown_thumbnails":
-    expects_arg: false
-    arg_optional: false
-  "sorl.thumbnail.templatetags.thumbnail::filter::resolution":
-    expects_arg: true
-    arg_optional: false
+  "sorl.thumbnail.templatetags.thumbnail::filter::background_margin": required_argument
+  "sorl.thumbnail.templatetags.thumbnail::filter::html_thumbnails": no_argument
+  "sorl.thumbnail.templatetags.thumbnail::filter::is_portrait": no_argument
+  "sorl.thumbnail.templatetags.thumbnail::filter::margin": required_argument
+  "sorl.thumbnail.templatetags.thumbnail::filter::markdown_thumbnails": no_argument
+  "sorl.thumbnail.templatetags.thumbnail::filter::resolution": required_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -737,39 +737,17 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim":
-    expects_arg: true
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim": required_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
     end_tag: endfragment

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -110,7 +110,5 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "wagtail.templatetags.wagtailcore_tags::filter::richtext":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -725,39 +725,17 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim":
-    expects_arg: true
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim": required_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
     end_tag: endfragment

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -110,7 +110,5 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "wagtail.templatetags.wagtailcore_tags::filter::richtext":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -746,39 +746,17 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim":
-    expects_arg: true
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim": required_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
     end_tag: endfragment

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -110,7 +110,5 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "wagtail.templatetags.wagtailcore_tags::filter::richtext":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -746,39 +746,17 @@ tag_rules:
         position: 0
     as_var: strip
 filter_arities:
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim":
-    expects_arg: true
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name":
-    expects_arg: false
-    arg_optional: false
-  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::admin_urlquote": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::cautious_slugify": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::ellipsistrim": required_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::fieldtype": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::format_content_type": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::has_unrendered_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::render_with_errors": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::timesince_simple": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::user_display_name": no_argument
+  "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
     end_tag: endfragment

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -110,7 +110,5 @@ tag_rules:
     extracted_args: []
     as_var: strip
 filter_arities:
-  "wagtail.templatetags.wagtailcore_tags::filter::richtext":
-    expects_arg: false
-    arg_optional: false
+  "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_defaultfilters.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_defaultfilters.snap
@@ -4,34 +4,14 @@ expression: sorted_snapshot(&result)
 ---
 tag_rules: {}
 filter_arities:
-  "django.template.defaultfilters::filter::add":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::addslashes":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::cut":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::date":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::default":
-    expects_arg: true
-    arg_optional: false
-  "django.template.defaultfilters::filter::escapejs":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::floatformat":
-    expects_arg: true
-    arg_optional: true
-  "django.template.defaultfilters::filter::lower":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::title":
-    expects_arg: false
-    arg_optional: false
-  "django.template.defaultfilters::filter::upper":
-    expects_arg: false
-    arg_optional: false
+  "django.template.defaultfilters::filter::add": required_argument
+  "django.template.defaultfilters::filter::addslashes": no_argument
+  "django.template.defaultfilters::filter::cut": required_argument
+  "django.template.defaultfilters::filter::date": optional_argument
+  "django.template.defaultfilters::filter::default": required_argument
+  "django.template.defaultfilters::filter::escapejs": no_argument
+  "django.template.defaultfilters::filter::floatformat": optional_argument
+  "django.template.defaultfilters::filter::lower": no_argument
+  "django.template.defaultfilters::filter::title": no_argument
+  "django.template.defaultfilters::filter::upper": no_argument
 block_specs: {}

--- a/crates/djls-semantic/src/filters.rs
+++ b/crates/djls-semantic/src/filters.rs
@@ -53,7 +53,7 @@ impl FilterAritySpecs {
     /// Later entries overwrite earlier ones (last-wins).
     pub fn merge_filter_arities(&mut self, filter_arities: &FilterArityMap) {
         for (key, arity) in filter_arities {
-            self.insert(key.clone(), arity.clone());
+            self.insert(key.clone(), *arity);
         }
     }
 }
@@ -122,5 +122,5 @@ pub(crate) fn effective_filter_arity_in_scope(
     alternatives_agree
         .then_some(agreed.flatten())
         .flatten()
-        .cloned()
+        .copied()
 }

--- a/crates/djls-semantic/src/scoping.rs
+++ b/crates/djls-semantic/src/scoping.rs
@@ -313,7 +313,7 @@ pub(crate) fn template_analysis_projection_for_file_in_scope<'db>(
                                     let arity = db
                                         .projectless_filter_arity_specs()
                                         .get(&filter.name)
-                                        .cloned();
+                                        .copied();
                                     let availability = if arity.is_some() {
                                         SymbolAvailability::Available
                                     } else {

--- a/crates/djls-semantic/src/validation.rs
+++ b/crates/djls-semantic/src/validation.rs
@@ -143,7 +143,7 @@ impl<'db> TemplateValidator<'db> {
                 facts.unknown_load_can_shadow,
             );
             if !facts.unknown_load_can_shadow
-                && let Some(arity) = facts.arity.as_ref()
+                && let Some(arity) = facts.arity
             {
                 filters::check_filter_arity_rule(self.db, filter, arity);
             }

--- a/crates/djls-semantic/src/validation/filters.rs
+++ b/crates/djls-semantic/src/validation/filters.rs
@@ -7,22 +7,25 @@ use crate::db::ValidationErrorAccumulator;
 use crate::errors::ValidationError;
 
 /// Internal helper for [`TemplateValidator`](crate::validation::TemplateValidator).
-pub(crate) fn check_filter_arity_rule(db: &dyn Db, filter: &Filter, arity: &FilterArity) {
-    let has_arg = filter.arg.is_some();
-
-    if arity.expects_arg && !arity.arg_optional && !has_arg {
-        // S115: required argument missing
-        ValidationErrorAccumulator(ValidationError::FilterMissingArgument {
-            filter: filter.name.clone(),
-            span: filter.span,
-        })
-        .accumulate(db);
-    } else if !arity.expects_arg && has_arg {
-        // S116: unexpected argument provided
-        ValidationErrorAccumulator(ValidationError::FilterUnexpectedArgument {
-            filter: filter.name.clone(),
-            span: filter.span,
-        })
-        .accumulate(db);
+pub(crate) fn check_filter_arity_rule(db: &dyn Db, filter: &Filter, arity: FilterArity) {
+    match arity {
+        FilterArity::NoArgument if filter.arg.is_some() => {
+            // S116: unexpected argument provided
+            ValidationErrorAccumulator(ValidationError::FilterUnexpectedArgument {
+                filter: filter.name.clone(),
+                span: filter.span,
+            })
+            .accumulate(db);
+        }
+        FilterArity::RequiredArgument if filter.arg.is_none() => {
+            // S115: required argument missing
+            ValidationErrorAccumulator(ValidationError::FilterMissingArgument {
+                filter: filter.name.clone(),
+                span: filter.span,
+            })
+            .accumulate(db);
+        }
+        FilterArity::NoArgument | FilterArity::RequiredArgument | FilterArity::OptionalArgument => {
+        }
     }
 }

--- a/crates/djls-testing/src/extraction.rs
+++ b/crates/djls-testing/src/extraction.rs
@@ -67,7 +67,7 @@ pub fn sorted_snapshot(bundle: &ExtractionBundle) -> serde_json::Result<SortedEx
         filter_arities: bundle
             .filter_arities
             .iter()
-            .map(|(key, arity)| (key_str(key), arity.clone()))
+            .map(|(key, arity)| (key_str(key), *arity))
             .collect(),
         block_specs: serde_json::from_value(serde_json::to_value(&bundle.block_specs)?)?,
     })


### PR DESCRIPTION
## Changes

Replace independent expects_arg and arg_optional booleans with FilterArity::NoArgument, RequiredArgument, and OptionalArgument. Update extraction, validation, IDE consumers, fixtures, and benchmarks. Serialize the enum with snake_case names; do not retain the obsolete boolean shape.

## Review and validation

Independently checked all 733 arity conversions across 144 snapshots: only the encoding changed. Kept extraction and validation behavior tests and benchmark names.

The completed seven-change stack passed cargo build, just testall (14 combinations), just e2e (44 tests), just clippy, just fmt, and just lint locally. Full-corpus benchmark workload snapshots passed unchanged. Hawk was not run locally; its CI job is pending in #834.

Stacked on cleanup-template-internals. Merge the preceding PR first, then retarget to main.