### PR TITLE
Use ordered borrowed tag arguments

### DIFF
--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -1151,7 +1151,6 @@ mod tests {
                         "sidebar".to_string(),
                         "site_header".to_string(),
                     ]),
-                    position: 0,
                 }]),
         );
         specs
@@ -1171,7 +1170,6 @@ mod tests {
             name: "name".to_string(),
             required: true,
             kind: TagArgumentKind::Variable,
-            position: 0,
         }])
     }
 

--- a/crates/djls-ide/src/snippets.rs
+++ b/crates/djls-ide/src/snippets.rs
@@ -49,7 +49,7 @@ fn generate_snippet_from_args(args: &[TagArgument]) -> String {
 fn generate_snippet_for_tag(tag_name: &str, spec: &TagSpec) -> String {
     let args = spec.arguments();
 
-    let args_snippet = generate_snippet_from_args(&args);
+    let args_snippet = generate_snippet_from_args(args);
 
     if args_snippet.is_empty() {
         tag_name.to_string()
@@ -102,49 +102,45 @@ mod tests {
 
     use super::*;
 
-    fn make_var(name: &str, required: bool, pos: usize) -> TagArgument {
+    fn make_var(name: &str, required: bool) -> TagArgument {
         TagArgument {
             name: name.to_string(),
             required,
             kind: TagArgumentKind::Variable,
-            position: pos,
         }
     }
 
-    fn make_literal(value: &str, required: bool, pos: usize) -> TagArgument {
+    fn make_literal(value: &str, required: bool) -> TagArgument {
         TagArgument {
             name: value.to_string(),
             required,
             kind: TagArgumentKind::Literal(value.to_string()),
-            position: pos,
         }
     }
 
-    fn make_choice(name: &str, required: bool, choices: Vec<&str>, pos: usize) -> TagArgument {
+    fn make_choice(name: &str, required: bool, choices: Vec<&str>) -> TagArgument {
         TagArgument {
             name: name.to_string(),
             required,
             kind: TagArgumentKind::Choice(choices.into_iter().map(String::from).collect()),
-            position: pos,
         }
     }
 
-    fn make_varargs(name: &str, required: bool, pos: usize) -> TagArgument {
+    fn make_varargs(name: &str, required: bool) -> TagArgument {
         TagArgument {
             name: name.to_string(),
             required,
             kind: TagArgumentKind::VarArgs,
-            position: pos,
         }
     }
 
     #[test]
     fn test_snippet_for_for_tag() {
         let args = vec![
-            make_var("item", true, 0),
-            make_literal("in", true, 1),
-            make_var("items", true, 2),
-            make_literal("reversed", false, 3),
+            make_var("item", true),
+            make_literal("in", true),
+            make_var("items", true),
+            make_literal("reversed", false),
         ];
 
         let snippet = generate_snippet_from_args(&args);
@@ -153,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_snippet_for_if_tag() {
-        let args = vec![make_var("condition", true, 0)];
+        let args = vec![make_var("condition", true)];
 
         let snippet = generate_snippet_from_args(&args);
         assert_eq!(snippet, "${1:condition}");
@@ -161,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_snippet_for_autoescape_tag() {
-        let args = vec![make_choice("mode", true, vec!["on", "off"], 0)];
+        let args = vec![make_choice("mode", true, vec!["on", "off"])];
 
         let snippet = generate_snippet_from_args(&args);
         assert_eq!(snippet, "${1|on,off|}");
@@ -188,7 +184,7 @@ mod tests {
             Cow::Borrowed(&[]),
             false,
         )
-        .with_arguments(vec![make_var("name", true, 0)]);
+        .with_arguments(vec![make_var("name", true)]);
 
         let snippet = generate_snippet_for_tag_with_end("block", &spec);
         assert_eq!(snippet, "block ${1:name} %}\n$0\n{% endblock ${1} %}");
@@ -207,7 +203,7 @@ mod tests {
             Cow::Borrowed(&[]),
             false,
         )
-        .with_arguments(vec![make_choice("mode", true, vec!["on", "off"], 0)]);
+        .with_arguments(vec![make_choice("mode", true, vec!["on", "off"])]);
 
         let snippet = generate_snippet_for_tag_with_end("autoescape", &spec);
         assert_eq!(
@@ -219,10 +215,10 @@ mod tests {
     #[test]
     fn test_snippet_for_url_tag() {
         let args = vec![
-            make_var("view_name", true, 0),
-            make_varargs("args", false, 1),
-            make_literal("as", false, 2),
-            make_var("varname", false, 3),
+            make_var("view_name", true),
+            make_varargs("args", false),
+            make_literal("as", false),
+            make_var("varname", false),
         ];
 
         let snippet = generate_snippet_from_args(&args);

--- a/crates/djls-ide/tests/completions.rs
+++ b/crates/djls-ide/tests/completions.rs
@@ -122,7 +122,6 @@ fn captured_closer_does_not_offer_colliding_standalone_arguments() {
                 name: "collision".to_string(),
                 kind: TagArgumentKind::Choice(vec!["standalone-choice".to_string()]),
                 required: true,
-                position: 0,
             },
         ]),
     );

--- a/crates/djls-project/src/templates/tags/analysis.rs
+++ b/crates/djls-project/src/templates/tags/analysis.rs
@@ -360,8 +360,7 @@ fn extract_arg_names(
     }
 
     let mut args = Vec::new();
-    for arg_index in 0..max_pos {
-        let pos = arg_index + 1;
+    for pos in 1..=max_pos {
         let pos_split = SplitPosition::Forward(pos);
 
         // Check if there's a required keyword at this position
@@ -370,7 +369,6 @@ fn extract_arg_names(
                 name: rk.value.clone(),
                 required: true,
                 kind: TagArgumentKind::Literal(rk.value.clone()),
-                position: arg_index,
             });
             continue;
         }
@@ -381,7 +379,6 @@ fn extract_arg_names(
                 name: name.clone(),
                 required: true,
                 kind: TagArgumentKind::Variable,
-                position: arg_index,
             });
             continue;
         }
@@ -391,7 +388,6 @@ fn extract_arg_names(
             name: format!("arg{pos}"),
             required: true,
             kind: TagArgumentKind::Variable,
-            position: arg_index,
         });
     }
 
@@ -476,11 +472,8 @@ def do_tag(parser, token):
         );
         assert_eq!(rule.extracted_args.len(), 3);
         assert_eq!(rule.extracted_args[0].name, "item");
-        assert_eq!(rule.extracted_args[0].position, 0);
         assert_eq!(rule.extracted_args[1].name, "connector");
-        assert_eq!(rule.extracted_args[1].position, 1);
         assert_eq!(rule.extracted_args[2].name, "varname");
-        assert_eq!(rule.extracted_args[2].position, 2);
     }
 
     #[test]
@@ -497,12 +490,9 @@ def do_tag(parser, token):
         );
         assert_eq!(rule.extracted_args.len(), 3);
         assert_eq!(rule.extracted_args[0].name, "format_string");
-        assert_eq!(rule.extracted_args[0].position, 0);
         // Position 2 (split index 2) has no named var — should get generic name
         assert_eq!(rule.extracted_args[1].name, "arg2");
-        assert_eq!(rule.extracted_args[1].position, 1);
         assert_eq!(rule.extracted_args[2].name, "target");
-        assert_eq!(rule.extracted_args[2].position, 2);
     }
 
     #[test]

--- a/crates/djls-project/src/templates/tags/signature.rs
+++ b/crates/djls-project/src/templates/tags/signature.rs
@@ -55,14 +55,13 @@ pub(crate) fn extract_parse_bits_rule(func: &StmtFunctionDef, as_var: AsVar) -> 
     }
 
     let mut extracted_args = Vec::new();
-    for (i, param) in effective_params.iter().enumerate() {
+    for param in effective_params {
         let name = param.parameter.name.to_string();
         let required = param.default.is_none();
         extracted_args.push(TagArgument {
             name,
             required,
             kind: TagArgumentKind::Variable,
-            position: i,
         });
     }
 
@@ -71,18 +70,16 @@ pub(crate) fn extract_parse_bits_rule(func: &StmtFunctionDef, as_var: AsVar) -> 
             name: vararg.name.to_string(),
             required: false,
             kind: TagArgumentKind::VarArgs,
-            position: effective_params.len(),
         });
     }
 
-    for (i, kwonly) in params.kwonlyargs.iter().enumerate() {
+    for kwonly in &params.kwonlyargs {
         let name = kwonly.parameter.name.to_string();
         let required = kwonly.default.is_none();
         extracted_args.push(TagArgument {
             name,
             required,
             kind: TagArgumentKind::Keyword,
-            position: effective_params.len() + usize::from(has_varargs) + i,
         });
     }
 

--- a/crates/djls-project/src/templates/tags/types.rs
+++ b/crates/djls-project/src/templates/tags/types.rs
@@ -86,6 +86,7 @@ pub struct TagRule {
     pub known_options: Option<KnownOptions>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diagnostic_messages: Option<Vec<ExtractedDiagnosticMessage>>,
+    /// Arguments in template source order.
     pub extracted_args: Vec<TagArgument>,
     /// Support for Django's `{% tag args... as varname %}` form.
     ///
@@ -276,8 +277,6 @@ pub struct TagArgument {
     pub required: bool,
     /// The kind of argument
     pub kind: TagArgumentKind,
-    /// Zero-based position index in the argument list (excluding tag name)
-    pub position: usize,
 }
 
 /// The kind of an extracted argument.

--- a/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__config_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__config_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: key
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__core_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__core_tags.py.snap
@@ -30,7 +30,6 @@ tag_rules:
       - name: result
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::plugin_full":
     arg_constraints:
@@ -43,7 +42,6 @@ tag_rules:
       - name: result
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::plugin_icon":
     arg_constraints:
@@ -56,7 +54,6 @@ tag_rules:
       - name: plugin
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::snapshot_base_url":
     arg_constraints:
@@ -69,7 +66,6 @@ tag_rules:
       - name: snapshot
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::snapshot_url":
     arg_constraints:
@@ -82,11 +78,9 @@ tag_rules:
       - name: snapshot
         required: true
         kind: Variable
-        position: 0
       - name: path
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::web_base_url":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__babybuddy__templatetags__babybuddy.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__babybuddy__templatetags__babybuddy.py.snap
@@ -22,7 +22,6 @@ tag_rules:
       - name: object
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::confirm_unlock_text":
     arg_constraints:
@@ -35,7 +34,6 @@ tag_rules:
       - name: object
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::get_child_count":
     arg_constraints:
@@ -72,7 +70,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::relative_url":
     arg_constraints:
@@ -85,11 +82,9 @@ tag_rules:
       - name: field_name
         required: true
         kind: Variable
-        position: 0
       - name: value
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::user_is_locked":
     arg_constraints:
@@ -102,7 +97,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::user_is_read_only":
     arg_constraints:
@@ -115,7 +109,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::version_string":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__breadcrumb.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__breadcrumb.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: current_child
         required: true
         kind: Variable
-        position: 0
       - name: target_url
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__timers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__timers.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: url_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "core.templatetags.timers::tag::quick_timer_nav":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__dashboard__templatetags__cards.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__dashboard__templatetags__cards.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
       - name: date
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "dashboard.templatetags.cards::tag::card_diaperchange_last":
     arg_constraints:
@@ -31,7 +29,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_diaperchange_types":
     arg_constraints:
@@ -44,11 +41,9 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
       - name: date
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "dashboard.templatetags.cards::tag::card_feeding_last":
     arg_constraints:
@@ -61,7 +56,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_feeding_last_method":
     arg_constraints:
@@ -74,7 +68,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_feeding_recent":
     arg_constraints:
@@ -87,11 +80,9 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
       - name: end_date
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "dashboard.templatetags.cards::tag::card_pumping_last":
     arg_constraints:
@@ -104,7 +95,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_sleep_last":
     arg_constraints:
@@ -117,7 +107,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_sleep_naps_day":
     arg_constraints:
@@ -130,11 +119,9 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
       - name: date
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "dashboard.templatetags.cards::tag::card_sleep_recent":
     arg_constraints:
@@ -147,11 +134,9 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
       - name: end_date
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "dashboard.templatetags.cards::tag::card_statistics":
     arg_constraints:
@@ -164,7 +149,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_timer_list":
     arg_constraints:
@@ -176,7 +160,6 @@ tag_rules:
       - name: child
         required: false
         kind: Variable
-        position: 0
     as_var: keep
   "dashboard.templatetags.cards::tag::card_tummytime_day":
     arg_constraints:
@@ -189,11 +172,9 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
       - name: date
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "dashboard.templatetags.cards::tag::card_tummytime_last":
     arg_constraints:
@@ -206,7 +187,6 @@ tag_rules:
       - name: child
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_list.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: spec
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: popup
         required: false
         kind: Variable
-        position: 1
       - name: to_field
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities:
   "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__log.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__log.py.snap
@@ -39,21 +39,17 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: as
         required: true
         kind:
           Literal: as
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: for_user
         required: true
         kind:
           Literal: for_user
-        position: 3
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
@@ -33,7 +33,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::cycle":
     arg_constraints:
@@ -62,7 +61,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::for":
     arg_constraints:
@@ -74,15 +72,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::lorem":
     arg_constraints:
@@ -104,15 +99,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::now":
     arg_constraints:
@@ -130,7 +122,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::querystring":
     arg_constraints: []
@@ -141,7 +132,6 @@ tag_rules:
       - name: query_dict
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:
@@ -179,25 +169,20 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: by
         required: true
         kind:
           Literal: by
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: var_name
         required: true
         kind: Variable
-        position: 4
     as_var: keep
   "django.template.defaulttags::tag::resetcycle":
     arg_constraints:
@@ -219,7 +204,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::templatetag":
     arg_constraints:
@@ -237,7 +221,6 @@ tag_rules:
       - name: tag
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::url":
     arg_constraints:
@@ -259,7 +242,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::widthratio":
     arg_constraints: []
@@ -281,24 +263,19 @@ tag_rules:
       - name: this_value_expr
         required: true
         kind: Variable
-        position: 0
       - name: max_value_expr
         required: true
         kind: Variable
-        position: 1
       - name: max_width
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: asvar
         required: true
         kind: Variable
-        position: 4
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
@@ -23,7 +23,6 @@ tag_rules:
       - name: block_name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::extends":
     arg_constraints:
@@ -45,7 +44,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::include":
     arg_constraints:
@@ -72,7 +70,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__cache.py.snap
@@ -23,11 +23,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -47,11 +47,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_current_language":
     arg_constraints:
@@ -67,11 +65,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_current_language_bidi":
     arg_constraints:
@@ -87,11 +83,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_language_info":
     arg_constraints:
@@ -110,20 +104,16 @@ tag_rules:
         required: true
         kind:
           Literal: for
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: as
         required: true
         kind:
           Literal: as
-        position: 2
       - name: arg4
         required: true
         kind: Variable
-        position: 3
     as_var: keep
   "django.templatetags.i18n::tag::get_language_info_list":
     arg_constraints:
@@ -142,20 +132,16 @@ tag_rules:
         required: true
         kind:
           Literal: for
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: as
         required: true
         kind:
           Literal: as
-        position: 2
       - name: arg4
         required: true
         kind: Variable
-        position: 3
     as_var: keep
   "django.templatetags.i18n::tag::language":
     arg_constraints:
@@ -177,7 +163,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::trans":
     arg_constraints:
@@ -205,7 +190,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::translate":
     arg_constraints:
@@ -233,7 +217,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.i18n::filter::language_bidi": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__l10n.py.snap
@@ -41,7 +41,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.l10n::filter::localize": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__tz.py.snap
@@ -17,11 +17,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.tz::tag::localtime":
     arg_constraints:
@@ -61,7 +59,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.tz::tag::timezone":
     arg_constraints:
@@ -83,7 +80,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.tz::filter::localtime": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
@@ -54,7 +54,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::minustwo":
     arg_constraints:
@@ -67,7 +66,6 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
     arg_constraints:
@@ -96,7 +94,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context":
     arg_constraints:
@@ -109,7 +106,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
     arg_constraints:
@@ -121,7 +117,6 @@ tag_rules:
       - name: kwarg
         required: false
         kind: Keyword
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
     arg_constraints:
@@ -133,7 +128,6 @@ tag_rules:
       - name: kwarg
         required: true
         kind: Keyword
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
     arg_constraints:
@@ -146,11 +140,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
@@ -161,7 +153,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_tag_takes_context_without_params":
     arg_constraints:
@@ -190,11 +181,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
     arg_constraints:
@@ -206,15 +195,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
     arg_constraints:
@@ -226,15 +212,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__inclusion.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
     arg_constraints:
@@ -55,7 +53,6 @@ tag_rules:
       - name: kwarg
         required: false
         kind: Keyword
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
     arg_constraints:
@@ -100,11 +97,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
     arg_constraints:
@@ -117,11 +112,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
     arg_constraints:
@@ -134,7 +127,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
     arg_constraints:
@@ -147,7 +139,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
     arg_constraints: []
@@ -158,7 +149,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
     arg_constraints: []
@@ -169,7 +159,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
     arg_constraints:
@@ -182,7 +171,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
     arg_constraints:
@@ -195,7 +183,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_takes_context_without_params":
     arg_constraints:
@@ -232,11 +219,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
     arg_constraints:
@@ -249,11 +234,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
     arg_constraints:
@@ -265,15 +248,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
     arg_constraints:
@@ -285,15 +265,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
     arg_constraints:
@@ -305,15 +282,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_list.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: spec
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: popup
         required: false
         kind: Variable
-        position: 1
       - name: to_field
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities:
   "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__log.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__log.py.snap
@@ -39,21 +39,17 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: as
         required: true
         kind:
           Literal: as
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: for_user
         required: true
         kind:
           Literal: for_user
-        position: 3
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__auth__templatetags__auth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__auth__templatetags__auth.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
@@ -33,7 +33,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::cycle":
     arg_constraints:
@@ -62,7 +61,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::for":
     arg_constraints:
@@ -74,15 +72,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::lorem":
     arg_constraints:
@@ -104,15 +99,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::now":
     arg_constraints:
@@ -130,7 +122,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::partial":
     arg_constraints:
@@ -142,7 +133,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::partialdef":
     arg_constraints:
@@ -159,12 +149,10 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: inline
         required: true
         kind:
           Literal: inline
-        position: 1
     as_var: keep
   "django.template.defaulttags::tag::querystring":
     arg_constraints: []
@@ -175,7 +163,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:
@@ -213,25 +200,20 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: by
         required: true
         kind:
           Literal: by
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: var_name
         required: true
         kind: Variable
-        position: 4
     as_var: keep
   "django.template.defaulttags::tag::resetcycle":
     arg_constraints:
@@ -253,7 +235,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::templatetag":
     arg_constraints:
@@ -271,7 +252,6 @@ tag_rules:
       - name: tag
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::url":
     arg_constraints:
@@ -293,7 +273,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::widthratio":
     arg_constraints: []
@@ -315,24 +294,19 @@ tag_rules:
       - name: this_value_expr
         required: true
         kind: Variable
-        position: 0
       - name: max_value_expr
         required: true
         kind: Variable
-        position: 1
       - name: max_width
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: asvar
         required: true
         kind: Variable
-        position: 4
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
@@ -23,7 +23,6 @@ tag_rules:
       - name: block_name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::extends":
     arg_constraints:
@@ -45,7 +44,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::include":
     arg_constraints:
@@ -72,7 +70,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__cache.py.snap
@@ -23,11 +23,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -47,11 +47,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_current_language":
     arg_constraints:
@@ -67,11 +65,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_current_language_bidi":
     arg_constraints:
@@ -87,11 +83,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_language_info":
     arg_constraints:
@@ -110,20 +104,16 @@ tag_rules:
         required: true
         kind:
           Literal: for
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: as
         required: true
         kind:
           Literal: as
-        position: 2
       - name: arg4
         required: true
         kind: Variable
-        position: 3
     as_var: keep
   "django.templatetags.i18n::tag::get_language_info_list":
     arg_constraints:
@@ -142,20 +132,16 @@ tag_rules:
         required: true
         kind:
           Literal: for
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: as
         required: true
         kind:
           Literal: as
-        position: 2
       - name: arg4
         required: true
         kind: Variable
-        position: 3
     as_var: keep
   "django.templatetags.i18n::tag::language":
     arg_constraints:
@@ -177,7 +163,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::trans":
     arg_constraints:
@@ -205,7 +190,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::translate":
     arg_constraints:
@@ -233,7 +217,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.i18n::filter::language_bidi": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__l10n.py.snap
@@ -41,7 +41,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.l10n::filter::localize": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__tz.py.snap
@@ -17,11 +17,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.tz::tag::localtime":
     arg_constraints:
@@ -61,7 +59,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.tz::tag::timezone":
     arg_constraints:
@@ -83,7 +80,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.tz::filter::localtime": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
@@ -54,7 +54,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::minustwo":
     arg_constraints:
@@ -67,7 +66,6 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
     arg_constraints:
@@ -96,7 +94,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context":
     arg_constraints:
@@ -109,7 +106,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
     arg_constraints:
@@ -121,7 +117,6 @@ tag_rules:
       - name: kwarg
         required: false
         kind: Keyword
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
     arg_constraints:
@@ -133,7 +128,6 @@ tag_rules:
       - name: kwarg
         required: true
         kind: Keyword
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
     arg_constraints:
@@ -146,11 +140,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
@@ -161,7 +153,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_tag_takes_context_without_params":
     arg_constraints:
@@ -190,11 +181,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
     arg_constraints:
@@ -206,15 +195,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
     arg_constraints:
@@ -226,15 +212,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__inclusion.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
     arg_constraints:
@@ -55,7 +53,6 @@ tag_rules:
       - name: kwarg
         required: false
         kind: Keyword
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
     arg_constraints:
@@ -100,11 +97,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
     arg_constraints:
@@ -117,11 +112,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
     arg_constraints:
@@ -134,7 +127,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
     arg_constraints:
@@ -147,7 +139,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
     arg_constraints: []
@@ -158,7 +149,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
     arg_constraints: []
@@ -169,7 +159,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
     arg_constraints:
@@ -182,7 +171,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
     arg_constraints:
@@ -195,7 +183,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_takes_context_without_params":
     arg_constraints:
@@ -232,11 +219,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
     arg_constraints:
@@ -249,11 +234,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
     arg_constraints:
@@ -265,15 +248,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
     arg_constraints:
@@ -285,15 +265,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
     arg_constraints:
@@ -305,15 +282,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_list.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: spec
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: popup
         required: false
         kind: Variable
-        position: 1
       - name: to_field
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities:
   "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__log.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__log.py.snap
@@ -39,21 +39,17 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: as
         required: true
         kind:
           Literal: as
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: for_user
         required: true
         kind:
           Literal: for_user
-        position: 3
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__auth__templatetags__auth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__auth__templatetags__auth.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
@@ -33,7 +33,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::csp_nonce_attr":
     arg_constraints:
@@ -45,7 +44,6 @@ tag_rules:
       - name: media
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::cycle":
     arg_constraints:
@@ -74,7 +72,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::for":
     arg_constraints:
@@ -86,15 +83,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::lorem":
     arg_constraints:
@@ -116,15 +110,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::now":
     arg_constraints:
@@ -142,7 +133,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::partial":
     arg_constraints:
@@ -154,7 +144,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::partialdef":
     arg_constraints:
@@ -171,12 +160,10 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: inline
         required: true
         kind:
           Literal: inline
-        position: 1
     as_var: keep
   "django.template.defaulttags::tag::querystring":
     arg_constraints: []
@@ -187,7 +174,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:
@@ -225,25 +211,20 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: by
         required: true
         kind:
           Literal: by
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: var_name
         required: true
         kind: Variable
-        position: 4
     as_var: keep
   "django.template.defaulttags::tag::resetcycle":
     arg_constraints:
@@ -265,7 +246,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::templatetag":
     arg_constraints:
@@ -283,7 +263,6 @@ tag_rules:
       - name: tag
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::url":
     arg_constraints:
@@ -305,7 +284,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::widthratio":
     arg_constraints: []
@@ -327,24 +305,19 @@ tag_rules:
       - name: this_value_expr
         required: true
         kind: Variable
-        position: 0
       - name: max_value_expr
         required: true
         kind: Variable
-        position: 1
       - name: max_width
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: asvar
         required: true
         kind: Variable
-        position: 4
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
@@ -23,7 +23,6 @@ tag_rules:
       - name: block_name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::extends":
     arg_constraints:
@@ -45,7 +44,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::include":
     arg_constraints:
@@ -72,7 +70,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__cache.py.snap
@@ -23,11 +23,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
@@ -47,11 +47,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_current_language":
     arg_constraints:
@@ -67,11 +65,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_current_language_bidi":
     arg_constraints:
@@ -87,11 +83,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.i18n::tag::get_language_info":
     arg_constraints:
@@ -110,20 +104,16 @@ tag_rules:
         required: true
         kind:
           Literal: for
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: as
         required: true
         kind:
           Literal: as
-        position: 2
       - name: arg4
         required: true
         kind: Variable
-        position: 3
     as_var: keep
   "django.templatetags.i18n::tag::get_language_info_list":
     arg_constraints:
@@ -142,20 +132,16 @@ tag_rules:
         required: true
         kind:
           Literal: for
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: as
         required: true
         kind:
           Literal: as
-        position: 2
       - name: arg4
         required: true
         kind: Variable
-        position: 3
     as_var: keep
   "django.templatetags.i18n::tag::language":
     arg_constraints:
@@ -177,7 +163,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::trans":
     arg_constraints:
@@ -205,7 +190,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::translate":
     arg_constraints:
@@ -233,7 +217,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.i18n::filter::language_bidi": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
@@ -41,7 +41,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.l10n::filter::localize": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
@@ -17,11 +17,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.tz::tag::localtime":
     arg_constraints:
@@ -61,7 +59,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.tz::tag::timezone":
     arg_constraints:
@@ -83,7 +80,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "django.templatetags.tz::filter::localtime": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
@@ -54,7 +54,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::minustwo":
     arg_constraints:
@@ -67,7 +66,6 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
     arg_constraints:
@@ -96,7 +94,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context":
     arg_constraints:
@@ -109,7 +106,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
     arg_constraints:
@@ -121,7 +117,6 @@ tag_rules:
       - name: kwarg
         required: false
         kind: Keyword
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
     arg_constraints:
@@ -133,7 +128,6 @@ tag_rules:
       - name: kwarg
         required: true
         kind: Keyword
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
     arg_constraints:
@@ -146,11 +140,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
@@ -161,7 +153,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
     arg_constraints:
@@ -174,11 +165,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
     arg_constraints:
@@ -190,15 +179,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
     arg_constraints:
@@ -210,15 +196,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__inclusion.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
     arg_constraints:
@@ -55,7 +53,6 @@ tag_rules:
       - name: kwarg
         required: false
         kind: Keyword
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
     arg_constraints:
@@ -100,11 +97,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
     arg_constraints:
@@ -117,11 +112,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
     arg_constraints:
@@ -134,7 +127,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
     arg_constraints:
@@ -147,7 +139,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
     arg_constraints: []
@@ -158,7 +149,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
     arg_constraints: []
@@ -169,7 +159,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
     arg_constraints:
@@ -182,7 +171,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
     arg_constraints:
@@ -195,7 +183,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
     arg_constraints:
@@ -216,11 +203,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
     arg_constraints:
@@ -233,11 +218,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
     arg_constraints:
@@ -249,15 +232,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
     arg_constraints:
@@ -269,15 +249,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
     arg_constraints:
@@ -289,15 +266,12 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
@@ -19,7 +19,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "actstream.templatetags.activity_tags::tag::follow_all_url":
     arg_constraints:
@@ -37,11 +36,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "actstream.templatetags.activity_tags::tag::follow_url":
     arg_constraints:
@@ -59,11 +56,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities:
   "actstream.templatetags.activity_tags::filter::activity_stream": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__account__templatetags__account.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__account__templatetags__account.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__socialaccount__templatetags__socialaccount.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__socialaccount__templatetags__socialaccount.py.snap
@@ -22,7 +22,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "allauth.socialaccount.templatetags.socialaccount::tag::provider_login_url":
     arg_constraints:
@@ -34,7 +33,6 @@ tag_rules:
       - name: provider
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "allauth.socialaccount.templatetags.socialaccount::tag::providers_media_js":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__templatetags__allauth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__templatetags__allauth.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-avatar__avatar__templatetags__avatar_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-avatar__avatar__templatetags__avatar_tags.py.snap
@@ -13,15 +13,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: width
         required: false
         kind: Variable
-        position: 1
       - name: height
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "avatar.templatetags.avatar_tags::tag::avatar_url":
     arg_constraints:
@@ -34,15 +31,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: width
         required: false
         kind: Variable
-        position: 1
       - name: height
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "avatar.templatetags.avatar_tags::tag::primary_avatar":
     arg_constraints:
@@ -55,15 +49,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: width
         required: false
         kind: Variable
-        position: 1
       - name: height
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "avatar.templatetags.avatar_tags::tag::render_avatar":
     arg_constraints:
@@ -76,15 +67,12 @@ tag_rules:
       - name: avatar
         required: true
         kind: Variable
-        position: 0
       - name: width
         required: false
         kind: Variable
-        position: 1
       - name: height
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities:
   "avatar.templatetags.avatar_tags::filter::has_avatar": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-baton__baton__templatetags__baton_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-baton__baton__templatetags__baton_tags.py.snap
@@ -30,7 +30,6 @@ tag_rules:
       - name: key
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "baton.templatetags.baton_tags::tag::baton_theme":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: content
         required: true
         kind: Variable
-        position: 0
       - name: alert_type
         required: false
         kind: Variable
-        position: 1
       - name: dismissable
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_button":
     arg_constraints: []
@@ -33,7 +30,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_css":
     arg_constraints:
@@ -60,7 +56,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_form":
     arg_constraints: []
@@ -71,7 +66,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_form_errors":
     arg_constraints: []
@@ -82,7 +76,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_formset":
     arg_constraints: []
@@ -93,7 +86,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_formset_errors":
     arg_constraints: []
@@ -104,7 +96,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_icon":
     arg_constraints:
@@ -116,7 +107,6 @@ tag_rules:
       - name: icon
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_javascript":
     arg_constraints:
@@ -128,7 +118,6 @@ tag_rules:
       - name: jquery
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_javascript_url":
     arg_constraints:
@@ -155,7 +144,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_messages":
     arg_constraints: []
@@ -166,7 +154,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_pagination":
     arg_constraints:
@@ -178,7 +165,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_theme_url":
     arg_constraints:
@@ -199,15 +185,12 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: name
         required: true
         kind: Variable
-        position: 1
       - name: value
         required: true
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities:
   "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_message_classes": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_admin.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_admin.py.snap
@@ -22,7 +22,6 @@ tag_rules:
       - name: cms_page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "cms.templatetags.cms_admin::tag::render_filter_field":
     arg_constraints:
@@ -35,11 +34,9 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: field
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "cms.templatetags.cms_admin::tag::show_admin_menu_for_pages":
     arg_constraints:
@@ -52,11 +49,9 @@ tag_rules:
       - name: descendants
         required: true
         kind: Variable
-        position: 0
       - name: depth
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "cms.templatetags.cms_admin::tag::submit_row_plugin":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_alias_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_alias_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_js_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_js_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: renderer
         required: true
         kind: Variable
-        position: 0
       - name: obj
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "cms.templatetags.cms_js_tags::tag::render_plugin_init_js":
     arg_constraints:
@@ -31,7 +29,6 @@ tag_rules:
       - name: plugin
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "cms.templatetags.cms_js_tags::filter::bool": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: template
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "cms.templatetags.cms_tags::tag::render_plugin":
     arg_constraints:
@@ -31,7 +29,6 @@ tag_rules:
       - name: plugin
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_placeholder":
     arg_constraints:
@@ -44,27 +41,21 @@ tag_rules:
       - name: context
         required: true
         kind: Variable
-        position: 0
       - name: placeholder_name
         required: true
         kind: Variable
-        position: 1
       - name: reverse_id
         required: true
         kind: Variable
-        position: 2
       - name: lang
         required: false
         kind: Variable
-        position: 3
       - name: site
         required: false
         kind: Variable
-        position: 4
       - name: use_cache
         required: false
         kind: Variable
-        position: 5
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_placeholder_by_id":
     arg_constraints:
@@ -77,27 +68,21 @@ tag_rules:
       - name: context
         required: true
         kind: Variable
-        position: 0
       - name: placeholder_name
         required: true
         kind: Variable
-        position: 1
       - name: reverse_id
         required: true
         kind: Variable
-        position: 2
       - name: lang
         required: false
         kind: Variable
-        position: 3
       - name: site
         required: false
         kind: Variable
-        position: 4
       - name: use_cache
         required: false
         kind: Variable
-        position: 5
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_uncached_placeholder":
     arg_constraints:
@@ -109,11 +94,9 @@ tag_rules:
       - name: context
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_uncached_placeholder_by_id":
     arg_constraints:
@@ -125,11 +108,9 @@ tag_rules:
       - name: context
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-compressor__compressor__templatetags__compress.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-compressor__compressor__templatetags__compress.py.snap
@@ -12,7 +12,6 @@ tag_rules:
       - name: kind
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_field.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_field.py.snap
@@ -14,19 +14,15 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: append
         required: false
         kind: Variable
-        position: 1
       - name: prepend
         required: false
         kind: Variable
-        position: 2
       - name: form_show_labels
         required: false
         kind: Variable
-        position: 3
     as_var: strip
 filter_arities:
   "crispy_forms.templatetags.crispy_forms_field::filter::classes": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crm__common__templatetags__crm_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crm__common__templatetags__crm_list.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crm__massmail__templatetags__mailbuilder.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crm__massmail__templatetags__mailbuilder.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: file_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "massmail.templatetags.mailbuilder::tag::cid_static":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: file_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-grappelli__grappelli__templatetags__grp_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-grappelli__grappelli__templatetags__grp_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: spec
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_admin_title":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-guardian__guardian__templatetags__guardian_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-guardian__guardian__templatetags__guardian_tags.py.snap
@@ -57,29 +57,23 @@ tag_rules:
       - name: for_whom
         required: true
         kind: Variable
-        position: 0
       - name: for
         required: true
         kind:
           Literal: for
-        position: 1
       - name: obj
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: arg5
         required: true
         kind: Variable
-        position: 4
       - name: arg6
         required: true
         kind: Variable
-        position: 5
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-htmx__src__django_htmx__templatetags__django_htmx.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-htmx__src__django_htmx__templatetags__django_htmx.py.snap
@@ -21,7 +21,6 @@ tag_rules:
       - name: minified
         required: false
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-import-export__import_export__templatetags__import_export_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-import-export__import_export__templatetags__import_export_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: value1
         required: true
         kind: Variable
-        position: 0
       - name: value2
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-jazzmin__jazzmin__templatetags__jazzmin.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-jazzmin__jazzmin__templatetags__jazzmin.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: action
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::admin_extra_filters":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_changeform_template":
     arg_constraints:
@@ -40,7 +38,6 @@ tag_rules:
       - name: adminform
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_jazzmin_settings":
     arg_constraints:
@@ -53,7 +50,6 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_jazzmin_ui_tweaks":
     arg_constraints:
@@ -82,11 +78,9 @@ tag_rules:
       - name: admin_form
         required: true
         kind: Variable
-        position: 0
       - name: inline_admin_formsets
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_side_menu":
     arg_constraints:
@@ -98,7 +92,6 @@ tag_rules:
       - name: using
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_top_menu":
     arg_constraints:
@@ -111,11 +104,9 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: admin_site
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_user_avatar":
     arg_constraints:
@@ -128,7 +119,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_user_menu":
     arg_constraints:
@@ -141,11 +131,9 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: admin_site
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::header_class":
     arg_constraints:
@@ -158,11 +146,9 @@ tag_rules:
       - name: header
         required: true
         kind: Variable
-        position: 0
       - name: forloop
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::jazzmin_list_filter":
     arg_constraints:
@@ -175,11 +161,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: spec
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::jazzmin_paginator_number":
     arg_constraints:
@@ -192,11 +176,9 @@ tag_rules:
       - name: change_list
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::jazzy_admin_url":
     arg_constraints:
@@ -209,11 +191,9 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: admin_site
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::sidebar_status":
     arg_constraints:
@@ -226,7 +206,6 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "jazzmin.templatetags.jazzmin::filter::app_is_installed": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__basket_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__basket_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: product
         required: true
         kind: Variable
-        position: 1
       - name: quantity_type
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__category_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__category_tags.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: depth
         required: false
         kind: Variable
-        position: 0
       - name: parent
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__dashboard_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__dashboard_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: except_field
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.oscar.templatetags.display_tags::tag::iffeature":
     arg_constraints: []
@@ -25,7 +24,6 @@ tag_rules:
       - name: app_name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__history_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__history_tags.py.snap
@@ -21,7 +21,6 @@ tag_rules:
       - name: current_product
         required: false
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__image_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__image_tags.py.snap
@@ -23,7 +23,6 @@ tag_rules:
       - name: image
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__product_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__product_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: product
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__purchase_info_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__purchase_info_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: line
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.oscar.templatetags.purchase_info_tags::tag::purchase_info_for_product":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: product
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__shipping_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__shipping_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: method
         required: true
         kind: Variable
-        position: 0
       - name: basket
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.oscar.templatetags.shipping_tags::tag::shipping_charge_discount":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: method
         required: true
         kind: Variable
-        position: 0
       - name: basket
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.oscar.templatetags.shipping_tags::tag::shipping_charge_excl_discount":
     arg_constraints:
@@ -48,11 +44,9 @@ tag_rules:
       - name: method
         required: true
         kind: Variable
-        position: 0
       - name: basket
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__sorting_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__sorting_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: title
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__url_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__url_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: domain
         required: true
         kind: Variable
-        position: 0
       - name: path
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__wishlist_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__wishlist_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: wishlists
         required: true
         kind: Variable
-        position: 0
       - name: product
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-pipeline__pipeline__templatetags__pipeline.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-pipeline__pipeline__templatetags__pipeline.py.snap
@@ -12,7 +12,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "pipeline.templatetags.pipeline::tag::stylesheet":
     arg_constraints: []
@@ -23,7 +22,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-qr-code__qr_code__templatetags__qr_code.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-qr-code__qr_code__templatetags__qr_code.py.snap
@@ -13,19 +13,15 @@ tag_rules:
       - name: contact_detail
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_email":
     arg_constraints:
@@ -37,19 +33,15 @@ tag_rules:
       - name: email
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_epc":
     arg_constraints:
@@ -61,19 +53,15 @@ tag_rules:
       - name: epc_data
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_event":
     arg_constraints:
@@ -85,19 +73,15 @@ tag_rules:
       - name: event
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_google_play":
     arg_constraints:
@@ -109,19 +93,15 @@ tag_rules:
       - name: package_id
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_mecard":
     arg_constraints:
@@ -133,19 +113,15 @@ tag_rules:
       - name: mecard
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_sms":
     arg_constraints:
@@ -157,19 +133,15 @@ tag_rules:
       - name: phone_number
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_tel":
     arg_constraints:
@@ -181,19 +153,15 @@ tag_rules:
       - name: phone_number
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_vcard":
     arg_constraints:
@@ -205,19 +173,15 @@ tag_rules:
       - name: vcard
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_wifi":
     arg_constraints:
@@ -229,19 +193,15 @@ tag_rules:
       - name: wifi_config
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_youtube":
     arg_constraints:
@@ -253,19 +213,15 @@ tag_rules:
       - name: video_id
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_from_data":
     arg_constraints:
@@ -277,19 +233,15 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_from_text":
     arg_constraints:
@@ -301,19 +253,15 @@ tag_rules:
       - name: text
         required: true
         kind: Variable
-        position: 0
       - name: use_data_uri_for_svg
         required: false
         kind: Variable
-        position: 1
       - name: alt_text
         required: false
         kind: Variable
-        position: 2
       - name: class_names
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_contact":
     arg_constraints:
@@ -325,7 +273,6 @@ tag_rules:
       - name: contact_detail
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_email":
     arg_constraints:
@@ -337,7 +284,6 @@ tag_rules:
       - name: email
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_epc":
     arg_constraints:
@@ -349,7 +295,6 @@ tag_rules:
       - name: epc_data
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_event":
     arg_constraints:
@@ -361,7 +306,6 @@ tag_rules:
       - name: event
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_google_play":
     arg_constraints:
@@ -373,7 +317,6 @@ tag_rules:
       - name: package_id
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_mecard":
     arg_constraints:
@@ -385,7 +328,6 @@ tag_rules:
       - name: mecard
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_sms":
     arg_constraints:
@@ -397,7 +339,6 @@ tag_rules:
       - name: phone_number
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_tel":
     arg_constraints:
@@ -409,7 +350,6 @@ tag_rules:
       - name: phone_number
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_vcard":
     arg_constraints:
@@ -421,7 +361,6 @@ tag_rules:
       - name: vcard
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_wifi":
     arg_constraints:
@@ -433,7 +372,6 @@ tag_rules:
       - name: wifi_config
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_youtube":
     arg_constraints:
@@ -445,7 +383,6 @@ tag_rules:
       - name: video_id
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_from_data":
     arg_constraints:
@@ -457,7 +394,6 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_from_text":
     arg_constraints:
@@ -469,7 +405,6 @@ tag_rules:
       - name: text
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-statici18n__src__statici18n__templatetags__statici18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-statici18n__src__statici18n__templatetags__statici18n.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: locale
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.statici18n.templatetags.statici18n::tag::statici18n":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: locale
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-tables2__django_tables2__templatetags__django_tables2.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-tables2__django_tables2__templatetags__django_tables2.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: export_format
         required: true
         kind: Variable
-        position: 0
       - name: export_trigger_param
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "django_tables2.templatetags.django_tables2::tag::render_attrs":
     arg_constraints:
@@ -30,7 +28,6 @@ tag_rules:
       - name: attrs
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "django_tables2.templatetags.django_tables2::filter::table_page_range": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: action
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.unfold.templatetags.unfold::tag::action_list":
     arg_constraints:
@@ -35,11 +34,9 @@ tag_rules:
       - name: object
         required: true
         kind: Variable
-        position: 0
       - name: arg
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.unfold.templatetags.unfold::tag::capture":
     arg_constraints:
@@ -78,16 +75,13 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: variable_name
         required: true
         kind: Variable
-        position: 1
       - name: silent
         required: true
         kind:
           Literal: silent
-        position: 2
     as_var: keep
   "src.unfold.templatetags.unfold::tag::component":
     arg_constraints:
@@ -104,7 +98,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "src.unfold.templatetags.unfold::tag::element_classes":
     arg_constraints:
@@ -117,7 +110,6 @@ tag_rules:
       - name: key
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.unfold.templatetags.unfold::tag::elided_page_range":
     arg_constraints:
@@ -130,11 +122,9 @@ tag_rules:
       - name: paginator
         required: true
         kind: Variable
-        position: 0
       - name: number
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.unfold.templatetags.unfold::tag::fieldset_line_classes":
     arg_constraints:
@@ -171,7 +161,6 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.unfold.templatetags.unfold::tag::header_title":
     arg_constraints:
@@ -192,11 +181,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.unfold.templatetags.unfold::tag::preserve_filters":
     arg_constraints:
@@ -217,11 +204,9 @@ tag_rules:
       - name: query_key
         required: true
         kind: Variable
-        position: 0
       - name: query_value
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.unfold.templatetags.unfold::tag::render_section":
     arg_constraints:
@@ -234,11 +219,9 @@ tag_rules:
       - name: section_class
         required: true
         kind: Variable
-        position: 0
       - name: instance
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.unfold.templatetags.unfold::tag::tab_list":
     arg_constraints:
@@ -251,11 +234,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: opts
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.unfold.templatetags.unfold::tag::tabs_primary_active":
     arg_constraints:
@@ -268,7 +249,6 @@ tag_rules:
       - name: inlines
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.unfold.templatetags.unfold::tag::unfold_querystring":
     arg_constraints: []
@@ -279,7 +259,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
 filter_arities:
   "src.unfold.templatetags.unfold::filter::add_css_class": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold_list.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: cl
         required: true
         kind: Variable
-        position: 0
       - name: i
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__core__templatetags__page_metadata_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__core__templatetags__page_metadata_tags.py.snap
@@ -13,19 +13,15 @@ tag_rules:
       - name: page_title
         required: false
         kind: Variable
-        position: 0
       - name: page_description
         required: false
         kind: Variable
-        position: 1
       - name: page_keywords
         required: false
         kind: Variable
-        position: 2
       - name: og_image_url
         required: false
         kind: Variable
-        position: 3
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__package__templatetags__package_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__package__templatetags__package_tags.py.snap
@@ -12,11 +12,9 @@ tag_rules:
       - name: repo
         required: true
         kind: Variable
-        position: 0
       - name: participant
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities:
   "package.templatetags.package_tags::filter::emojify": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__blog__templatetags__weblog.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__blog__templatetags__weblog.py.snap
@@ -14,19 +14,15 @@ tag_rules:
       - name: num
         required: true
         kind: Variable
-        position: 0
       - name: summary_first
         required: false
         kind: Variable
-        position: 1
       - name: hide_readmore
         required: false
         kind: Variable
-        position: 2
       - name: header_tag
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "blog.templatetags.weblog::tag::render_month_links":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: searched_python_objects
         required: true
         kind: Variable
-        position: 0
       - name: python_objects
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "docs.templatetags.docs::tag::get_all_doc_versions":
     arg_constraints:
@@ -30,7 +28,6 @@ tag_rules:
       - name: url
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "docs.templatetags.docs::tag::search_form":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__foundation__templatetags__meetings.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__foundation__templatetags__meetings.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: num
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__fundraising__templatetags__fundraising_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__fundraising__templatetags__fundraising_extras.py.snap
@@ -36,11 +36,9 @@ tag_rules:
       - name: levels
         required: false
         kind: VarArgs
-        position: 0
       - name: header
         required: false
         kind: Keyword
-        position: 1
     as_var: keep
 filter_arities:
   "fundraising.templatetags.fundraising_extras::filter::as_percentage": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__date_format.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__date_format.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: datestr
         required: true
         kind: Variable
-        position: 0
       - name: dateformat
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__release_notes.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__release_notes.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: version
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "releases.templatetags.release_notes::tag::release_notes":
     arg_constraints:
@@ -27,11 +26,9 @@ tag_rules:
       - name: version
         required: true
         kind: Variable
-        position: 0
       - name: show_version
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__base_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__base_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: resource
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: perms
         required: true
         kind: Variable
-        position: 2
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::display_edit_request_button":
     arg_constraints:
@@ -35,15 +32,12 @@ tag_rules:
       - name: resource
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: perms
         required: true
         kind: Variable
-        position: 2
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::facets":
     arg_constraints:
@@ -64,7 +58,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::get_context_resourcetype":
     arg_constraints:
@@ -93,7 +86,6 @@ tag_rules:
       - name: placeholder_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::get_visibile_resources":
     arg_constraints:
@@ -106,7 +98,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "geonode.base.templatetags.base_tags::tag::render_nav_menu":
     arg_constraints:
@@ -119,7 +110,6 @@ tag_rules:
       - name: placeholder_name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "geonode.base.templatetags.base_tags::filter::get_item": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__user_messages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__user_messages.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: thread
         required: true
         kind: Variable
-        position: 0
       - name: current_user
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::get_item":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: dictionary
         required: true
         kind: Variable
-        position: 0
       - name: key
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::is_unread":
     arg_constraints:
@@ -48,11 +44,9 @@ tag_rules:
       - name: thread
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::random_uuid":
     arg_constraints:
@@ -73,11 +67,9 @@ tag_rules:
       - name: notice_type_label
         required: true
         kind: Variable
-        position: 0
       - name: current_user
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__client__templatetags__client_lib_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__client__templatetags__client_lib_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: layer
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::dataset_list_url":
     arg_constraints:
@@ -43,7 +42,6 @@ tag_rules:
       - name: document
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::document_list_url":
     arg_constraints:
@@ -64,7 +62,6 @@ tag_rules:
       - name: geoapp
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::geoapp_list_url":
     arg_constraints:
@@ -93,7 +90,6 @@ tag_rules:
       - name: map
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::map_list_url":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__groups__templatetags__groups_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__groups__templatetags__groups_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: group_profile
         required: true
         kind: Variable
-        position: 0
       - name: css_classes
         required: false
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__contact_roles.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__contact_roles.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: form
         required: true
         kind: Variable
-        position: 0
       - name: contact
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities:
   "geonode.layers.templatetags.contact_roles::filter::get_contact_role_id": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__dataset_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__dataset_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: resource
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.layers.templatetags.dataset_tags::tag::get_sld_name_from_url":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: sld_url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.layers.templatetags.dataset_tags::tag::get_style_name_from_legend_url":
     arg_constraints:
@@ -40,7 +38,6 @@ tag_rules:
       - name: legend_url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "geonode.layers.templatetags.dataset_tags::filter::camelize": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__people__templatetags__socialaccount_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__people__templatetags__socialaccount_extra.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.people.templatetags.socialaccount_extra::tag::get_other_social_providers":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.people.templatetags.socialaccount_extra::tag::get_user_social_providers":
     arg_constraints:
@@ -40,7 +38,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "geonode.people.templatetags.socialaccount_extra::tag::user_providers":
     arg_constraints:
@@ -53,7 +50,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__proxy__templatetags__proxy_lib_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__proxy__templatetags__proxy_lib_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: resourceid
         required: true
         kind: Variable
-        position: 0
       - name: url
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__services__templatetags__services_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__services__templatetags__services_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: service_id
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__social__templatetags__social_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__social__templatetags__social_tags.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: action
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__hc_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__hc_extras.py.snap
@@ -70,7 +70,6 @@ tag_rules:
       - name: sort
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::support_email":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__bootstrap.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__bootstrap.py.snap
@@ -12,7 +12,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
@@ -54,11 +54,9 @@ tag_rules:
       - name: used
         required: true
         kind: Variable
-        position: 0
       - name: limit
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "horizon.templatetags.horizon::tag::template_cache_age":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__openstack_dashboard__templatetags__themes.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__openstack_dashboard__templatetags__themes.py.snap
@@ -22,7 +22,6 @@ tag_rules:
       - name: asset
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "openstack_dashboard.templatetags.themes::tag::theme_cookie":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_generic.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_generic.py.snap
@@ -20,7 +20,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "hyperkitty.templatetags.hk_generic::tag::is_message_new":
     arg_constraints:
@@ -33,7 +32,6 @@ tag_rules:
       - name: refdate
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "hyperkitty.templatetags.hk_generic::tag::settings_value_equals":
     arg_constraints:
@@ -46,11 +44,9 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
       - name: value
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities:
   "hyperkitty.templatetags.hk_generic::filter::date_with_senders_timezone": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__InvenTree__templatetags__inventree_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__InvenTree__templatetags__inventree_extras.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::define":
     arg_constraints:
@@ -29,11 +27,9 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_commit_date":
     arg_constraints: []
@@ -44,7 +40,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_commit_hash":
     arg_constraints: []
@@ -55,7 +50,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_customize":
     arg_constraints:
@@ -67,11 +61,9 @@ tag_rules:
       - name: reference
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_installer":
     arg_constraints: []
@@ -82,7 +74,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_instance_name":
     arg_constraints: []
@@ -93,7 +84,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_title":
     arg_constraints: []
@@ -104,7 +94,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_version":
     arg_constraints: []
@@ -115,11 +104,9 @@ tag_rules:
       - name: shortstring
         required: false
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::render_date":
     arg_constraints:
@@ -132,7 +119,6 @@ tag_rules:
       - name: date_object
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::setting_object":
     arg_constraints:
@@ -144,11 +130,9 @@ tag_rules:
       - name: key
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::settings_value":
     arg_constraints:
@@ -160,11 +144,9 @@ tag_rules:
       - name: key
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::str2bool":
     arg_constraints:
@@ -176,11 +158,9 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::to_list":
     arg_constraints: []
@@ -191,7 +171,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
 filter_arities:
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::filter::keyvalue": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__plugin__templatetags__plugin_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__plugin__templatetags__plugin_extras.py.snap
@@ -12,7 +12,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::mixin_available":
     arg_constraints:
@@ -24,11 +23,9 @@ tag_rules:
       - name: mixin
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::mixin_enabled":
     arg_constraints:
@@ -40,15 +37,12 @@ tag_rules:
       - name: plugin
         required: true
         kind: Variable
-        position: 0
       - name: key
         required: true
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::plugin_list":
     arg_constraints: []
@@ -59,7 +53,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::plugin_settings":
     arg_constraints:
@@ -71,11 +64,9 @@ tag_rules:
       - name: plugin
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::safe_url":
     arg_constraints:
@@ -87,11 +78,9 @@ tag_rules:
       - name: view_name
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__barcode.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__barcode.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
       - name: barcode_class
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.barcode::tag::clean_barcode":
     arg_constraints:
@@ -30,7 +28,6 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.barcode::tag::datamatrix":
     arg_constraints:
@@ -42,7 +39,6 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.barcode::tag::qrcode":
     arg_constraints:
@@ -54,7 +50,6 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__report.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__report.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: y
         required: true
         kind: Variable
-        position: 1
       - name: cast
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::asset":
     arg_constraints:
@@ -35,7 +32,6 @@ tag_rules:
       - name: filename
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::company_image":
     arg_constraints:
@@ -47,15 +43,12 @@ tag_rules:
       - name: company
         required: true
         kind: Variable
-        position: 0
       - name: preview
         required: false
         kind: Variable
-        position: 1
       - name: thumbnail
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::convert_currency":
     arg_constraints:
@@ -67,11 +60,9 @@ tag_rules:
       - name: money
         required: true
         kind: Variable
-        position: 0
       - name: currency
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::create_currency":
     arg_constraints:
@@ -83,11 +74,9 @@ tag_rules:
       - name: amount
         required: true
         kind: Variable
-        position: 0
       - name: currency
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::divide":
     arg_constraints:
@@ -100,15 +89,12 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: y
         required: true
         kind: Variable
-        position: 1
       - name: cast
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::encode_svg_image":
     arg_constraints:
@@ -121,7 +107,6 @@ tag_rules:
       - name: filename
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::filter_db_model":
     arg_constraints:
@@ -133,7 +118,6 @@ tag_rules:
       - name: model_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::filter_queryset":
     arg_constraints:
@@ -145,7 +129,6 @@ tag_rules:
       - name: queryset
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::format_date":
     arg_constraints:
@@ -158,15 +141,12 @@ tag_rules:
       - name: dt
         required: true
         kind: Variable
-        position: 0
       - name: timezone
         required: false
         kind: Variable
-        position: 1
       - name: fmt
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::format_datetime":
     arg_constraints:
@@ -179,15 +159,12 @@ tag_rules:
       - name: dt
         required: true
         kind: Variable
-        position: 0
       - name: timezone
         required: false
         kind: Variable
-        position: 1
       - name: fmt
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::format_number":
     arg_constraints:
@@ -200,27 +177,21 @@ tag_rules:
       - name: number
         required: true
         kind: Variable
-        position: 0
       - name: decimal_places
         required: false
         kind: Variable
-        position: 1
       - name: multiplier
         required: false
         kind: Variable
-        position: 2
       - name: integer
         required: false
         kind: Variable
-        position: 3
       - name: leading
         required: false
         kind: Variable
-        position: 4
       - name: separator
         required: false
         kind: Variable
-        position: 5
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::getindex":
     arg_constraints:
@@ -233,11 +204,9 @@ tag_rules:
       - name: container
         required: true
         kind: Variable
-        position: 0
       - name: index
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::getkey":
     arg_constraints:
@@ -250,15 +219,12 @@ tag_rules:
       - name: container
         required: true
         kind: Variable
-        position: 0
       - name: key
         required: true
         kind: Variable
-        position: 1
       - name: backup_value
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::icon":
     arg_constraints:
@@ -270,7 +236,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::include_icon_fonts":
     arg_constraints:
@@ -282,11 +247,9 @@ tag_rules:
       - name: ttf
         required: false
         kind: Variable
-        position: 0
       - name: woff
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::internal_link":
     arg_constraints:
@@ -299,11 +262,9 @@ tag_rules:
       - name: link
         required: true
         kind: Variable
-        position: 0
       - name: text
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::modulo":
     arg_constraints:
@@ -316,15 +277,12 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: y
         required: true
         kind: Variable
-        position: 1
       - name: cast
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::multiply":
     arg_constraints:
@@ -337,15 +295,12 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: y
         required: true
         kind: Variable
-        position: 1
       - name: cast
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::order_queryset":
     arg_constraints:
@@ -357,11 +312,9 @@ tag_rules:
       - name: queryset
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::parameter":
     arg_constraints:
@@ -374,11 +327,9 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
       - name: parameter_name
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::part_image":
     arg_constraints:
@@ -390,15 +341,12 @@ tag_rules:
       - name: part
         required: true
         kind: Variable
-        position: 0
       - name: preview
         required: false
         kind: Variable
-        position: 1
       - name: thumbnail
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::part_parameter":
     arg_constraints:
@@ -411,11 +359,9 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
       - name: parameter_name
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::render_currency":
     arg_constraints:
@@ -427,7 +373,6 @@ tag_rules:
       - name: money
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::render_html_text":
     arg_constraints:
@@ -439,7 +384,6 @@ tag_rules:
       - name: text
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::subtract":
     arg_constraints:
@@ -452,15 +396,12 @@ tag_rules:
       - name: x
         required: true
         kind: Variable
-        position: 0
       - name: y
         required: true
         kind: Variable
-        position: 1
       - name: cast
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::uploaded_image":
     arg_constraints:
@@ -472,31 +413,24 @@ tag_rules:
       - name: filename
         required: true
         kind: Variable
-        position: 0
       - name: replace_missing
         required: false
         kind: Variable
-        position: 1
       - name: replacement_file
         required: false
         kind: Variable
-        position: 2
       - name: validate
         required: false
         kind: Variable
-        position: 3
       - name: width
         required: false
         kind: Variable
-        position: 4
       - name: height
         required: false
         kind: Variable
-        position: 5
       - name: rotate
         required: false
         kind: Variable
-        position: 6
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__web__templatetags__spa_helper.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__web__templatetags__spa_helper.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: manifest_path
         required: false
         kind: Variable
-        position: 0
       - name: app
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.backend.InvenTree.web.templatetags.spa_helper::tag::spa_settings":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__bookmarks.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__bookmarks.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: search
         required: true
         kind: Variable
-        position: 0
       - name: mode
         required: false
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__pagination.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__pagination.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "bookmarks.templatetags.shared::tag::formhelp":
     arg_constraints: []
@@ -24,7 +23,6 @@ tag_rules:
       - name: field_var
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "bookmarks.templatetags.shared::tag::formlabel":
     arg_constraints:
@@ -37,11 +35,9 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: label_text
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "bookmarks.templatetags.shared::tag::markdown":
     arg_constraints:
@@ -54,7 +50,6 @@ tag_rules:
       - name: markdown_text
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "bookmarks.templatetags.shared::filter::first_char": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__admin__templatetags__misago_admin_form.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__admin__templatetags__misago_admin_form.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: label_class
         required: false
         kind: Variable
-        position: 1
       - name: field_class
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_dimensions_row":
     arg_constraints:
@@ -35,19 +32,15 @@ tag_rules:
       - name: field_width
         required: true
         kind: Variable
-        position: 0
       - name: field_height
         required: true
         kind: Variable
-        position: 1
       - name: label_class
         required: false
         kind: Variable
-        position: 2
       - name: field_class
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_image_row":
     arg_constraints:
@@ -60,31 +53,24 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: label_class
         required: false
         kind: Variable
-        position: 1
       - name: field_class
         required: false
         kind: Variable
-        position: 2
       - name: image_class
         required: false
         kind: Variable
-        position: 3
       - name: delete_field
         required: false
         kind: Variable
-        position: 4
       - name: size
         required: false
         kind: Variable
-        position: 5
       - name: dimensions
         required: false
         kind: Variable
-        position: 6
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_input":
     arg_constraints:
@@ -97,7 +83,6 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_row":
     arg_constraints:
@@ -110,15 +95,12 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: label_class
         required: false
         kind: Variable
-        position: 1
       - name: field_class
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::render_attrs":
     arg_constraints:
@@ -131,11 +113,9 @@ tag_rules:
       - name: attrs
         required: true
         kind: Variable
-        position: 0
       - name: class_name
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "misago.admin.templatetags.misago_admin_form::tag::render_bool_attrs":
     arg_constraints:
@@ -148,7 +128,6 @@ tag_rules:
       - name: attrs
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "misago.admin.templatetags.misago_admin_form::filter::get_options": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__components__templatetags__misago_component.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__components__templatetags__misago_component.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: data
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_absoluteurl.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_absoluteurl.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: url_or_name
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_capture.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_capture.py.snap
@@ -16,11 +16,9 @@ tag_rules:
         required: true
         kind:
           Literal: trimmed
-        position: 0
       - name: variable
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_pagetitle.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_pagetitle.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: title
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__parser__templatetags__misago_rich_text.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__parser__templatetags__misago_rich_text.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: html
         required: true
         kind: Variable
-        position: 0
       - name: data
         required: false
         kind: Variable
-        position: 1
       - name: thread
         required: false
         kind: Keyword
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__plugins__templatetags__misago_plugins.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__plugins__templatetags__misago_plugins.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "misago.plugins.templatetags.misago_plugins::tag::pluginoutlet":
     arg_constraints:
@@ -25,7 +24,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__threads__templatetags__misago_poststags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__threads__templatetags__misago_poststags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: post
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__custom_links.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__custom_links.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__dashboard.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__dashboard.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: widget
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__log_levels.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__log_levels.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: level
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__builtins__tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__builtins__tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: bg_color
         required: false
         kind: Variable
-        position: 1
       - name: show_empty
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::checkmark":
     arg_constraints:
@@ -35,19 +32,15 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: show_false
         required: false
         kind: Variable
-        position: 1
       - name: "true"
         required: false
         kind: Variable
-        position: 2
       - name: "false"
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::copy_content":
     arg_constraints:
@@ -60,19 +53,15 @@ tag_rules:
       - name: target
         required: true
         kind: Variable
-        position: 0
       - name: prefix
         required: false
         kind: Variable
-        position: 1
       - name: color
         required: false
         kind: Variable
-        position: 2
       - name: classes
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::customfield_value":
     arg_constraints:
@@ -85,11 +74,9 @@ tag_rules:
       - name: customfield
         required: true
         kind: Variable
-        position: 0
       - name: value
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::formaction":
     arg_constraints:
@@ -109,11 +96,9 @@ tag_rules:
       - name: viewname
         required: true
         kind: Variable
-        position: 0
       - name: return_url
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::render":
     arg_constraints:
@@ -126,7 +111,6 @@ tag_rules:
       - name: component
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.builtins.tags::tag::static_with_params":
     arg_constraints:
@@ -138,7 +122,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.builtins.tags::tag::tag":
     arg_constraints:
@@ -151,11 +134,9 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: viewname
         required: false
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__buttons.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__buttons.py.snap
@@ -13,15 +13,12 @@ tag_rules:
       - name: actions
         required: true
         kind: Variable
-        position: 0
       - name: obj
         required: true
         kind: Variable
-        position: 1
       - name: multi
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "netbox.utilities.templatetags.buttons::tag::add_button":
     arg_constraints:
@@ -34,15 +31,12 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: false
         kind: Variable
-        position: 1
       - name: return_url
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::bookmark_button":
     arg_constraints:
@@ -55,7 +49,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::bulk_delete_button":
     arg_constraints:
@@ -68,15 +61,12 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: false
         kind: Variable
-        position: 1
       - name: query_params
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::bulk_edit_button":
     arg_constraints:
@@ -89,15 +79,12 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: false
         kind: Variable
-        position: 1
       - name: query_params
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::clone_button":
     arg_constraints:
@@ -110,7 +97,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::delete_button":
     arg_constraints:
@@ -123,7 +109,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::edit_button":
     arg_constraints:
@@ -136,7 +121,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::export_button":
     arg_constraints:
@@ -149,7 +133,6 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::import_button":
     arg_constraints:
@@ -162,11 +145,9 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::subscribe_button":
     arg_constraints:
@@ -179,7 +160,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::sync_button":
     arg_constraints:
@@ -192,7 +172,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__form_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__form_helpers.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: form
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_errors":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: form
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_field":
     arg_constraints:
@@ -40,15 +38,12 @@ tag_rules:
       - name: field
         required: true
         kind: Variable
-        position: 0
       - name: bulk_nullable
         required: false
         kind: Variable
-        position: 1
       - name: label
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_fieldset":
     arg_constraints:
@@ -61,11 +56,9 @@ tag_rules:
       - name: form
         required: true
         kind: Variable
-        position: 0
       - name: fieldset
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_form":
     arg_constraints:
@@ -78,7 +71,6 @@ tag_rules:
       - name: form
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "netbox.utilities.templatetags.form_helpers::filter::getfield": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__helpers.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "netbox.utilities.templatetags.helpers::tag::applied_filters":
     arg_constraints:
@@ -30,15 +28,12 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
       - name: form
         required: true
         kind: Variable
-        position: 1
       - name: query_params
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "netbox.utilities.templatetags.helpers::tag::querystring":
     arg_constraints:
@@ -50,7 +45,6 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.helpers::tag::table_config_form":
     arg_constraints:
@@ -63,11 +57,9 @@ tag_rules:
       - name: table
         required: true
         kind: Variable
-        position: 0
       - name: table_name
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "netbox.utilities.templatetags.helpers::tag::utilization_graph":
     arg_constraints:
@@ -80,15 +72,12 @@ tag_rules:
       - name: utilization
         required: true
         kind: Variable
-        position: 0
       - name: warning_threshold
         required: false
         kind: Variable
-        position: 1
       - name: danger_threshold
         required: false
         kind: Variable
-        position: 2
     as_var: keep
 filter_arities:
   "netbox.utilities.templatetags.helpers::filter::as_range": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__mptt.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__mptt.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__plugins.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__plugins.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_buttons":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_full_width_page":
     arg_constraints:
@@ -40,7 +38,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_head":
     arg_constraints:
@@ -61,7 +58,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_list_buttons":
     arg_constraints:
@@ -74,7 +70,6 @@ tag_rules:
       - name: model
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_navbar":
     arg_constraints:
@@ -95,7 +90,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__tabs.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__tabs.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: instance
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__cache_large.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__cache_large.py.snap
@@ -23,11 +23,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__eventsignal.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__eventsignal.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: event
         required: true
         kind: Variable
-        position: 0
       - name: signame
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.pretix.base.templatetags.eventsignal::tag::signal":
     arg_constraints:
@@ -29,11 +27,9 @@ tag_rules:
       - name: signame
         required: true
         kind: Variable
-        position: 0
       - name: request
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__html_time.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__html_time.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: dt_format
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__icon.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__icon.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: key
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__safelink.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__safelink.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: answer
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.pretix.base.templatetags.safelink::tag::safelink":
     arg_constraints:
@@ -31,7 +29,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__textbubble.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__textbubble.py.snap
@@ -21,11 +21,9 @@ tag_rules:
       - name: type
         required: true
         kind: Variable
-        position: 0
       - name: args
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__urlreplace.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__urlreplace.py.snap
@@ -13,11 +13,9 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: pairs
         required: false
         kind: VarArgs
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__hierarkey_form.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__hierarkey_form.py.snap
@@ -12,11 +12,9 @@ tag_rules:
       - name: event
         required: true
         kind: Variable
-        position: 0
       - name: url
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__emaildigest__templatetags__emaildigest_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__emaildigest__templatetags__emaildigest_extra.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__news__templatetags__news_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__news__templatetags__news_extra.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "news.templatetags.news_extra::tag::more_link":
     arg_constraints:
@@ -34,7 +33,6 @@ tag_rules:
       - name: item
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "news.templatetags.news_extra::tag::user_arrows":
     arg_constraints:
@@ -47,11 +45,9 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: item
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities:
   "news.templatetags.news_extra::filter::comment_markdown": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__core_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__core_tags.py.snap
@@ -14,19 +14,15 @@ tag_rules:
       - name: project
         required: true
         kind: Variable
-        position: 0
       - name: version
         required: false
         kind: Variable
-        position: 1
       - name: page
         required: false
         kind: Variable
-        position: 2
       - name: path
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "readthedocs.core.templatetags.core_tags::tag::readthedocs_version":
     arg_constraints:
@@ -46,15 +42,12 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: field
         required: true
         kind: Variable
-        position: 1
       - name: values
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
 filter_arities:
   "readthedocs.core.templatetags.core_tags::filter::escapejson": optional_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__privacy_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__privacy_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "readthedocs.core.templatetags.privacy_tags::filter::is_admin": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_api.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_api.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.sentry.templatetags.sentry_api::tag::get_recipient_context":
     arg_constraints:
@@ -27,11 +26,9 @@ tag_rules:
       - name: request
         required: true
         kind: Variable
-        position: 0
       - name: escape
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.sentry.templatetags.sentry_api::tag::serialize":
     arg_constraints:
@@ -44,7 +41,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.sentry.templatetags.sentry_api::tag::serialize_detailed_org":
     arg_constraints:
@@ -57,7 +53,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_assets.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_assets.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: module
         required: true
         kind: Variable
-        position: 0
       - name: path
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "src.sentry.templatetags.sentry_assets::tag::crossorigin":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_avatars.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_avatars.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "src.sentry.templatetags.sentry_avatars::tag::avatar_for_email":
     arg_constraints:
@@ -31,11 +29,9 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "src.sentry.templatetags.sentry_avatars::tag::email_avatar":
     arg_constraints:
@@ -48,19 +44,15 @@ tag_rules:
       - name: display_name
         required: true
         kind: Variable
-        position: 0
       - name: identifier
         required: true
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
       - name: try_gravatar
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "src.sentry.templatetags.sentry_avatars::tag::gravatar_url":
     arg_constraints:
@@ -73,15 +65,12 @@ tag_rules:
       - name: email
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: true
         kind: Variable
-        position: 1
       - name: default
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.sentry.templatetags.sentry_avatars::tag::letter_avatar_svg":
     arg_constraints:
@@ -94,15 +83,12 @@ tag_rules:
       - name: display_name
         required: true
         kind: Variable
-        position: 0
       - name: identifier
         required: true
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.sentry.templatetags.sentry_avatars::tag::profile_photo_url":
     arg_constraints:
@@ -115,11 +101,9 @@ tag_rules:
       - name: user_id
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_features.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_features.py.snap
@@ -23,7 +23,6 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_helpers.py.snap
@@ -30,19 +30,15 @@ tag_rules:
       - name: organization
         required: true
         kind: Variable
-        position: 0
       - name: path
         required: true
         kind: Variable
-        position: 1
       - name: query
         required: false
         kind: Variable
-        position: 2
       - name: fragment
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::percent":
     arg_constraints:
@@ -55,15 +51,12 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
       - name: total
         required: true
         kind: Variable
-        position: 1
       - name: format
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::random_int":
     arg_constraints:
@@ -76,11 +69,9 @@ tag_rules:
       - name: a
         required: true
         kind: Variable
-        position: 0
       - name: b
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::security_contact":
     arg_constraints:
@@ -101,7 +92,6 @@ tag_rules:
       - name: value
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::system_origin":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_platforms.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_platforms.py.snap
@@ -14,19 +14,15 @@ tag_rules:
       - name: display_name
         required: true
         kind: Variable
-        position: 0
       - name: identifier
         required: true
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
       - name: rounded
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "src.sentry.templatetags.sentry_platforms::tag::platform_avatar":
     arg_constraints:
@@ -39,11 +35,9 @@ tag_rules:
       - name: display_name
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_calendar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_calendar.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: date
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "blog.templatetags.blog_calendar::tag::render_calendar_month_only":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: date
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
       - name: value
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "blog.templatetags.blog_tags::tag::blog_mixed_list":
     arg_constraints:
@@ -31,7 +29,6 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "blog.templatetags.blog_tags::tag::blog_mixed_list_with_dates":
     arg_constraints:
@@ -44,19 +41,15 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
       - name: year_headers
         required: false
         kind: Variable
-        position: 1
       - name: day_headers
         required: false
         kind: Variable
-        position: 2
       - name: day_links
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "blog.templatetags.blog_tags::tag::comments_list":
     arg_constraints:
@@ -69,7 +62,6 @@ tag_rules:
       - name: comments
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "blog.templatetags.blog_tags::tag::comments_list_with_headers":
     arg_constraints:
@@ -82,7 +74,6 @@ tag_rules:
       - name: comments
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "blog.templatetags.blog_tags::tag::page_href":
     arg_constraints:
@@ -95,7 +86,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "blog.templatetags.blog_tags::tag::remove_id_filters":
     arg_constraints:
@@ -116,11 +106,9 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
       - name: value
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "blog.templatetags.blog_tags::tag::replace_qsarg":
     arg_constraints:
@@ -133,11 +121,9 @@ tag_rules:
       - name: name
         required: true
         kind: Variable
-        position: 0
       - name: value
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities:
   "blog.templatetags.blog_tags::filter::markdownify": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__entry_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__entry_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: entry
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "blog.templatetags.entry_tags::tag::entry_footer_no_date":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: entry
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities:
   "blog.templatetags.entry_tags::filter::break_up_long_words": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__tag_cloud.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__tag_cloud.py.snap
@@ -22,7 +22,6 @@ tag_rules:
       - name: tags
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
     arg_constraints:
@@ -39,11 +37,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
     arg_constraints:
@@ -63,27 +59,21 @@ tag_rules:
       - name: user
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
       - name: tooltip
         required: false
         kind: Variable
-        position: 3
       - name: tooltip_html
         required: false
         kind: Variable
-        position: 4
       - name: edit_link
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
     arg_constraints:
@@ -96,15 +86,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
       - name: gravatar_only
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
     arg_constraints:
@@ -116,7 +103,6 @@ tag_rules:
       - name: default
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
     arg_constraints:
@@ -129,19 +115,15 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
       - name: is_expanded
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: icon_name
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
     arg_constraints:
@@ -154,11 +136,9 @@ tag_rules:
       - name: app_label
         required: true
         kind: Variable
-        position: 0
       - name: model_name
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -169,7 +149,6 @@ tag_rules:
       - name: classes
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
     arg_constraints:
@@ -182,15 +161,12 @@ tag_rules:
       - name: dialog_id
         required: true
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: text
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
     arg_constraints:
@@ -202,51 +178,39 @@ tag_rules:
       - name: field
         required: false
         kind: Variable
-        position: 0
       - name: rendered_field
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: show_label
         required: false
         kind: Variable
-        position: 3
       - name: id_for_label
         required: false
         kind: Variable
-        position: 4
       - name: sr_only_label
         required: false
         kind: Variable
-        position: 5
       - name: icon
         required: false
         kind: Variable
-        position: 6
       - name: help_text
         required: false
         kind: Variable
-        position: 7
       - name: help_text_id
         required: false
         kind: Variable
-        position: 8
       - name: show_add_comment_button
         required: false
         kind: Variable
-        position: 9
       - name: label_text
         required: false
         kind: Variable
-        position: 10
       - name: error_message_id
         required: false
         kind: Variable
-        position: 11
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
     arg_constraints:
@@ -275,7 +239,6 @@ tag_rules:
       - name: hook_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
     arg_constraints:
@@ -288,15 +251,12 @@ tag_rules:
       - name: date
         required: true
         kind: Variable
-        position: 0
       - name: description
         required: false
         kind: Variable
-        position: 1
       - name: placement
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
     arg_constraints:
@@ -316,19 +276,15 @@ tag_rules:
       - name: name
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: title
         required: false
         kind: Variable
-        position: 2
       - name: wrapped
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
     arg_constraints:
@@ -341,7 +297,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::js_translation_strings":
     arg_constraints:
@@ -370,7 +325,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
     arg_constraints:
@@ -383,7 +337,6 @@ tag_rules:
       - name: locale_id
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locales":
     arg_constraints:
@@ -395,7 +348,6 @@ tag_rules:
       - name: serialize
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
     arg_constraints:
@@ -408,7 +360,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
     arg_constraints:
@@ -421,7 +372,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::notification_static":
     arg_constraints:
@@ -434,7 +384,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
     arg_constraints:
@@ -447,39 +396,30 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: url_root_name
         required: false
         kind: Variable
-        position: 2
       - name: include_self
         required: false
         kind: Variable
-        position: 3
       - name: is_expanded
         required: false
         kind: Variable
-        position: 4
       - name: querystring_value
         required: false
         kind: Variable
-        position: 5
       - name: trailing_breadcrumb_title
         required: false
         kind: Variable
-        position: 6
       - name: classname
         required: false
         kind: Variable
-        position: 7
       - name: icon_name
         required: false
         kind: Variable
-        position: 8
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
     arg_constraints:
@@ -492,15 +432,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: view_name
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
     arg_constraints:
@@ -513,15 +450,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: next_url
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
     arg_constraints:
@@ -534,7 +468,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
     arg_constraints:
@@ -547,19 +480,15 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: base_url
         required: false
         kind: Variable
-        position: 1
       - name: page_key
         required: false
         kind: Variable
-        position: 2
       - name: classname
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
     arg_constraints:
@@ -572,11 +501,9 @@ tag_rules:
       - name: page_number
         required: true
         kind: Variable
-        position: 0
       - name: page_key
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
     arg_constraints:
@@ -589,7 +516,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
     arg_constraints:
@@ -601,7 +527,6 @@ tag_rules:
       - name: current
         required: false
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
     arg_constraints:
@@ -629,27 +554,21 @@ tag_rules:
       - name: label
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: url
         required: false
         kind: Variable
-        position: 2
       - name: title
         required: false
         kind: Variable
-        position: 3
       - name: hidden_label
         required: false
         kind: Variable
-        position: 4
       - name: attrs
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
     arg_constraints:
@@ -662,7 +581,6 @@ tag_rules:
       - name: collection
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
     arg_constraints:
@@ -675,7 +593,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
     arg_constraints:
@@ -688,19 +605,15 @@ tag_rules:
       - name: last_update
         required: true
         kind: Variable
-        position: 0
       - name: show_time_prefix
         required: false
         kind: Variable
-        position: 1
       - name: user_display_name
         required: false
         kind: Variable
-        position: 2
       - name: use_shorthand
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
     arg_constraints:
@@ -713,7 +626,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
     arg_constraints:
@@ -734,7 +646,6 @@ tag_rules:
       - name: workflow_state
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: position
         required: false
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -13,15 +13,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: search_query
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
     arg_constraints:
@@ -35,15 +32,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
     arg_constraints:
@@ -56,15 +50,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: max_width
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: image
         required: true
         kind: Variable
-        position: 0
       - name: filter_spec
         required: true
         kind: Variable
-        position: 1
       - name: viewname
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -29,7 +27,6 @@ tag_rules:
       - name: block_var_token
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
     arg_constraints:
@@ -42,11 +39,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
     arg_constraints:
@@ -59,7 +54,6 @@ tag_rules:
       - name: slug
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: permission_bound_field
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.users.templatetags.wagtailusers_tags::tag::user_listing_buttons":
     arg_constraints:
@@ -27,7 +26,6 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
     arg_constraints:
@@ -47,11 +45,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
     arg_constraints:
@@ -71,27 +67,21 @@ tag_rules:
       - name: user
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
       - name: tooltip
         required: false
         kind: Variable
-        position: 3
       - name: tooltip_html
         required: false
         kind: Variable
-        position: 4
       - name: edit_link
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
     arg_constraints:
@@ -104,15 +94,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
       - name: gravatar_only
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
     arg_constraints:
@@ -124,7 +111,6 @@ tag_rules:
       - name: default
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
     arg_constraints:
@@ -137,19 +123,15 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
       - name: is_expanded
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: icon_name
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
     arg_constraints:
@@ -162,11 +144,9 @@ tag_rules:
       - name: app_label
         required: true
         kind: Variable
-        position: 0
       - name: model_name
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -177,7 +157,6 @@ tag_rules:
       - name: classes
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
     arg_constraints:
@@ -190,15 +169,12 @@ tag_rules:
       - name: dialog_id
         required: true
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: text
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
     arg_constraints:
@@ -210,51 +186,39 @@ tag_rules:
       - name: field
         required: false
         kind: Variable
-        position: 0
       - name: rendered_field
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: show_label
         required: false
         kind: Variable
-        position: 3
       - name: id_for_label
         required: false
         kind: Variable
-        position: 4
       - name: sr_only_label
         required: false
         kind: Variable
-        position: 5
       - name: icon
         required: false
         kind: Variable
-        position: 6
       - name: help_text
         required: false
         kind: Variable
-        position: 7
       - name: help_text_id
         required: false
         kind: Variable
-        position: 8
       - name: show_add_comment_button
         required: false
         kind: Variable
-        position: 9
       - name: label_text
         required: false
         kind: Variable
-        position: 10
       - name: error_message_id
         required: false
         kind: Variable
-        position: 11
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
     arg_constraints:
@@ -283,7 +247,6 @@ tag_rules:
       - name: hook_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
     arg_constraints:
@@ -296,15 +259,12 @@ tag_rules:
       - name: date
         required: true
         kind: Variable
-        position: 0
       - name: description
         required: false
         kind: Variable
-        position: 1
       - name: placement
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
     arg_constraints:
@@ -324,19 +284,15 @@ tag_rules:
       - name: name
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: title
         required: false
         kind: Variable
-        position: 2
       - name: wrapped
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
     arg_constraints:
@@ -349,7 +305,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
     arg_constraints:
@@ -370,7 +325,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
     arg_constraints:
@@ -383,7 +337,6 @@ tag_rules:
       - name: locale_id
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
     arg_constraints:
@@ -396,7 +349,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
     arg_constraints:
@@ -409,7 +361,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::notification_static":
     arg_constraints:
@@ -422,7 +373,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
     arg_constraints:
@@ -435,39 +385,30 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: url_root_name
         required: false
         kind: Variable
-        position: 2
       - name: include_self
         required: false
         kind: Variable
-        position: 3
       - name: is_expanded
         required: false
         kind: Variable
-        position: 4
       - name: querystring_value
         required: false
         kind: Variable
-        position: 5
       - name: trailing_breadcrumb_title
         required: false
         kind: Variable
-        position: 6
       - name: classname
         required: false
         kind: Variable
-        position: 7
       - name: icon_name
         required: false
         kind: Variable
-        position: 8
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
     arg_constraints:
@@ -480,15 +421,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: view_name
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
     arg_constraints:
@@ -501,15 +439,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: next_url
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
     arg_constraints:
@@ -522,7 +457,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
     arg_constraints:
@@ -535,19 +469,15 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: base_url
         required: false
         kind: Variable
-        position: 1
       - name: page_key
         required: false
         kind: Variable
-        position: 2
       - name: classname
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
     arg_constraints:
@@ -560,11 +490,9 @@ tag_rules:
       - name: page_number
         required: true
         kind: Variable
-        position: 0
       - name: page_key
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
     arg_constraints:
@@ -577,7 +505,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
     arg_constraints:
@@ -589,7 +516,6 @@ tag_rules:
       - name: current
         required: false
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
     arg_constraints:
@@ -617,27 +543,21 @@ tag_rules:
       - name: label
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: url
         required: false
         kind: Variable
-        position: 2
       - name: title
         required: false
         kind: Variable
-        position: 3
       - name: hidden_label
         required: false
         kind: Variable
-        position: 4
       - name: attrs
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
     arg_constraints:
@@ -650,7 +570,6 @@ tag_rules:
       - name: collection
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
     arg_constraints:
@@ -663,7 +582,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
     arg_constraints:
@@ -676,19 +594,15 @@ tag_rules:
       - name: last_update
         required: true
         kind: Variable
-        position: 0
       - name: show_time_prefix
         required: false
         kind: Variable
-        position: 1
       - name: user_display_name
         required: false
         kind: Variable
-        position: 2
       - name: use_shorthand
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
     arg_constraints:
@@ -701,7 +615,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
     arg_constraints:
@@ -722,7 +635,6 @@ tag_rules:
       - name: workflow_state
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: position
         required: false
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -13,15 +13,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: search_query
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
     arg_constraints:
@@ -35,15 +32,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
     arg_constraints:
@@ -56,15 +50,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: max_width
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: image
         required: true
         kind: Variable
-        position: 0
       - name: filter_spec
         required: true
         kind: Variable
-        position: 1
       - name: viewname
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -29,7 +27,6 @@ tag_rules:
       - name: block_var_token
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
     arg_constraints:
@@ -42,11 +39,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
     arg_constraints:
@@ -59,7 +54,6 @@ tag_rules:
       - name: slug
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: permission_bound_field
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_edit_url":
     arg_constraints:
@@ -27,11 +26,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
     arg_constraints:
@@ -60,11 +57,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
     arg_constraints:
@@ -84,27 +79,21 @@ tag_rules:
       - name: user
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
       - name: tooltip
         required: false
         kind: Variable
-        position: 3
       - name: tooltip_html
         required: false
         kind: Variable
-        position: 4
       - name: edit_link
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
     arg_constraints:
@@ -117,15 +106,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
       - name: gravatar_only
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
     arg_constraints:
@@ -137,7 +123,6 @@ tag_rules:
       - name: default
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
     arg_constraints:
@@ -150,19 +135,15 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
       - name: is_expanded
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: icon_name
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::build_absolute_url":
     arg_constraints:
@@ -175,7 +156,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
     arg_constraints:
@@ -188,11 +168,9 @@ tag_rules:
       - name: app_label
         required: true
         kind: Variable
-        position: 0
       - name: model_name
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -203,7 +181,6 @@ tag_rules:
       - name: classes
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
     arg_constraints:
@@ -216,15 +193,12 @@ tag_rules:
       - name: dialog_id
         required: true
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: text
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
     arg_constraints:
@@ -236,59 +210,45 @@ tag_rules:
       - name: field
         required: false
         kind: Variable
-        position: 0
       - name: rendered_field
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: show_label
         required: false
         kind: Variable
-        position: 3
       - name: id_for_label
         required: false
         kind: Variable
-        position: 4
       - name: sr_only_label
         required: false
         kind: Variable
-        position: 5
       - name: icon
         required: false
         kind: Variable
-        position: 6
       - name: help_text
         required: false
         kind: Variable
-        position: 7
       - name: help_text_id
         required: false
         kind: Variable
-        position: 8
       - name: show_add_comment_button
         required: false
         kind: Variable
-        position: 9
       - name: label_text
         required: false
         kind: Variable
-        position: 10
       - name: error_message_id
         required: false
         kind: Variable
-        position: 11
       - name: wrapper_id
         required: false
         kind: Variable
-        position: 12
       - name: attrs
         required: false
         kind: Variable
-        position: 13
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
     arg_constraints:
@@ -317,7 +277,6 @@ tag_rules:
       - name: hook_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
     arg_constraints:
@@ -330,15 +289,12 @@ tag_rules:
       - name: date
         required: true
         kind: Variable
-        position: 0
       - name: description
         required: false
         kind: Variable
-        position: 1
       - name: placement
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
     arg_constraints:
@@ -358,19 +314,15 @@ tag_rules:
       - name: name
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: title
         required: false
         kind: Variable
-        position: 2
       - name: wrapped
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
     arg_constraints:
@@ -383,7 +335,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
     arg_constraints:
@@ -404,7 +355,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
     arg_constraints:
@@ -417,7 +367,6 @@ tag_rules:
       - name: locale_id
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
     arg_constraints:
@@ -430,7 +379,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
     arg_constraints:
@@ -443,7 +391,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
     arg_constraints:
@@ -456,39 +403,30 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: url_root_name
         required: false
         kind: Variable
-        position: 2
       - name: include_self
         required: false
         kind: Variable
-        position: 3
       - name: is_expanded
         required: false
         kind: Variable
-        position: 4
       - name: querystring_value
         required: false
         kind: Variable
-        position: 5
       - name: trailing_breadcrumb_title
         required: false
         kind: Variable
-        position: 6
       - name: classname
         required: false
         kind: Variable
-        position: 7
       - name: icon_name
         required: false
         kind: Variable
-        position: 8
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
     arg_constraints:
@@ -501,15 +439,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: view_name
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
     arg_constraints:
@@ -522,15 +457,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: next_url
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
     arg_constraints:
@@ -543,7 +475,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
     arg_constraints:
@@ -556,19 +487,15 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: base_url
         required: false
         kind: Variable
-        position: 1
       - name: page_key
         required: false
         kind: Variable
-        position: 2
       - name: classname
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
     arg_constraints:
@@ -581,11 +508,9 @@ tag_rules:
       - name: page_number
         required: true
         kind: Variable
-        position: 0
       - name: page_key
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
     arg_constraints:
@@ -598,7 +523,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
     arg_constraints:
@@ -610,7 +534,6 @@ tag_rules:
       - name: current
         required: false
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
     arg_constraints:
@@ -638,27 +561,21 @@ tag_rules:
       - name: label
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: url
         required: false
         kind: Variable
-        position: 2
       - name: title
         required: false
         kind: Variable
-        position: 3
       - name: hidden_label
         required: false
         kind: Variable
-        position: 4
       - name: attrs
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
     arg_constraints:
@@ -671,7 +588,6 @@ tag_rules:
       - name: collection
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
     arg_constraints:
@@ -684,7 +600,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
     arg_constraints:
@@ -697,19 +612,15 @@ tag_rules:
       - name: last_update
         required: true
         kind: Variable
-        position: 0
       - name: show_time_prefix
         required: false
         kind: Variable
-        position: 1
       - name: user_display_name
         required: false
         kind: Variable
-        position: 2
       - name: use_shorthand
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
     arg_constraints:
@@ -722,7 +633,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
     arg_constraints:
@@ -743,7 +653,6 @@ tag_rules:
       - name: workflow_state
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: position
         required: false
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -13,15 +13,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: search_query
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
     arg_constraints:
@@ -35,15 +32,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
     arg_constraints:
@@ -56,15 +50,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: max_width
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: image
         required: true
         kind: Variable
-        position: 0
       - name: filter_spec
         required: true
         kind: Variable
-        position: 1
       - name: viewname
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -29,7 +27,6 @@ tag_rules:
       - name: block_var_token
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
     arg_constraints:
@@ -42,11 +39,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
     arg_constraints:
@@ -59,7 +54,6 @@ tag_rules:
       - name: slug
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: permission_bound_field
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_edit_url":
     arg_constraints:
@@ -27,11 +26,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
     arg_constraints:
@@ -60,11 +57,9 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
       - name: action
         required: true
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
     arg_constraints:
@@ -84,27 +79,21 @@ tag_rules:
       - name: user
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: size
         required: false
         kind: Variable
-        position: 2
       - name: tooltip
         required: false
         kind: Variable
-        position: 3
       - name: tooltip_html
         required: false
         kind: Variable
-        position: 4
       - name: edit_link
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
     arg_constraints:
@@ -117,15 +106,12 @@ tag_rules:
       - name: user
         required: true
         kind: Variable
-        position: 0
       - name: size
         required: false
         kind: Variable
-        position: 1
       - name: gravatar_only
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
     arg_constraints:
@@ -137,7 +123,6 @@ tag_rules:
       - name: default
         required: false
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
     arg_constraints:
@@ -150,19 +135,15 @@ tag_rules:
       - name: items
         required: true
         kind: Variable
-        position: 0
       - name: is_expanded
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: icon_name
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::build_absolute_url":
     arg_constraints:
@@ -175,7 +156,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
     arg_constraints:
@@ -188,11 +168,9 @@ tag_rules:
       - name: app_label
         required: true
         kind: Variable
-        position: 0
       - name: model_name
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -203,7 +181,6 @@ tag_rules:
       - name: classes
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
     arg_constraints:
@@ -216,15 +193,12 @@ tag_rules:
       - name: dialog_id
         required: true
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: text
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
     arg_constraints:
@@ -236,59 +210,45 @@ tag_rules:
       - name: field
         required: false
         kind: Variable
-        position: 0
       - name: rendered_field
         required: false
         kind: Variable
-        position: 1
       - name: classname
         required: false
         kind: Variable
-        position: 2
       - name: show_label
         required: false
         kind: Variable
-        position: 3
       - name: id_for_label
         required: false
         kind: Variable
-        position: 4
       - name: sr_only_label
         required: false
         kind: Variable
-        position: 5
       - name: icon
         required: false
         kind: Variable
-        position: 6
       - name: help_text
         required: false
         kind: Variable
-        position: 7
       - name: help_text_id
         required: false
         kind: Variable
-        position: 8
       - name: show_add_comment_button
         required: false
         kind: Variable
-        position: 9
       - name: label_text
         required: false
         kind: Variable
-        position: 10
       - name: error_message_id
         required: false
         kind: Variable
-        position: 11
       - name: wrapper_id
         required: false
         kind: Variable
-        position: 12
       - name: attrs
         required: false
         kind: Variable
-        position: 13
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
     arg_constraints:
@@ -317,7 +277,6 @@ tag_rules:
       - name: hook_name
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
     arg_constraints:
@@ -330,15 +289,12 @@ tag_rules:
       - name: date
         required: true
         kind: Variable
-        position: 0
       - name: description
         required: false
         kind: Variable
-        position: 1
       - name: placement
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
     arg_constraints:
@@ -358,19 +314,15 @@ tag_rules:
       - name: name
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: title
         required: false
         kind: Variable
-        position: 2
       - name: wrapped
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
     arg_constraints:
@@ -383,7 +335,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
     arg_constraints:
@@ -404,7 +355,6 @@ tag_rules:
       - name: obj
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
     arg_constraints:
@@ -417,7 +367,6 @@ tag_rules:
       - name: locale_id
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
     arg_constraints:
@@ -430,7 +379,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
     arg_constraints:
@@ -443,7 +391,6 @@ tag_rules:
       - name: message
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
     arg_constraints:
@@ -456,39 +403,30 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: url_root_name
         required: false
         kind: Variable
-        position: 2
       - name: include_self
         required: false
         kind: Variable
-        position: 3
       - name: is_expanded
         required: false
         kind: Variable
-        position: 4
       - name: querystring_value
         required: false
         kind: Variable
-        position: 5
       - name: trailing_breadcrumb_title
         required: false
         kind: Variable
-        position: 6
       - name: classname
         required: false
         kind: Variable
-        position: 7
       - name: icon_name
         required: false
         kind: Variable
-        position: 8
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
     arg_constraints:
@@ -501,15 +439,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: view_name
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
     arg_constraints:
@@ -522,15 +457,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: user
         required: true
         kind: Variable
-        position: 1
       - name: next_url
         required: false
         kind: Variable
-        position: 2
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
     arg_constraints:
@@ -543,7 +475,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
     arg_constraints:
@@ -556,19 +487,15 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: base_url
         required: false
         kind: Variable
-        position: 1
       - name: page_key
         required: false
         kind: Variable
-        position: 2
       - name: classname
         required: false
         kind: Variable
-        position: 3
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
     arg_constraints:
@@ -581,11 +508,9 @@ tag_rules:
       - name: page_number
         required: true
         kind: Variable
-        position: 0
       - name: page_key
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
     arg_constraints:
@@ -598,7 +523,6 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
     arg_constraints:
@@ -610,7 +534,6 @@ tag_rules:
       - name: current
         required: false
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
     arg_constraints:
@@ -638,27 +561,21 @@ tag_rules:
       - name: label
         required: false
         kind: Variable
-        position: 0
       - name: classname
         required: false
         kind: Variable
-        position: 1
       - name: url
         required: false
         kind: Variable
-        position: 2
       - name: title
         required: false
         kind: Variable
-        position: 3
       - name: hidden_label
         required: false
         kind: Variable
-        position: 4
       - name: attrs
         required: false
         kind: Variable
-        position: 5
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
     arg_constraints:
@@ -671,7 +588,6 @@ tag_rules:
       - name: collection
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
     arg_constraints:
@@ -684,7 +600,6 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
     arg_constraints:
@@ -697,19 +612,15 @@ tag_rules:
       - name: last_update
         required: true
         kind: Variable
-        position: 0
       - name: show_time_prefix
         required: false
         kind: Variable
-        position: 1
       - name: user_display_name
         required: false
         kind: Variable
-        position: 2
       - name: use_shorthand
         required: false
         kind: Variable
-        position: 3
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
     arg_constraints:
@@ -722,7 +633,6 @@ tag_rules:
       - name: path
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
     arg_constraints:
@@ -743,7 +653,6 @@ tag_rules:
       - name: workflow_state
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -13,7 +13,6 @@ tag_rules:
       - name: position
         required: false
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -13,15 +13,12 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: url_name
         required: true
         kind: Variable
-        position: 1
       - name: args
         required: false
         kind: VarArgs
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: search_query
         required: true
         kind: Variable
-        position: 0
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
     arg_constraints:
@@ -35,15 +32,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
     arg_constraints:
@@ -56,15 +50,12 @@ tag_rules:
       - name: row_index
         required: true
         kind: Variable
-        position: 0
       - name: col_index
         required: true
         kind: Variable
-        position: 1
       - name: table_header
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: max_width
         required: false
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: image
         required: true
         kind: Variable
-        position: 0
       - name: filter_spec
         required: true
         kind: Variable
-        position: 1
       - name: viewname
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -14,11 +14,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -29,7 +27,6 @@ tag_rules:
       - name: block_var_token
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
     arg_constraints:
@@ -42,11 +39,9 @@ tag_rules:
       - name: page
         required: true
         kind: Variable
-        position: 0
       - name: fallback
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
     arg_constraints:
@@ -59,7 +54,6 @@ tag_rules:
       - name: slug
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -14,7 +14,6 @@ tag_rules:
       - name: permission_bound_field
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_custom_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_custom_tags.snap
@@ -30,7 +30,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
     arg_constraints:
@@ -43,11 +42,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
     arg_constraints:
@@ -60,11 +57,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: true
         kind: Variable
-        position: 1
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_defaulttags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_defaulttags.snap
@@ -33,7 +33,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::cycle":
     arg_constraints:
@@ -62,7 +61,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::for":
     arg_constraints:
@@ -74,15 +72,12 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
     as_var: keep
   "django.template.defaulttags::tag::now":
     arg_constraints:
@@ -100,7 +95,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::partial":
     arg_constraints:
@@ -112,7 +106,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::partialdef":
     arg_constraints:
@@ -129,12 +122,10 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: inline
         required: true
         kind:
           Literal: inline
-        position: 1
     as_var: keep
   "django.template.defaulttags::tag::querystring":
     arg_constraints: []
@@ -145,7 +136,6 @@ tag_rules:
       - name: args
         required: false
         kind: VarArgs
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:
@@ -183,25 +173,20 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: by
         required: true
         kind:
           Literal: by
-        position: 1
       - name: arg3
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: var_name
         required: true
         kind: Variable
-        position: 4
     as_var: keep
   "django.template.defaulttags::tag::templatetag":
     arg_constraints:
@@ -219,7 +204,6 @@ tag_rules:
       - name: tag
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.defaulttags::tag::url":
     arg_constraints:
@@ -241,7 +225,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: strip
   "django.template.defaulttags::tag::widthratio":
     arg_constraints: []
@@ -263,24 +246,19 @@ tag_rules:
       - name: this_value_expr
         required: true
         kind: Variable
-        position: 0
       - name: max_value_expr
         required: true
         kind: Variable
-        position: 1
       - name: max_width
         required: true
         kind: Variable
-        position: 2
       - name: as
         required: true
         kind:
           Literal: as
-        position: 3
       - name: asvar
         required: true
         kind: Variable
-        position: 4
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/extraction__golden_django_admin_urls.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_django_admin_urls.snap
@@ -14,15 +14,12 @@ tag_rules:
       - name: url
         required: true
         kind: Variable
-        position: 0
       - name: popup
         required: false
         kind: Variable
-        position: 1
       - name: to_field
         required: false
         kind: Variable
-        position: 2
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_django_tz.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_django_tz.snap
@@ -17,11 +17,9 @@ tag_rules:
         required: true
         kind:
           Literal: as
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
   "django.templatetags.tz::tag::localtime":
     arg_constraints:
@@ -61,7 +59,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.tz::tag::timezone":
     arg_constraints:
@@ -83,7 +80,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
@@ -59,7 +59,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.templatetags.i18n::tag::translate":
     arg_constraints:
@@ -87,7 +86,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/extraction__golden_inclusion_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_inclusion_tags.snap
@@ -30,11 +30,9 @@ tag_rules:
       - name: one
         required: true
         kind: Variable
-        position: 0
       - name: two
         required: false
         kind: Variable
-        position: 1
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
     arg_constraints:
@@ -47,7 +45,6 @@ tag_rules:
       - name: arg
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
@@ -23,7 +23,6 @@ tag_rules:
       - name: block_name
         required: true
         kind: Variable
-        position: 0
     as_var: keep
   "django.template.loader_tags::tag::include":
     arg_constraints:
@@ -50,7 +49,6 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
     as_var: keep
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/extraction__golden_non_bits_variable.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_non_bits_variable.snap
@@ -19,11 +19,9 @@ tag_rules:
       - name: arg1
         required: true
         kind: Variable
-        position: 0
       - name: arg2
         required: true
         kind: Variable
-        position: 1
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-semantic/src/tags/specs.rs
+++ b/crates/djls-semantic/src/tags/specs.rs
@@ -264,7 +264,6 @@ impl TagSpecs {
                             name: arg.name.clone(),
                             required: arg.required,
                             kind: kind.clone(),
-                            position: pos,
                         });
 
                         if arg.required {
@@ -414,10 +413,10 @@ impl TagSpec {
     }
 
     #[must_use]
-    pub fn arguments(&self) -> Vec<TagArgument> {
+    pub fn arguments(&self) -> &[TagArgument] {
         self.extracted_rules
-            .as_ref()
-            .map_or_else(Vec::new, |rules| rules.extracted_args.clone())
+            .as_deref()
+            .map_or(&[], |rules| rules.extracted_args.as_slice())
     }
 
     #[must_use]
@@ -1022,19 +1021,16 @@ mod tests {
                         name: "item".to_string(),
                         required: true,
                         kind: TagArgumentKind::Variable,
-                        position: 0,
                     },
                     TagArgument {
                         name: "in".to_string(),
                         required: true,
                         kind: TagArgumentKind::Literal("in".to_string()),
-                        position: 1,
                     },
                     TagArgument {
                         name: "iterable".to_string(),
                         required: true,
                         kind: TagArgumentKind::Variable,
-                        position: 2,
                     },
                 ],
                 ..Default::default()


### PR DESCRIPTION
## Changes

Use vector order as the sole argument-position contract. Remove TagArgument.position from producers and fixtures while retaining meaningful SplitPosition coordinates.

Return a borrowed slice from TagSpec::arguments instead of cloning names and choice lists on each read.

The snapshot changes remove exactly 1,474 scalar argument-position fields; no other snapshot values changed.

## Validation

Focused extraction, corpus, tag-analysis, tag-spec, snippet, and completion tests passed. The complete stack also passed all 14 Python/Django combinations, 44 e2e tests, formatting, Clippy, all-target/all-feature check, and pre-commit checks locally. Hawk is reserved for CI.