### PR TITLE
Remove unused semantic Model Graph access

### DIFF
--- a/crates/djls-bench/src/db.rs
+++ b/crates/djls-bench/src/db.rs
@@ -240,10 +240,6 @@ impl SemanticDb for Db {
     fn projectless_filter_arity_specs(&self) -> &FilterAritySpecs {
         &self.projectless_filter_arity_specs
     }
-
-    fn model_graph(&self) -> &djls_project::ModelGraph {
-        djls_project::ModelGraph::empty_ref()
-    }
 }
 
 #[cfg(test)]

--- a/crates/djls-db/src/db.rs
+++ b/crates/djls-db/src/db.rs
@@ -14,7 +14,6 @@ use djls_conf::DiagnosticsConfig;
 use djls_conf::Settings;
 use djls_project::Db as ProjectDb;
 use djls_project::Project;
-use djls_project::compute_model_graph;
 use djls_semantic::Db as SemanticDb;
 use djls_semantic::FilterAritySpecs;
 use djls_semantic::TagSpecs;
@@ -164,13 +163,6 @@ impl SemanticDb for DjangoDatabase {
         );
         FilterAritySpecs::empty_ref()
     }
-
-    fn model_graph(&self) -> &djls_project::ModelGraph {
-        self.project()
-            .map_or(djls_project::ModelGraph::empty_ref(), |project| {
-                compute_model_graph(self, project)
-            })
-    }
 }
 
 #[salsa::db]
@@ -223,10 +215,10 @@ mod invalidation_tests {
     use djls_project::TemplateLibrary;
     use djls_project::TemplateLibraryId;
     use djls_project::TemplateSymbolKind;
+    use djls_project::compute_model_graph;
     use djls_project::template_library_catalog;
     use djls_project::template_library_definition_facts;
     use djls_project::template_library_filter_facts;
-    use djls_semantic::Db as SemanticDb;
     use djls_semantic::SemanticOffsetContext;
     use djls_semantic::ValidationErrorAccumulator;
     use djls_semantic::build_template_tree_for_file;
@@ -2761,7 +2753,8 @@ def my_filter(value, arg):
     #[test]
     fn model_graph_empty_when_no_models() {
         let (db, _event_log) = test_db_with_project();
-        let graph = db.model_graph();
+        let project = db.project().expect("fixture should have a Project");
+        let graph = compute_model_graph(&db, project);
         assert!(graph.is_empty());
     }
 
@@ -2769,14 +2762,15 @@ def my_filter(value, arg):
     fn model_graph_cached_on_repeated_access() {
         let (db, event_log) = test_db_with_project();
 
-        let _graph1 = db.model_graph();
+        let project = db.project().expect("fixture should have a Project");
+        let _graph1 = compute_model_graph(&db, project);
         let events = event_log.take();
         assert!(
             was_executed(&db, &events, "compute_model_graph"),
             "compute_model_graph should execute on first call"
         );
 
-        let _graph2 = db.model_graph();
+        let _graph2 = compute_model_graph(&db, project);
         let events = event_log.take();
         assert!(
             !was_executed(&db, &events, "compute_model_graph"),
@@ -2823,7 +2817,7 @@ def my_filter(value, arg):
         let project = Project::bootstrap(&db, &root, &settings);
         db.project = Some(project);
 
-        let graph = db.model_graph();
+        let graph = compute_model_graph(&db, project);
         assert!(graph.models_named("First").next().is_some());
         assert!(graph.models_named("Second").next().is_some());
         let events = event_log.take();
@@ -2844,7 +2838,7 @@ def my_filter(value, arg):
         SourceChanges::new([ChangeEvent::ContentChanged(first_model.path(&db).clone())])
             .apply(&mut db);
 
-        let graph = db.model_graph();
+        let graph = compute_model_graph(&db, project);
         assert!(graph.models_named("First").next().is_none());
         assert!(graph.models_named("FirstRenamed").next().is_some());
         assert!(graph.models_named("Second").next().is_some());

--- a/crates/djls-project/src/models/graph.rs
+++ b/crates/djls-project/src/models/graph.rs
@@ -787,12 +787,6 @@ impl Serialize for ModelGraph {
 
 impl ModelGraph {
     #[must_use]
-    pub fn empty_ref() -> &'static Self {
-        static EMPTY: std::sync::LazyLock<ModelGraph> = std::sync::LazyLock::new(ModelGraph::new);
-        &EMPTY
-    }
-
-    #[must_use]
     pub(crate) fn new() -> Self {
         Self::default()
     }

--- a/crates/djls-semantic/src/db.rs
+++ b/crates/djls-semantic/src/db.rs
@@ -1,6 +1,5 @@
 use djls_conf::DiagnosticsConfig;
 use djls_project::Db as ProjectDb;
-use djls_project::ModelGraph;
 use djls_project::ScopedTemplateLibraries;
 use djls_project::TemplateLibraryCatalog;
 use djls_project::scoped_template_libraries;
@@ -22,13 +21,6 @@ pub trait Db: ProjectDb {
 
     /// Explicit fixture seam for Filter validation without a Project.
     fn projectless_filter_arity_specs(&self) -> &FilterAritySpecs;
-
-    /// Get the merged model graph for the current project.
-    ///
-    /// Combines models from both workspace `models.py` files and installed
-    /// packages (site-packages). Returns an empty graph when no project is
-    /// configured.
-    fn model_graph(&self) -> &ModelGraph;
 }
 
 pub fn scoped_template_libraries_for_file(

--- a/crates/djls-testing/src/db.rs
+++ b/crates/djls-testing/src/db.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::Ordering;
 
 use camino::Utf8Path;
 use djls_project::Db as ProjectDb;
-use djls_project::ModelGraph;
 use djls_project::Project;
 use djls_semantic::Db as SemanticDb;
 use djls_semantic::FilterAritySpecs;
@@ -277,9 +276,5 @@ impl SemanticDb for TestDatabase {
 
     fn projectless_filter_arity_specs(&self) -> &FilterAritySpecs {
         &self.projectless_filter_arity_specs
-    }
-
-    fn model_graph(&self) -> &ModelGraph {
-        ModelGraph::empty_ref()
     }
 }


### PR DESCRIPTION
## Changes

Remove the unused model_graph method from the semantic database trait and its production, test, and benchmark implementations. Remove the now-unused shared empty graph accessor.

Keep the Model Graph implementation and its production query. Database tests call compute_model_graph directly and retain caching and per-file invalidation assertions.

## Validation

All 3 focused database Model Graph tests passed. Benchmark targets compiled. The complete stack passed all 14 Python/Django combinations, 44 e2e tests, formatting, Clippy, all-target/all-feature check, and pre-commit checks locally. Hawk is reserved for CI.