### PR TITLE
Test production diagnostic and relation behavior

### DIFF
--- a/crates/djls-conf/src/diagnostics.rs
+++ b/crates/djls-conf/src/diagnostics.rs
@@ -85,10 +85,6 @@ impl DiagnosticsConfig {
 mod tests {
     use super::*;
 
-    fn is_enabled(config: &DiagnosticsConfig, code: &str) -> bool {
-        config.get_severity(code) != DiagnosticSeverity::Off
-    }
-
     #[test]
     fn test_get_severity_default() {
         let config = DiagnosticsConfig::default();
@@ -160,51 +156,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_enabled_default() {
-        let config = DiagnosticsConfig::default();
-        assert!(is_enabled(&config, "S100"));
-        assert!(is_enabled(&config, "T100"));
-    }
-
-    #[test]
-    fn test_is_enabled_with_off() {
-        let mut severity = HashMap::new();
-        severity.insert("S100".to_string(), DiagnosticSeverity::Off);
-
-        let config = DiagnosticsConfig { severity };
-
-        assert!(!is_enabled(&config, "S100"));
-        assert!(is_enabled(&config, "S101"));
-    }
-
-    #[test]
-    fn test_is_enabled_with_prefix_off() {
-        let mut severity = HashMap::new();
-        severity.insert("T".to_string(), DiagnosticSeverity::Off);
-
-        let config = DiagnosticsConfig { severity };
-
-        assert!(!is_enabled(&config, "T100"));
-        assert!(!is_enabled(&config, "T900"));
-        assert!(is_enabled(&config, "S100"));
-    }
-
-    #[test]
-    fn test_is_enabled_prefix_off_with_specific_override() {
-        let mut severity = HashMap::new();
-        severity.insert("T".to_string(), DiagnosticSeverity::Off);
-        severity.insert("T100".to_string(), DiagnosticSeverity::Hint);
-
-        let config = DiagnosticsConfig { severity };
-
-        // T100 has specific override, so it's enabled
-        assert!(is_enabled(&config, "T100"));
-        // Other T codes are off
-        assert!(!is_enabled(&config, "T900"));
-        assert!(!is_enabled(&config, "T901"));
-    }
-
-    #[test]
     fn test_deserialize_diagnostics_config() {
         let toml = r#"
             [severity]
@@ -244,22 +195,17 @@ mod tests {
 
         // S100 is exact match - off
         assert_eq!(config.get_severity("S100"), DiagnosticSeverity::Off);
-        assert!(!is_enabled(&config, "S100"));
 
         // S101 matches S10 prefix - info
         assert_eq!(config.get_severity("S101"), DiagnosticSeverity::Info);
-        assert!(is_enabled(&config, "S101"));
 
         // S200 matches S prefix - warning
         assert_eq!(config.get_severity("S200"), DiagnosticSeverity::Warning);
-        assert!(is_enabled(&config, "S200"));
 
         // T100 has exact match - hint
         assert_eq!(config.get_severity("T100"), DiagnosticSeverity::Hint);
-        assert!(is_enabled(&config, "T100"));
 
         // T900 matches T prefix - off
         assert_eq!(config.get_severity("T900"), DiagnosticSeverity::Off);
-        assert!(!is_enabled(&config, "T900"));
     }
 }

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -473,50 +473,6 @@ impl Relation {
             RelationType::GenericForeignKey { .. } => None,
         }
     }
-
-    #[cfg(test)]
-    fn effective_related_name_matches(
-        &self,
-        source_model: &str,
-        module_name: &str,
-        field_name: &str,
-    ) -> bool {
-        match &self.relation_type {
-            RelationType::ForeignKey { related_name, .. }
-            | RelationType::ManyToMany { related_name, .. } => match related_name {
-                Some(RelatedName::Named(name)) => {
-                    template_related_name_matches(name, source_model, module_name, field_name)
-                }
-                Some(RelatedName::Suppressed) => false,
-                None => field_name
-                    .strip_suffix("_set")
-                    .is_some_and(|prefix| source_model.to_lowercase() == prefix),
-            },
-            RelationType::OneToOne { related_name, .. } => match related_name {
-                Some(RelatedName::Named(name)) => {
-                    template_related_name_matches(name, source_model, module_name, field_name)
-                }
-                Some(RelatedName::Suppressed) => false,
-                None => source_model.to_lowercase() == field_name,
-            },
-            RelationType::GenericForeignKey { .. } => false,
-        }
-    }
-}
-
-#[cfg(test)]
-fn template_related_name_matches(
-    template: &str,
-    source_model: &str,
-    module_name: &str,
-    field_name: &str,
-) -> bool {
-    if !template.contains("%(") {
-        return template == field_name;
-    }
-
-    let lower = source_model.to_lowercase();
-    substitute_related_name(template, &lower, module_name) == field_name
 }
 
 fn substitute_related_name(template: &str, lower_model: &str, module_name: &str) -> String {
@@ -1333,41 +1289,6 @@ impl ModelGraph {
         }
     }
 
-    /// Look up models that point at `scope` via a reverse relation.
-    ///
-    /// Returns `(source_model_id, effective_related_name)` pairs. Skips
-    /// `GenericForeignKey` relations.
-    #[cfg(test)]
-    fn resolve_reverse<'a>(
-        &'a self,
-        scope: &'a ModelId,
-    ) -> impl Iterator<Item = (&'a ModelId, String)> + 'a {
-        self.records.iter().flat_map(move |(source_id, record)| {
-            let model = &record.definition;
-            (model.kind == ModelKind::Concrete)
-                .then(|| {
-                    self.owned_relation_bindings(source_id).filter_map(
-                        move |(binding, relation)| {
-                            let (target_id, _target_model) =
-                                self.resolve_relation_target_entry(binding, relation)?;
-                            if target_id != scope {
-                                return None;
-                            }
-
-                            relation
-                                .effective_related_name(
-                                    model.name.value().as_str(),
-                                    model.module_name.as_str(),
-                                )
-                                .map(|name| (source_id, name))
-                        },
-                    )
-                })
-                .into_iter()
-                .flatten()
-        })
-    }
-
     /// Resolve a field access on a model — checks forward relations first,
     /// then reverse relations.
     #[must_use]
@@ -1751,17 +1672,6 @@ mod tests {
     }
 
     #[test]
-    fn reverse_lookup() {
-        let graph = user_order_graph();
-        let reverses: Vec<_> = graph
-            .resolve_reverse(model_id(&graph, "User"))
-            .map(|(src, name)| (src.name().to_string(), name))
-            .collect();
-        assert!(reverses.contains(&("Order".into(), "orders".into())));
-        assert!(reverses.contains(&("Profile".into(), "profile".into())));
-    }
-
-    #[test]
     fn resolve_relation_forward_and_reverse() {
         let graph = user_order_graph();
         assert_eq!(
@@ -1899,18 +1809,11 @@ mod tests {
                 relation.effective_related_name("Order", "shop.models"),
                 None
             );
-            for candidate in ["+", "order+", "foo+"] {
-                assert!(!relation.effective_related_name_matches(
-                    "Order",
-                    "shop.models",
-                    candidate
-                ));
-            }
         }
     }
 
     #[test]
-    fn named_related_name_still_matches_after_substitution() {
+    fn parsed_related_name_substitutes_the_model_name() {
         let relation_type = RelationType::from_field_class(
             "ForeignKey",
             Spanned::new(
@@ -1932,16 +1835,10 @@ mod tests {
         ));
         let relation = relation("user", relation_type);
 
-        assert!(relation.effective_related_name_matches(
-            "SpecialOrder",
-            "shop.models",
-            "specialorder_orders"
-        ));
-        assert!(!relation.effective_related_name_matches(
-            "SpecialOrder",
-            "shop.models",
-            "specialorder_set"
-        ));
+        assert_eq!(
+            relation.effective_related_name("SpecialOrder", "shop.models"),
+            Some("specialorder_orders".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Remove tests of the test-only is_enabled expression. Keep production severity tests and the IDE test that verifies disabled diagnostics suppress code actions.

Delete test-only relation-name matching and reverse-lookup implementations. Assert name substitution through production code; existing graph tests already cover forward and reverse lookup.

## Validation

- Configuration tests: 33 passed.
- Model Graph unit tests: 21 passed.
- IDE severity-off regression test passed.
- The complete stack passed the 14-combination test matrix, all 44 e2e tests, formatting, Clippy, all-target/all-feature check, and pre-commit checks locally. Hawk is reserved for CI.