### PR TITLE
Preserve block body policy when extraction is inconclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed duplicate names and excess inclusion-tag arguments producing invented Template Library definitions.
 - Fixed false duplicate-option diagnostics for tag parsers that check membership without raising an error.
 - Fixed tag-rule extraction using incorrect argument positions after unsupported `pop()` calls.
+- Fixed custom tags with mixed body-parser paths suppressing diagnostics and references for bodies Django still parses.
 - **Internal**: Normalized glibc string-comparison dispatch across Intel and AMD CodSpeed simulation runners.
 
 ## [6.1.0]

--- a/crates/djls-bench/src/snapshots/djls_bench__check__tests__check_workload_corpus_all.snap
+++ b/crates/djls-bench/src/snapshots/djls_bench__check__tests__check_workload_corpus_all.snap
@@ -9,24 +9,24 @@ input:
   sorted_records_sha256: 8ffe302b4b0d09aae1d18f434e1a468a2bf6d0947a48b36b9ea66a7b8a49b690
 output:
   check_parser_count: 0
-  check_validation_count: 19448
+  check_validation_count: 19443
   check_code_counts:
     S101: 1
     S108: 10384
-    S111: 4107
+    S111: 4102
     S120: 4956
-  per_file_checks_sha256: 40a2f378fbe97261bbe9d0528a30cfdbedc226e28914c01818456b0e207bffa2
+  per_file_checks_sha256: 40e6509b35b932160bc1fcb26b84fec27039a10a3711c5ecb9a6b5d7359174ea
   ide_eligible_file_count: 6214
-  ide_diagnostic_count: 19448
+  ide_diagnostic_count: 19443
   ide_code_counts:
     S101: 1
     S108: 10384
-    S111: 4107
+    S111: 4102
     S120: 4956
-  normalized_ide_diagnostics_sha256: ddef6fcdc534b86f9770f46e8bb4ffb59bc6a47897bddf41b05b60af4753e0e6
-  files_with_diagnostics: 3714
-  diagnostic_bearing_paths_sha256: 901f10dec884fad8ce8991475b6f9c627dbdac1dd749c255f618963f850eaf97
+  normalized_ide_diagnostics_sha256: 4c1eca09683529fa26d13d905c8a633f2d8cec7234e26b97de5b7d31ef0d1d5f
+  files_with_diagnostics: 3710
+  diagnostic_bearing_paths_sha256: a8a0f1bd52a6193912b93033f514f90b5c3206d83bd69d03c8ba34e145b942cd
   rendered:
-    item_count: 19448
-    total_bytes: 5180960
-    output_sha256: 1c08314ad1e274d0e069d8bb24e77f0b4c94e0421e7f4a2e5cbeb6b77006a8ae
+    item_count: 19443
+    total_bytes: 5179423
+    output_sha256: f4958c4894f7a5ca6878b4fa32b8f337b05dfab2b51796376bc3cb95d56f7c8a

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -1143,15 +1143,20 @@ mod tests {
         let mut specs = TagSpecs::default();
         specs.insert(
             "cache".to_string(),
-            TagSpec::new(Cow::Borrowed("test.tags"), None, Cow::Borrowed(&[]), false)
-                .with_arguments(vec![TagArgument {
-                    name: "fragment_name".to_string(),
-                    required: true,
-                    kind: TagArgumentKind::Choice(vec![
-                        "sidebar".to_string(),
-                        "site_header".to_string(),
-                    ]),
-                }]),
+            TagSpec::new(
+                Cow::Borrowed("test.tags"),
+                None,
+                Cow::Borrowed(&[]),
+                djls_semantic::BodyAnalysis::Analyze,
+            )
+            .with_arguments(vec![TagArgument {
+                name: "fragment_name".to_string(),
+                required: true,
+                kind: TagArgumentKind::Choice(vec![
+                    "sidebar".to_string(),
+                    "site_header".to_string(),
+                ]),
+            }]),
         );
         specs
     }
@@ -1164,7 +1169,7 @@ mod tests {
                 required: true,
             }),
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_arguments(vec![TagArgument {
             name: "name".to_string(),
@@ -1491,7 +1496,7 @@ mod tests {
                 Cow::Borrowed("django.templatetags.static"),
                 None,
                 Cow::Borrowed(&[]),
-                false,
+                djls_semantic::BodyAnalysis::Analyze,
             ),
         );
 

--- a/crates/djls-ide/src/snippets.rs
+++ b/crates/djls-ide/src/snippets.rs
@@ -182,7 +182,7 @@ mod tests {
                 required: true,
             }),
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_arguments(vec![make_var("name", true)]);
 
@@ -201,7 +201,7 @@ mod tests {
                 required: true,
             }),
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_arguments(vec![make_choice("mode", true, vec!["on", "off"])]);
 

--- a/crates/djls-ide/tests/completions.rs
+++ b/crates/djls-ide/tests/completions.rs
@@ -117,13 +117,17 @@ fn captured_closer_does_not_offer_colliding_standalone_arguments() {
     let mut specs = builtin_tag_specs();
     specs.insert(
         "endif".to_string(),
-        TagSpec::new("test.tags".into(), None, Cow::Borrowed(&[]), false).with_arguments(vec![
-            TagArgument {
-                name: "collision".to_string(),
-                kind: TagArgumentKind::Choice(vec!["standalone-choice".to_string()]),
-                required: true,
-            },
-        ]),
+        TagSpec::new(
+            "test.tags".into(),
+            None,
+            Cow::Borrowed(&[]),
+            djls_semantic::BodyAnalysis::Analyze,
+        )
+        .with_arguments(vec![TagArgument {
+            name: "collision".to_string(),
+            kind: TagArgumentKind::Choice(vec!["standalone-choice".to_string()]),
+            required: true,
+        }]),
     );
     let db = TestDatabase::new().with_projectless_tag_specs(specs);
 

--- a/crates/djls-project/src/lib.rs
+++ b/crates/djls-project/src/lib.rs
@@ -45,6 +45,7 @@ pub use templates::ArgumentCountConstraint;
 pub use templates::AsVar;
 pub use templates::BlockSpec;
 pub use templates::BlockSpecs;
+pub use templates::BodyAnalysisEvidence;
 pub use templates::ChoiceAt;
 pub use templates::EffectiveDefinitionLibrary;
 pub use templates::ExtractedDiagnosticConstraint;

--- a/crates/djls-project/src/templates.rs
+++ b/crates/djls-project/src/templates.rs
@@ -63,6 +63,7 @@ pub use tags::ArgumentCountConstraint;
 pub use tags::AsVar;
 pub use tags::BlockSpec;
 pub use tags::BlockSpecs;
+pub use tags::BodyAnalysisEvidence;
 pub use tags::ChoiceAt;
 pub use tags::ExtractedDiagnosticConstraint;
 pub use tags::ExtractedDiagnosticMessage;

--- a/crates/djls-project/src/templates/registrations.rs
+++ b/crates/djls-project/src/templates/registrations.rs
@@ -1399,7 +1399,7 @@ fn template_library_source_analysis<'db>(
                     BlockSpec {
                         end_tag,
                         intermediates: block_spec.intermediates,
-                        opaque: block_spec.opaque,
+                        body_analysis_evidence: block_spec.body_analysis_evidence,
                     },
                 );
             }

--- a/crates/djls-project/src/templates/tags.rs
+++ b/crates/djls-project/src/templates/tags.rs
@@ -26,6 +26,7 @@ pub use crate::templates::tags::types::ArgumentCountConstraint;
 pub use crate::templates::tags::types::AsVar;
 pub use crate::templates::tags::types::BlockSpec;
 pub use crate::templates::tags::types::BlockSpecs;
+pub use crate::templates::tags::types::BodyAnalysisEvidence;
 pub use crate::templates::tags::types::ChoiceAt;
 pub use crate::templates::tags::types::ExtractedDiagnosticConstraint;
 pub use crate::templates::tags::types::ExtractedDiagnosticMessage;

--- a/crates/djls-project/src/templates/tags/blocks.rs
+++ b/crates/djls-project/src/templates/tags/blocks.rs
@@ -10,6 +10,7 @@ use ruff_python_ast::StmtFunctionDef;
 
 use crate::ast::ExprExt;
 use crate::templates::tags::analysis::AbstractValue;
+use crate::templates::tags::types::BodyAnalysisEvidence;
 use crate::templates::tags::types::SplitPosition;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,7 +34,7 @@ impl EndTagEvidence {
 pub(crate) struct ExtractedBlockSpec {
     pub(crate) end_tag: EndTagEvidence,
     pub(crate) intermediates: Vec<String>,
-    pub(crate) opaque: bool,
+    pub(crate) body_analysis_evidence: BodyAnalysisEvidence,
 }
 
 pub(super) fn is_tag_name_value(value: &AbstractValue) -> bool {
@@ -52,9 +53,9 @@ pub(super) fn is_tag_name_value(value: &AbstractValue) -> bool {
 /// - If a stop-token leads to another `parser.parse()` call → intermediate
 /// - If a stop-token leads to return/node construction → terminal (end-tag)
 ///
-/// Also detects opaque blocks via `parser.skip_past(...)` patterns.
+/// Also records body-consumption evidence from `parser.skip_past(...)` patterns.
 ///
-/// Returns `None` when no block structure is detected or inference is ambiguous.
+/// Returns `None` when no block structure or body-consumption evidence is detected.
 #[must_use]
 pub(crate) fn extract_block_spec(func: &StmtFunctionDef) -> Option<ExtractedBlockSpec> {
     let parser_var = func
@@ -69,23 +70,50 @@ pub(crate) fn extract_block_spec(func: &StmtFunctionDef) -> Option<ExtractedBloc
         .get(1)
         .map(|p| p.parameter.name.to_string())?;
 
-    // Check for opaque block patterns first: parser.skip_past("endtag")
-    if let Some(spec) = opaque::detect(&func.body, &parser_var) {
-        return Some(spec);
-    }
+    let skip_past = opaque::detect(&func.body, &parser_var);
+    let parse_detected = parse_calls::is_detected(&func.body, &parser_var);
+    let parse_spec = parse_calls::detect(&func.body, &parser_var, &token_var)
+        .or_else(|| dynamic_end::detect(&func.body, &parser_var, &token_var));
+    let body_analysis_evidence = match (skip_past.is_some(), parse_detected) {
+        (false, _) => BodyAnalysisEvidence::NotDetected,
+        (true, false) => BodyAnalysisEvidence::SkipPast,
+        (true, true) => BodyAnalysisEvidence::Mixed,
+    };
 
-    // Try parser.parse((...)) calls with control flow classification
-    if let Some(spec) = parse_calls::detect(&func.body, &parser_var, &token_var) {
-        return Some(spec);
-    }
+    let mut spec = match (skip_past, parse_detected) {
+        (Some(skip_spec), true) => combine_mixed_structure(&skip_spec, parse_spec),
+        (Some(skip_spec), false) => skip_spec,
+        (None, _) => {
+            parse_spec.or_else(|| next_token::detect(&func.body, &parser_var, &token_var))?
+        }
+    };
+    spec.body_analysis_evidence = body_analysis_evidence;
+    Some(spec)
+}
 
-    // Try dynamic end-tag patterns: parser.parse((f"end{tag_name}",))
-    if let Some(spec) = dynamic_end::detect(&func.body, &parser_var, &token_var) {
-        return Some(spec);
-    }
+fn combine_mixed_structure(
+    skip_spec: &ExtractedBlockSpec,
+    parse_spec: Option<ExtractedBlockSpec>,
+) -> ExtractedBlockSpec {
+    let Some(parse_spec) = parse_spec else {
+        return ExtractedBlockSpec {
+            end_tag: EndTagEvidence::Unknown,
+            intermediates: Vec::new(),
+            body_analysis_evidence: BodyAnalysisEvidence::Mixed,
+        };
+    };
 
-    // Try parser.next_token() loop patterns (e.g., blocktrans/blocktranslate)
-    next_token::detect(&func.body, &parser_var, &token_var)
+    let end_tag = match (&skip_spec.end_tag, &parse_spec.end_tag) {
+        (EndTagEvidence::Literal(skip), EndTagEvidence::Literal(parse)) if skip == parse => {
+            EndTagEvidence::Literal(skip.clone())
+        }
+        _ => EndTagEvidence::Unknown,
+    };
+    ExtractedBlockSpec {
+        end_tag,
+        intermediates: parse_spec.intermediates,
+        body_analysis_evidence: BodyAnalysisEvidence::Mixed,
+    }
 }
 
 /// Check if an expression is the parser variable (or `self.parser`).
@@ -244,7 +272,10 @@ mod tests {
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag.as_literal(), Some("endverbatim"));
         assert!(spec.intermediates.is_empty());
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Corpus: do_if in defaulttags.py — parse(("elif", "else", "endif")) with while/if branches
@@ -256,7 +287,10 @@ mod tests {
         assert_eq!(spec.end_tag.as_literal(), Some("endif"));
         assert!(spec.intermediates.contains(&"elif".to_string()));
         assert!(spec.intermediates.contains(&"else".to_string()));
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Corpus: comment in defaulttags.py — skip_past("endcomment")
@@ -267,7 +301,151 @@ mod tests {
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag.as_literal(), Some("endcomment"));
         assert!(spec.intermediates.is_empty());
-        assert!(spec.opaque);
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::SkipPast);
+    }
+
+    #[test]
+    fn mixed_parse_and_skip_past_keeps_mixed_body_evidence() {
+        let source = r#"
+def mixed(parser, token):
+    if token.contents:
+        parser.skip_past("endmixed")
+    else:
+        parser.parse(("endmixed",))
+    return MixedNode()
+"#;
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain mixed parser evidence");
+
+        assert_eq!(spec.end_tag.as_literal(), Some("endmixed"));
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::Mixed);
+    }
+
+    #[test]
+    fn mixed_parse_and_skip_past_with_conflicting_closers_is_unknown() {
+        let source = r#"
+def mixed(parser, token):
+    if token.contents:
+        parser.skip_past("endskipped")
+    else:
+        parser.parse(("endparsed",))
+    return MixedNode()
+"#;
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain mixed parser evidence");
+
+        assert_eq!(spec.end_tag, EndTagEvidence::Unknown);
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::Mixed);
+    }
+
+    #[test]
+    fn mixed_parse_and_skip_past_with_unknown_closer_is_unknown() {
+        let source = r#"
+def mixed(parser, token):
+    if token.contents:
+        parser.skip_past(token.contents)
+    else:
+        parser.parse(("endmixed",))
+    return MixedNode()
+"#;
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain mixed parser evidence");
+
+        assert_eq!(spec.end_tag, EndTagEvidence::Unknown);
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::Mixed);
+    }
+
+    #[test]
+    fn mixed_parse_and_skip_past_preserves_parse_intermediates() {
+        let source = r#"
+def mixed(parser, token):
+    if token.contents:
+        parser.skip_past("endmixed")
+    else:
+        body = parser.parse(("otherwise", "endmixed"))
+        if parser.next_token().contents == "otherwise":
+            alternate = parser.parse(("endmixed",))
+    return MixedNode(body, alternate)
+"#;
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain mixed parser evidence");
+
+        assert_eq!(spec.end_tag.as_literal(), Some("endmixed"));
+        assert_eq!(spec.intermediates, vec!["otherwise".to_string()]);
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::Mixed);
+    }
+
+    #[test]
+    fn nested_and_annotated_parse_calls_are_mixed_evidence() {
+        for parse_statement in [
+            "body: NodeList = parser.parse((\"endmixed\",))",
+            "return MixedNode(parser.parse((\"endmixed\",)))",
+        ] {
+            let source = format!(
+                "def mixed(parser, token):\n    parser.skip_past(\"endmixed\")\n    {parse_statement}\n"
+            );
+            let func = parse_function(&source);
+            let spec = extract_block_spec(&func).expect("should retain mixed parser evidence");
+
+            assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::Mixed);
+        }
+    }
+
+    #[test]
+    fn parser_parse_default_arguments_are_mixed_evidence() {
+        let source = r#"
+def mixed(parser, token):
+    parser.skip_past("endmixed")
+    parser.parse()
+    return MixedNode()
+"#;
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain mixed parser evidence");
+
+        assert_eq!(spec.end_tag, EndTagEvidence::Unknown);
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::Mixed);
+    }
+
+    #[test]
+    fn parse_call_in_nested_function_is_not_mixed_evidence() {
+        let source = r#"
+def skipped(parser, token):
+    parser.skip_past("endskipped")
+    def helper():
+        parser.parse(("endskipped",))
+    return SkippedNode()
+"#;
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain skip evidence");
+
+        assert_eq!(spec.end_tag.as_literal(), Some("endskipped"));
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::SkipPast);
+    }
+
+    #[test]
+    fn skip_past_without_arguments_is_not_evidence() {
+        let source = r"
+def invalid(parser, token):
+    parser.skip_past()
+    return InvalidNode()
+";
+        let func = parse_function(source);
+
+        assert!(extract_block_spec(&func).is_none());
+    }
+
+    #[test]
+    fn skip_past_with_unknown_closer_keeps_positive_body_evidence() {
+        let source = r"
+def raw(parser, token):
+    parser.skip_past(token.contents)
+    return RawNode()
+";
+        let func = parse_function(source);
+        let spec = extract_block_spec(&func).expect("should retain skip evidence");
+
+        assert_eq!(spec.end_tag, EndTagEvidence::Unknown);
+        assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::SkipPast);
     }
 
     // Fabricated: tests non-conventional closer ("done" instead of "end*").
@@ -318,7 +496,10 @@ def do_block(parser, token):
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag, EndTagEvidence::SelfNamed);
         assert!(spec.intermediates.is_empty());
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Corpus: do_for in defaulttags.py — parse(("empty", "endfor")) then
@@ -330,7 +511,10 @@ def do_block(parser, token):
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag.as_literal(), Some("endfor"));
         assert_eq!(spec.intermediates, vec!["empty".to_string()]);
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Corpus: now in defaulttags.py — no parser.parse() or skip_past calls
@@ -380,7 +564,10 @@ def do_if(parser, token):
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag.as_literal(), Some("endblock"));
         assert!(spec.intermediates.is_empty());
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Corpus: spaceless in defaulttags.py — parse(("endspaceless",)) +
@@ -403,7 +590,10 @@ def do_if(parser, token):
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag, EndTagEvidence::SelfNamed);
         assert_eq!(spec.intermediates, vec!["plural".to_string()]);
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Fabricated: next_token loop with a static end-tag comparison.
@@ -428,7 +618,10 @@ def do_custom_block(parser, token):
         let spec = extract_block_spec(&func).expect("should extract block spec");
         assert_eq!(spec.end_tag.as_literal(), Some("endcustom"));
         assert!(spec.intermediates.is_empty());
-        assert!(!spec.opaque);
+        assert_eq!(
+            spec.body_analysis_evidence,
+            BodyAnalysisEvidence::NotDetected
+        );
     }
 
     // Fabricated: next_token loop with both an intermediate and a static end-tag.

--- a/crates/djls-project/src/templates/tags/blocks/dynamic_end.rs
+++ b/crates/djls-project/src/templates/tags/blocks/dynamic_end.rs
@@ -23,6 +23,7 @@ use crate::templates::tags::blocks::EndTagEvidence;
 use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::is_parser_receiver;
 use crate::templates::tags::blocks::is_tag_name_value;
+use crate::templates::tags::types::BodyAnalysisEvidence;
 
 /// Detect dynamic end-tag patterns: `parser.parse((f"end{tag_name}",))`.
 ///
@@ -40,7 +41,7 @@ pub(super) fn detect(
     Some(ExtractedBlockSpec {
         end_tag,
         intermediates: Vec::new(),
-        opaque: false,
+        body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
     })
 }
 

--- a/crates/djls-project/src/templates/tags/blocks/next_token.rs
+++ b/crates/djls-project/src/templates/tags/blocks/next_token.rs
@@ -13,6 +13,7 @@ use crate::templates::tags::blocks::EndTagEvidence;
 use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::dynamic_end;
 use crate::templates::tags::blocks::is_token_contents_expr;
+use crate::templates::tags::types::BodyAnalysisEvidence;
 
 /// Detect block structure from `parser.next_token()` loop patterns.
 ///
@@ -69,7 +70,7 @@ pub(super) fn detect(
     Some(ExtractedBlockSpec {
         end_tag,
         intermediates,
-        opaque: false,
+        body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
     })
 }
 

--- a/crates/djls-project/src/templates/tags/blocks/opaque.rs
+++ b/crates/djls-project/src/templates/tags/blocks/opaque.rs
@@ -12,22 +12,41 @@ use crate::ast::walk_stmts;
 use crate::templates::tags::blocks::EndTagEvidence;
 use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::is_parser_receiver;
+use crate::templates::tags::types::BodyAnalysisEvidence;
 
-/// Detect opaque block patterns: `parser.skip_past("endtag")`.
+#[derive(Debug)]
+enum SkipPastCall {
+    Literal(String),
+    Unknown,
+}
+
+/// Detect `parser.skip_past(...)` calls and any literal closer they establish.
 pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<ExtractedBlockSpec> {
     let skip_past_tokens = collect_skip_past_tokens(body, parser_var);
     if skip_past_tokens.is_empty() {
         return None;
     }
-    let end_tag = if skip_past_tokens.len() == 1 {
-        EndTagEvidence::Literal(skip_past_tokens[0].clone())
-    } else {
-        EndTagEvidence::Unknown
+
+    let mut literal_tokens = Vec::new();
+    let mut has_unknown = false;
+    for token in skip_past_tokens {
+        match token {
+            SkipPastCall::Literal(token) => {
+                if !literal_tokens.contains(&token) {
+                    literal_tokens.push(token);
+                }
+            }
+            SkipPastCall::Unknown => has_unknown = true,
+        }
+    }
+    let end_tag = match literal_tokens.as_slice() {
+        [token] if !has_unknown => EndTagEvidence::Literal(token.clone()),
+        _ => EndTagEvidence::Unknown,
     };
     Some(ExtractedBlockSpec {
         end_tag,
         intermediates: Vec::new(),
-        opaque: true,
+        body_analysis_evidence: BodyAnalysisEvidence::SkipPast,
     })
 }
 
@@ -35,7 +54,7 @@ pub(super) fn detect(body: &[Stmt], parser_var: &str) -> Option<ExtractedBlockSp
 ///
 /// Uses Ruff's statement visitor to avoid hand-written recursion across
 /// statement variants.
-fn collect_skip_past_tokens(body: &[Stmt], parser_var: &str) -> Vec<String> {
+fn collect_skip_past_tokens(body: &[Stmt], parser_var: &str) -> Vec<SkipPastCall> {
     let mut tokens = Vec::new();
     walk_stmts(body, Recurse::WithinScope, |stmt| {
         let token = match stmt {
@@ -65,9 +84,7 @@ fn collect_skip_past_tokens(body: &[Stmt], parser_var: &str) -> Vec<String> {
             | Stmt::Continue(_)
             | Stmt::IpyEscapeCommand(_) => None,
         };
-        if let Some(token) = token
-            && !tokens.contains(&token)
-        {
+        if let Some(token) = token {
             tokens.push(token);
         }
         ControlFlow::Continue(())
@@ -76,7 +93,7 @@ fn collect_skip_past_tokens(body: &[Stmt], parser_var: &str) -> Vec<String> {
 }
 
 /// Check if an expression is `parser.skip_past("token")` and extract the token.
-fn extract_skip_past_token(expr: &Expr, parser_var: &str) -> Option<String> {
+fn extract_skip_past_token(expr: &Expr, parser_var: &str) -> Option<SkipPastCall> {
     let Expr::Call(ExprCall {
         func, arguments, ..
     }) = expr
@@ -95,8 +112,14 @@ fn extract_skip_past_token(expr: &Expr, parser_var: &str) -> Option<String> {
     if !is_parser_receiver(obj, parser_var) {
         return None;
     }
-    if arguments.args.is_empty() {
-        return None;
-    }
-    arguments.args[0].string_literal().map(str::to_string)
+    let argument = arguments
+        .args
+        .first()
+        .or_else(|| arguments.keywords.first().map(|keyword| &keyword.value))?;
+    Some(
+        argument
+            .string_literal()
+            .map(str::to_string)
+            .map_or(SkipPastCall::Unknown, SkipPastCall::Literal),
+    )
 }

--- a/crates/djls-project/src/templates/tags/blocks/parse_calls.rs
+++ b/crates/djls-project/src/templates/tags/blocks/parse_calls.rs
@@ -6,6 +6,8 @@ use ruff_python_ast::ExprCall;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
 use ruff_python_ast::StmtIf;
+use ruff_python_ast::visitor;
+use ruff_python_ast::visitor::Visitor;
 
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
@@ -15,6 +17,7 @@ use crate::templates::tags::blocks::ExtractedBlockSpec;
 use crate::templates::tags::blocks::extract_string_sequence;
 use crate::templates::tags::blocks::is_parser_receiver;
 use crate::templates::tags::blocks::is_token_contents_expr;
+use crate::templates::tags::types::BodyAnalysisEvidence;
 
 /// Detect block structure from `parser.parse((...))` calls with control flow analysis.
 ///
@@ -33,6 +36,46 @@ pub(super) fn detect(
     }
 
     classify_stop_tokens(body, parser_var, token_var, &parse_calls)
+}
+
+/// Return whether the body contains an observed `parser.parse(...)` call.
+pub(super) fn is_detected(body: &[Stmt], parser_var: &str) -> bool {
+    let mut visitor = ParseCallVisitor {
+        parser_var,
+        detected: false,
+    };
+    for statement in body {
+        visitor.visit_stmt(statement);
+        if visitor.detected {
+            break;
+        }
+    }
+    visitor.detected
+}
+
+struct ParseCallVisitor<'parser> {
+    parser_var: &'parser str,
+    detected: bool,
+}
+
+impl<'ast> Visitor<'ast> for ParseCallVisitor<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        if self.detected || matches!(stmt, Stmt::FunctionDef(_) | Stmt::ClassDef(_)) {
+            return;
+        }
+        visitor::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if self.detected || matches!(expr, Expr::Lambda(_)) {
+            return;
+        }
+        if is_parser_parse_call(expr, self.parser_var) {
+            self.detected = true;
+            return;
+        }
+        visitor::walk_expr(self, expr);
+    }
 }
 
 /// Information about a single `parser.parse((...))` call site.
@@ -87,22 +130,10 @@ fn collect_parser_parse_calls(body: &[Stmt], parser_var: &str) -> Vec<ParseCallI
 
 /// Check if an expression is a `parser.parse((...))` call and extract stop-tokens.
 fn extract_parse_call_info(expr: &Expr, parser_var: &str) -> Option<ParseCallInfo> {
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let Expr::Call(ExprCall { arguments, .. }) = expr else {
         return None;
     };
-    let Expr::Attribute(ExprAttribute {
-        attr, value: obj, ..
-    }) = func.as_ref()
-    else {
-        return None;
-    };
-    if attr.as_str() != "parse" {
-        return None;
-    }
-    if !is_parser_receiver(obj, parser_var) {
+    if !is_parser_parse_call(expr, parser_var) {
         return None;
     }
     if arguments.args.is_empty() {
@@ -115,6 +146,19 @@ fn extract_parse_call_info(expr: &Expr, parser_var: &str) -> Option<ParseCallInf
     }
 
     Some(ParseCallInfo { stop_tokens })
+}
+
+fn is_parser_parse_call(expr: &Expr, parser_var: &str) -> bool {
+    let Expr::Call(ExprCall { func, .. }) = expr else {
+        return false;
+    };
+    let Expr::Attribute(ExprAttribute {
+        attr, value: obj, ..
+    }) = func.as_ref()
+    else {
+        return false;
+    };
+    attr.as_str() == "parse" && is_parser_receiver(obj, parser_var)
 }
 
 /// Classify stop-tokens into end-tags and intermediates using control flow analysis.
@@ -201,7 +245,7 @@ fn classify_stop_tokens(
     Some(ExtractedBlockSpec {
         end_tag,
         intermediates,
-        opaque: false,
+        body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
     })
 }
 

--- a/crates/djls-project/src/templates/tags/types.rs
+++ b/crates/djls-project/src/templates/tags/types.rs
@@ -255,11 +255,27 @@ pub enum OptionRejection {
     Detected,
 }
 
-/// Block structure extracted from `parser.parse((...))` control flow patterns.
+/// Evidence about how a tag's compile function consumes its body.
 ///
-/// Describes the end-tag and intermediate tags for a block tag, inferred
-/// exclusively from `parser.parse()` call patterns and control flow — never
-/// from string prefix heuristics.
+/// This records source observations only. Template semantics decide whether the
+/// body should be analyzed after combining this evidence with builtin and
+/// configured fallback meaning.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BodyAnalysisEvidence {
+    /// No `parser.skip_past(...)` call was found.
+    #[default]
+    NotDetected,
+    /// `parser.skip_past(...)` was found without a `parser.parse(...)` call.
+    SkipPast,
+    /// Both `parser.skip_past(...)` and `parser.parse(...)` were found.
+    Mixed,
+}
+
+/// Block structure extracted from template parser calls.
+///
+/// Describes the end-tag and intermediate tags inferred from parser call
+/// patterns without deriving semantic body policy from absence of evidence.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlockSpec {
     /// The closing tag name (e.g., `"endfor"`), or `None` if inference was
@@ -268,9 +284,8 @@ pub struct BlockSpec {
     /// Intermediate tags that cause `parser.parse()` to stop and resume
     /// (e.g., `"else"`, `"elif"` for `{% if %}`).
     pub intermediates: Vec<String>,
-    /// Whether the block is opaque (content should not be parsed).
-    /// Detected from `parser.skip_past(...)` patterns.
-    pub opaque: bool,
+    /// Source evidence about whether the compile function skips or parses its body.
+    pub body_analysis_evidence: BodyAnalysisEvidence,
 }
 
 /// Argument structure extracted from a tag's registration.

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -1,5 +1,6 @@
 use camino::Utf8Path;
 use djls_project::ArgumentCountConstraint;
+use djls_project::BodyAnalysisEvidence;
 use djls_project::FilterArity;
 use djls_project::PythonModuleName;
 use djls_project::SymbolKey;
@@ -1820,9 +1821,7 @@ fn corpus_block_with_intermediates() {
     assert!(spec.intermediates.contains(&"else".to_string()));
 }
 
-// Corpus: `comment` in defaulttags.py — opaque block (skip_past).
-// Real `verbatim` actually uses parser.parse(), not skip_past — only
-// `comment` is truly opaque in defaulttags.py.
+// Corpus: `comment` in defaulttags.py uses skip_past.
 #[test]
 fn corpus_opaque_block() {
     let result = extract_source(DEFAULTTAGS_SOURCE, "django.template.defaulttags")
@@ -1830,22 +1829,22 @@ fn corpus_opaque_block() {
     let key = SymbolKey::tag("django.template.defaulttags", "comment");
     assert!(result.block_specs.as_map().contains_key(&key));
     let spec = &result.block_specs.as_map()[&key];
-    assert!(spec.opaque);
+    assert_eq!(spec.body_analysis_evidence, BodyAnalysisEvidence::SkipPast);
     assert_eq!(spec.end_tag.as_deref(), Some("endcomment"));
 }
 
-// Corpus: `verbatim` in defaulttags.py — uses parser.parse(), not
-// skip_past. No split_contents call (no argument validation).
+// Corpus: `verbatim` in defaulttags.py uses parser.parse(), so extraction
+// records no skip evidence. Semantic builtin policy still makes its body opaque.
 #[test]
-fn corpus_non_opaque_no_split_contents() {
+fn corpus_verbatim_has_no_skip_evidence() {
     let result = extract_source(DEFAULTTAGS_SOURCE, "django.template.defaulttags")
         .expect("non-opaque extraction fixture should build");
     let key = SymbolKey::tag("django.template.defaulttags", "verbatim");
     assert!(result.block_specs.as_map().contains_key(&key));
     let spec = &result.block_specs.as_map()[&key];
-    assert!(
-        !spec.opaque,
-        "real verbatim uses parser.parse(), not skip_past"
+    assert_eq!(
+        spec.body_analysis_evidence,
+        BodyAnalysisEvidence::NotDetected
     );
     assert_eq!(spec.end_tag.as_deref(), Some("endverbatim"));
 }
@@ -1915,7 +1914,10 @@ fn corpus_simple_block() {
     let spec = &result.block_specs.as_map()[&key];
     assert_eq!(spec.end_tag.as_deref(), Some("endblock"));
     assert!(spec.intermediates.is_empty());
-    assert!(!spec.opaque);
+    assert_eq!(
+        spec.body_analysis_evidence,
+        BodyAnalysisEvidence::NotDetected
+    );
 }
 
 // Corpus: `title` in defaultfilters.py — filter with no arg (value only).

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__defaulttags.py.snap
@@ -292,42 +292,42 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.defaulttags::tag::autoescape":
+    body_analysis_evidence: not_detected
     end_tag: endautoescape
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::comment":
+    body_analysis_evidence: skip_past
     end_tag: endcomment
     intermediates: []
-    opaque: true
   "django.template.defaulttags::tag::filter":
+    body_analysis_evidence: not_detected
     end_tag: endfilter
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::for":
+    body_analysis_evidence: not_detected
     end_tag: endfor
     intermediates:
       - empty
-    opaque: false
   "django.template.defaulttags::tag::if":
+    body_analysis_evidence: not_detected
     end_tag: endif
     intermediates:
       - elif
       - else
-    opaque: false
   "django.template.defaulttags::tag::ifchanged":
+    body_analysis_evidence: not_detected
     end_tag: endifchanged
     intermediates:
       - else
-    opaque: false
   "django.template.defaulttags::tag::spaceless":
+    body_analysis_evidence: not_detected
     end_tag: endspaceless
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::verbatim":
+    body_analysis_evidence: not_detected
     end_tag: endverbatim
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::with":
+    body_analysis_evidence: not_detected
     end_tag: endwith
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__template__loader_tags.py.snap
@@ -77,6 +77,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.loader_tags::tag::block":
+    body_analysis_evidence: not_detected
     end_tag: endblock
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__cache.py.snap
@@ -32,6 +32,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.cache::tag::cache":
+    body_analysis_evidence: not_detected
     end_tag: endcache
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__i18n.py.snap
@@ -242,16 +242,16 @@ filter_arities:
   "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
+    body_analysis_evidence: not_detected
     end_tag: endblocktrans
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
+    body_analysis_evidence: not_detected
     end_tag: endblocktranslate
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::language":
+    body_analysis_evidence: not_detected
     end_tag: endlanguage
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__l10n.py.snap
@@ -48,6 +48,6 @@ filter_arities:
   "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
+    body_analysis_evidence: not_detected
     end_tag: endlocalize
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__django__templatetags__tz.py.snap
@@ -91,10 +91,10 @@ filter_arities:
   "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
+    body_analysis_evidence: not_detected
     end_tag: endlocaltime
     intermediates: []
-    opaque: false
   "django.templatetags.tz::tag::timezone":
+    body_analysis_evidence: not_detected
     end_tag: endtimezone
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__tests__template_tests__templatetags__tag_27584.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-4.2__tests__template_tests__templatetags__tag_27584.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "tests.template_tests.templatetags.tag_27584::tag::badtag":
+    body_analysis_evidence: not_detected
     end_tag: endbadtag
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
@@ -280,42 +280,42 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.defaulttags::tag::autoescape":
+    body_analysis_evidence: not_detected
     end_tag: endautoescape
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::comment":
+    body_analysis_evidence: skip_past
     end_tag: endcomment
     intermediates: []
-    opaque: true
   "django.template.defaulttags::tag::filter":
+    body_analysis_evidence: not_detected
     end_tag: endfilter
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::for":
+    body_analysis_evidence: not_detected
     end_tag: endfor
     intermediates:
       - empty
-    opaque: false
   "django.template.defaulttags::tag::if":
+    body_analysis_evidence: not_detected
     end_tag: endif
     intermediates:
       - elif
       - else
-    opaque: false
   "django.template.defaulttags::tag::ifchanged":
+    body_analysis_evidence: not_detected
     end_tag: endifchanged
     intermediates:
       - else
-    opaque: false
   "django.template.defaulttags::tag::spaceless":
+    body_analysis_evidence: not_detected
     end_tag: endspaceless
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::verbatim":
+    body_analysis_evidence: not_detected
     end_tag: endverbatim
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::with":
+    body_analysis_evidence: not_detected
     end_tag: endwith
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__loader_tags.py.snap
@@ -74,6 +74,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.loader_tags::tag::block":
+    body_analysis_evidence: not_detected
     end_tag: endblock
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__cache.py.snap
@@ -30,6 +30,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.cache::tag::cache":
+    body_analysis_evidence: not_detected
     end_tag: endcache
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__i18n.py.snap
@@ -225,16 +225,16 @@ filter_arities:
   "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
+    body_analysis_evidence: not_detected
     end_tag: endblocktrans
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
+    body_analysis_evidence: not_detected
     end_tag: endblocktranslate
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::language":
+    body_analysis_evidence: not_detected
     end_tag: endlanguage
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__l10n.py.snap
@@ -47,6 +47,6 @@ filter_arities:
   "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
+    body_analysis_evidence: not_detected
     end_tag: endlocalize
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__templatetags__tz.py.snap
@@ -87,10 +87,10 @@ filter_arities:
   "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
+    body_analysis_evidence: not_detected
     end_tag: endlocaltime
     intermediates: []
-    opaque: false
   "django.templatetags.tz::tag::timezone":
+    body_analysis_evidence: not_detected
     end_tag: endtimezone
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__tag_27584.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__tag_27584.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "tests.template_tests.templatetags.tag_27584::tag::badtag":
+    body_analysis_evidence: not_detected
     end_tag: endbadtag
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
@@ -311,42 +311,42 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.defaulttags::tag::autoescape":
+    body_analysis_evidence: not_detected
     end_tag: endautoescape
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::comment":
+    body_analysis_evidence: skip_past
     end_tag: endcomment
     intermediates: []
-    opaque: true
   "django.template.defaulttags::tag::filter":
+    body_analysis_evidence: not_detected
     end_tag: endfilter
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::for":
+    body_analysis_evidence: not_detected
     end_tag: endfor
     intermediates:
       - empty
-    opaque: false
   "django.template.defaulttags::tag::if":
+    body_analysis_evidence: not_detected
     end_tag: endif
     intermediates:
       - elif
       - else
-    opaque: false
   "django.template.defaulttags::tag::ifchanged":
+    body_analysis_evidence: not_detected
     end_tag: endifchanged
     intermediates:
       - else
-    opaque: false
   "django.template.defaulttags::tag::spaceless":
+    body_analysis_evidence: not_detected
     end_tag: endspaceless
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::verbatim":
+    body_analysis_evidence: not_detected
     end_tag: endverbatim
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::with":
+    body_analysis_evidence: not_detected
     end_tag: endwith
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__loader_tags.py.snap
@@ -74,6 +74,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.loader_tags::tag::block":
+    body_analysis_evidence: not_detected
     end_tag: endblock
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__cache.py.snap
@@ -30,6 +30,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.cache::tag::cache":
+    body_analysis_evidence: not_detected
     end_tag: endcache
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__i18n.py.snap
@@ -225,16 +225,16 @@ filter_arities:
   "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
+    body_analysis_evidence: not_detected
     end_tag: endblocktrans
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
+    body_analysis_evidence: not_detected
     end_tag: endblocktranslate
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::language":
+    body_analysis_evidence: not_detected
     end_tag: endlanguage
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__l10n.py.snap
@@ -47,6 +47,6 @@ filter_arities:
   "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
+    body_analysis_evidence: not_detected
     end_tag: endlocalize
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__templatetags__tz.py.snap
@@ -87,10 +87,10 @@ filter_arities:
   "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
+    body_analysis_evidence: not_detected
     end_tag: endlocaltime
     intermediates: []
-    opaque: false
   "django.templatetags.tz::tag::timezone":
+    body_analysis_evidence: not_detected
     end_tag: endtimezone
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__tag_27584.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__tag_27584.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "tests.template_tests.templatetags.tag_27584::tag::badtag":
+    body_analysis_evidence: not_detected
     end_tag: endbadtag
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
@@ -322,42 +322,42 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.defaulttags::tag::autoescape":
+    body_analysis_evidence: not_detected
     end_tag: endautoescape
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::comment":
+    body_analysis_evidence: skip_past
     end_tag: endcomment
     intermediates: []
-    opaque: true
   "django.template.defaulttags::tag::filter":
+    body_analysis_evidence: not_detected
     end_tag: endfilter
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::for":
+    body_analysis_evidence: not_detected
     end_tag: endfor
     intermediates:
       - empty
-    opaque: false
   "django.template.defaulttags::tag::if":
+    body_analysis_evidence: not_detected
     end_tag: endif
     intermediates:
       - elif
       - else
-    opaque: false
   "django.template.defaulttags::tag::ifchanged":
+    body_analysis_evidence: not_detected
     end_tag: endifchanged
     intermediates:
       - else
-    opaque: false
   "django.template.defaulttags::tag::spaceless":
+    body_analysis_evidence: not_detected
     end_tag: endspaceless
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::verbatim":
+    body_analysis_evidence: not_detected
     end_tag: endverbatim
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::with":
+    body_analysis_evidence: not_detected
     end_tag: endwith
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__loader_tags.py.snap
@@ -74,6 +74,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.loader_tags::tag::block":
+    body_analysis_evidence: not_detected
     end_tag: endblock
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__cache.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__cache.py.snap
@@ -30,6 +30,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.cache::tag::cache":
+    body_analysis_evidence: not_detected
     end_tag: endcache
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__i18n.py.snap
@@ -225,16 +225,16 @@ filter_arities:
   "django.templatetags.i18n::filter::language_name_translated": no_argument
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
+    body_analysis_evidence: not_detected
     end_tag: endblocktrans
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
+    body_analysis_evidence: not_detected
     end_tag: endblocktranslate
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::language":
+    body_analysis_evidence: not_detected
     end_tag: endlanguage
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__l10n.py.snap
@@ -47,6 +47,6 @@ filter_arities:
   "django.templatetags.l10n::filter::unlocalize": no_argument
 block_specs:
   "django.templatetags.l10n::tag::localize":
+    body_analysis_evidence: not_detected
     end_tag: endlocalize
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__templatetags__tz.py.snap
@@ -87,10 +87,10 @@ filter_arities:
   "django.templatetags.tz::filter::utc": no_argument
 block_specs:
   "django.templatetags.tz::tag::localtime":
+    body_analysis_evidence: not_detected
     end_tag: endlocaltime
     intermediates: []
-    opaque: false
   "django.templatetags.tz::tag::timezone":
+    body_analysis_evidence: not_detected
     end_tag: endtimezone
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__tag_27584.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__tag_27584.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "tests.template_tests.templatetags.tag_27584::tag::badtag":
+    body_analysis_evidence: not_detected
     end_tag: endbadtag
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__templatetags__allauth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__templatetags__allauth.py.snap
@@ -17,14 +17,14 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "allauth.templatetags.allauth::tag::element":
+    body_analysis_evidence: not_detected
     end_tag: endelement
     intermediates: []
-    opaque: false
   "allauth.templatetags.allauth::tag::setvar":
+    body_analysis_evidence: not_detected
     end_tag: endsetvar
     intermediates: []
-    opaque: false
   "allauth.templatetags.allauth::tag::slot":
+    body_analysis_evidence: not_detected
     end_tag: endslot
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
@@ -197,6 +197,6 @@ filter_arities:
   "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_setting": no_argument
 block_specs:
   "src.bootstrap3.templatetags.bootstrap3::tag::buttons":
+    body_analysis_evidence: not_detected
     end_tag: endbuttons
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-compressor__compressor__templatetags__compress.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-compressor__compressor__templatetags__compress.py.snap
@@ -16,6 +16,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "compressor.templatetags.compress::tag::compress":
+    body_analysis_evidence: not_detected
     end_tag: endcompress
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_utils.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_utils.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "crispy_forms.templatetags.crispy_forms_utils::tag::specialspaceless":
+    body_analysis_evidence: not_detected
     end_tag: endspecialspaceless
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-fastdev__django_fastdev__templatetags__fastdev.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-fastdev__django_fastdev__templatetags__fastdev.py.snap
@@ -6,8 +6,8 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "django_fastdev.templatetags.fastdev::tag::ifexists":
+    body_analysis_evidence: not_detected
     end_tag: endifexists
     intermediates:
       - elifexists
       - else
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-markdownify__markdownify__templatetags__markdownify.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-markdownify__markdownify__templatetags__markdownify.py.snap
@@ -7,6 +7,6 @@ filter_arities:
   "markdownify.templatetags.markdownify::filter::markdownify": optional_argument
 block_specs:
   "markdownify.templatetags.markdownify::tag::markdownify":
+    body_analysis_evidence: not_detected
     end_tag: endmarkdownify
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
@@ -28,6 +28,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "src.oscar.templatetags.display_tags::tag::iffeature":
+    body_analysis_evidence: not_detected
     end_tag: endiffeature
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
@@ -273,10 +273,10 @@ filter_arities:
   "src.unfold.templatetags.unfold::filter::tabs_errors_count": no_argument
 block_specs:
   "src.unfold.templatetags.unfold::tag::capture":
+    body_analysis_evidence: not_detected
     end_tag: endcapture
     intermediates: []
-    opaque: false
   "src.unfold.templatetags.unfold::tag::component":
+    body_analysis_evidence: not_detected
     end_tag: endcomponent
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
@@ -41,6 +41,6 @@ filter_arities:
   "docs.templatetags.docs::filter::fragment": no_argument
 block_specs:
   "docs.templatetags.docs::tag::pygment":
+    body_analysis_evidence: not_detected
     end_tag: endpygment
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__asciitable.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__asciitable.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "hc.front.templatetags.asciitable::tag::table":
+    body_analysis_evidence: not_detected
     end_tag: endtable
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__linemode.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__linemode.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "hc.front.templatetags.linemode::tag::linemode":
+    body_analysis_evidence: not_detected
     end_tag: endlinemode
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
@@ -73,10 +73,10 @@ filter_arities:
   "horizon.templatetags.horizon::filter::quotainf": optional_argument
 block_specs:
   "horizon.templatetags.horizon::tag::jstemplate":
+    body_analysis_evidence: not_detected
     end_tag: endjstemplate
     intermediates: []
-    opaque: false
   "horizon.templatetags.horizon::tag::minifyspace":
+    body_analysis_evidence: not_detected
     end_tag: endminifyspace
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
@@ -59,10 +59,10 @@ filter_arities:
   "bookmarks.templatetags.shared::filter::remaining_chars": required_argument
 block_specs:
   "bookmarks.templatetags.shared::tag::formhelp":
+    body_analysis_evidence: not_detected
     end_tag: endformhelp
     intermediates: []
-    opaque: false
   "bookmarks.templatetags.shared::tag::htmlmin":
+    body_analysis_evidence: not_detected
     end_tag: endhtmlmin
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_capture.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_capture.py.snap
@@ -23,6 +23,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "misago.core.templatetags.misago_capture::tag::capture":
+    body_analysis_evidence: not_detected
     end_tag: endcapture
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__cache_large.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__cache_large.py.snap
@@ -30,6 +30,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "src.pretix.base.templatetags.cache_large::tag::cache_large":
+    body_analysis_evidence: not_detected
     end_tag: endcache_large
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__hierarkey_form.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__hierarkey_form.py.snap
@@ -19,6 +19,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "src.pretix.control.templatetags.hierarkey_form::tag::propagated":
+    body_analysis_evidence: not_detected
     end_tag: endpropagated
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__captureas.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__helpers__templatetags__captureas.py.snap
@@ -6,6 +6,6 @@ tag_rules: {}
 filter_arities: {}
 block_specs:
   "src.pretix.helpers.templatetags.captureas::tag::captureas":
+    body_analysis_evidence: not_detected
     end_tag: endcaptureas
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_assets.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_assets.py.snap
@@ -37,6 +37,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "src.sentry.templatetags.sentry_assets::tag::script":
+    body_analysis_evidence: not_detected
     end_tag: endscript
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_features.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_features.py.snap
@@ -27,7 +27,7 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "src.sentry.templatetags.sentry_features::tag::feature":
+    body_analysis_evidence: not_detected
     end_tag: endfeature
     intermediates:
       - else
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -661,6 +661,6 @@ filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
+    body_analysis_evidence: not_detected
     end_tag: endfragment
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -650,6 +650,6 @@ filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
+    body_analysis_evidence: not_detected
     end_tag: endfragment
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -668,6 +668,6 @@ filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
+    body_analysis_evidence: not_detected
     end_tag: endfragment
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -668,6 +668,6 @@ filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::widgettype": no_argument
 block_specs:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::fragment":
+    body_analysis_evidence: not_detected
     end_tag: endfragment
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_allauth_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_allauth_tags.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/djls-project/tests/extraction.rs
-expression: sorted_snapshot(&result)
+expression: "sorted_snapshot(&result).expect(\"allauth extraction snapshot should serialize\")"
 ---
 tag_rules: {}
 filter_arities: {}
 block_specs:
   "allauth.templatetags.allauth::tag::element":
+    body_analysis_evidence: not_detected
     end_tag: endelement
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_defaulttags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_defaulttags.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/extraction.rs
-expression: sorted_snapshot(&result)
+expression: "sorted_snapshot(&result).expect(\"default-tags extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.template.defaulttags::tag::autoescape":
@@ -263,29 +263,29 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.defaulttags::tag::autoescape":
+    body_analysis_evidence: not_detected
     end_tag: endautoescape
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::comment":
+    body_analysis_evidence: skip_past
     end_tag: endcomment
     intermediates: []
-    opaque: true
   "django.template.defaulttags::tag::for":
+    body_analysis_evidence: not_detected
     end_tag: endfor
     intermediates:
       - empty
-    opaque: false
   "django.template.defaulttags::tag::if":
+    body_analysis_evidence: not_detected
     end_tag: endif
     intermediates:
       - elif
       - else
-    opaque: false
   "django.template.defaulttags::tag::spaceless":
+    body_analysis_evidence: not_detected
     end_tag: endspaceless
     intermediates: []
-    opaque: false
   "django.template.defaulttags::tag::verbatim":
+    body_analysis_evidence: not_detected
     end_tag: endverbatim
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_django_tz.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_django_tz.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djls-project/tests/extraction.rs
-expression: sorted_snapshot(&result)
+expression: "sorted_snapshot(&result).expect(\"timezone extraction snapshot should serialize\")"
 ---
 tag_rules:
   "django.templatetags.tz::tag::get_current_timezone":
@@ -84,10 +84,10 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.tz::tag::localtime":
+    body_analysis_evidence: not_detected
     end_tag: endlocaltime
     intermediates: []
-    opaque: false
   "django.templatetags.tz::tag::timezone":
+    body_analysis_evidence: not_detected
     end_tag: endtimezone
     intermediates: []
-    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_i18n.snap
@@ -90,12 +90,12 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.templatetags.i18n::tag::blocktrans":
+    body_analysis_evidence: not_detected
     end_tag: endblocktrans
     intermediates:
       - plural
-    opaque: false
   "django.templatetags.i18n::tag::blocktranslate":
+    body_analysis_evidence: not_detected
     end_tag: endblocktranslate
     intermediates:
       - plural
-    opaque: false

--- a/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_loader_tags.snap
@@ -53,6 +53,6 @@ tag_rules:
 filter_arities: {}
 block_specs:
   "django.template.loader_tags::tag::block":
+    body_analysis_evidence: not_detected
     end_tag: endblock
     intermediates: []
-    opaque: false

--- a/crates/djls-semantic/src/lib.rs
+++ b/crates/djls-semantic/src/lib.rs
@@ -68,6 +68,7 @@ pub use structure::build_template_outline_for_file;
 pub use structure::build_template_tree_for_file;
 pub use structure::compute_opaque_regions;
 pub use structure::semantic_grammar_vocabulary;
+pub use tags::BodyAnalysis;
 pub use tags::EndTag;
 pub use tags::IntermediateTag;
 pub use tags::LibraryTagSpecs;

--- a/crates/djls-semantic/src/structure/builder.rs
+++ b/crates/djls-semantic/src/structure/builder.rs
@@ -208,7 +208,7 @@ impl<'grammar> TemplateTreeBuilder<'grammar> {
             Some(TagClassification::Opener(contract)) => {
                 let parent = self.active_region();
 
-                if contract.opaque {
+                if contract.body_analysis.is_opaque() {
                     self.stack.push(TreeFrame::Opaque(OpaqueFrame {
                         opener_name: name.to_string(),
                         contract: contract.clone(),

--- a/crates/djls-semantic/src/structure/grammar.rs
+++ b/crates/djls-semantic/src/structure/grammar.rs
@@ -14,6 +14,7 @@ use djls_templates::TagBit;
 use crate::db::Db;
 use crate::scoping::LoadState;
 use crate::scoping::LoadedLibraries;
+use crate::tags::BodyAnalysis;
 use crate::tags::TagSpec;
 use crate::tags::effective_tag_spec_in_scope;
 use crate::tags::library_tag_specs;
@@ -93,7 +94,7 @@ pub fn semantic_grammar_vocabulary(db: &dyn Db, project: Project) -> SemanticGra
                     .or_default(),
                 definition.clone(),
             );
-            if !spec.opaque {
+            if !spec.body_analysis().is_opaque() {
                 for intermediate in spec.intermediate_tags.iter() {
                     push_candidate(
                         vocabulary
@@ -127,7 +128,7 @@ pub(crate) struct OpeningContract {
     pub(crate) closer: String,
     pub(crate) intermediates: Vec<String>,
     pub(crate) end_required: bool,
-    pub(crate) opaque: bool,
+    pub(crate) body_analysis: BodyAnalysis,
 }
 
 impl OpeningContract {
@@ -135,7 +136,7 @@ impl OpeningContract {
         let end = spec.end_tag.as_ref()?;
         Some(Self {
             closer: end.name.as_ref().to_string(),
-            intermediates: if spec.opaque {
+            intermediates: if spec.body_analysis().is_opaque() {
                 Vec::new()
             } else {
                 spec.intermediate_tags
@@ -144,7 +145,7 @@ impl OpeningContract {
                     .collect()
             },
             end_required: end.required,
-            opaque: spec.opaque,
+            body_analysis: spec.body_analysis(),
         })
     }
 
@@ -363,7 +364,7 @@ fn classify_project_orphan(
         vocabulary.intermediate_candidates(spelling),
         load_state,
         |spec| {
-            !spec.opaque
+            !spec.body_analysis().is_opaque()
                 && spec
                     .intermediate_tags
                     .iter()

--- a/crates/djls-semantic/src/tags.rs
+++ b/crates/djls-semantic/src/tags.rs
@@ -14,6 +14,7 @@ use djls_source::File;
 use djls_source::Offset;
 use djls_templates::NodeList;
 pub(crate) use rules::evaluate_tag_rules;
+pub use specs::BodyAnalysis;
 pub use specs::EndTag;
 pub use specs::IntermediateTag;
 pub use specs::TagSpec;

--- a/crates/djls-semantic/src/tags/specs.rs
+++ b/crates/djls-semantic/src/tags/specs.rs
@@ -11,6 +11,7 @@ use djls_conf::TagLibraryDef;
 use djls_conf::TagSpecDef;
 use djls_conf::TagTypeDef;
 use djls_project::BlockSpecs;
+use djls_project::BodyAnalysisEvidence;
 use djls_project::TagArgument;
 use djls_project::TagArgumentKind;
 use djls_project::TagRule;
@@ -50,32 +51,34 @@ impl TagSpecs {
                 continue;
             }
             if let Some(spec) = self.0.get_mut(&key.name) {
-                // An unknown closer is insufficient evidence to modify an
-                // existing spec.
-                let Some(end_tag_name) = &block_spec.end_tag else {
-                    continue;
-                };
-
-                spec.end_tag = Some(EndTag {
-                    name: end_tag_name.clone().into(),
-                    required: true,
-                });
-                // Override intermediates from extraction
-                spec.intermediate_tags = if block_spec.intermediates.is_empty() {
-                    Cow::Borrowed(&[])
-                } else {
-                    Cow::Owned(
-                        block_spec
-                            .intermediates
-                            .iter()
-                            .map(|name| IntermediateTag {
-                                name: name.clone().into(),
-                            })
-                            .collect(),
-                    )
-                };
-                // Propagate opaque flag from extraction
-                spec.opaque = block_spec.opaque;
+                // Closer evidence and body policy resolve independently. An
+                // unknown closer preserves fallback structure, while positive
+                // body evidence can still refine how the body is treated.
+                if let Some(end_tag_name) = &block_spec.end_tag {
+                    spec.end_tag = Some(EndTag {
+                        name: end_tag_name.clone().into(),
+                        required: true,
+                    });
+                    spec.intermediate_tags = if block_spec.intermediates.is_empty() {
+                        Cow::Borrowed(&[])
+                    } else {
+                        Cow::Owned(
+                            block_spec
+                                .intermediates
+                                .iter()
+                                .map(|name| IntermediateTag {
+                                    name: name.clone().into(),
+                                })
+                                .collect(),
+                        )
+                    };
+                }
+                match block_spec.body_analysis_evidence {
+                    BodyAnalysisEvidence::NotDetected | BodyAnalysisEvidence::Mixed => {}
+                    BodyAnalysisEvidence::SkipPast => {
+                        spec.body_analysis = BodyAnalysis::Opaque;
+                    }
+                }
             } else {
                 // Tag not yet in specs — create a new entry from extraction
                 let end_tag = block_spec.end_tag.as_ref().map(|name| EndTag {
@@ -95,7 +98,9 @@ impl TagSpecs {
                         module: key.registration_module.clone().into(),
                         end_tag,
                         intermediate_tags: Cow::Owned(intermediate_tags),
-                        opaque: block_spec.opaque,
+                        body_analysis: BodyAnalysis::from_evidence(
+                            block_spec.body_analysis_evidence,
+                        ),
                         role: None,
                         extracted_rules: None,
                     },
@@ -122,7 +127,7 @@ impl TagSpecs {
                         key.registration_module.clone().into(),
                         None,
                         Cow::Borrowed(&[]),
-                        false,
+                        BodyAnalysis::Analyze,
                     )
                     .with_extracted_rules(Arc::clone(tag_rule)),
                 );
@@ -299,7 +304,7 @@ impl TagSpecs {
                         module: library.module.clone().into(),
                         end_tag,
                         intermediate_tags: Cow::Owned(intermediate_tags),
-                        opaque: false,
+                        body_analysis: BodyAnalysis::Analyze,
                         role: None,
                         extracted_rules,
                     },
@@ -343,6 +348,28 @@ impl IntoIterator for TagSpecs {
     }
 }
 
+/// Whether semantic features should analyze a tag body.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BodyAnalysis {
+    #[default]
+    Analyze,
+    Opaque,
+}
+
+impl BodyAnalysis {
+    fn from_evidence(evidence: BodyAnalysisEvidence) -> Self {
+        match evidence {
+            BodyAnalysisEvidence::NotDetected | BodyAnalysisEvidence::Mixed => Self::Analyze,
+            BodyAnalysisEvidence::SkipPast => Self::Opaque,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_opaque(self) -> bool {
+        matches!(self, Self::Opaque)
+    }
+}
+
 /// Specification for a Django template tag's structure, validation rules, and role.
 ///
 /// Argument validation is handled by `extracted_rules` (derived from Python AST
@@ -354,7 +381,7 @@ pub struct TagSpec {
     module: S,
     pub end_tag: Option<EndTag>,
     pub(crate) intermediate_tags: L<IntermediateTag>,
-    pub(crate) opaque: bool,
+    pub(crate) body_analysis: BodyAnalysis,
     role: Option<TagRole>,
     /// Extraction-derived validation rules from Python AST analysis.
     ///
@@ -369,13 +396,13 @@ impl TagSpec {
         module: Cow<'static, str>,
         end_tag: Option<EndTag>,
         intermediate_tags: Cow<'static, [IntermediateTag]>,
-        opaque: bool,
+        body_analysis: BodyAnalysis,
     ) -> Self {
         Self {
             module,
             end_tag,
             intermediate_tags,
-            opaque,
+            body_analysis,
             role: None,
             extracted_rules: None,
         }
@@ -384,6 +411,11 @@ impl TagSpec {
     #[must_use]
     pub(crate) fn module(&self) -> &str {
         self.module.as_ref()
+    }
+
+    #[must_use]
+    pub fn body_analysis(&self) -> BodyAnalysis {
+        self.body_analysis
     }
 
     #[must_use]
@@ -466,7 +498,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
         module: B(module),
         end_tag: None,
         intermediate_tags: B(&[]),
-        opaque: false,
+        body_analysis: BodyAnalysis::Analyze,
         role: None,
         extracted_rules: None,
     };
@@ -475,7 +507,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
         module: B(module),
         end_tag: None,
         intermediate_tags: B(&[]),
-        opaque: false,
+        body_analysis: BodyAnalysis::Analyze,
         role: Some(role),
         extracted_rules: None,
     };
@@ -483,7 +515,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
     let block = |module: &'static str,
                  end: &'static str,
                  intermediates: Vec<IntermediateTag>,
-                 opaque: bool,
+                 body_analysis: BodyAnalysis,
                  role: TagRole| TagSpec {
         module: B(module),
         end_tag: Some(EndTag {
@@ -491,7 +523,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
             required: true,
         }),
         intermediate_tags: Cow::Owned(intermediates),
-        opaque,
+        body_analysis,
         role: Some(role),
         extracted_rules: None,
     };
@@ -501,23 +533,47 @@ pub fn builtin_tag_specs() -> TagSpecs {
     // defaulttags
     specs.insert(
         "autoescape".into(),
-        block(dt, "endautoescape", vec![], false, TagRole::ControlTag),
+        block(
+            dt,
+            "endautoescape",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert(
         "comment".into(),
-        block(dt, "endcomment", vec![], true, TagRole::ControlTag),
+        block(
+            dt,
+            "endcomment",
+            vec![],
+            BodyAnalysis::Opaque,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert("csrf_token".into(), simple(dt));
     specs.insert("cycle".into(), simple(dt));
     specs.insert("debug".into(), simple(dt));
     specs.insert(
         "filter".into(),
-        block(dt, "endfilter", vec![], false, TagRole::ControlTag),
+        block(
+            dt,
+            "endfilter",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert("firstof".into(), simple(dt));
     specs.insert(
         "for".into(),
-        block(dt, "endfor", vec![im("empty")], false, TagRole::ControlTag),
+        block(
+            dt,
+            "endfor",
+            vec![im("empty")],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert(
         "if".into(),
@@ -525,7 +581,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
             dt,
             "endif",
             vec![im("elif"), im("else")],
-            false,
+            BodyAnalysis::Analyze,
             TagRole::ControlTag,
         ),
     );
@@ -535,7 +591,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
             dt,
             "endifchanged",
             vec![im("else")],
-            false,
+            BodyAnalysis::Analyze,
             TagRole::ControlTag,
         ),
     );
@@ -548,24 +604,48 @@ pub fn builtin_tag_specs() -> TagSpecs {
     specs.insert("regroup".into(), simple(dt));
     specs.insert(
         "spaceless".into(),
-        block(dt, "endspaceless", vec![], false, TagRole::ControlTag),
+        block(
+            dt,
+            "endspaceless",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert("templatetag".into(), simple(dt));
     specs.insert("url".into(), simple_role(dt, TagRole::RouteReference));
     specs.insert(
         "verbatim".into(),
-        block(dt, "endverbatim", vec![], true, TagRole::ControlTag),
+        block(
+            dt,
+            "endverbatim",
+            vec![],
+            BodyAnalysis::Opaque,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert("widthratio".into(), simple(dt));
     specs.insert(
         "with".into(),
-        block(dt, "endwith", vec![], false, TagRole::ControlTag),
+        block(
+            dt,
+            "endwith",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
 
     // loader_tags
     specs.insert(
         "block".into(),
-        block(lt, "endblock", vec![], false, TagRole::TemplateBlock),
+        block(
+            lt,
+            "endblock",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::TemplateBlock,
+        ),
     );
     specs.insert(
         "extends".into(),
@@ -589,7 +669,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
             i18n,
             "endblocktrans",
             vec![im("plural")],
-            false,
+            BodyAnalysis::Analyze,
             TagRole::ControlTag,
         ),
     );
@@ -599,7 +679,7 @@ pub fn builtin_tag_specs() -> TagSpecs {
             i18n,
             "endblocktranslate",
             vec![im("plural")],
-            false,
+            BodyAnalysis::Analyze,
             TagRole::ControlTag,
         ),
     );
@@ -609,13 +689,25 @@ pub fn builtin_tag_specs() -> TagSpecs {
     // cache
     specs.insert(
         "cache".into(),
-        block(cache, "endcache", vec![], false, TagRole::ControlTag),
+        block(
+            cache,
+            "endcache",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
 
     // l10n
     specs.insert(
         "localize".into(),
-        block(l10n, "endlocalize", vec![], false, TagRole::ControlTag),
+        block(
+            l10n,
+            "endlocalize",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
 
     // static
@@ -627,11 +719,23 @@ pub fn builtin_tag_specs() -> TagSpecs {
     // tz
     specs.insert(
         "localtime".into(),
-        block(tz, "endlocaltime", vec![], false, TagRole::ControlTag),
+        block(
+            tz,
+            "endlocaltime",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
     specs.insert(
         "timezone".into(),
-        block(tz, "endtimezone", vec![], false, TagRole::ControlTag),
+        block(
+            tz,
+            "endtimezone",
+            vec![],
+            BodyAnalysis::Analyze,
+            TagRole::ControlTag,
+        ),
     );
 
     TagSpecs::new(specs)
@@ -659,7 +763,7 @@ mod tests {
                 module: "django.template.defaulttags".into(),
                 end_tag: None,
                 intermediate_tags: Cow::Borrowed(&[]),
-                opaque: false,
+                body_analysis: BodyAnalysis::Analyze,
                 role: None,
                 extracted_rules: None,
             },
@@ -682,7 +786,7 @@ mod tests {
                         name: "else".into(),
                     },
                 ]),
-                opaque: false,
+                body_analysis: BodyAnalysis::Analyze,
                 role: None,
                 extracted_rules: None,
             },
@@ -705,7 +809,7 @@ mod tests {
                         name: "else".into(),
                     }, // Note: else is shared
                 ]),
-                opaque: false,
+                body_analysis: BodyAnalysis::Analyze,
                 role: None,
                 extracted_rules: None,
             },
@@ -721,7 +825,7 @@ mod tests {
                     required: true,
                 }),
                 intermediate_tags: Cow::Borrowed(&[]),
-                opaque: false,
+                body_analysis: BodyAnalysis::Analyze,
                 role: None,
                 extracted_rules: None,
             },
@@ -777,7 +881,7 @@ mod tests {
                 module: "custom.module".into(),
                 end_tag: None,
                 intermediate_tags: Cow::Borrowed(&[]),
-                opaque: false,
+                body_analysis: BodyAnalysis::Analyze,
                 role: None,
                 extracted_rules: None,
             },
@@ -791,7 +895,7 @@ mod tests {
                     required: false,
                 }),
                 intermediate_tags: Cow::Borrowed(&[]),
-                opaque: false,
+                body_analysis: BodyAnalysis::Analyze,
                 role: None,
                 extracted_rules: None,
             },
@@ -843,7 +947,7 @@ mod tests {
             BlockSpec {
                 end_tag: Some("endif".to_string()),
                 intermediates: vec!["elif".to_string(), "else".to_string(), "elseif".to_string()],
-                opaque: false,
+                body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
             },
         );
 
@@ -884,7 +988,7 @@ mod tests {
                 intermediate_tags: Cow::Owned(vec![IntermediateTag {
                     name: "middle".into(),
                 }]),
-                opaque: true,
+                body_analysis: BodyAnalysis::Opaque,
                 role: None,
                 extracted_rules: None,
             },
@@ -901,7 +1005,7 @@ mod tests {
             BlockSpec {
                 end_tag: None,
                 intermediates: vec![],
-                opaque: false,
+                body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
             },
         );
 
@@ -916,6 +1020,86 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_block_specs_unknown_end_tag_still_applies_body_evidence() {
+        let mut specs = create_test_specs();
+        let mut block_specs = BlockSpecs::default();
+        block_specs.insert(
+            SymbolKey::tag("django.template.defaulttags", "if"),
+            BlockSpec {
+                end_tag: None,
+                intermediates: vec![],
+                body_analysis_evidence: BodyAnalysisEvidence::SkipPast,
+            },
+        );
+
+        specs.merge_block_specs(&block_specs);
+
+        let if_spec = specs
+            .get("if")
+            .expect("the existing block spec should remain available");
+        assert_eq!(
+            if_spec
+                .end_tag
+                .as_ref()
+                .map(|end_tag| end_tag.name.as_ref()),
+            Some("endif")
+        );
+        assert_eq!(if_spec.body_analysis(), BodyAnalysis::Opaque);
+    }
+
+    #[test]
+    fn test_merge_block_specs_mixed_evidence_preserves_builtin_body_policy() {
+        let mut specs = create_test_specs();
+        specs
+            .get_mut("if")
+            .expect("the test spec should exist")
+            .body_analysis = BodyAnalysis::Opaque;
+        let mut block_specs = BlockSpecs::default();
+        block_specs.insert(
+            SymbolKey::tag("django.template.defaulttags", "if"),
+            BlockSpec {
+                end_tag: None,
+                intermediates: vec![],
+                body_analysis_evidence: BodyAnalysisEvidence::Mixed,
+            },
+        );
+
+        specs.merge_block_specs(&block_specs);
+
+        assert_eq!(
+            specs
+                .get("if")
+                .expect("the existing block spec should remain available")
+                .body_analysis(),
+            BodyAnalysis::Opaque
+        );
+    }
+
+    #[test]
+    fn test_merge_block_specs_mixed_evidence_analyzes_new_custom_body() {
+        let mut specs = create_test_specs();
+        let mut block_specs = BlockSpecs::default();
+        block_specs.insert(
+            SymbolKey::tag("myapp.templatetags.custom", "mixed"),
+            BlockSpec {
+                end_tag: Some("endmixed".to_string()),
+                intermediates: vec![],
+                body_analysis_evidence: BodyAnalysisEvidence::Mixed,
+            },
+        );
+
+        specs.merge_block_specs(&block_specs);
+
+        assert_eq!(
+            specs
+                .get("mixed")
+                .expect("the custom block spec should be inserted")
+                .body_analysis(),
+            BodyAnalysis::Analyze
+        );
+    }
+
+    #[test]
     fn test_merge_block_specs_unknown_end_tag_inserts_new_spec_without_end_tag() {
         let mut specs = create_test_specs();
         let original_count = specs.len();
@@ -926,7 +1110,7 @@ mod tests {
             BlockSpec {
                 end_tag: None,
                 intermediates: vec![],
-                opaque: false,
+                body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
             },
         );
 
@@ -950,7 +1134,7 @@ mod tests {
             BlockSpec {
                 end_tag: Some("endmyblock".to_string()),
                 intermediates: vec!["mymiddle".to_string()],
-                opaque: false,
+                body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
             },
         );
 
@@ -986,7 +1170,7 @@ mod tests {
             BlockSpec {
                 end_tag: Some("endlower".to_string()),
                 intermediates: vec![],
-                opaque: false,
+                body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
             },
         );
 

--- a/crates/djls-semantic/tests/inheritance.rs
+++ b/crates/djls-semantic/tests/inheritance.rs
@@ -101,7 +101,7 @@ fn extracts_partial_defs_from_partial_role_specs() {
                 required: true,
             }),
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_role(TagRole::TemplatePartial),
     )])));
@@ -134,7 +134,7 @@ fn absent_effective_tag_does_not_fall_back_to_project_global_specs() {
             Cow::Borrowed("missing.templatetags.layout"),
             None,
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_role(TagRole::TemplateReference(TemplateReferenceKind::Extends)),
     );
@@ -595,7 +595,7 @@ fn template_inheritance_follows_extends_role_not_builtin_name() {
             Cow::Borrowed("myapp.templatetags.layout"),
             None,
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_role(TagRole::TemplateReference(TemplateReferenceKind::Extends)),
     )])));
@@ -980,7 +980,7 @@ fn extracts_blocks_and_extends_by_role_not_builtin_names() {
                     required: true,
                 }),
                 Cow::Borrowed(&[]),
-                false,
+                djls_semantic::BodyAnalysis::Analyze,
             )
             .with_role(TagRole::TemplateBlock),
         ),
@@ -990,7 +990,7 @@ fn extracts_blocks_and_extends_by_role_not_builtin_names() {
                 Cow::Borrowed("myapp.templatetags.layout"),
                 None,
                 Cow::Borrowed(&[]),
-                false,
+                djls_semantic::BodyAnalysis::Analyze,
             )
             .with_role(TagRole::TemplateReference(TemplateReferenceKind::Extends)),
         ),

--- a/crates/djls-semantic/tests/references.rs
+++ b/crates/djls-semantic/tests/references.rs
@@ -221,6 +221,47 @@ fn template_references_ignore_include_inside_verbatim() {
 }
 
 #[test]
+fn extracted_verbatim_suppresses_references_while_custom_mixed_body_stays_active() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/test/project")
+        .django_settings_module("testproject.settings")
+        .file(
+            "/test/project/testproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
+        )
+        .file(
+            "/test/project/django/template/defaulttags.py",
+            include_str!(
+                "../../djls-project/src/templates/tags/testdata/django_defaulttags.py"
+            ),
+        )
+        .file(
+            "/test/project/custom_tags.py",
+            "from django import template\nregister = template.Library()\n@register.tag\ndef panel(parser, token):\n    if token.contents:\n        body = parser.parse(('endpanel',))\n    else:\n        parser.skip_past('endpanel')\n    return Node(body)\n",
+        )
+        .file(
+            "/test/project/templates/child.html",
+            "{% verbatim %}{% include 'partial.html' %}{% endverbatim %}{% load custom %}{% panel %}{% include 'partial.html' %}{% endpanel %}",
+        )
+        .file("/test/project/templates/partial.html", "partial")
+        .install(&mut db)
+        .expect("body-analysis fixture should install into the test database");
+    let partial = TemplateName::new(&db, "partial.html".to_string());
+
+    let references = references_to_template_name(&db, project, partial);
+
+    assert_eq!(references.len(), 1);
+    assert_eq!(references[0].kind(&db), TemplateReferenceKind::Include);
+    assert_eq!(
+        references[0].span(&db).start_usize(),
+        "{% verbatim %}{% include 'partial.html' %}{% endverbatim %}{% load custom %}{% panel %}{% include 'partial.html' %}{% endpanel %}"
+            .rfind("'partial.html'")
+            .expect("active reference should exist")
+            + 1
+    );
+}
+
+#[test]
 fn template_references_ignore_extends_inside_comment() {
     let mut db = TestDatabase::new();
     let project = project_with_templates(
@@ -418,7 +459,7 @@ fn captured_else_does_not_retain_a_colliding_loader_role() {
             Cow::Borrowed("test.loader"),
             None,
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_role(TagRole::TemplateLibraryLoader),
     )])));

--- a/crates/djls-semantic/tests/structure_opaque.rs
+++ b/crates/djls-semantic/tests/structure_opaque.rs
@@ -41,7 +41,7 @@ fn opaque_opener_treats_intermediate_as_raw_content() {
                 name: "opaque_else".into(),
             }]
             .into(),
-            true,
+            djls_semantic::BodyAnalysis::Opaque,
         ),
     );
     let db = TestDatabase::new().with_projectless_tag_specs(specs);

--- a/crates/djls-semantic/tests/structure_outline.rs
+++ b/crates/djls-semantic/tests/structure_outline.rs
@@ -124,7 +124,7 @@ fn loader_role_outline_does_not_depend_on_load_spelling() {
             Cow::Borrowed("test.loader"),
             None,
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_role(TagRole::TemplateLibraryLoader),
     )])));
@@ -205,7 +205,7 @@ fn custom_callable_block_tags_produce_callable_outline_items() {
                 required: true,
             }),
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         )
         .with_role(TagRole::TemplateTag),
     )])));
@@ -230,7 +230,7 @@ fn tags_without_role_hide_standalone_tags_but_keep_blocks() {
                     required: true,
                 }),
                 Cow::Borrowed(&[]),
-                false,
+                djls_semantic::BodyAnalysis::Analyze,
             ),
         ),
         (
@@ -239,7 +239,7 @@ fn tags_without_role_hide_standalone_tags_but_keep_blocks() {
                 Cow::Borrowed("myapp.templatetags.custom"),
                 None,
                 Cow::Borrowed(&[]),
-                false,
+                djls_semantic::BodyAnalysis::Analyze,
             ),
         ),
     ])));

--- a/crates/djls-semantic/tests/structure_tree.rs
+++ b/crates/djls-semantic/tests/structure_tree.rs
@@ -555,7 +555,7 @@ fn shared_intermediate_inside_opaque_block_has_no_structure() {
             Cow::Owned(vec![IntermediateTag {
                 name: Cow::Borrowed("else"),
             }]),
-            true,
+            djls_semantic::BodyAnalysis::Opaque,
         ),
     )])));
     let db = TestDatabase::new().with_projectless_tag_specs(specs);
@@ -608,7 +608,7 @@ fn opaque_closer_name_can_also_be_structured_opener() {
                     required: true,
                 }),
                 Cow::Borrowed(&[]),
-                true,
+                djls_semantic::BodyAnalysis::Opaque,
             ),
         ),
         (
@@ -620,7 +620,7 @@ fn opaque_closer_name_can_also_be_structured_opener() {
                     required: true,
                 }),
                 Cow::Borrowed(&[]),
-                false,
+                djls_semantic::BodyAnalysis::Analyze,
             ),
         ),
     ])));
@@ -685,7 +685,12 @@ fn specs_with_standalone_structural_spellings() -> TagSpecs {
         ["endif", "else", "empty"].map(|name| {
             (
                 name.to_string(),
-                TagSpec::new(Cow::Borrowed("test"), None, Cow::Borrowed(&[]), false),
+                TagSpec::new(
+                    Cow::Borrowed("test"),
+                    None,
+                    Cow::Borrowed(&[]),
+                    djls_semantic::BodyAnalysis::Analyze,
+                ),
             )
         }),
     )));
@@ -787,7 +792,7 @@ fn unclosed_optional_opaque_block_reports_unclosed_without_node() {
                 required: false,
             }),
             Cow::Borrowed(&[]),
-            true,
+            djls_semantic::BodyAnalysis::Opaque,
         ),
     )])));
     let db = TestDatabase::new().with_projectless_tag_specs(specs);
@@ -1073,7 +1078,7 @@ fn custom_block_tags_from_specs_are_blocks() {
                 required: true,
             }),
             Cow::Borrowed(&[]),
-            false,
+            djls_semantic::BodyAnalysis::Analyze,
         ),
     )])));
     let db = TestDatabase::new().with_projectless_tag_specs(specs);

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -1052,7 +1052,12 @@ fn captured_closer_does_not_retain_a_colliding_standalone_spec() {
     let mut specs = builtin_tag_specs();
     specs.insert(
         "endif".to_string(),
-        TagSpec::new("test.tags".into(), None, Cow::Borrowed(&[]), false),
+        TagSpec::new(
+            "test.tags".into(),
+            None,
+            Cow::Borrowed(&[]),
+            djls_semantic::BodyAnalysis::Analyze,
+        ),
     );
     let db = TestDatabase::new().with_projectless_tag_specs(specs);
 
@@ -1114,15 +1119,20 @@ fn captured_intermediate_does_not_apply_a_colliding_standalone_contract() {
     let mut specs = builtin_tag_specs();
     specs.insert(
         "else".to_string(),
-        TagSpec::new("test.loader".into(), None, Cow::Borrowed(&[]), false)
-            .with_role(TagRole::TemplateLibraryLoader)
-            .with_extracted_rules(
-                TagRule {
-                    arg_constraints: vec![ArgumentCountConstraint::Exact(3)],
-                    ..TagRule::default()
-                }
-                .into(),
-            ),
+        TagSpec::new(
+            "test.loader".into(),
+            None,
+            Cow::Borrowed(&[]),
+            djls_semantic::BodyAnalysis::Analyze,
+        )
+        .with_role(TagRole::TemplateLibraryLoader)
+        .with_extracted_rules(
+            TagRule {
+                arg_constraints: vec![ArgumentCountConstraint::Exact(3)],
+                ..TagRule::default()
+            }
+            .into(),
+        ),
     );
     let db = TestDatabase::new().with_projectless_tag_specs(specs);
 
@@ -2130,6 +2140,45 @@ fn opaque_region_suppresses_all_validation() {
     assert!(
         validation_errors.is_empty(),
         "No expression/filter/scoping errors expected inside verbatim, got: {validation_errors:?}"
+    );
+}
+
+#[test]
+fn extracted_verbatim_policy_stays_opaque_while_custom_mixed_body_is_analyzed() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .file(
+            "/proj/myproject/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
+        )
+        .file(
+            "/proj/django/template/defaulttags.py",
+            include_str!(
+                "../../djls-project/src/templates/tags/testdata/django_defaulttags.py"
+            ),
+        )
+        .file(
+            "/proj/custom_tags.py",
+            "from django import template\nregister = template.Library()\n@register.tag\ndef panel(parser, token):\n    if token.contents:\n        body = parser.parse(('endpanel',))\n    else:\n        parser.skip_past('endpanel')\n    return Node(body)\n",
+        )
+        .file(
+            "/proj/templates/page.html",
+            "{% verbatim %}{% if and hidden %}{% endverbatim %}{% load custom %}{% panel %}{% if and active %}{% endpanel %}",
+        )
+        .install(&mut db)
+        .expect("body-analysis fixture should install into the test database");
+
+    let errors = collect_file_errors(&db, "/proj/templates/page.html")
+        .expect("fixture file validation errors should be collected");
+    let expression_errors = errors
+        .iter()
+        .filter(|error| matches!(error, ValidationError::ExpressionSyntaxError { .. }))
+        .count();
+
+    assert_eq!(
+        expression_errors, 1,
+        "verbatim must suppress its body while a custom parser.parse body stays active: {errors:?}"
     );
 }
 


### PR DESCRIPTION
## Changes

Separate extracted body-handling evidence from the decision to analyze a template body. Source extraction records `BodyAnalysisEvidence::{NotDetected, SkipPast, Mixed}`. Semantic specs and their consumers use `BodyAnalysis::{Analyze, Opaque}` instead of a boolean.

Missing or mixed evidence preserves builtin policy. This keeps Django `verbatim` opaque when its Python implementation uses `parser.parse`, rather than overwriting the builtin with a false negative. New custom blocks default to analysis unless skip-only evidence establishes opacity. This is a bounded source-pattern policy, not occurrence-specific Python control-flow analysis.

Resolve closer evidence independently. Positive skip evidence survives an unknown closer; mixed paths retain a common literal closer only when both agree, and retain observed parse intermediates. Mixed detection includes nested and annotated parse expressions while excluding nested function scopes.

Public configuration and optional closing-tag behavior are unchanged.

## Verification

- Added production extraction/fusion regressions for `verbatim` diagnostic and reference suppression, alongside an active mixed custom body.
- Added extraction and fusion tests for mixed evidence, conflicting/unknown closers, nested calls, and builtin-policy preservation. All 26 block-extraction unit tests passed.
- Project, Semantic, and IDE suites passed. Active and archived extraction snapshots were migrated without deleting coverage.
- The full-corpus check now reports five fewer S111 diagnostics: unknown `limitTo` filters inside GeoNode `verbatim` regions. Corpus inputs remain 7,269 files and 11,921,621 bytes with the same input hash. Updated the expected output snapshot; benchmark names and measured operations are unchanged.
- `just fmt`, `just clippy`, `cargo check --all-targets --all-features`, `just lint`, `just test`, and `just e2e` (44 tests) passed.
- Hawk remains for CI. The full Python/Django matrix was not rerun.

Appended above #855 in stack #856. The next PR handles correlated argument forms separately.
