### PR TITLE
Remove single-choice formatter selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Removed
 
+- Removed the `format.backend` configuration option; `djangofmt` remains the formatter.
 - Removed the unused `debug` configuration option.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,6 @@ version = "0.0.0"
 dependencies = [
  "camino",
  "djangofmt",
- "djls-conf",
  "djls-source",
  "thiserror 2.0.20",
 ]

--- a/crates/djls-conf/src/format.rs
+++ b/crates/djls-conf/src/format.rs
@@ -1,20 +1,9 @@
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Default, PartialEq, Eq, Clone)]
 pub struct FormatConfig {
-    #[serde(default = "default_enabled")]
-    enabled: bool,
     #[serde(default)]
-    backend: FormatBackend,
-}
-
-impl Default for FormatConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            backend: FormatBackend::Djangofmt,
-        }
-    }
+    enabled: bool,
 }
 
 impl FormatConfig {
@@ -22,20 +11,4 @@ impl FormatConfig {
     pub fn enabled(&self) -> bool {
         self.enabled
     }
-
-    #[must_use]
-    pub fn backend(&self) -> FormatBackend {
-        self.backend
-    }
-}
-
-#[derive(Debug, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "kebab-case")]
-pub enum FormatBackend {
-    #[default]
-    Djangofmt,
-}
-
-fn default_enabled() -> bool {
-    false
 }

--- a/crates/djls-conf/src/lib.rs
+++ b/crates/djls-conf/src/lib.rs
@@ -22,7 +22,6 @@ use thiserror::Error;
 pub use crate::diagnostics::DiagnosticSeverity;
 pub use crate::diagnostics::DiagnosticsConfig;
 pub use crate::django_environments::DjangoEnvironmentConfig;
-pub use crate::format::FormatBackend;
 pub use crate::format::FormatConfig;
 pub use crate::tagspecs::ArgKindDef;
 pub use crate::tagspecs::ArgTypeDef;
@@ -410,11 +409,10 @@ django_settings_module = "override.settings"
             let dir = tempdir().expect("test should create temporary project directory");
             fs::write(
                 dir.path().join("djls.toml"),
-                r#"
+                r"
 [format]
 enabled = true
-backend = "djangofmt"
-"#,
+",
             )
             .expect("test should write format djls.toml fixture");
             let project_root = Utf8Path::from_path(dir.path())
@@ -423,7 +421,6 @@ backend = "djangofmt"
                 .expect("format djls.toml fixture should load settings");
 
             assert!(settings.format().enabled());
-            assert_eq!(settings.format().backend(), FormatBackend::Djangofmt);
         }
 
         #[test]

--- a/crates/djls-format/Cargo.toml
+++ b/crates/djls-format/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 camino = { workspace = true }
-djls-conf = { workspace = true }
 djls-source = { workspace = true }
 djangofmt = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/djls-format/src/lib.rs
+++ b/crates/djls-format/src/lib.rs
@@ -3,7 +3,6 @@ mod djangofmt;
 use std::num::NonZeroU8;
 
 use camino::Utf8Path;
-use djls_conf::FormatBackend;
 use djls_source::LineEnding;
 use thiserror::Error;
 
@@ -170,12 +169,9 @@ pub enum FormatError {
 pub fn format_template(
     source: &str,
     path: &Utf8Path,
-    backend: FormatBackend,
     format_options: FormatOptions,
 ) -> Result<FormatOutcome, FormatError> {
-    let formatted = match backend {
-        FormatBackend::Djangofmt => djangofmt::format(source, path, format_options),
-    }?;
+    let formatted = djangofmt::format(source, path, format_options)?;
     let Some(formatted) = formatted else {
         return Ok(FormatOutcome::Ignored);
     };
@@ -288,7 +284,6 @@ mod tests {
             format_template(
                 source,
                 Utf8Path::new("template.html"),
-                FormatBackend::Djangofmt,
                 FormatOptions::default(),
             )
             .expect("valid template should format successfully"),
@@ -307,7 +302,6 @@ mod tests {
             format_template(
                 source,
                 Utf8Path::new("template.html"),
-                FormatBackend::Djangofmt,
                 FormatOptions::default(),
             )
             .expect("already formatted template should be accepted"),
@@ -323,7 +317,6 @@ mod tests {
             format_template(
                 source,
                 Utf8Path::new("template.html"),
-                FormatBackend::Djangofmt,
                 FormatOptions::default(),
             )
             .expect("ignored template should be recognized"),

--- a/crates/djls-ide/src/formatting.rs
+++ b/crates/djls-ide/src/formatting.rs
@@ -1,4 +1,3 @@
-use djls_conf::FormatBackend;
 use djls_format::FormatOptions;
 use djls_format::FormatOutcome;
 use djls_format::IndentStyle;
@@ -13,7 +12,6 @@ pub fn format_document(
     db: &dyn Db,
     file: File,
     encoding: PositionEncoding,
-    backend: FormatBackend,
     formatting_options: &ls_types::FormattingOptions,
 ) -> Vec<ls_types::TextEdit> {
     let Ok(source) = file.try_source(db) else {
@@ -34,15 +32,14 @@ pub fn format_document(
         .insert_final_newline(formatting_options.insert_final_newline.unwrap_or(false))
         .trim_final_newlines(formatting_options.trim_final_newlines.unwrap_or(false));
 
-    let formatted =
-        match djls_format::format_template(source.as_str(), path, backend, format_options) {
-            Ok(FormatOutcome::Changed(formatted)) => formatted,
-            Ok(FormatOutcome::Unchanged | FormatOutcome::Ignored) => return Vec::new(),
-            Err(error) => {
-                tracing::debug!("Formatting failed for {path}: {error}");
-                return Vec::new();
-            }
-        };
+    let formatted = match djls_format::format_template(source.as_str(), path, format_options) {
+        Ok(FormatOutcome::Changed(formatted)) => formatted,
+        Ok(FormatOutcome::Unchanged | FormatOutcome::Ignored) => return Vec::new(),
+        Err(error) => {
+            tracing::debug!("Formatting failed for {path}: {error}");
+            return Vec::new();
+        }
+    };
 
     let (line, character) = file.end_line_col(db, encoding).into();
     vec![ls_types::TextEdit::new(

--- a/crates/djls-ide/tests/formatting.rs
+++ b/crates/djls-ide/tests/formatting.rs
@@ -1,5 +1,4 @@
 use camino::Utf8Path;
-use djls_conf::FormatBackend;
 use djls_ide::format_document;
 use djls_source::PositionEncoding;
 use djls_testing::TestDatabase;
@@ -24,13 +23,7 @@ fn format_document_returns_full_document_edit() {
         .expect("template fixture file should exist");
     let options = formatting_options();
 
-    let edits = format_document(
-        &db,
-        file,
-        PositionEncoding::Utf16,
-        FormatBackend::Djangofmt,
-        &options,
-    );
+    let edits = format_document(&db, file, PositionEncoding::Utf16, &options);
 
     assert_eq!(edits.len(), 1);
     assert_eq!(

--- a/crates/djls-server/src/server.rs
+++ b/crates/djls-server/src/server.rs
@@ -678,9 +678,8 @@ impl LanguageServer for DjangoLanguageServer {
                     return Vec::new();
                 };
                 let db = snapshot.db();
-                let format_config = db.settings().format().clone();
 
-                if !format_config.enabled() {
+                if !db.settings().format().enabled() {
                     return Vec::new();
                 }
 
@@ -695,7 +694,6 @@ impl LanguageServer for DjangoLanguageServer {
                     db,
                     file,
                     snapshot.client_info().position_encoding(),
-                    format_config.backend(),
                     &params.options,
                 )
             })

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -95,13 +95,11 @@ Configure Django template formatting. Formatting is disabled by default and must
 ```toml
 [format]
 enabled = true
-backend = "djangofmt"
 ```
 
 **Options:**
 
 - `enabled` — Enable LSP whole-document formatting for Django templates. Default: `false`.
-- `backend` — Formatter backend. Currently supported: `"djangofmt"`. Default: `"djangofmt"`.
 
 When enabled, editor "format document" requests are handled by `djangofmt`. DJLS passes through standard editor formatting options when the client provides them, including tab width, spaces vs tabs, trailing whitespace trimming, final newline insertion, and final newline trimming.
 
@@ -287,8 +285,7 @@ Pass configuration through your editor's LSP client using `initializationOptions
   "pythonpath": ["/path/to/shared/libs"],
   "env_file": ".env",
   "format": {
-    "enabled": true,
-    "backend": "djangofmt"
+    "enabled": true
   },
   "diagnostics": {
     "severity": {
@@ -318,7 +315,6 @@ env_file = ".env"  # Optional: path to env file (auto-detects .env by default)
 
 [tool.djls.format]
 enabled = true
-backend = "djangofmt"
 
 [tool.djls.diagnostics.severity]
 S100 = "off"


### PR DESCRIPTION
## Changes

Remove the one-variant FormatBackend enum, the documented format.backend option, and the parameter passed through server, IDE, and formatter layers. Remove the formatter crate’s resulting unused configuration dependency.

Formatting remains disabled by default and uses djangofmt when enabled. Keep the formatter adapter, typed outcomes, normalization, and editor formatting options unchanged. Update configuration examples and the changelog.

## Validation

Focused configuration (33), formatter (8), IDE formatting (1), and server (79) tests passed.

At this stack tip, all local gates passed:
- just testall: all 14 supported Python/Django combinations
- just e2e: 44 tests
- just fmt
- just clippy
- cargo check --all-targets --all-features
- just lint

Hawk was deliberately left to CI at the maintainer’s request.