### PR TITLE
Preserve explicit client configuration overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,13 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Removed eager Django Model scanning and Model Graph construction from project discovery and cache warm-up.
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
 
+### Removed
+
+- Removed the unused `debug` configuration option.
+
 ### Fixed
 
+- Fixed explicit `false` and empty LSP initialization options failing to override project configuration.
 - Fixed `djls check` scanning the project root when template settings branches differ only in context processors.
 - Fixed duplicate names and excess inclusion-tag arguments producing invented Template Library definitions.
 

--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -69,8 +69,6 @@ pub enum ConfigError {
 
 #[derive(Debug, Deserialize, Default, PartialEq, Clone)]
 pub struct Settings {
-    #[serde(default)]
-    debug: bool,
     venv_path: Option<Utf8PathBuf>,
     django_settings_module: Option<String>,
     #[serde(default)]
@@ -86,41 +84,74 @@ pub struct Settings {
     format: FormatConfig,
 }
 
+/// Settings supplied by a caller on top of configuration loaded from disk.
+///
+/// Each field retains whether the caller supplied it, including values such as
+/// `false` and empty lists that differ from an omitted field.
+#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
+pub struct SettingsOverrides {
+    venv_path: Option<Utf8PathBuf>,
+    django_settings_module: Option<String>,
+    django_environments: Option<Vec<DjangoEnvironmentConfig>>,
+    pythonpath: Option<Vec<Utf8PathBuf>>,
+    env_file: Option<String>,
+    tagspecs: Option<TagSpecDef>,
+    diagnostics: Option<DiagnosticsConfig>,
+    format: Option<FormatConfig>,
+}
+
+impl SettingsOverrides {
+    /// Resolve these overrides against default settings without reading config files.
+    #[must_use]
+    pub fn resolve(self) -> Settings {
+        let mut settings = Settings::default();
+        settings.apply_overrides(self);
+        settings
+    }
+}
+
 impl Settings {
-    pub fn new(project_root: &Utf8Path, overrides: Option<Settings>) -> Result<Self, ConfigError> {
+    pub fn new(
+        project_root: &Utf8Path,
+        overrides: Option<SettingsOverrides>,
+    ) -> Result<Self, ConfigError> {
         let user_config_file =
             project_dirs().map(|proj_dirs| proj_dirs.config_dir().join("djls.toml"));
 
         let mut settings = Self::load_from_paths(project_root, user_config_file.as_deref())?;
 
         if let Some(overrides) = overrides {
-            let has_django_environments = !overrides.django_environments.is_empty();
-
-            settings.debug = overrides.debug || settings.debug;
-            settings.venv_path = overrides.venv_path.or(settings.venv_path);
-            settings.django_settings_module = overrides
-                .django_settings_module
-                .or(settings.django_settings_module);
-            if has_django_environments {
-                settings.django_environments = overrides.django_environments;
-            }
-            if !overrides.pythonpath.is_empty() {
-                settings.pythonpath = overrides.pythonpath;
-            }
-            settings.env_file = overrides.env_file.or(settings.env_file);
-            if !overrides.tagspecs.libraries.is_empty() {
-                settings.tagspecs = overrides.tagspecs;
-            }
-            // For diagnostics, override if the config is non-default
-            if overrides.diagnostics != DiagnosticsConfig::default() {
-                settings.diagnostics = overrides.diagnostics;
-            }
-            if overrides.format != FormatConfig::default() {
-                settings.format = overrides.format;
-            }
+            settings.apply_overrides(overrides);
         }
 
         Ok(settings)
+    }
+
+    fn apply_overrides(&mut self, overrides: SettingsOverrides) {
+        if let Some(venv_path) = overrides.venv_path {
+            self.venv_path = Some(venv_path);
+        }
+        if let Some(django_settings_module) = overrides.django_settings_module {
+            self.django_settings_module = Some(django_settings_module);
+        }
+        if let Some(django_environments) = overrides.django_environments {
+            self.django_environments = django_environments;
+        }
+        if let Some(pythonpath) = overrides.pythonpath {
+            self.pythonpath = pythonpath;
+        }
+        if let Some(env_file) = overrides.env_file {
+            self.env_file = Some(env_file);
+        }
+        if let Some(tagspecs) = overrides.tagspecs {
+            self.tagspecs = tagspecs;
+        }
+        if let Some(diagnostics) = overrides.diagnostics {
+            self.diagnostics = diagnostics;
+        }
+        if let Some(format) = overrides.format {
+            self.format = format;
+        }
     }
 
     fn load_from_paths(
@@ -229,7 +260,6 @@ mod tests {
             assert_eq!(
                 settings,
                 Settings {
-                    debug: false,
                     venv_path: None,
                     django_settings_module: None,
                     django_environments: vec![],
@@ -249,19 +279,16 @@ mod tests {
         #[test]
         fn test_load_djls_toml_only() {
             let dir = tempdir().expect("test should create temporary project directory");
-            fs::write(dir.path().join("djls.toml"), "debug = true")
-                .expect("test should write djls.toml fixture");
+            fs::write(
+                dir.path().join("djls.toml"),
+                "django_settings_module = 'project.settings'",
+            )
+            .expect("test should write djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::new(project_root, None)
                 .expect("valid djls.toml fixture should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }
 
         #[test]
@@ -309,38 +336,29 @@ mod tests {
         #[test]
         fn test_load_dot_djls_toml_only() {
             let dir = tempdir().expect("test should create temporary project directory");
-            fs::write(dir.path().join(".djls.toml"), "debug = true")
-                .expect("test should write .djls.toml fixture");
+            fs::write(
+                dir.path().join(".djls.toml"),
+                "django_settings_module = 'project.settings'",
+            )
+            .expect("test should write .djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::new(project_root, None)
                 .expect("valid .djls.toml fixture should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }
 
         #[test]
         fn test_load_pyproject_toml_only() {
             let dir = tempdir().expect("test should create temporary project directory");
-            let content = "[tool.djls]\ndebug = true\n";
+            let content = "[tool.djls]\ndjango_settings_module = 'project.settings'\n";
             fs::write(dir.path().join("pyproject.toml"), content)
                 .expect("test should write pyproject.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::new(project_root, None)
                 .expect("valid pyproject.toml fixture should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }
 
         #[test]
@@ -410,7 +428,7 @@ django_settings_module = "project.settings"
             )
             .expect("test should write base Django environment djls.toml fixture");
 
-            let override_settings: Settings = toml::from_str(
+            let override_settings: SettingsOverrides = toml::from_str(
                 r#"
 [[django_environments]]
 root = "override"
@@ -495,65 +513,62 @@ T100 = "hint"
         #[test]
         fn test_project_priority_djls_overrides_dot_djls() {
             let dir = tempdir().expect("test should create temporary project directory");
-            fs::write(dir.path().join(".djls.toml"), "debug = false")
-                .expect("test should write lower-priority .djls.toml fixture");
-            fs::write(dir.path().join("djls.toml"), "debug = true")
-                .expect("test should write higher-priority djls.toml fixture");
+            fs::write(
+                dir.path().join(".djls.toml"),
+                "django_settings_module = 'dot.settings'",
+            )
+            .expect("test should write lower-priority .djls.toml fixture");
+            fs::write(
+                dir.path().join("djls.toml"),
+                "django_settings_module = 'active.settings'",
+            )
+            .expect("test should write higher-priority djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::new(project_root, None)
                 .expect("project configuration priority fixtures should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("active.settings"));
         }
 
         #[test]
         fn test_project_priority_dot_djls_overrides_pyproject() {
             let dir = tempdir().expect("test should create temporary project directory");
-            let pyproject_content = "[tool.djls]\ndebug = false\n";
+            let pyproject_content = "[tool.djls]\ndjango_settings_module = 'pyproject.settings'\n";
             fs::write(dir.path().join("pyproject.toml"), pyproject_content)
                 .expect("test should write lower-priority pyproject.toml fixture");
-            fs::write(dir.path().join(".djls.toml"), "debug = true")
-                .expect("test should write higher-priority .djls.toml fixture");
+            fs::write(
+                dir.path().join(".djls.toml"),
+                "django_settings_module = 'active.settings'",
+            )
+            .expect("test should write higher-priority .djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::new(project_root, None)
                 .expect("project configuration priority fixtures should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("active.settings"));
         }
 
         #[test]
         fn test_project_priority_all_files_djls_wins() {
             let dir = tempdir().expect("test should create temporary project directory");
-            let pyproject_content = "[tool.djls]\ndebug = false\n";
+            let pyproject_content = "[tool.djls]\ndjango_settings_module = 'pyproject.settings'\n";
             fs::write(dir.path().join("pyproject.toml"), pyproject_content)
                 .expect("test should write lowest-priority pyproject.toml fixture");
-            fs::write(dir.path().join(".djls.toml"), "debug = false")
-                .expect("test should write middle-priority .djls.toml fixture");
-            fs::write(dir.path().join("djls.toml"), "debug = true")
-                .expect("test should write highest-priority djls.toml fixture");
+            fs::write(
+                dir.path().join(".djls.toml"),
+                "django_settings_module = 'dot.settings'",
+            )
+            .expect("test should write middle-priority .djls.toml fixture");
+            fs::write(
+                dir.path().join("djls.toml"),
+                "django_settings_module = 'active.settings'",
+            )
+            .expect("test should write highest-priority djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::new(project_root, None)
                 .expect("all project configuration priority fixtures should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("active.settings"));
         }
 
         #[test]
@@ -562,9 +577,9 @@ T100 = "hint"
                 tempdir().expect("test should create temporary user configuration directory");
             let project_dir = tempdir().expect("test should create temporary project directory");
             let user_conf_path = user_dir.path().join("config.toml");
-            fs::write(&user_conf_path, "debug = true")
+            fs::write(&user_conf_path, "django_settings_module = 'user.settings'")
                 .expect("test should write lower-priority user configuration fixture");
-            let pyproject_content = "[tool.djls]\ndebug = false\n";
+            let pyproject_content = "[tool.djls]\ndjango_settings_module = 'active.settings'\n";
             fs::write(project_dir.path().join("pyproject.toml"), pyproject_content)
                 .expect("test should write higher-priority pyproject.toml fixture");
 
@@ -572,13 +587,7 @@ T100 = "hint"
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
                 .expect("user and project configuration priority fixtures should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: false,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("active.settings"));
         }
 
         #[test]
@@ -587,21 +596,122 @@ T100 = "hint"
                 tempdir().expect("test should create temporary user configuration directory");
             let project_dir = tempdir().expect("test should create temporary project directory");
             let user_conf_path = user_dir.path().join("config.toml");
-            fs::write(&user_conf_path, "debug = true")
+            fs::write(&user_conf_path, "django_settings_module = 'user.settings'")
                 .expect("test should write lower-priority user configuration fixture");
-            fs::write(project_dir.path().join("djls.toml"), "debug = false")
-                .expect("test should write higher-priority djls.toml fixture");
+            fs::write(
+                project_dir.path().join("djls.toml"),
+                "django_settings_module = 'active.settings'",
+            )
+            .expect("test should write higher-priority djls.toml fixture");
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
                 .expect("user and djls.toml priority fixtures should load settings");
+            assert_eq!(settings.django_settings_module(), Some("active.settings"));
+        }
+    }
+
+    mod overrides {
+        use super::*;
+
+        #[test]
+        fn test_explicit_false_and_empty_values_override_project_settings() {
+            let dir = tempdir().expect("test should create temporary project directory");
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+django_settings_module = "project.settings"
+pythonpath = ["inherited"]
+
+[format]
+enabled = true
+
+[diagnostics.severity]
+S100 = "off"
+"#,
+            )
+            .expect("test should write project settings fixture");
+            let overrides: SettingsOverrides = serde_json::from_value(serde_json::json!({
+                "django_settings_module": "client.settings",
+                "pythonpath": [],
+                "format": { "enabled": false },
+                "diagnostics": {},
+            }))
+            .expect("client settings overrides should deserialize");
+            let project_root = Utf8Path::from_path(dir.path())
+                .expect("temporary project directory path should be valid UTF-8");
+
+            let settings = Settings::new(project_root, Some(overrides))
+                .expect("project settings and explicit client overrides should load");
+
+            assert_eq!(settings.django_settings_module(), Some("client.settings"));
+            assert!(settings.pythonpath().is_empty());
+            assert!(!settings.format().enabled());
             assert_eq!(
-                settings,
-                Settings {
-                    debug: false,
-                    ..Default::default()
+                settings.diagnostics().get_severity("S100"),
+                DiagnosticSeverity::Error
+            );
+        }
+
+        #[test]
+        fn test_active_diagnostics_override_project_diagnostics() {
+            let dir = tempdir().expect("test should create temporary project directory");
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+[diagnostics.severity]
+S100 = "off"
+"#,
+            )
+            .expect("test should write project settings fixture");
+            let overrides: SettingsOverrides = serde_json::from_value(serde_json::json!({
+                "diagnostics": {
+                    "severity": { "S100": "warning" }
                 }
+            }))
+            .expect("active diagnostics override should deserialize");
+            let project_root = Utf8Path::from_path(dir.path())
+                .expect("temporary project directory path should be valid UTF-8");
+
+            let settings = Settings::new(project_root, Some(overrides))
+                .expect("active client diagnostics should override project diagnostics");
+
+            assert_eq!(
+                settings.diagnostics().get_severity("S100"),
+                DiagnosticSeverity::Warning
+            );
+        }
+
+        #[test]
+        fn test_omitted_values_preserve_project_settings() {
+            let dir = tempdir().expect("test should create temporary project directory");
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+pythonpath = ["inherited"]
+
+[format]
+enabled = true
+
+[diagnostics.severity]
+S100 = "off"
+"#,
+            )
+            .expect("test should write project settings fixture");
+            let overrides: SettingsOverrides = serde_json::from_value(serde_json::json!({}))
+                .expect("empty client settings overrides should deserialize");
+            let project_root = Utf8Path::from_path(dir.path())
+                .expect("temporary project directory path should be valid UTF-8");
+
+            let settings = Settings::new(project_root, Some(overrides))
+                .expect("omitted client settings should preserve project settings");
+
+            assert_eq!(settings.pythonpath(), &[Utf8PathBuf::from("inherited")]);
+            assert!(settings.format().enabled());
+            assert_eq!(
+                settings.diagnostics().get_severity("S100"),
+                DiagnosticSeverity::Off
             );
         }
     }
@@ -615,20 +725,14 @@ T100 = "hint"
                 tempdir().expect("test should create temporary user configuration directory");
             let project_dir = tempdir().expect("test should create temporary project directory");
             let user_conf_path = user_dir.path().join("config.toml");
-            fs::write(&user_conf_path, "debug = true")
+            fs::write(&user_conf_path, "django_settings_module = 'user.settings'")
                 .expect("test should write user configuration fixture");
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
                 .expect("valid user configuration fixture should load settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("user.settings"));
         }
 
         #[test]
@@ -637,7 +741,7 @@ T100 = "hint"
                 tempdir().expect("test should create temporary user configuration directory");
             let project_dir = tempdir().expect("test should create temporary project directory");
             let user_conf_path = user_dir.path().join("config.toml");
-            let pyproject_content = "[tool.djls]\ndebug = true\n";
+            let pyproject_content = "[tool.djls]\ndjango_settings_module = 'project.settings'\n";
             fs::write(project_dir.path().join("pyproject.toml"), pyproject_content)
                 .expect("test should write pyproject.toml fixture");
 
@@ -645,32 +749,23 @@ T100 = "hint"
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
                 .expect("missing optional user configuration should not prevent loading settings");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }
 
         #[test]
         fn test_user_config_path_not_provided() {
             let project_dir = tempdir().expect("test should create temporary project directory");
-            fs::write(project_dir.path().join("djls.toml"), "debug = true")
-                .expect("test should write djls.toml fixture");
+            fs::write(
+                project_dir.path().join("djls.toml"),
+                "django_settings_module = 'project.settings'",
+            )
+            .expect("test should write djls.toml fixture");
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let settings = Settings::load_from_paths(project_root, None)
                 .expect("settings should load without a user configuration path");
-            assert_eq!(
-                settings,
-                Settings {
-                    debug: true,
-                    ..Default::default()
-                }
-            );
+            assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }
     }
 
@@ -750,12 +845,12 @@ end_tag = { name = "endblock", optional = false }
         #[test]
         fn test_invalid_toml_content() {
             let dir = tempdir().expect("test should create temporary project directory");
-            fs::write(dir.path().join("djls.toml"), "debug = not_a_boolean")
+            fs::write(dir.path().join("djls.toml"), "pythonpath = 'not an array'")
                 .expect("test should write invalid djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
             let error = Settings::new(project_root, None)
-                .expect_err("invalid debug value should be rejected");
+                .expect_err("invalid Python path value should be rejected");
             assert!(matches!(error, ConfigError::Config(_)));
         }
 

--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -15,6 +15,8 @@ use config::File;
 use config::FileFormat;
 use directories::ProjectDirs;
 use serde::Deserialize;
+use serde_json::Map;
+use serde_json::Value;
 use thiserror::Error;
 
 pub use crate::diagnostics::DiagnosticSeverity;
@@ -59,6 +61,8 @@ pub fn log_dir() -> anyhow::Result<Utf8PathBuf> {
 pub enum ConfigError {
     #[error("Configuration build/deserialize error")]
     Config(#[from] ExternalConfigError),
+    #[error("Failed to convert configuration overrides")]
+    Overrides(#[from] serde_json::Error),
     #[error("Failed to read pyproject.toml")]
     PyprojectIo(#[from] std::io::Error),
     #[error("Failed to parse pyproject.toml TOML")]
@@ -84,79 +88,23 @@ pub struct Settings {
     format: FormatConfig,
 }
 
-/// Settings supplied by a caller on top of configuration loaded from disk.
-///
-/// Each field retains whether the caller supplied it, including values such as
-/// `false` and empty lists that differ from an omitted field.
-#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
-pub struct SettingsOverrides {
-    venv_path: Option<Utf8PathBuf>,
-    django_settings_module: Option<String>,
-    django_environments: Option<Vec<DjangoEnvironmentConfig>>,
-    pythonpath: Option<Vec<Utf8PathBuf>>,
-    env_file: Option<String>,
-    tagspecs: Option<TagSpecDef>,
-    diagnostics: Option<DiagnosticsConfig>,
-    format: Option<FormatConfig>,
-}
-
-impl SettingsOverrides {
-    /// Resolve these overrides against default settings without reading config files.
-    #[must_use]
-    pub fn resolve(self) -> Settings {
-        let mut settings = Settings::default();
-        settings.apply_overrides(self);
-        settings
-    }
-}
-
 impl Settings {
+    /// Load file settings, replacing supplied top-level fields before applying defaults.
+    /// Omitted fields and JSON nulls leave file settings unchanged.
     pub fn new(
         project_root: &Utf8Path,
-        overrides: Option<SettingsOverrides>,
+        overrides: Option<Map<String, Value>>,
     ) -> Result<Self, ConfigError> {
         let user_config_file =
             project_dirs().map(|proj_dirs| proj_dirs.config_dir().join("djls.toml"));
 
-        let mut settings = Self::load_from_paths(project_root, user_config_file.as_deref())?;
-
-        if let Some(overrides) = overrides {
-            settings.apply_overrides(overrides);
-        }
-
-        Ok(settings)
-    }
-
-    fn apply_overrides(&mut self, overrides: SettingsOverrides) {
-        if let Some(venv_path) = overrides.venv_path {
-            self.venv_path = Some(venv_path);
-        }
-        if let Some(django_settings_module) = overrides.django_settings_module {
-            self.django_settings_module = Some(django_settings_module);
-        }
-        if let Some(django_environments) = overrides.django_environments {
-            self.django_environments = django_environments;
-        }
-        if let Some(pythonpath) = overrides.pythonpath {
-            self.pythonpath = pythonpath;
-        }
-        if let Some(env_file) = overrides.env_file {
-            self.env_file = Some(env_file);
-        }
-        if let Some(tagspecs) = overrides.tagspecs {
-            self.tagspecs = tagspecs;
-        }
-        if let Some(diagnostics) = overrides.diagnostics {
-            self.diagnostics = diagnostics;
-        }
-        if let Some(format) = overrides.format {
-            self.format = format;
-        }
+        Self::load_from_paths(project_root, user_config_file.as_deref(), overrides)
     }
 
     fn load_from_paths(
         project_root: &Utf8Path,
         user_config_path: Option<&Path>,
+        overrides: Option<Map<String, Value>>,
     ) -> Result<Self, ConfigError> {
         let mut builder = Config::builder();
 
@@ -192,9 +140,17 @@ impl Settings {
                 .required(false),
         );
 
-        let config = builder.build()?;
-        let settings: Self = config.try_deserialize()?;
-        Ok(settings)
+        let mut values = builder.build()?.cache.into_table()?;
+        if let Some(mut overrides) = overrides {
+            overrides.retain(|_, value| !value.is_null());
+            // config sources deep-merge tables. Client sections replace them instead,
+            // so an explicit empty diagnostics map can clear inherited severities.
+            // Deserialize values directly; Config::try_from drops empty collections.
+            let overrides: config::Map<String, config::Value> =
+                serde_json::from_value(Value::Object(overrides))?;
+            values.extend(overrides);
+        }
+        Ok(config::Value::from(values).try_deserialize()?)
     }
 
     #[must_use]
@@ -428,7 +384,7 @@ django_settings_module = "project.settings"
             )
             .expect("test should write base Django environment djls.toml fixture");
 
-            let override_settings: SettingsOverrides = toml::from_str(
+            let override_settings: Map<String, Value> = toml::from_str(
                 r#"
 [[django_environments]]
 root = "override"
@@ -585,7 +541,7 @@ T100 = "hint"
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
-            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
+            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path), None)
                 .expect("user and project configuration priority fixtures should load settings");
             assert_eq!(settings.django_settings_module(), Some("active.settings"));
         }
@@ -606,7 +562,7 @@ T100 = "hint"
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
-            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
+            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path), None)
                 .expect("user and djls.toml priority fixtures should load settings");
             assert_eq!(settings.django_settings_module(), Some("active.settings"));
         }
@@ -632,7 +588,7 @@ S100 = "off"
 "#,
             )
             .expect("test should write project settings fixture");
-            let overrides: SettingsOverrides = serde_json::from_value(serde_json::json!({
+            let overrides: Map<String, Value> = serde_json::from_value(serde_json::json!({
                 "django_settings_module": "client.settings",
                 "pythonpath": [],
                 "format": { "enabled": false },
@@ -655,17 +611,18 @@ S100 = "off"
         }
 
         #[test]
-        fn test_active_diagnostics_override_project_diagnostics() {
+        fn test_supplied_diagnostics_replace_the_whole_section() {
             let dir = tempdir().expect("test should create temporary project directory");
             fs::write(
                 dir.path().join("djls.toml"),
                 r#"
 [diagnostics.severity]
 S100 = "off"
+S101 = "off"
 "#,
             )
             .expect("test should write project settings fixture");
-            let overrides: SettingsOverrides = serde_json::from_value(serde_json::json!({
+            let overrides: Map<String, Value> = serde_json::from_value(serde_json::json!({
                 "diagnostics": {
                     "severity": { "S100": "warning" }
                 }
@@ -681,6 +638,40 @@ S100 = "off"
                 settings.diagnostics().get_severity("S100"),
                 DiagnosticSeverity::Warning
             );
+            assert_eq!(
+                settings.diagnostics().get_severity("S101"),
+                DiagnosticSeverity::Error
+            );
+        }
+
+        #[test]
+        fn test_null_overrides_preserve_project_settings() {
+            let dir = tempdir().expect("test should create temporary project directory");
+            fs::write(
+                dir.path().join("djls.toml"),
+                r#"
+django_settings_module = "project.settings"
+pythonpath = ["inherited"]
+
+[format]
+enabled = true
+"#,
+            )
+            .expect("test should write project settings fixture");
+            let project_root = Utf8Path::from_path(dir.path())
+                .expect("temporary project directory path should be valid UTF-8");
+            let overrides = Map::from_iter([
+                ("django_settings_module".into(), Value::Null),
+                ("pythonpath".into(), Value::Null),
+                ("format".into(), Value::Null),
+            ]);
+
+            let settings = Settings::new(project_root, Some(overrides))
+                .expect("null overrides should leave project settings unchanged");
+
+            assert_eq!(settings.django_settings_module(), Some("project.settings"));
+            assert_eq!(settings.pythonpath(), &[Utf8PathBuf::from("inherited")]);
+            assert!(settings.format().enabled());
         }
 
         #[test]
@@ -699,7 +690,7 @@ S100 = "off"
 "#,
             )
             .expect("test should write project settings fixture");
-            let overrides: SettingsOverrides = serde_json::from_value(serde_json::json!({}))
+            let overrides: Map<String, Value> = serde_json::from_value(serde_json::json!({}))
                 .expect("empty client settings overrides should deserialize");
             let project_root = Utf8Path::from_path(dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
@@ -730,7 +721,7 @@ S100 = "off"
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
-            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
+            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path), None)
                 .expect("valid user configuration fixture should load settings");
             assert_eq!(settings.django_settings_module(), Some("user.settings"));
         }
@@ -747,7 +738,7 @@ S100 = "off"
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
-            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path))
+            let settings = Settings::load_from_paths(project_root, Some(&user_conf_path), None)
                 .expect("missing optional user configuration should not prevent loading settings");
             assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }
@@ -763,7 +754,7 @@ S100 = "off"
 
             let project_root = Utf8Path::from_path(project_dir.path())
                 .expect("temporary project directory path should be valid UTF-8");
-            let settings = Settings::load_from_paths(project_root, None)
+            let settings = Settings::load_from_paths(project_root, None, None)
                 .expect("settings should load without a user configuration path");
             assert_eq!(settings.django_settings_module(), Some("project.settings"));
         }

--- a/crates/djls-project/tests/django_projects.rs
+++ b/crates/djls-project/tests/django_projects.rs
@@ -36,7 +36,7 @@ fn fixture_root(name: &str) -> TestResult<Utf8PathBuf> {
 
 fn bootstrap_fixture(
     name: &str,
-    overrides: Option<djls_conf::Settings>,
+    overrides: Option<djls_conf::SettingsOverrides>,
 ) -> TestResult<(OsTestDatabase, Project, Utf8PathBuf)> {
     let root = fixture_root(name)?;
     let mut db = OsTestDatabase::new();
@@ -46,9 +46,9 @@ fn bootstrap_fixture(
     Ok((db, project, root))
 }
 
-fn venv_override(venv: &Utf8Path) -> TestResult<djls_conf::Settings> {
+fn venv_override(venv: &Utf8Path) -> TestResult<djls_conf::SettingsOverrides> {
     let escaped = venv.as_str().replace('\\', "\\\\").replace('"', "\\\"");
-    Ok(toml::from_str::<djls_conf::Settings>(&format!(
+    Ok(toml::from_str::<djls_conf::SettingsOverrides>(&format!(
         "venv_path = \"{escaped}\""
     ))?)
 }

--- a/crates/djls-project/tests/django_projects.rs
+++ b/crates/djls-project/tests/django_projects.rs
@@ -36,7 +36,7 @@ fn fixture_root(name: &str) -> TestResult<Utf8PathBuf> {
 
 fn bootstrap_fixture(
     name: &str,
-    overrides: Option<djls_conf::SettingsOverrides>,
+    overrides: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> TestResult<(OsTestDatabase, Project, Utf8PathBuf)> {
     let root = fixture_root(name)?;
     let mut db = OsTestDatabase::new();
@@ -44,13 +44,6 @@ fn bootstrap_fixture(
     let project = Project::bootstrap(&db, root.as_path(), &settings);
     db.set_project(project);
     Ok((db, project, root))
-}
-
-fn venv_override(venv: &Utf8Path) -> TestResult<djls_conf::SettingsOverrides> {
-    let escaped = venv.as_str().replace('\\', "\\\\").replace('"', "\\\"");
-    Ok(toml::from_str::<djls_conf::SettingsOverrides>(&format!(
-        "venv_path = \"{escaped}\""
-    ))?)
 }
 
 fn template_dirs(db: &OsTestDatabase, project: Project) -> Vec<Utf8PathBuf> {
@@ -66,7 +59,7 @@ fn template_dirs(db: &OsTestDatabase, project: Project) -> Vec<Utf8PathBuf> {
 fn src_layout_discovers_nested_roots_settings_models_and_libraries() {
     let root = fixture_root("src-layout").expect("src-layout fixture root should resolve");
     let venv = root.join(".venv");
-    let overrides = venv_override(&venv).expect("src-layout venv override should deserialize");
+    let overrides = serde_json::Map::from_iter([("venv_path".into(), serde_json::json!(venv))]);
     let (db, project, root) = bootstrap_fixture("src-layout", Some(overrides))
         .expect("src-layout fixture should bootstrap");
 
@@ -115,7 +108,7 @@ fn src_layout_discovers_nested_roots_settings_models_and_libraries() {
 fn editable_pth_discovers_editable_roots_libraries_and_shadowing() {
     let root = fixture_root("editable-pth").expect("editable-pth fixture root should resolve");
     let venv = root.join(".venv");
-    let overrides = venv_override(&venv).expect("editable-pth venv override should deserialize");
+    let overrides = serde_json::Map::from_iter([("venv_path".into(), serde_json::json!(venv))]);
     let (db, project, root) = bootstrap_fixture("editable-pth", Some(overrides))
         .expect("editable-pth fixture should bootstrap");
 
@@ -174,7 +167,7 @@ fn editable_pth_discovers_editable_roots_libraries_and_shadowing() {
 fn namespace_apps_discovers_namespace_dirs_config_tails_and_libraries() {
     let root = fixture_root("namespace-apps").expect("namespace-apps fixture root should resolve");
     let venv = root.join(".venv");
-    let overrides = venv_override(&venv).expect("namespace-apps venv override should deserialize");
+    let overrides = serde_json::Map::from_iter([("venv_path".into(), serde_json::json!(venv))]);
     let (db, project, root) = bootstrap_fixture("namespace-apps", Some(overrides))
         .expect("namespace-apps fixture should bootstrap");
 

--- a/crates/djls-server/src/client.rs
+++ b/crates/djls-server/src/client.rs
@@ -1,4 +1,4 @@
-use djls_conf::Settings;
+use djls_conf::SettingsOverrides;
 use djls_source::PositionEncoding;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -60,8 +60,8 @@ impl ClientInfo {
     }
 
     #[must_use]
-    pub(crate) fn config_overrides(&self) -> &Settings {
-        &self.options.settings
+    pub(crate) fn config_overrides(&self) -> &SettingsOverrides {
+        &self.options.overrides
     }
 
     #[must_use]
@@ -170,7 +170,7 @@ impl ClientCapabilities {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub(crate) struct ClientOptions {
     #[serde(flatten)]
-    pub settings: Settings,
+    pub overrides: SettingsOverrides,
 
     #[serde(flatten)]
     pub unknown: FxHashMap<String, Value>,

--- a/crates/djls-server/src/client.rs
+++ b/crates/djls-server/src/client.rs
@@ -1,7 +1,8 @@
-use djls_conf::SettingsOverrides;
+use djls_conf::Settings;
 use djls_source::PositionEncoding;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+use serde_json::Map;
 use serde_json::Value;
 use tower_lsp_server::ls_types;
 
@@ -13,7 +14,7 @@ pub(crate) struct ClientInfo {
     client: Client,
     position_encoding: PositionEncoding,
     capabilities: ClientCapabilities,
-    options: ClientOptions,
+    overrides: Map<String, Value>,
 }
 
 impl ClientInfo {
@@ -50,7 +51,7 @@ impl ClientInfo {
             client,
             position_encoding,
             capabilities,
-            options,
+            overrides: options.overrides,
         }
     }
 
@@ -60,8 +61,8 @@ impl ClientInfo {
     }
 
     #[must_use]
-    pub(crate) fn config_overrides(&self) -> &SettingsOverrides {
-        &self.options.overrides
+    pub(crate) fn config_overrides(&self) -> &Map<String, Value> {
+        &self.overrides
     }
 
     #[must_use]
@@ -170,10 +171,14 @@ impl ClientCapabilities {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub(crate) struct ClientOptions {
     #[serde(flatten)]
-    pub overrides: SettingsOverrides,
+    pub settings: Settings,
 
     #[serde(flatten)]
     pub unknown: FxHashMap<String, Value>,
+
+    // Keep supplied keys for reloads; serializing settings would also include defaults.
+    #[serde(skip)]
+    pub overrides: Map<String, Value>,
 }
 
 #[cfg(test)]

--- a/crates/djls-server/src/ext.rs
+++ b/crates/djls-server/src/ext.rs
@@ -6,6 +6,7 @@ use djls_source::LineIndex;
 use djls_source::Offset;
 use djls_source::PositionEncoding;
 use djls_source::Range;
+use serde::Deserialize;
 use tower_lsp_server::ls_types;
 
 use crate::client::Client;
@@ -92,14 +93,28 @@ impl InitializeParamsExt for ls_types::InitializeParams {
         let client_options: ClientOptions = self
             .initialization_options
             .as_ref()
-            .and_then(|v| match serde_json::from_value(v.clone()) {
-                Ok(opts) => Some(opts),
-                Err(err) => {
-                    tracing::error!(
-                        "Failed to deserialize initialization options: {}. Using defaults.",
-                        err
-                    );
-                    None
+            .and_then(|value| {
+                let mut value = value.clone();
+                if let Some(fields) = value.as_object_mut() {
+                    // Null means no override, including for non-optional settings.
+                    fields.retain(|_, value| !value.is_null());
+                }
+                match ClientOptions::deserialize(&value) {
+                    Ok(mut opts) => {
+                        if let serde_json::Value::Object(fields) = value {
+                            opts.overrides = fields;
+                            opts.overrides
+                                .retain(|key, _| !opts.unknown.contains_key(key));
+                        }
+                        Some(opts)
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            "Failed to deserialize initialization options: {}. Using defaults.",
+                            err
+                        );
+                        None
+                    }
                 }
             })
             .unwrap_or_default();
@@ -198,6 +213,81 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+
+    #[test]
+    fn client_options_keep_supplied_fields_separate_from_startup_defaults() {
+        let supplied = serde_json::json!({
+            "pythonpath": [],
+            "format": { "enabled": false },
+            "diagnostics": {},
+            "unknown_setting": true,
+        });
+        let params = ls_types::InitializeParams {
+            initialization_options: Some(supplied),
+            ..Default::default()
+        };
+
+        let options = params.client_options();
+
+        assert!(options.settings.pythonpath().is_empty());
+        assert!(!options.settings.format().enabled());
+        assert_eq!(
+            serde_json::Value::Object(options.overrides),
+            serde_json::json!({
+                "pythonpath": [],
+                "format": { "enabled": false },
+                "diagnostics": {},
+            })
+        );
+        assert_eq!(options.unknown.len(), 1);
+        assert_eq!(options.unknown["unknown_setting"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn invalid_client_options_discard_overrides_as_well_as_startup_settings() {
+        for supplied in [
+            serde_json::json!({"pythonpath": "not an array", "env_file": "client.env"}),
+            serde_json::json!({"format": {"enabled": "false"}, "env_file": "client.env"}),
+            serde_json::json!([]),
+            serde_json::json!(null),
+            serde_json::json!(false),
+        ] {
+            let params = ls_types::InitializeParams {
+                initialization_options: Some(supplied.clone()),
+                ..Default::default()
+            };
+
+            let options = params.client_options();
+
+            assert_eq!(
+                options.settings,
+                djls_conf::Settings::default(),
+                "{supplied}"
+            );
+            assert!(options.overrides.is_empty(), "{supplied}");
+        }
+    }
+
+    #[test]
+    fn null_client_fields_do_not_discard_other_overrides() {
+        let params = ls_types::InitializeParams {
+            initialization_options: Some(serde_json::json!({
+                "pythonpath": null,
+                "format": null,
+                "django_settings_module": null,
+                "env_file": "client.env",
+            })),
+            ..Default::default()
+        };
+
+        let options = params.client_options();
+
+        assert_eq!(options.settings.env_file(), Some("client.env"));
+        assert_eq!(
+            serde_json::Value::Object(options.overrides),
+            serde_json::json!({"env_file": "client.env"})
+        );
+    }
 
     #[test]
     fn test_position_encoding_kind_unknown_returns_none() {

--- a/crates/djls-server/src/reload.rs
+++ b/crates/djls-server/src/reload.rs
@@ -1792,13 +1792,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lsp_overrides_preserve_explicit_false_and_empty_values() {
+        let tempdir = tempdir().expect("temporary project directory should be created");
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf())
+            .expect("temporary project path should be valid UTF-8");
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            r#"
+django_settings_module = "project.settings"
+pythonpath = ["inherited"]
+
+[format]
+enabled = true
+
+[diagnostics.severity]
+S100 = "off"
+"#,
+        )
+        .expect("project settings fixture should be written");
+
+        let params = ls_types::InitializeParams {
+            workspace_folders: Some(vec![ls_types::WorkspaceFolder {
+                uri: ls_types::Uri::from_file_path(root.as_std_path())
+                    .expect("project root should convert to a file URI"),
+                name: "test_project".to_string(),
+            }]),
+            initialization_options: Some(serde_json::json!({
+                "django_settings_module": "client.settings",
+                "pythonpath": [],
+                "format": { "enabled": false },
+                "diagnostics": {},
+            })),
+            ..Default::default()
+        };
+        let session = Arc::new(Mutex::new(Session::new(&params)));
+
+        let settings = match load_project_settings(&session).await {
+            StageOutcome::Complete(settings) => settings,
+            StageOutcome::Cancelled | StageOutcome::Failed => {
+                panic!("valid project settings and LSP overrides should load")
+            }
+        };
+
+        assert_eq!(settings.django_settings_module(), Some("client.settings"));
+        assert!(settings.pythonpath().is_empty());
+        assert!(!settings.format().enabled());
+        assert_eq!(
+            settings.diagnostics().get_severity("S100"),
+            djls_conf::DiagnosticSeverity::Error
+        );
+    }
+
+    #[tokio::test]
+    async fn omitted_lsp_overrides_preserve_project_values() {
+        let tempdir = tempdir().expect("temporary project directory should be created");
+        let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf())
+            .expect("temporary project path should be valid UTF-8");
+        std::fs::write(
+            root.join("djls.toml").as_std_path(),
+            r#"
+pythonpath = ["inherited"]
+
+[format]
+enabled = true
+
+[diagnostics.severity]
+S100 = "off"
+"#,
+        )
+        .expect("project settings fixture should be written");
+
+        let params = ls_types::InitializeParams {
+            workspace_folders: Some(vec![ls_types::WorkspaceFolder {
+                uri: ls_types::Uri::from_file_path(root.as_std_path())
+                    .expect("project root should convert to a file URI"),
+                name: "test_project".to_string(),
+            }]),
+            initialization_options: Some(serde_json::json!({})),
+            ..Default::default()
+        };
+        let session = Arc::new(Mutex::new(Session::new(&params)));
+
+        let settings = match load_project_settings(&session).await {
+            StageOutcome::Complete(settings) => settings,
+            StageOutcome::Cancelled | StageOutcome::Failed => {
+                panic!("valid project settings and omitted LSP overrides should load")
+            }
+        };
+
+        assert_eq!(settings.pythonpath(), &[Utf8PathBuf::from("inherited")]);
+        assert!(settings.format().enabled());
+        assert_eq!(
+            settings.diagnostics().get_severity("S100"),
+            djls_conf::DiagnosticSeverity::Off
+        );
+    }
+
+    #[tokio::test]
     async fn project_settings_load_error_skips_discovery_inputs() {
         let tempdir = tempdir().expect("temporary project directory should be created");
         let root = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf())
             .expect("temporary project path should be valid UTF-8");
         std::fs::write(
             root.join("djls.toml").as_std_path(),
-            "debug = not_a_boolean",
+            "pythonpath = 'not an array'",
         )
         .expect("invalid project settings fixture should be written");
 

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -383,12 +383,12 @@ impl Session {
 
         let client_options = params.client_options();
 
-        let client_settings = client_options.settings.clone();
+        let initial_settings = client_options.overrides.clone().resolve();
 
         let workspace = Workspace::new();
         let db = DjangoDatabase::new(
             workspace.overlay(),
-            &client_settings,
+            &initial_settings,
             project_path.as_deref(),
         );
 

--- a/crates/djls-server/src/session.rs
+++ b/crates/djls-server/src/session.rs
@@ -383,12 +383,10 @@ impl Session {
 
         let client_options = params.client_options();
 
-        let initial_settings = client_options.overrides.clone().resolve();
-
         let workspace = Workspace::new();
         let db = DjangoDatabase::new(
             workspace.overlay(),
-            &initial_settings,
+            &client_options.settings,
             project_path.as_deref(),
         );
 

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -550,8 +550,11 @@ fn check_rejects_mixed_stdin_and_paths() {
 #[test]
 fn check_invalid_settings_error_precedes_mixed_stdin_and_paths_error() {
     let dir = tempdir().expect("temporary test directory should be created");
-    fs::write(dir.path().join("djls.toml"), "debug = not_a_boolean\n")
-        .expect("invalid test configuration should be written");
+    fs::write(
+        dir.path().join("djls.toml"),
+        "pythonpath = 'not an array'\n",
+    )
+    .expect("invalid test configuration should be written");
 
     let output = Command::new(djls_binary())
         .args(["check", "-", "template.html"])

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -105,12 +105,6 @@ backend = "djangofmt"
 
 When enabled, editor "format document" requests are handled by `djangofmt`. DJLS passes through standard editor formatting options when the client provides them, including tab width, spaces vs tabs, trailing whitespace trimming, final newline insertion, and final newline trimming.
 
-### `debug`
-
-**Default:** `false`
-
-Enable debug logging for troubleshooting language server issues.
-
 ### `diagnostics`
 
 Configure diagnostic severity levels. All diagnostics are enabled by default at "error" severity level.
@@ -284,7 +278,7 @@ When configuration is needed, the server supports multiple methods in priority o
 
 ### LSP client
 
-Pass configuration through your editor's LSP client using `initializationOptions`. This has the highest priority and is useful for workspace-specific overrides.
+Pass configuration through your editor's LSP client using `initializationOptions`. This has the highest priority and is useful for workspace-specific overrides. Only fields present in `initializationOptions` override file settings; explicit `false` values and empty lists or maps clear the corresponding file setting.
 
 ```json
 {


### PR DESCRIPTION
## Changes

Merge supplied client fields with file configuration before deserializing Settings. Explicit false and empty lists or maps replace file settings; omitted fields and top-level nulls preserve them. Supplied nested sections replace the whole section rather than deep-merging it.

Settings is the only field schema. The LSP parser uses it for validation and startup defaults, then retains the known supplied JSON keys for reloads. Invalid initialization options still fall back to defaults, and unknown keys still produce a warning. The follow-up commit removes SettingsOverrides and its field-by-field assignments.

Use config value deserialization and a root-table replacement: adding a config source would deep-merge tables, and Config::try_from drops empty collections. Existing regression tests caught that empty-collection loss during this revision.

Remove the unused debug setting and use active settings in precedence tests. Keep django_environments and the multisite fixture for the established multi-environment requirement.

## Validation

- Configuration, server initialization/reload, and project fixture tests passed.
- Kept explicit-false/empty and omission regressions; expanded coverage for whole-section replacement, nulls, invalid-client fallback, and unknown-key handling.
- Both the revised PR and rebased stack tip passed just test, just e2e (44 tests), just fmt, just clippy, cargo check --all-targets --all-features, and just lint.
- Hawk remains for CI. The full Python/Django matrix was not rerun for this revision.

First PR in cleanup stack #856.