### PR TITLE
Normalize glibc dispatch in CodSpeed simulations

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -51,6 +51,10 @@ jobs:
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8
+        env:
+          # Use the same glibc memcmp path on Intel and AMD simulation runners.
+          # https://codspeed.io/blog/why-glibc-faster-github-actions
+          GLIBC_TUNABLES: glibc.cpu.hwcaps=-AVX2
         with:
           mode: simulation
           run: cargo codspeed run -p djls-bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed duplicate names and excess inclusion-tag arguments producing invented Template Library definitions.
 - Fixed false duplicate-option diagnostics for tag parsers that check membership without raising an error.
 - Fixed tag-rule extraction using incorrect argument positions after unsupported `pop()` calls.
+- **Internal**: Normalized glibc string-comparison dispatch across Intel and AMD CodSpeed simulation runners.
 
 ## [6.1.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ valgrind --version  # should contain "codspeed"
 
 #### Usage
 
-The `just dev profile` command runs benchmarks under [valgrind-codspeed](https://github.com/CodSpeedHQ/valgrind-codspeed), the same callgrind fork used in CI. It produces deterministic per-function instruction counts with call trees, and automatically strips harness overhead.
+The `just dev profile` command runs benchmarks under [valgrind-codspeed](https://github.com/CodSpeedHQ/valgrind-codspeed), the same callgrind fork used in CI. It records per-function instruction counts with call trees, and automatically strips harness overhead.
 
 ```bash
 just dev profile <bench> [filter]


### PR DESCRIPTION
## Investigation

The resolve_relations report on #851 compares 481.2 µs on an Intel Xeon Platinum 8573C with 546.5 µs on an AMD EPYC 9V74. CodSpeed explicitly flags the different runtime environments. The Ubuntu image, Rust compiler, cargo-codspeed, and CodSpeed runner versions match.

The benchmark performs 100 repetitions of three model lookups, three forward-relation lookups, and three reverse-relation lookups. Graph construction and index warm-up happen outside measurement. Its hash maps use deterministic hashing. The PR removes an unused database method, not the measured lookup code.

Profiles point to CPU-dependent glibc string comparison. CodSpeed fixes simulated cache sizes but still exposes CPU features to glibc, which selects different memcmp implementations. [CodSpeed documents this issue and the workaround](https://codspeed.io/blog/why-glibc-faster-github-actions).

## Change

Set GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX2 on the simulation action so glibc selects the common SSE2 memcmp path. Leave all benchmark names, inputs, operations, and production code unchanged. Remove the unconditional claim of deterministic instruction counts from CONTRIBUTING.md.

This deliberately changes the benchmark runtime. Compare future results with a baseline that also uses this setting. A difference against the old unmasked baseline is not evidence of an application speedup or regression. This addresses glibc dispatch, not every possible source of variance.

## Validation

- Six local Callgrind runs of the same optimized binary, with fixed cache geometry: three native runs each recorded 687,220 benchmark instructions and used __memcmp_avx2_movbe; three masked runs each recorded 678,620 and used __memcmp_sse2. These demonstrate the dispatch change and local repeatability, not a reproduction of the exact CI percentage.
- Benchmark workload tests passed with the tunable set and the corpus required.
- just test and just e2e (44 tests) passed.
- just fmt, just clippy, cargo check --all-targets --all-features, and just lint passed.
- Hawk was left to CI.

Sixth PR in cleanup stack #856. Rebased directly onto #852 after withdrawing #853; formatter selection and format.backend remain unchanged.