### PR TITLE
Model option rejection evidence and tracked pop positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed explicit `false` and empty LSP initialization options failing to override project configuration.
 - Fixed `djls check` scanning the project root when template settings branches differ only in context processors.
 - Fixed duplicate names and excess inclusion-tag arguments producing invented Template Library definitions.
+- Fixed false duplicate-option diagnostics for tag parsers that check membership without raising an error.
+- Fixed tag-rule extraction using incorrect argument positions after unsupported `pop()` calls.
 
 ## [6.1.0]
 

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -59,6 +59,7 @@ pub use templates::KnownOptions;
 pub use templates::LibraryName;
 pub use templates::LoadableLibraryLookup;
 pub use templates::MissingTemplateLibraryLookup;
+pub use templates::OptionRejection;
 pub use templates::RequiredKeyword;
 pub use templates::ScopedTemplateLibraries;
 pub use templates::ScopedTemplateReferenceResolution;

--- a/crates/djls-project/src/templates.rs
+++ b/crates/djls-project/src/templates.rs
@@ -69,6 +69,7 @@ pub use tags::ExtractedDiagnosticMessage;
 pub use tags::ExtractedMessageArg;
 pub use tags::ExtractedMessageTemplate;
 pub use tags::KnownOptions;
+pub use tags::OptionRejection;
 pub use tags::RequiredKeyword;
 pub use tags::SplitPosition;
 pub use tags::TagArgument;

--- a/crates/djls-project/src/templates/tags.rs
+++ b/crates/djls-project/src/templates/tags.rs
@@ -32,6 +32,7 @@ pub use crate::templates::tags::types::ExtractedDiagnosticMessage;
 pub use crate::templates::tags::types::ExtractedMessageArg;
 pub use crate::templates::tags::types::ExtractedMessageTemplate;
 pub use crate::templates::tags::types::KnownOptions;
+pub use crate::templates::tags::types::OptionRejection;
 pub use crate::templates::tags::types::RequiredKeyword;
 pub use crate::templates::tags::types::SplitPosition;
 pub use crate::templates::tags::types::TagArgument;

--- a/crates/djls-project/src/templates/tags/analysis/expressions.rs
+++ b/crates/djls-project/src/templates/tags/analysis/expressions.rs
@@ -12,6 +12,7 @@ use ruff_python_ast::Number;
 use crate::ast::ExprExt;
 use crate::templates::tags::analysis::CallContext;
 use crate::templates::tags::analysis::calls::resolve_call;
+use crate::templates::tags::analysis::mutations::PopPosition;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
 use crate::templates::tags::analysis::state::TokenSplit;
@@ -235,21 +236,15 @@ fn eval_pop_return(obj: &AbstractValue, args: &Arguments) -> AbstractValue {
         return AbstractValue::Unknown;
     };
 
-    if let Some(arg) = args.args.first() {
-        // bits.pop(0) — return element at front_offset
-        if let Some(0) = arg.non_negative_integer() {
-            return AbstractValue::SplitElement {
-                index: split.resolve_index(0),
-            };
-        }
-    } else {
-        // bits.pop() — return last element (before pop)
-        return AbstractValue::SplitElement {
+    match PopPosition::from_arguments(args) {
+        PopPosition::Front => AbstractValue::SplitElement {
+            index: split.resolve_index(0),
+        },
+        PopPosition::Back => AbstractValue::SplitElement {
             index: SplitPosition::Backward(split.back_offset() + 1),
-        };
+        },
+        PopPosition::Untracked => AbstractValue::Unknown,
     }
-
-    AbstractValue::Unknown
 }
 
 /// Convert an i64 to an `AbstractValue` index element based on sign.

--- a/crates/djls-project/src/templates/tags/analysis/mutations.rs
+++ b/crates/djls-project/src/templates/tags/analysis/mutations.rs
@@ -12,7 +12,6 @@ use ruff_python_ast::StmtWhile;
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
-use crate::templates::tags::analysis::exceptions::direct_raise_exception;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
 use crate::templates::tags::types::KnownOptions;
@@ -92,18 +91,11 @@ pub(super) fn try_extract_option_loop(while_stmt: &StmtWhile, env: &Env) -> Opti
 
     // Scan if/elif/else chains for option value checks
     let mut values = Vec::new();
-    let mut rejects_unknown = false;
     let mut allow_duplicates = true;
 
     for stmt in &while_stmt.body {
         if let Stmt::If(if_stmt) = stmt {
-            extract_option_checks(
-                if_stmt,
-                &option_var,
-                &mut values,
-                &mut rejects_unknown,
-                &mut allow_duplicates,
-            );
+            extract_option_checks(if_stmt, &option_var, &mut values, &mut allow_duplicates);
         }
     }
 
@@ -114,7 +106,6 @@ pub(super) fn try_extract_option_loop(while_stmt: &StmtWhile, env: &Env) -> Opti
     Some(KnownOptions {
         values,
         allow_duplicates,
-        rejects_unknown,
     })
 }
 
@@ -143,60 +134,22 @@ fn extract_option_checks(
     if_stmt: &StmtIf,
     option_var: &str,
     values: &mut Vec<String>,
-    rejects_unknown: &mut bool,
     allow_duplicates: &mut bool,
 ) {
-    let mut visitor =
-        OptionCheckVisitor::new(option_var, values, rejects_unknown, allow_duplicates);
-    visitor.visit_if(if_stmt);
-}
+    let tests = std::iter::once(if_stmt.test.as_ref()).chain(
+        if_stmt
+            .elif_else_clauses
+            .iter()
+            .filter_map(|clause| clause.test.as_ref()),
+    );
 
-struct OptionCheckVisitor<'a> {
-    option_var: &'a str,
-    values: &'a mut Vec<String>,
-    rejects_unknown: &'a mut bool,
-    allow_duplicates: &'a mut bool,
-}
-
-impl<'a> OptionCheckVisitor<'a> {
-    fn new(
-        option_var: &'a str,
-        values: &'a mut Vec<String>,
-        rejects_unknown: &'a mut bool,
-        allow_duplicates: &'a mut bool,
-    ) -> Self {
-        Self {
-            option_var,
-            values,
-            rejects_unknown,
-            allow_duplicates,
-        }
-    }
-
-    fn visit_if(&mut self, if_stmt: &StmtIf) {
-        if is_duplicate_check(&if_stmt.test, self.option_var) {
-            *self.allow_duplicates = false;
-        } else if let Some(opt_name) = extract_option_equality(&if_stmt.test, self.option_var)
-            && !self.values.contains(&opt_name)
+    for test in tests {
+        if is_duplicate_check(test, option_var) {
+            *allow_duplicates = false;
+        } else if let Some(opt_name) = extract_option_equality(test, option_var)
+            && !values.contains(&opt_name)
         {
-            self.values.push(opt_name);
-        }
-
-        for clause in &if_stmt.elif_else_clauses {
-            if let Some(test) = &clause.test {
-                if is_duplicate_check(test, self.option_var) {
-                    *self.allow_duplicates = false;
-                } else if let Some(opt_name) = extract_option_equality(test, self.option_var)
-                    && !self.values.contains(&opt_name)
-                {
-                    self.values.push(opt_name);
-                }
-            } else {
-                // else branch — if it raises, unknown options are rejected
-                if direct_raise_exception(&clause.body).is_some() {
-                    *self.rejects_unknown = true;
-                }
-            }
+            values.push(opt_name);
         }
     }
 }

--- a/crates/djls-project/src/templates/tags/analysis/mutations.rs
+++ b/crates/djls-project/src/templates/tags/analysis/mutations.rs
@@ -1,5 +1,6 @@
 use std::ops::ControlFlow;
 
+use ruff_python_ast::Arguments;
 use ruff_python_ast::CmpOp;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
@@ -12,16 +13,40 @@ use ruff_python_ast::StmtWhile;
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
 use crate::ast::walk_stmts;
+use crate::templates::tags::analysis::exceptions::direct_raise_exception;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
 use crate::templates::tags::types::KnownOptions;
+use crate::templates::tags::types::OptionRejection;
 
 /// Info about a `bits.pop(...)` call for mutation tracking.
 pub(super) struct PopInfo {
     /// The variable name being popped from (e.g., "bits")
     var_name: String,
-    /// Whether this is `pop(0)` (from front) or `pop()` (from end)
-    from_front: bool,
+    position: PopPosition,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum PopPosition {
+    Front,
+    Back,
+    Untracked,
+}
+
+impl PopPosition {
+    pub(super) fn from_arguments(args: &Arguments) -> Self {
+        if !args.keywords.is_empty() {
+            return Self::Untracked;
+        }
+        match args.args.as_ref() {
+            [] => Self::Back,
+            [arg] if arg.non_negative_integer() == Some(0) || arg.negative_integer() == Some(0) => {
+                Self::Front
+            }
+            [arg] if arg.negative_integer() == Some(1) => Self::Back,
+            _ => Self::Untracked,
+        }
+    }
 }
 
 /// Try to extract pop call info from an expression, without evaluating it.
@@ -37,15 +62,9 @@ pub(super) fn try_extract_pop_call(expr: &Expr) -> Option<PopInfo> {
     }
     let var_name = value.name_target()?;
 
-    let from_front = if let Some(arg) = call.arguments.args.first() {
-        arg.non_negative_integer() == Some(0)
-    } else {
-        false
-    };
-
     Some(PopInfo {
         var_name: var_name.to_string(),
-        from_front,
+        position: PopPosition::from_arguments(&call.arguments),
     })
 }
 
@@ -53,11 +72,11 @@ pub(super) fn try_extract_pop_call(expr: &Expr) -> Option<PopInfo> {
 pub(super) fn apply_pop_mutation(env: &mut Env, pop_info: &PopInfo) {
     env.mutate(&pop_info.var_name, |v| {
         if let AbstractValue::SplitResult(split) = v {
-            *split = if pop_info.from_front {
-                split.after_pop_front()
-            } else {
-                split.after_pop_back()
-            };
+            match pop_info.position {
+                PopPosition::Front => *split = split.after_pop_front(),
+                PopPosition::Back => *split = split.after_pop_back(),
+                PopPosition::Untracked => *v = AbstractValue::Unknown,
+            }
         }
     });
 }
@@ -90,23 +109,23 @@ pub(super) fn try_extract_option_loop(while_stmt: &StmtWhile, env: &Env) -> Opti
     let option_var = find_option_pop_var(&while_stmt.body, loop_var)?;
 
     // Scan if/elif/else chains for option value checks
-    let mut values = Vec::new();
-    let mut allow_duplicates = true;
+    let mut options = KnownOptions {
+        values: Vec::new(),
+        duplicate_rejection: OptionRejection::NotDetected,
+        unknown_rejection: OptionRejection::NotDetected,
+    };
 
     for stmt in &while_stmt.body {
         if let Stmt::If(if_stmt) = stmt {
-            extract_option_checks(if_stmt, &option_var, &mut values, &mut allow_duplicates);
+            extract_option_checks(if_stmt, &option_var, &mut options);
         }
     }
 
-    if values.is_empty() {
+    if options.values.is_empty() {
         return None;
     }
 
-    Some(KnownOptions {
-        values,
-        allow_duplicates,
-    })
+    Some(options)
 }
 
 /// Find the variable assigned from `loop_var.pop(0)` in a while-loop body.
@@ -117,8 +136,9 @@ fn find_option_pop_var(body: &[Stmt], loop_var: &str) -> Option<String> {
             && assign.targets.len() == 1
             && let Some(name) = assign.targets[0].name_target()
         {
-            let is_pop_zero = try_extract_pop_call(&assign.value)
-                .is_some_and(|info| info.var_name == loop_var && info.from_front);
+            let is_pop_zero = try_extract_pop_call(&assign.value).is_some_and(|info| {
+                info.var_name == loop_var && info.position == PopPosition::Front
+            });
             if is_pop_zero {
                 option_var = Some(name.to_string());
                 return ControlFlow::Break(());
@@ -130,26 +150,25 @@ fn find_option_pop_var(body: &[Stmt], loop_var: &str) -> Option<String> {
 }
 
 /// Extract option names from if/elif/else chains checking the option variable.
-fn extract_option_checks(
-    if_stmt: &StmtIf,
-    option_var: &str,
-    values: &mut Vec<String>,
-    allow_duplicates: &mut bool,
-) {
-    let tests = std::iter::once(if_stmt.test.as_ref()).chain(
+fn extract_option_checks(if_stmt: &StmtIf, option_var: &str, options: &mut KnownOptions) {
+    let clauses = std::iter::once((Some(if_stmt.test.as_ref()), if_stmt.body.as_slice())).chain(
         if_stmt
             .elif_else_clauses
             .iter()
-            .filter_map(|clause| clause.test.as_ref()),
+            .map(|clause| (clause.test.as_ref(), clause.body.as_slice())),
     );
 
-    for test in tests {
-        if is_duplicate_check(test, option_var) {
-            *allow_duplicates = false;
-        } else if let Some(opt_name) = extract_option_equality(test, option_var)
-            && !values.contains(&opt_name)
-        {
-            values.push(opt_name);
+    for (test, body) in clauses {
+        if let Some(test) = test {
+            if is_duplicate_check(test, option_var) && direct_raise_exception(body).is_some() {
+                options.duplicate_rejection = OptionRejection::Detected;
+            } else if let Some(opt_name) = extract_option_equality(test, option_var)
+                && !options.values.contains(&opt_name)
+            {
+                options.values.push(opt_name);
+            }
+        } else if direct_raise_exception(body).is_some() {
+            options.unknown_rejection = OptionRejection::Detected;
         }
     }
 }

--- a/crates/djls-project/src/templates/tags/analysis/statements.rs
+++ b/crates/djls-project/src/templates/tags/analysis/statements.rs
@@ -890,10 +890,8 @@ def do_tag(parser, token):
         crate::templates::tags::analysis::analyze_compile_function(func)
     }
 
-    // Fabricated: simple option loop without duplicate check. No corpus
-    // function has an option loop that allows duplicates — real Django tags
-    // always check for duplicates via `if option in options:` or `if option
-    // in seen:`. Keep as unit test for the simpler code path. (b)
+    // Fabricated: simple option loop without duplicate checking. No corpus
+    // function covers this simpler extraction path. (b)
     #[test]
     fn option_loop_basic() {
         let rule = analyze(
@@ -913,12 +911,11 @@ def do_tag(parser, token):
         );
         let opts = rule.known_options.expect("should have known_options");
         assert_eq!(opts.values, vec!["with".to_string(), "only".to_string()]);
-        assert!(opts.rejects_unknown);
         assert!(opts.allow_duplicates);
     }
 
     // Corpus: do_translate in i18n.py — option loop with `seen = set()`
-    // duplicate check. Options: "noop", "context", "as". Rejects unknown.
+    // duplicate check. Options: "noop", "context", "as".
     #[test]
     fn option_loop_with_duplicate_check() {
         let func = django_function("django/templatetags/i18n.py", "do_translate")
@@ -929,40 +926,11 @@ def do_tag(parser, token):
             opts.values,
             vec!["noop".to_string(), "context".to_string(), "as".to_string()]
         );
-        assert!(opts.rejects_unknown);
         assert!(!opts.allow_duplicates);
-    }
-
-    // Fabricated: option loop without else/raise — allows unknown options.
-    // No corpus function has this pattern (real Django tags always reject
-    // unknown options). Keep as unit test for permissive code path. (b)
-    #[test]
-    fn option_loop_allows_unknown() {
-        let rule = analyze(
-            r#"
-def do_tag(parser, token):
-    bits = token.split_contents()
-    remaining = bits[1:]
-    while remaining:
-        option = remaining.pop(0)
-        if option == "noescape":
-            pass
-        elif option == "trimmed":
-            pass
-"#,
-        );
-        let opts = rule.known_options.expect("should have known_options");
-        assert_eq!(
-            opts.values,
-            vec!["noescape".to_string(), "trimmed".to_string()]
-        );
-        assert!(!opts.rejects_unknown);
-        assert!(opts.allow_duplicates);
     }
 
     // Corpus: do_include in loader_tags.py — option loop with dict-based
     // duplicate check (`if option in options:`). Options: "with", "only".
-    // Rejects unknown, rejects duplicates.
     #[test]
     fn option_loop_include_pattern() {
         let func = django_function("django/template/loader_tags.py", "do_include")
@@ -970,7 +938,6 @@ def do_tag(parser, token):
         let rule = analyze_func(&func);
         let opts = rule.known_options.expect("should have known_options");
         assert_eq!(opts.values, vec!["with".to_string(), "only".to_string()]);
-        assert!(opts.rejects_unknown);
         assert!(!opts.allow_duplicates);
     }
 

--- a/crates/djls-project/src/templates/tags/analysis/statements.rs
+++ b/crates/djls-project/src/templates/tags/analysis/statements.rs
@@ -349,6 +349,7 @@ mod tests {
     use crate::templates::tags::analysis::state::Env;
     use crate::templates::tags::analysis::state::TokenSplit;
     use crate::templates::tags::testing::django_function;
+    use crate::templates::tags::types::OptionRejection;
     use crate::templates::tags::types::SplitPosition;
 
     fn parse_function(source: &str) -> StmtFunctionDef {
@@ -758,24 +759,22 @@ def do_tag(parser, token):
     }
 
     #[test]
-    fn pop_0_with_assignment() {
-        let env = eval_body(
-            r"
-def do_tag(parser, token):
-    bits = token.split_contents()
-    tag_name = bits.pop(0)
-",
-        );
-        assert_eq!(
-            env.get("tag_name"),
-            &AbstractValue::SplitElement {
-                index: SplitPosition::Forward(0)
-            }
-        );
-        assert_eq!(
-            env.get("bits"),
-            &AbstractValue::SplitResult(TokenSplit::fresh().after_slice_from(1))
-        );
+    fn pop_zero_with_assignment() {
+        for index in ["0", "-0"] {
+            let env = eval_body(&format!(
+                "def do_tag(parser, token):\n    bits = token.split_contents()\n    tag_name = bits.pop({index})\n"
+            ));
+            assert_eq!(
+                env.get("tag_name"),
+                &AbstractValue::SplitElement {
+                    index: SplitPosition::Forward(0)
+                }
+            );
+            assert_eq!(
+                env.get("bits"),
+                &AbstractValue::SplitResult(TokenSplit::fresh().after_slice_from(1))
+            );
+        }
     }
 
     #[test]
@@ -812,6 +811,61 @@ def do_tag(parser, token):
             env.get("bits"),
             &AbstractValue::SplitResult(TokenSplit::fresh().after_pop_back())
         );
+    }
+
+    #[test]
+    fn explicit_pop_minus_one_tracks_return_and_mutation() {
+        let env = eval_body(
+            r"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    bits.pop()
+    last = bits.pop(-1)
+",
+        );
+        assert_eq!(
+            env.get("last"),
+            &AbstractValue::SplitElement {
+                index: SplitPosition::Backward(2)
+            }
+        );
+        assert_eq!(
+            env.get("bits"),
+            &AbstractValue::SplitResult(TokenSplit::fresh().after_pop_back().after_pop_back())
+        );
+    }
+
+    #[test]
+    fn untracked_pop_discards_return_and_remaining_positions() {
+        for call in [
+            "bits.pop(2)",
+            "bits.pop(-2)",
+            "bits.pop(index)",
+            "bits.pop(*indices)",
+            "bits.pop(0, 1)",
+            "bits.pop(index=0)",
+        ] {
+            let env = eval_body(&format!(
+                "def do_tag(parser, token):\n    bits = token.split_contents()\n    popped = {call}\n    following = bits[1]\n"
+            ));
+            assert_eq!(env.get("popped"), &AbstractValue::Unknown, "{call}");
+            assert_eq!(env.get("bits"), &AbstractValue::Unknown, "{call}");
+            assert_eq!(env.get("following"), &AbstractValue::Unknown, "{call}");
+        }
+    }
+
+    #[test]
+    fn untracked_pop_statement_discards_remaining_positions() {
+        let env = eval_body(
+            r"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    bits.pop(2)
+    following = bits[1]
+",
+        );
+        assert_eq!(env.get("bits"), &AbstractValue::Unknown);
+        assert_eq!(env.get("following"), &AbstractValue::Unknown);
     }
 
     #[test]
@@ -911,7 +965,8 @@ def do_tag(parser, token):
         );
         let opts = rule.known_options.expect("should have known_options");
         assert_eq!(opts.values, vec!["with".to_string(), "only".to_string()]);
-        assert!(opts.allow_duplicates);
+        assert_eq!(opts.duplicate_rejection, OptionRejection::NotDetected);
+        assert_eq!(opts.unknown_rejection, OptionRejection::Detected);
     }
 
     // Corpus: do_translate in i18n.py — option loop with `seen = set()`
@@ -926,7 +981,8 @@ def do_tag(parser, token):
             opts.values,
             vec!["noop".to_string(), "context".to_string(), "as".to_string()]
         );
-        assert!(!opts.allow_duplicates);
+        assert_eq!(opts.duplicate_rejection, OptionRejection::Detected);
+        assert_eq!(opts.unknown_rejection, OptionRejection::Detected);
     }
 
     // Corpus: do_include in loader_tags.py — option loop with dict-based
@@ -938,7 +994,73 @@ def do_tag(parser, token):
         let rule = analyze_func(&func);
         let opts = rule.known_options.expect("should have known_options");
         assert_eq!(opts.values, vec!["with".to_string(), "only".to_string()]);
-        assert!(!opts.allow_duplicates);
+        assert_eq!(opts.duplicate_rejection, OptionRejection::Detected);
+        assert_eq!(opts.unknown_rejection, OptionRejection::Detected);
+    }
+
+    #[test]
+    fn option_loop_without_rejection_guards() {
+        let rule = analyze(
+            r#"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    remaining = bits[1:]
+    while remaining:
+        option = remaining.pop(0)
+        if option == "noescape":
+            pass
+        elif option == "trimmed":
+            pass
+"#,
+        );
+        let opts = rule.known_options.expect("should have known_options");
+        assert_eq!(opts.values, vec!["noescape", "trimmed"]);
+        assert_eq!(opts.duplicate_rejection, OptionRejection::NotDetected);
+        assert_eq!(opts.unknown_rejection, OptionRejection::NotDetected);
+    }
+
+    #[test]
+    fn option_loop_membership_without_raise_is_not_duplicate_rejection() {
+        let rule = analyze(
+            r#"
+def do_tag(parser, token):
+    remaining = token.split_contents()[1:]
+    seen = set()
+    while remaining:
+        option = remaining.pop(0)
+        if option in seen:
+            continue
+        if option == "only":
+            seen.add(option)
+"#,
+        );
+        let opts = rule.known_options.expect("should have known_options");
+        assert_eq!(opts.values, vec!["only"]);
+        assert_eq!(opts.duplicate_rejection, OptionRejection::NotDetected);
+        assert_eq!(opts.unknown_rejection, OptionRejection::NotDetected);
+    }
+
+    #[test]
+    fn option_loop_duplicate_rejection_does_not_imply_unknown_rejection() {
+        let rule = analyze(
+            r#"
+def do_tag(parser, token):
+    remaining = token.split_contents()[1:]
+    seen = set()
+    while remaining:
+        option = remaining.pop(0)
+        if option in seen:
+            raise TemplateSyntaxError("duplicate option")
+        if option == "only":
+            seen.add(option)
+        else:
+            continue
+"#,
+        );
+        let opts = rule.known_options.expect("should have known_options");
+        assert_eq!(opts.values, vec!["only"]);
+        assert_eq!(opts.duplicate_rejection, OptionRejection::Detected);
+        assert_eq!(opts.unknown_rejection, OptionRejection::NotDetected);
     }
 
     #[test]

--- a/crates/djls-project/src/templates/tags/types.rs
+++ b/crates/djls-project/src/templates/tags/types.rs
@@ -243,7 +243,6 @@ pub struct ChoiceAt {
 pub struct KnownOptions {
     pub values: Vec<String>,
     pub allow_duplicates: bool,
-    pub rejects_unknown: bool,
 }
 
 /// Block structure extracted from `parser.parse((...))` control flow patterns.

--- a/crates/djls-project/src/templates/tags/types.rs
+++ b/crates/djls-project/src/templates/tags/types.rs
@@ -242,7 +242,17 @@ pub struct ChoiceAt {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KnownOptions {
     pub values: Vec<String>,
-    pub allow_duplicates: bool,
+    pub duplicate_rejection: OptionRejection,
+    pub unknown_rejection: OptionRejection,
+}
+
+/// Whether extraction recognized a rejection guard in an option-parsing loop.
+/// Non-detection does not establish that the tag accepts the input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionRejection {
+    NotDetected,
+    Detected,
 }
 
 /// Block structure extracted from `parser.parse((...))` control flow patterns.

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__loader_tags.py.snap
@@ -57,7 +57,6 @@ tag_rules:
         - with
         - only
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__loader_tags.py.snap
@@ -56,7 +56,8 @@ tag_rules:
       values:
         - with
         - only
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
@@ -15,7 +15,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -30,7 +29,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -190,7 +188,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -218,7 +215,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
@@ -14,7 +14,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -28,7 +29,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -187,7 +189,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -214,7 +217,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
@@ -55,7 +55,6 @@ tag_rules:
         - with
         - only
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.template.loader_tags::tag::block":
@@ -54,7 +54,8 @@ tag_rules:
       values:
         - with
         - only
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -15,7 +15,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -30,7 +29,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -175,7 +173,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -202,7 +199,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: sorted_snapshot(&bundle)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.templatetags.i18n::tag::blocktrans":
@@ -14,7 +14,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -28,7 +29,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -172,7 +174,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -198,7 +201,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
@@ -55,7 +55,6 @@ tag_rules:
         - with
         - only
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.template.loader_tags::tag::block":
@@ -54,7 +54,8 @@ tag_rules:
       values:
         - with
         - only
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -15,7 +15,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -30,7 +29,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -175,7 +173,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -202,7 +199,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: sorted_snapshot(&bundle)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.templatetags.i18n::tag::blocktrans":
@@ -14,7 +14,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -28,7 +29,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -172,7 +174,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -198,7 +201,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
@@ -55,7 +55,6 @@ tag_rules:
         - with
         - only
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
@@ -54,7 +54,8 @@ tag_rules:
       values:
         - with
         - only
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
@@ -15,7 +15,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -30,7 +29,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -175,7 +173,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -202,7 +199,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
@@ -14,7 +14,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -28,7 +29,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::get_available_languages":
@@ -172,7 +174,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -198,7 +201,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
@@ -93,7 +93,6 @@ tag_rules:
         - with
         - include_context
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args:
       - name: arg1
         required: true

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
   "src.unfold.templatetags.unfold::tag::action_item_classes":
@@ -92,7 +92,8 @@ tag_rules:
       values:
         - with
         - include_context
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args:
       - name: arg1
         required: true

--- a/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
@@ -15,7 +15,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -30,7 +29,6 @@ tag_rules:
         - trimmed
         - asvar
       allow_duplicates: false
-      rejects_unknown: true
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::trans":
@@ -44,7 +42,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -71,7 +68,6 @@ tag_rules:
         - context
         - as
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/extraction.rs
-expression: sorted_snapshot(&result)
+expression: "sorted_snapshot(&result).expect(\"i18n extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.templatetags.i18n::tag::blocktrans":
@@ -14,7 +14,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::blocktranslate":
@@ -28,7 +29,8 @@ tag_rules:
         - context
         - trimmed
         - asvar
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     extracted_args: []
     as_var: keep
   "django.templatetags.i18n::tag::trans":
@@ -41,7 +43,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:
@@ -67,7 +70,8 @@ tag_rules:
         - noop
         - context
         - as
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
@@ -34,7 +34,6 @@ tag_rules:
         - with
         - only
       allow_duplicates: false
-      rejects_unknown: true
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/extraction.rs
-expression: sorted_snapshot(&result)
+expression: "sorted_snapshot(&result).expect(\"loader-tags extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.template.loader_tags::tag::block":
@@ -33,7 +33,8 @@ tag_rules:
       values:
         - with
         - only
-      allow_duplicates: false
+      duplicate_rejection: detected
+      unknown_rejection: detected
     diagnostic_messages:
       - constraint:
           ArgumentCount:

--- a/crates/djls-semantic/src/tags/rules.rs
+++ b/crates/djls-semantic/src/tags/rules.rs
@@ -24,18 +24,6 @@ trait Constraint {
     ) -> Option<ValidationError>;
 }
 
-/// Resolve a `SplitPosition` to a `bits` index.
-///
-/// Delegates to `SplitPosition::to_bits_index`, which handles the offset
-/// between `split_contents()` coordinates (tag name at index 0) and `bits`
-/// coordinates (arguments only, tag name excluded).
-///
-/// Returns `None` if the position is out of bounds or refers to the tag name
-/// — the argument count constraint should catch those cases.
-fn resolve_position_index(position: &SplitPosition, bits_len: usize) -> Option<usize> {
-    position.to_bits_index(bits_len)
-}
-
 /// Constraints express the conditions from Django source that raise exceptions
 /// in guard patterns. The extraction captures what makes the tag **valid**:
 /// - `Exact(N)`: valid when `split_len == N`
@@ -115,7 +103,7 @@ impl Constraint for RequiredKeyword {
         span: Span,
         message: Option<String>,
     ) -> Option<ValidationError> {
-        let bits_index = resolve_position_index(&self.position, bits.len())?;
+        let bits_index = self.position.to_bits_index(bits.len())?;
         let bit = bits.get(bits_index)?;
 
         if bit == &self.value {
@@ -144,7 +132,7 @@ impl Constraint for ChoiceAt {
         span: Span,
         message: Option<String>,
     ) -> Option<ValidationError> {
-        let bits_index = resolve_position_index(&self.position, bits.len())?;
+        let bits_index = self.position.to_bits_index(bits.len())?;
         let bit = bits.get(bits_index)?;
 
         if self.values.iter().any(|value| value == bit) {
@@ -235,8 +223,7 @@ pub(crate) fn evaluate_tag_rules(
                     // Pick the first as representative error, but phrase it
                     // as a choice to be clearer.
                     let values: Vec<&str> = keywords.iter().map(|kw| kw.value.as_str()).collect();
-                    let bits_index =
-                        resolve_position_index(&keywords[0].position, effective_bits.len());
+                    let bits_index = keywords[0].position.to_bits_index(effective_bits.len());
                     if bits_index.is_some() {
                         let choices = values.join("' or '");
                         errors.push(ValidationError::ExtractedRuleViolation {
@@ -408,9 +395,9 @@ fn python_repr(value: &str) -> String {
 
 /// Evaluate known options constraints.
 ///
-/// Scans `bits` for option-style arguments and validates them against the
-/// known set. Returns errors for unknown options (when `rejects_unknown`)
-/// and duplicate options (when `!allow_duplicates`).
+/// Scans `bits` for known option-style arguments and reports duplicates when
+/// the extracted rule disallows them. Unknown bits may be positional values,
+/// so they cannot be rejected without tag-specific parsing context.
 fn evaluate_known_options(
     tag_name: &str,
     bits: &[String],
@@ -433,9 +420,6 @@ fn evaluate_known_options(
             }
             seen.push(bit.clone());
         }
-        // NOTE: `rejects_unknown` is not enforced — distinguishing unknown
-        // options from positional values (e.g. `with key=val`) is unreliable
-        // without full tag-specific parsing context.
     }
 
     errors
@@ -448,16 +432,8 @@ mod tests {
 
     use super::*;
 
-    fn make_span() -> Span {
-        Span::new(0, 10)
-    }
-
     fn make_bits(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| (*s).to_string()).collect()
-    }
-
-    fn empty_rule() -> TagRule {
-        TagRule::default()
     }
 
     // --- ArgumentCountConstraint tests ---
@@ -466,11 +442,11 @@ mod tests {
     fn exact_constraint_passes_when_matched() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::Exact(4)],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // 3 bits + tag name = split_len 4
         let bits = make_bits(&["item", "in", "items"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -478,11 +454,11 @@ mod tests {
     fn exact_constraint_fails_when_wrong_count() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::Exact(4)],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // 2 bits + tag name = split_len 3, expected 4
         let bits = make_bits(&["item", "in"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -503,9 +479,9 @@ mod tests {
                     "'custom' tag takes one argument".to_string(),
                 ),
             }]),
-            ..empty_rule()
+            ..TagRule::default()
         };
-        let errors = evaluate_tag_rules("custom", &[], &rule, make_span());
+        let errors = evaluate_tag_rules("custom", &[], &rule, Span::new(0, 10));
         assert!(matches!(
             &errors[0],
             ValidationError::ExtractedRuleViolation { message, .. }
@@ -526,9 +502,9 @@ mod tests {
                     args: vec![ExtractedMessageArg::SplitElement(SplitPosition::Forward(0))],
                 },
             }]),
-            ..empty_rule()
+            ..TagRule::default()
         };
-        let errors = evaluate_tag_rules("custom", &[], &rule, make_span());
+        let errors = evaluate_tag_rules("custom", &[], &rule, Span::new(0, 10));
         assert!(matches!(
             &errors[0],
             ValidationError::ExtractedRuleViolation { message, .. }
@@ -540,10 +516,10 @@ mod tests {
     fn min_constraint_passes_when_sufficient() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::Min(2)],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["arg1", "arg2"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -551,10 +527,10 @@ mod tests {
     fn min_constraint_fails_when_too_few() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::Min(4)],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["arg1"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -567,10 +543,10 @@ mod tests {
     fn max_constraint_passes_when_under() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::Max(5)],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["a", "b", "c"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -578,11 +554,11 @@ mod tests {
     fn max_constraint_fails_when_over() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::Max(3)],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["a", "b", "c"]);
         // split_len = 4, max = 3
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -595,11 +571,11 @@ mod tests {
     fn one_of_constraint_passes_when_in_set() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::OneOf(vec![2, 4, 6])],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // split_len = 4 (3 bits + tag name)
         let bits = make_bits(&["a", "b", "c"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -607,11 +583,11 @@ mod tests {
     fn one_of_constraint_fails_when_not_in_set() {
         let rule = TagRule {
             arg_constraints: vec![ArgumentCountConstraint::OneOf(vec![2, 4])],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // split_len = 3 (2 bits + tag name), not in {2, 4}
         let bits = make_bits(&["a", "b"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -629,11 +605,11 @@ mod tests {
                 position: SplitPosition::Forward(2),
                 value: "in".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // bits[1] (position 2 in split_contents - 1) = "in"
         let bits = make_bits(&["item", "in", "items"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -644,10 +620,10 @@ mod tests {
                 position: SplitPosition::Forward(2),
                 value: "in".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["item", "from", "items"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -663,12 +639,12 @@ mod tests {
                 position: SplitPosition::Backward(2),
                 value: "as".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // bits = ["'view_name'", "arg1", "as", "varname"]
         // bits[-2] = "as"
         let bits = make_bits(&["'view_name'", "arg1", "as", "varname"]);
-        let errors = evaluate_tag_rules("url", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("url", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -679,10 +655,10 @@ mod tests {
                 position: SplitPosition::Backward(2),
                 value: "as".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["'view_name'", "arg1", "with", "varname"]);
-        let errors = evaluate_tag_rules("url", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("url", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
     }
 
@@ -693,10 +669,10 @@ mod tests {
                 position: SplitPosition::Forward(5),
                 value: "in".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["item"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty(), "Out-of-bounds keyword should be skipped");
     }
 
@@ -707,10 +683,10 @@ mod tests {
                 position: SplitPosition::Forward(0),
                 value: "for".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["item", "in", "items"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty(), "Position 0 (tag name) should be skipped");
     }
 
@@ -722,12 +698,11 @@ mod tests {
             known_options: Some(KnownOptions {
                 values: vec!["only".to_string(), "with".to_string()],
                 allow_duplicates: false,
-                rejects_unknown: false,
             }),
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["'template.html'", "with", "x=1", "with", "y=2"]);
-        let errors = evaluate_tag_rules("include", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("include", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -742,12 +717,11 @@ mod tests {
             known_options: Some(KnownOptions {
                 values: vec!["only".to_string(), "with".to_string()],
                 allow_duplicates: true,
-                rejects_unknown: false,
             }),
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["'template.html'", "with", "x=1", "with", "y=2"]);
-        let errors = evaluate_tag_rules("include", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("include", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -755,9 +729,9 @@ mod tests {
 
     #[test]
     fn empty_rules_no_errors() {
-        let rule = empty_rule();
+        let rule = TagRule::default();
         let bits = make_bits(&["anything", "goes", "here"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -777,7 +751,7 @@ mod tests {
         // split_len = 5 (4 bits + tag name), satisfies Min(4) and Max(6)
         // bits[1] = "in", satisfies keyword
         let bits = make_bits(&["item", "in", "items", "reversed"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -793,7 +767,7 @@ mod tests {
         };
         // split_len = 3, fails Min(4); bits[1] = "from", fails keyword
         let bits = make_bits(&["item", "from"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 2);
     }
 
@@ -805,14 +779,14 @@ mod tests {
                 position: SplitPosition::Forward(2),
                 value: "in".to_string(),
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
 
         // {% for item in items %} → bits = ["item", "in", "items"]
         // split_contents = ["for", "item", "in", "items"]
         // position 2 in split_contents = "in" = bits[1] ✓
         let bits = make_bits(&["item", "in", "items"]);
-        let errors = evaluate_tag_rules("for", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("for", &bits, &rule, Span::new(0, 10));
         assert!(
             errors.is_empty(),
             "Position 2 in split_contents should map to bits[1]"
@@ -834,7 +808,7 @@ mod tests {
         };
         // {% user_display user as foo %} → bits = ["user", "as", "foo"]
         let bits = make_bits(&["user", "as", "foo"]);
-        let errors = evaluate_tag_rules("user_display", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("user_display", &bits, &rule, Span::new(0, 10));
         assert!(
             errors.is_empty(),
             "simple_tag with `as varname` should pass: {errors:?}"
@@ -851,7 +825,7 @@ mod tests {
         };
         // {% get_providers as providers %} → bits = ["as", "providers"]
         let bits = make_bits(&["as", "providers"]);
-        let errors = evaluate_tag_rules("get_providers", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("get_providers", &bits, &rule, Span::new(0, 10));
         assert!(
             errors.is_empty(),
             "simple_tag with 0 params + `as varname` should pass: {errors:?}"
@@ -868,7 +842,7 @@ mod tests {
         };
         // {% user_display user %} → bits = ["user"]
         let bits = make_bits(&["user"]);
-        let errors = evaluate_tag_rules("user_display", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("user_display", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty(), "Normal usage should pass: {errors:?}");
     }
 
@@ -882,7 +856,7 @@ mod tests {
         };
         // {% user_display user extra %} → bits = ["user", "extra"]
         let bits = make_bits(&["user", "extra"]);
-        let errors = evaluate_tag_rules("user_display", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("user_display", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1, "Extra args without `as` should still fail");
     }
 
@@ -896,7 +870,7 @@ mod tests {
         };
         // bits = ["user", "as", "foo"] → split_len=4, Max(2) fails
         let bits = make_bits(&["user", "as", "foo"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert_eq!(
             errors.len(),
             1,
@@ -913,10 +887,10 @@ mod tests {
                 position: SplitPosition::Forward(1),
                 values: vec!["on".to_string(), "off".to_string()],
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["on"]);
-        let errors = evaluate_tag_rules("autoescape", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("autoescape", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -927,10 +901,10 @@ mod tests {
                 position: SplitPosition::Forward(1),
                 values: vec!["on".to_string(), "off".to_string()],
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["unknown"]);
-        let errors = evaluate_tag_rules("autoescape", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("autoescape", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             &errors[0],
@@ -946,11 +920,11 @@ mod tests {
                 position: SplitPosition::Backward(1),
                 values: vec!["yes".to_string(), "no".to_string()],
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // bits[-1] = "yes"
         let bits = make_bits(&["something", "yes"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -961,10 +935,10 @@ mod tests {
                 position: SplitPosition::Forward(5),
                 values: vec!["a".to_string()],
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         let bits = make_bits(&["x"]);
-        let errors = evaluate_tag_rules("mytag", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("mytag", &bits, &rule, Span::new(0, 10));
         assert!(errors.is_empty());
     }
 
@@ -976,11 +950,11 @@ mod tests {
                 position: SplitPosition::Forward(1),
                 values: vec!["on".to_string(), "off".to_string()],
             }],
-            ..empty_rule()
+            ..TagRule::default()
         };
         // Correct count, wrong value
         let bits = make_bits(&["bad"]);
-        let errors = evaluate_tag_rules("autoescape", &bits, &rule, make_span());
+        let errors = evaluate_tag_rules("autoescape", &bits, &rule, Span::new(0, 10));
         assert_eq!(errors.len(), 1); // Only choice violation, count is correct
         assert!(matches!(
             &errors[0],

--- a/crates/djls-semantic/src/tags/rules.rs
+++ b/crates/djls-semantic/src/tags/rules.rs
@@ -7,6 +7,7 @@ use djls_project::ExtractedDiagnosticMessage;
 use djls_project::ExtractedMessageArg;
 use djls_project::ExtractedMessageTemplate;
 use djls_project::KnownOptions;
+use djls_project::OptionRejection;
 use djls_project::RequiredKeyword;
 use djls_project::SplitPosition;
 use djls_project::TagRule;
@@ -395,15 +396,20 @@ fn python_repr(value: &str) -> String {
 
 /// Evaluate known options constraints.
 ///
-/// Scans `bits` for known option-style arguments and reports duplicates when
-/// the extracted rule disallows them. Unknown bits may be positional values,
-/// so they cannot be rejected without tag-specific parsing context.
+/// Scans `bits` for duplicates when extraction detected a rejection guard.
+/// Unknown-option rejection remains a source fact: unknown bits may be
+/// positional values, so validation needs tag-specific parsing context to use it.
 fn evaluate_known_options(
     tag_name: &str,
     bits: &[String],
     options: &KnownOptions,
     span: Span,
 ) -> Vec<ValidationError> {
+    match options.duplicate_rejection {
+        OptionRejection::NotDetected => return Vec::new(),
+        OptionRejection::Detected => {}
+    }
+
     let mut errors = Vec::new();
     let mut seen = Vec::new();
 
@@ -411,7 +417,7 @@ fn evaluate_known_options(
         let is_known = options.values.iter().any(|v| v == bit);
 
         if is_known {
-            if !options.allow_duplicates && seen.contains(bit) {
+            if seen.contains(bit) {
                 errors.push(ValidationError::ExtractedRuleViolation {
                     tag: tag_name.to_string(),
                     message: format!("Tag '{tag_name}' received duplicate option '{bit}'"),
@@ -697,7 +703,8 @@ mod tests {
         let rule = TagRule {
             known_options: Some(KnownOptions {
                 values: vec!["only".to_string(), "with".to_string()],
-                allow_duplicates: false,
+                duplicate_rejection: OptionRejection::Detected,
+                unknown_rejection: OptionRejection::Detected,
             }),
             ..TagRule::default()
         };
@@ -712,11 +719,12 @@ mod tests {
     }
 
     #[test]
-    fn known_options_duplicates_allowed() {
+    fn known_options_without_duplicate_rejection_produce_no_error() {
         let rule = TagRule {
             known_options: Some(KnownOptions {
                 values: vec!["only".to_string(), "with".to_string()],
-                allow_duplicates: true,
+                duplicate_rejection: OptionRejection::NotDetected,
+                unknown_rejection: OptionRejection::Detected,
             }),
             ..TagRule::default()
         };


### PR DESCRIPTION
## Changes

Replace the option booleans with explicit extraction evidence. KnownOptions now keeps duplicate_rejection and unknown_rejection, each an OptionRejection::Detected or NotDetected. Non-detection does not claim acceptance. Restore the unknown-option fact and the permissive-loop test removed by the first version of this PR.

A duplicate rejection guard now requires a direct raise in the membership-check body. A membership check used to ignore or otherwise handle duplicates no longer creates a duplicate diagnostic. These remain bounded source-pattern recognizers, not a proof of arbitrary Python control flow.

Keep unknown-option rejection as a source fact without enforcing it in the generic validator: unknown tokens can be positional arguments or option values. The semantic consumer matches duplicate rejection explicitly.

Replace PopInfo.from_front with PopPosition::{Front, Back, Untracked}, shared by return-value evaluation and mutation. Track pop(0), pop(-0), pop(), and pop(-1). Other indices, dynamic indices, and unsupported call shapes discard sequence precision instead of being mistaken for back pops.

Retain the small structural cleanups: one option-check function instead of a single-use visitor object, direct SplitPosition::to_bits_index calls, and explicit constructors in rule tests. Public configuration options and argument/closing-tag requiredness are unchanged.

## Trace findings kept outside this PR

- Block extraction opacity is evidence, while semantic opacity is parser policy. Missing skip_past evidence can overwrite builtin verbatim opacity. Recorded separately for a focused fusion fix.
- Requiredness and argument kind are mostly independent. The more substantial problem is manual extraction flattening alternate forms, such as widthratio, into arguments all marked required. Recorded separately rather than mechanically replacing required booleans.

## Validation

- 128 tag-analysis unit tests, 32 semantic rule tests, 89 extraction tests, and the locked-corpus snapshot test passed.
- Regenerated active snapshots with insta and migrated the two archived Django 4.2 snapshots. Programmatically compared all 26 option records against the pre-removal PR base: both facts preserved under the enum schema, with no other snapshot body changes. Insta also refreshed stale expression metadata.
- just test and just e2e (44 tests) passed on the revised PR.
- Formatting, Clippy, all-target/all-feature check, and pre-commit checks passed on the revision and rebased stack tip.
- Hawk remains for CI. The full Python/Django matrix was not rerun for this revision.

Fifth PR in stack #856. The revision is a follow-up commit; #855 is rebased onto it.