### PR TITLE
Deduplicate equivalent template settings projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Removed eager Django Model scanning and Model Graph construction from project discovery and cache warm-up.
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
 
+### Fixed
+
+- Fixed `djls check` scanning the project root when template settings branches differ only in context processors.
+
 ## [6.1.0]
 
 ### Added

--- a/crates/djls-project/src/templates/settings_cases.rs
+++ b/crates/djls-project/src/templates/settings_cases.rs
@@ -133,7 +133,29 @@ impl TemplateSettingsCases {
                     .collect(),
                 SettingCase::Unset => Vec::new(),
             };
-            result.push_settings_case(installed_apps, slots);
+            // Source settings retain fields such as context processors that this projection
+            // does not consume. Collapse identical projections before assigning their IDs.
+            let already_present = result.settings_cases.iter().any(|existing| {
+                existing.installed_apps == installed_apps
+                    && existing.slots.len() == slots.len()
+                    && existing
+                        .slots
+                        .iter()
+                        .zip(&slots)
+                        .all(|(existing_slot, backend_settings)| {
+                            match (existing_slot, backend_settings) {
+                                (TemplateBackendSlot::Backend(existing), Some(settings)) => {
+                                    &existing.data == settings
+                                }
+                                (TemplateBackendSlot::Remainder, None) => true,
+                                (TemplateBackendSlot::Backend(_), None)
+                                | (TemplateBackendSlot::Remainder, Some(_)) => false,
+                            }
+                        })
+            });
+            if !already_present {
+                result.push_settings_case(installed_apps, slots);
+            }
         }
         result
     }

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -1862,16 +1862,20 @@ TEMPLATES[0]['DIRS'].remove('/proj/removed')",
 }
 
 #[test]
-fn template_dirs_merge_equivalent_explicit_backend_branches() {
+fn template_settings_projection_merges_branches_differing_only_in_context_processors() {
     let mut db = TestDatabase::new();
     let project = project_with_settings(
         &mut db,
         "myproject.settings",
         &[
-            ("/proj/templates/index.html", "index"),
+            ("/proj/templates/index.html", "{% load shared %}"),
+            (
+                "/proj/custom_tags.py",
+                "from django import template\nregister = template.Library()\n",
+            ),
             (
                 "/proj/myproject/settings.py",
-                "if FLAG:\n    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'OPTIONS': {'context_processors': ['project.context_processors.site']}}]\nelse:\n    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'OPTIONS': {'context_processors': ['project.context_processors.site']}}]\n",
+                "INSTALLED_APPS = []\nif FLAG:\n    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'custom_tags'}, 'context_processors': ['project.context_processors.site']}}]\nelse:\n    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'custom_tags'}, 'context_processors': ['project.context_processors.admin']}}]\n",
             ),
         ],
     ).expect("settings project fixture should build");
@@ -1883,21 +1887,37 @@ fn template_dirs_merge_equivalent_explicit_backend_branches() {
             .as_array()
             .expect("expected JSON field should be an array")
             .len(),
-        1
-    );
-    assert_eq!(
-        settings["templates"]["cases"][0]["known"]["backends"]
-            .as_array()
-            .expect("expected JSON field should be an array")
-            .len(),
-        1
+        2,
+        "source settings must retain context processor alternatives"
     );
 
+    assert_eq!(
+        complete_template_dirs(&db, project),
+        [Utf8PathBuf::from("/proj/templates")]
+    );
     let origins: Vec<_> = template_resolution(&db, project)
         .origins(&db)
         .map(|origin| origin.path_buf(&db).clone())
         .collect();
     assert_eq!(origins, [Utf8PathBuf::from("/proj/templates/index.html")]);
+
+    let file = db
+        .file(Utf8Path::new("/proj/templates/index.html"))
+        .expect("template fixture should exist in the test database");
+    let libraries = scoped_template_libraries(&db, project, file);
+    assert_eq!(
+        libraries.library_chains(&["shared"]).len(),
+        1,
+        "context processors must not duplicate the consumed library alternative"
+    );
+    assert_eq!(
+        libraries
+            .loadable_library_str("shared")
+            .found()
+            .expect("projected backend should provide the configured library")
+            .module_name_str(),
+        "custom_tags"
+    );
 }
 
 #[test]

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -601,6 +601,110 @@ fn check_without_paths_scans_known_template_directories() {
 }
 
 #[test]
+fn check_without_paths_does_not_broaden_context_processor_only_branches() {
+    let dir = tempdir().expect("temporary test directory should be created");
+    setup_project(dir.path()).expect("test project fixture should be configured");
+
+    let configured = dir.path().join("configured");
+    fs::create_dir_all(&configured).expect("configured Template directory should be created");
+    fs::write(
+        configured.join("configured-broken.html"),
+        "{% block content %}\n",
+    )
+    .expect("configured Template fixture should be written");
+    fs::write(dir.path().join("root-broken.html"), "{% block content %}\n")
+        .expect("project-root Template fixture should be written");
+
+    let config = fs::read_to_string(dir.path().join("djls.toml"))
+        .expect("test project configuration should be readable");
+    fs::write(
+        dir.path().join("djls.toml"),
+        format!("django_settings_module = \"settings\"\n{config}"),
+    )
+    .expect("Django settings module should be configured");
+    fs::write(
+        dir.path().join("settings.py"),
+        format!(
+            "INSTALLED_APPS = []\nif FLAG:\n    TEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['{root}'], 'APP_DIRS': False, 'OPTIONS': {{'context_processors': ['project.context_processors.site']}}}}]\nelse:\n    TEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['{root}'], 'APP_DIRS': False, 'OPTIONS': {{'context_processors': ['project.context_processors.admin']}}}}]\n",
+            root = configured.display()
+        ),
+    )
+    .expect("branched Django Template settings should be written");
+
+    let output = Command::new(djls_binary())
+        .arg("check")
+        .current_dir(dir.path())
+        .output()
+        .expect("djls check process should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("configured-broken.html"), "{stdout}");
+    assert!(!stdout.contains("root-broken.html"), "{stdout}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Found 1 error in 1 file.\n"
+    );
+}
+
+#[test]
+fn check_without_paths_keeps_fallback_for_different_backend_libraries() {
+    let dir = tempdir().expect("temporary test directory should be created");
+    setup_project(dir.path()).expect("test project fixture should be configured");
+
+    let configured = dir.path().join("configured");
+    fs::create_dir_all(&configured).expect("configured Template directory should be created");
+    fs::write(
+        configured.join("configured.html"),
+        "{% block content %}{% endblock %}\n",
+    )
+    .expect("configured Template fixture should be written");
+    fs::write(dir.path().join("root-broken.html"), "{% block content %}\n")
+        .expect("project-root Template fixture should be written");
+
+    let config = fs::read_to_string(dir.path().join("djls.toml"))
+        .expect("test project configuration should be readable");
+    fs::write(
+        dir.path().join("djls.toml"),
+        format!("django_settings_module = \"settings\"\n{config}"),
+    )
+    .expect("Django settings module should be configured");
+    fs::write(
+        dir.path().join("settings.py"),
+        format!(
+            "INSTALLED_APPS = []\nif FLAG:\n    TEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['{root}'], 'APP_DIRS': False, 'OPTIONS': {{'libraries': {{'shared': 'alpha_tags'}}}}}}]\nelse:\n    TEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['{root}'], 'APP_DIRS': False, 'OPTIONS': {{'libraries': {{'shared': 'beta_tags'}}}}}}]\n",
+            root = configured.display()
+        ),
+    )
+    .expect("branched Django Template settings should be written");
+
+    let output = Command::new(djls_binary())
+        .arg("check")
+        .current_dir(dir.path())
+        .output()
+        .expect("djls check process should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("root-broken.html"),
+        "different configured libraries must retain separate backend alternatives: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn check_without_paths_falls_back_when_roots_may_be_omitted() {
     let dir = tempfile::tempdir().expect("temporary test directory should be created");
     setup_project(dir.path()).expect("test project fixture should be configured");


### PR DESCRIPTION
## Changes

Collapse equivalent consumed installed-app/backend cases before assigning template settings case IDs. Keep context-processor alternatives in source settings and preserve real differences in libraries, ordering, and unknown backend slots.

This prevents djls check from broadening discovery to the project root solely because settings branches differ in context processors.

## Review and validation

Placed deduplication at the projection boundary, not in the shared case constructor. Project and CLI regressions showed the context-processor-only case failing before the fix and passing afterward. A separate CLI test retains conservative fallback when configured libraries differ.

The completed seven-change stack passed cargo build, just testall (14 combinations), just e2e (44 tests), just clippy, just fmt, and just lint locally. Full-corpus benchmark workload snapshots passed unchanged. Hawk was not run locally; its CI job is pending in #834.

Stacked on defer-model-work. Merge the preceding PR first, then retarget to main.