### PR TITLE
Preserve Django registration options and simple block structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Fixed static validation for context-aware and curried tag registrations and for `simple_block_tag` block structure.
 - Fixed unloaded-tag diagnostics and load quick fixes disappearing when an unrelated template library has unknown registrations.
 - Fixed explicit `false` and empty LSP initialization options failing to override project configuration.
 - Fixed `djls check` scanning the project root when template settings branches differ only in context processors.

--- a/crates/djls-project/src/python/source_occurrences.rs
+++ b/crates/djls-project/src/python/source_occurrences.rs
@@ -37,6 +37,7 @@ enum Binding {
     ModuleMember(PythonModule, Box<Binding>),
     LazyFromImport(LazyFromImport),
     String(String),
+    Boolean(bool),
     Function(PythonFunctionDefinition),
     Unknown,
 }
@@ -45,6 +46,7 @@ enum Binding {
 enum ResolvedValue {
     Module(PythonModule),
     String(String),
+    Boolean(bool),
     Function(PythonFunctionDefinition),
 }
 
@@ -95,6 +97,7 @@ impl PythonFunctionDefinition {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum PythonOccurrenceValue {
     String(String),
+    Boolean(bool),
     Function(PythonFunctionDefinition),
 }
 
@@ -151,14 +154,30 @@ impl<'db> PythonSourceLookup<'db> {
         }
         match self.lookup(expression) {
             Some(PythonOccurrenceValue::String(value)) => Some(value),
-            Some(PythonOccurrenceValue::Function(_)) | None => None,
+            Some(PythonOccurrenceValue::Boolean(_) | PythonOccurrenceValue::Function(_)) | None => {
+                None
+            }
+        }
+    }
+
+    pub(crate) fn exact_bool(&mut self, expression: &Expr) -> Option<bool> {
+        if let Some(value) = expression.bool_literal() {
+            return Some(value);
+        }
+        match self.lookup(expression) {
+            Some(PythonOccurrenceValue::Boolean(value)) => Some(value),
+            Some(PythonOccurrenceValue::String(_) | PythonOccurrenceValue::Function(_)) | None => {
+                None
+            }
         }
     }
 
     pub(crate) fn function(&mut self, expression: &Expr) -> Option<PythonFunctionDefinition> {
         match self.lookup(expression) {
             Some(PythonOccurrenceValue::Function(definition)) => Some(definition),
-            Some(PythonOccurrenceValue::String(_)) | None => None,
+            Some(PythonOccurrenceValue::String(_) | PythonOccurrenceValue::Boolean(_)) | None => {
+                None
+            }
         }
     }
 
@@ -394,7 +413,7 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
                     }
                 }
             }
-            Binding::String(_) | Binding::Function(_) | Binding::Unknown => {}
+            Binding::String(_) | Binding::Boolean(_) | Binding::Function(_) | Binding::Unknown => {}
         }
     }
 
@@ -411,6 +430,9 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
         if let Some(value) = expression.string_literal() {
             return Some(Binding::String(value.to_string()));
         }
+        if let Some(value) = expression.bool_literal() {
+            return Some(Binding::Boolean(value));
+        }
         if let Some(name) = expression.name_target() {
             return self.bindings.get(name).cloned();
         }
@@ -422,6 +444,7 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
             Binding::ModuleMember(_, _)
             | Binding::LazyFromImport(_)
             | Binding::String(_)
+            | Binding::Boolean(_)
             | Binding::Function(_)
             | Binding::Unknown => return None,
         };
@@ -438,6 +461,9 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
         }
         if let Some(value) = expression.string_literal() {
             return Some(ResolvedValue::String(value.to_string()));
+        }
+        if let Some(value) = expression.bool_literal() {
+            return Some(ResolvedValue::Boolean(value));
         }
         let path = expression.path_segments()?;
         let (root, tail) = path.split_first()?;
@@ -461,11 +487,13 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
             }
             Binding::ModuleMember(_, value) => self.resolve_binding(*value, tail, depth),
             Binding::String(value) if tail.is_empty() => Some(ResolvedValue::String(value)),
+            Binding::Boolean(value) if tail.is_empty() => Some(ResolvedValue::Boolean(value)),
             Binding::Function(function) if tail.is_empty() => {
                 Some(ResolvedValue::Function(function))
             }
             Binding::LazyFromImport(_)
             | Binding::String(_)
+            | Binding::Boolean(_)
             | Binding::Function(_)
             | Binding::Unknown => None,
         }
@@ -615,6 +643,7 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
                                 .value
                                 .string_literal()
                                 .map(|value| ResolvedValue::String(value.to_string()))
+                                .or_else(|| assign.value.bool_literal().map(ResolvedValue::Boolean))
                         } else {
                             None
                         };
@@ -626,11 +655,12 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
                     }
                     if assign.target.name_target() == Some(root) {
                         value = if path.len() == 1 {
-                            assign
-                                .value
-                                .as_deref()
-                                .and_then(ExprExt::string_literal)
-                                .map(|value| ResolvedValue::String(value.to_string()))
+                            assign.value.as_deref().and_then(|value| {
+                                value
+                                    .string_literal()
+                                    .map(|value| ResolvedValue::String(value.to_string()))
+                                    .or_else(|| value.bool_literal().map(ResolvedValue::Boolean))
+                            })
                         } else {
                             None
                         };
@@ -697,7 +727,7 @@ impl<'db> SourceOccurrenceAnalysis<'db> {
             ResolvedValue::Module(module) if path.len() > 1 => {
                 self.resolve_module_path(&module, &path[1..], depth + 1)
             }
-            resolved @ ResolvedValue::String(_) => Some(resolved),
+            resolved @ (ResolvedValue::String(_) | ResolvedValue::Boolean(_)) => Some(resolved),
             resolved @ (ResolvedValue::Module(_) | ResolvedValue::Function(_))
                 if path.len() == 1 =>
             {
@@ -870,6 +900,7 @@ fn span_contains(outer: Span, inner: Span) -> bool {
 fn occurrence_value(value: ResolvedValue) -> Option<PythonOccurrenceValue> {
     match value {
         ResolvedValue::String(value) => Some(PythonOccurrenceValue::String(value)),
+        ResolvedValue::Boolean(value) => Some(PythonOccurrenceValue::Boolean(value)),
         ResolvedValue::Function(function) => Some(PythonOccurrenceValue::Function(function)),
         ResolvedValue::Module(_) => None,
     }
@@ -899,6 +930,7 @@ fn binding_from_value(value: ResolvedValue) -> Binding {
     match value {
         ResolvedValue::Module(module) => Binding::Module(module),
         ResolvedValue::String(value) => Binding::String(value),
+        ResolvedValue::Boolean(value) => Binding::Boolean(value),
         ResolvedValue::Function(function) => Binding::Function(function),
     }
 }

--- a/crates/djls-project/src/templates/registrations.rs
+++ b/crates/djls-project/src/templates/registrations.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
-use ruff_python_ast::Keyword;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtExpr;
 use ruff_python_ast::StmtFunctionDef;
@@ -32,15 +31,63 @@ use crate::python::RecoveredPythonModule;
 use crate::python::import::DirectImportClause;
 use crate::python::import::FromImportSyntax;
 
-/// Decorator helper names on `django.template.Library` that register filters.
-const FILTER_DECORATORS: &[&str] = &["filter"];
-
 /// Information about a single tag or filter registration found in source code.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RegistrationInfo {
     name: String,
     kind: RegistrationKind,
     callable: RegistrationCallable,
+    options: RegistrationOptions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RegistrationOptions {
+    pub(crate) context: ContextProvision,
+    pub(crate) block_end: Option<RegisteredEnd>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextProvision {
+    None,
+    Context,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RegisteredEnd {
+    Default,
+    Named(String),
+    Unknown,
+}
+
+impl RegistrationOptions {
+    fn resolve(
+        kind: RegistrationKind,
+        takes_context: Option<&Expr>,
+        end_name: Option<&Expr>,
+        mut python_facts: Option<&mut PythonSourceLookup<'_>>,
+    ) -> Self {
+        let context = match takes_context {
+            None | Some(Expr::NoneLiteral(_)) => ContextProvision::None,
+            Some(value) => match value.bool_literal().or_else(|| {
+                python_facts
+                    .as_mut()
+                    .and_then(|facts| facts.exact_bool(value))
+            }) {
+                Some(true) => ContextProvision::Context,
+                Some(false) => ContextProvision::None,
+                None => ContextProvision::Unknown,
+            },
+        };
+        let block_end = matches!(kind, RegistrationKind::SimpleBlockTag).then(|| match end_name {
+            None | Some(Expr::NoneLiteral(_)) => RegisteredEnd::Default,
+            Some(value) => python_facts
+                .and_then(|facts| facts.exact_string(value))
+                .or_else(|| value.string_literal().map(str::to_string))
+                .map_or(RegisteredEnd::Unknown, RegisteredEnd::Named),
+        });
+        Self { context, block_end }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,7 +250,7 @@ fn collect_from_class_body(body: &[Stmt], analysis: &mut RegistrationSourceAnaly
         if let Stmt::FunctionDef(function) = stmt
             && register_is_module_binding
         {
-            collect_from_decorated_function(function, None, analysis);
+            collect_from_decorated_function(function, None, None, analysis);
             if body_contains_register(&function.body) {
                 analysis.open_inventory();
             }
@@ -489,7 +536,12 @@ fn analyze_registrations_from_body_in_module(
                     analysis.open_inventory();
                 }
                 let local_source = LocalFunctionSource::from_function(function);
-                collect_from_decorated_function(function, Some(local_source), &mut analysis);
+                collect_from_decorated_function(
+                    function,
+                    Some(local_source),
+                    python_facts.as_deref_mut(),
+                    &mut analysis,
+                );
                 if body_contains_register(&function.body) {
                     analysis.open_inventory();
                 }
@@ -636,19 +688,12 @@ fn collect_func_defs(body: &[Stmt]) -> Vec<&StmtFunctionDef> {
 }
 
 /// Extract registrations from a decorated function definition.
-///
-/// Handles patterns like:
-/// - `@register.tag` (bare decorator)
-/// - `@register.simple_tag(name="alias")`
-/// - `@register.tag("name")`
-/// - `@register.filter`
 fn collect_from_decorated_function(
     func_def: &StmtFunctionDef,
     local_source: Option<LocalFunctionSource>,
+    mut python_facts: Option<&mut PythonSourceLookup<'_>>,
     analysis: &mut RegistrationSourceAnalysis,
 ) {
-    let func_name = func_def.name.as_str();
-
     // Decorators execute from the function outward, so registrations must be recorded bottom-up.
     for (index, decorator) in func_def.decorator_list.iter().enumerate().rev() {
         let expression = &decorator.expression;
@@ -660,41 +705,26 @@ fn collect_from_decorated_function(
         }
         analysis.observe_register_use();
 
-        if registration_decorator_has_dynamic_name(expression) {
-            analysis.open_inventory();
-            continue;
-        }
-
-        let registration_source = local_source.filter(|_| {
+        let navigation = local_source.filter(|_| {
             func_def.decorator_list[index + 1..]
                 .iter()
                 .all(|decorator| registration_decorator_rooted_at_register(&decorator.expression))
         });
-
-        if let Some((name, kind)) = tag_name_from_decorator(expression, func_name) {
-            analysis.registrations.push(RegistrationInfo {
-                name,
-                kind,
-                callable: RegistrationCallable::DecoratedLocal {
-                    function_name: func_name.to_string(),
-                    navigation: registration_source,
-                },
-            });
-            continue;
-        }
-
-        if let Some(name) = filter_name_from_decorator(expression, func_name) {
-            analysis.registrations.push(RegistrationInfo {
-                name,
-                kind: RegistrationKind::Filter,
-                callable: RegistrationCallable::DecoratedLocal {
-                    function_name: func_name.to_string(),
-                    navigation: registration_source,
-                },
-            });
-        } else {
+        let applied = LoweredCallable::Decorated {
+            function: func_def,
+            navigation,
+        };
+        let Some(lowered) = lower_registration_expression(expression, Some(applied)) else {
             analysis.open_inventory();
-        }
+            continue;
+        };
+        let Some(registration) =
+            registration_from_lowered(lowered, &BTreeMap::new(), python_facts.as_deref_mut())
+        else {
+            analysis.open_inventory();
+            continue;
+        };
+        analysis.registrations.push(registration);
     }
 }
 
@@ -705,6 +735,17 @@ fn direct_register_helper(expr: &Expr) -> Option<&str> {
     (value.name_target() == Some("register")).then_some(attr.as_str())
 }
 
+fn registration_kind(helper: &str) -> Option<RegistrationKind> {
+    match helper {
+        "tag" => Some(RegistrationKind::Tag),
+        "simple_tag" => Some(RegistrationKind::SimpleTag),
+        "inclusion_tag" => Some(RegistrationKind::InclusionTag),
+        "simple_block_tag" => Some(RegistrationKind::SimpleBlockTag),
+        "filter" => Some(RegistrationKind::Filter),
+        _ => None,
+    }
+}
+
 fn registration_decorator_rooted_at_register(expr: &Expr) -> bool {
     let helper = if matches!(expr, Expr::Attribute(_)) {
         direct_register_helper(expr)
@@ -713,87 +754,71 @@ fn registration_decorator_rooted_at_register(expr: &Expr) -> bool {
     } else {
         None
     };
-    helper.is_some_and(|helper| {
-        tag_decorator_kind(helper).is_some() || FILTER_DECORATORS.contains(&helper)
-    })
-}
-
-fn has_dynamic_name_keyword(keywords: &[Keyword]) -> bool {
-    keywords.iter().any(|keyword| {
-        keyword.arg.as_ref().is_some_and(|arg| arg == "name")
-            && keyword.value.string_literal().is_none()
-    })
-}
-
-fn registration_arguments_are_unsupported(helper: &str, call: &ExprCall) -> bool {
-    if call
-        .arguments
-        .args
-        .iter()
-        .any(|arg| matches!(arg, Expr::Starred(_)))
-    {
-        return true;
-    }
-    call.arguments.keywords.iter().any(|keyword| {
-        let Some(name) = keyword
-            .arg
-            .as_ref()
-            .map(ruff_python_ast::Identifier::as_str)
-        else {
-            return true;
-        };
-        match helper {
-            "tag" => !matches!(name, "name" | "compile_function" | "func"),
-            "filter" => false,
-            "simple_tag" => !matches!(name, "func" | "takes_context" | "name"),
-            "inclusion_tag" => !matches!(name, "filename" | "func" | "takes_context" | "name"),
-            "simple_block_tag" => !matches!(name, "func" | "takes_context" | "name" | "end_name"),
-            _ => true,
-        }
-    })
-}
-
-fn registration_decorator_has_dynamic_name(expr: &Expr) -> bool {
-    let Expr::Call(call) = expr else {
-        return false;
-    };
-    if has_dynamic_name_keyword(&call.arguments.keywords) {
-        return true;
-    }
-    direct_register_helper(&call.func).is_some_and(|helper| {
-        if registration_arguments_are_unsupported(helper, call) {
-            return true;
-        }
-        let args = &call.arguments.args;
-        match helper {
-            "tag" | "filter" => {
-                args.len() > 1
-                    || args
-                        .first()
-                        .is_some_and(|arg| arg.string_literal().is_none())
-            }
-            "simple_tag" | "simple_block_tag" => !args.is_empty(),
-            "inclusion_tag" => args.len() > 1,
-            _ => true,
-        }
-    })
+    helper.and_then(registration_kind).is_some()
 }
 
 #[derive(Clone, Copy, Debug)]
-struct LoweredRegistrationCall<'a> {
-    kind: RegistrationKind,
-    name: Option<&'a Expr>,
-    callable: Option<&'a Expr>,
+enum LoweredCallable<'a> {
+    Expression(&'a Expr),
+    Decorated {
+        function: &'a StmtFunctionDef,
+        navigation: Option<LocalFunctionSource>,
+    },
 }
 
-fn lower_registration_call(call: &ExprCall) -> Option<LoweredRegistrationCall<'_>> {
+#[derive(Clone, Copy, Debug)]
+struct LoweredRegistration<'a> {
+    kind: RegistrationKind,
+    name: Option<&'a Expr>,
+    callable: Option<LoweredCallable<'a>>,
+    takes_context: Option<&'a Expr>,
+    end_name: Option<&'a Expr>,
+}
+
+fn lower_registration_expression<'a>(
+    expression: &'a Expr,
+    applied: Option<LoweredCallable<'a>>,
+) -> Option<LoweredRegistration<'a>> {
+    let mut lowered = if matches!(expression, Expr::Attribute(_)) {
+        let helper = direct_register_helper(expression)?;
+        let kind = registration_kind(helper)?;
+        if matches!(kind, RegistrationKind::InclusionTag) {
+            return None;
+        }
+        LoweredRegistration {
+            kind,
+            name: None,
+            callable: None,
+            takes_context: None,
+            end_name: None,
+        }
+    } else if let Expr::Call(call) = expression {
+        lower_registration_call(call, applied.is_some())?
+    } else {
+        return None;
+    };
+    if let Some(applied) = applied {
+        if lowered.callable.is_some() {
+            return None;
+        }
+        lowered.callable = Some(applied);
+    }
+    Some(lowered)
+}
+
+#[allow(clippy::too_many_lines)]
+fn lower_registration_call(
+    call: &ExprCall,
+    has_applied_callable: bool,
+) -> Option<LoweredRegistration<'_>> {
     let helper = direct_register_helper(&call.func)?;
     let args = &call.arguments.args;
     let keywords = &call.arguments.keywords;
-    let has_starred = args
+    if args
         .iter()
-        .any(|argument| matches!(argument, Expr::Starred(_)));
-    if has_starred || keywords.iter().any(|keyword| keyword.arg.is_none()) {
+        .any(|argument| matches!(argument, Expr::Starred(_)))
+        || keywords.iter().any(|keyword| keyword.arg.is_none())
+    {
         return None;
     }
 
@@ -805,20 +830,27 @@ fn lower_registration_call(call: &ExprCall) -> Option<LoweredRegistrationCall<'_
     };
     let keywords_are_supported = |supported: &[&str]| {
         keywords.iter().all(|keyword| {
-            let Some(name) = keyword.arg.as_ref() else {
-                return false;
-            };
-            supported.contains(&name.as_str())
+            keyword
+                .arg
+                .as_ref()
+                .is_some_and(|name| supported.contains(&name.as_str()))
         })
     };
 
     let (kind, name, callable) = match helper {
-        "tag" if keywords_are_supported(&["name", "compile_function", "func"]) => {
+        "tag" if keywords_are_supported(&["name", "compile_function"]) => {
             let name_keyword = keyword(&["name"]);
-            let callable_keyword = keyword(&["compile_function", "func"]);
+            let callable_keyword = keyword(&["compile_function"]);
             match &args[..] {
-                [name, callable] if name_keyword.is_none() && callable_keyword.is_none() => {
+                [name, callable]
+                    if name_keyword.is_none()
+                        && callable_keyword.is_none()
+                        && !matches!(name, Expr::NoneLiteral(_)) =>
+                {
                     (RegistrationKind::Tag, Some(name), Some(callable))
+                }
+                [name] if has_applied_callable && name_keyword.is_none() => {
+                    (RegistrationKind::Tag, Some(name), callable_keyword)
                 }
                 [name] if name.string_literal().is_some() && name_keyword.is_none() => {
                     (RegistrationKind::Tag, Some(name), callable_keyword)
@@ -842,13 +874,13 @@ fn lower_registration_call(call: &ExprCall) -> Option<LoweredRegistrationCall<'_
         "inclusion_tag"
             if keywords_are_supported(&["filename", "func", "takes_context", "name"]) =>
         {
-            let callable_keyword = keyword(&["func"]);
-            let callable = match &args[..] {
-                [_template, callable] if callable_keyword.is_none() => Some(callable),
-                [_] | [] => callable_keyword,
-                _ => return None,
-            };
-            (RegistrationKind::InclusionTag, keyword(&["name"]), callable)
+            let filename_keyword = keyword(&["filename"]);
+            if !matches!((&args[..], filename_keyword), ([_], None) | ([], Some(_))) {
+                return None;
+            }
+            // Django accepts `func` in this signature but never reads it. The returned
+            // decorator always registers the function to which it is later applied.
+            (RegistrationKind::InclusionTag, keyword(&["name"]), None)
         }
         "simple_block_tag"
             if keywords_are_supported(&["func", "takes_context", "name", "end_name"]) =>
@@ -865,12 +897,22 @@ fn lower_registration_call(call: &ExprCall) -> Option<LoweredRegistrationCall<'_
                 callable,
             )
         }
+        // Library.filter accepts arbitrary registration flags such as is_safe and
+        // needs_autoescape in both direct and decorator forms.
         "filter" => {
             let name_keyword = keyword(&["name"]);
-            let callable_keyword = keyword(&["filter_func", "func"]);
+            let callable_keyword = keyword(&["filter_func"]);
+            let func_flag = keyword(&["func"]);
             match &args[..] {
-                [name, callable] if name_keyword.is_none() && callable_keyword.is_none() => {
+                [name, callable]
+                    if name_keyword.is_none()
+                        && callable_keyword.is_none()
+                        && !matches!(name, Expr::NoneLiteral(_)) =>
+                {
                     (RegistrationKind::Filter, Some(name), Some(callable))
+                }
+                [name] if has_applied_callable && name_keyword.is_none() => {
+                    (RegistrationKind::Filter, Some(name), callable_keyword)
                 }
                 [name] if name.string_literal().is_some() && name_keyword.is_none() => {
                     (RegistrationKind::Filter, Some(name), callable_keyword)
@@ -878,208 +920,202 @@ fn lower_registration_call(call: &ExprCall) -> Option<LoweredRegistrationCall<'_
                 [callable] if name_keyword.is_none() => {
                     (RegistrationKind::Filter, None, Some(callable))
                 }
-                [] => (RegistrationKind::Filter, name_keyword, callable_keyword),
+                [] if !(has_applied_callable
+                    && func_flag.is_some()
+                    && name_keyword.is_none_or(|name| matches!(name, Expr::NoneLiteral(_)))) =>
+                {
+                    (RegistrationKind::Filter, name_keyword, callable_keyword)
+                }
                 _ => return None,
             }
         }
         _ => return None,
     };
 
-    Some(LoweredRegistrationCall {
+    if matches!(kind, RegistrationKind::Tag | RegistrationKind::Filter)
+        && args.is_empty()
+        && callable.is_some()
+        && name.is_none_or(|name| matches!(name, Expr::NoneLiteral(_)))
+    {
+        // Unlike simple_tag, these helpers require a name with their callable keyword.
+        return None;
+    }
+
+    Some(LoweredRegistration {
         kind,
         name,
-        callable,
+        callable: callable.map(LoweredCallable::Expression),
+        takes_context: keyword(&["takes_context"]),
+        end_name: keyword(&["end_name"]),
     })
 }
 
-/// Extract a tag name from a decorator expression.
-///
-/// Returns `Some((name, kind))` if the decorator is a tag registration.
-fn tag_name_from_decorator(expr: &Expr, func_name: &str) -> Option<(String, RegistrationKind)> {
-    // Bare decorator: `@register.tag`
-    if let Some(attr) = direct_register_helper(expr)
-        && let Some(kind) = tag_decorator_kind(attr)
-    {
-        return Some((func_name.to_string(), kind));
-    }
-
-    // Call decorator: `@register.tag(...)` or `@register.simple_tag(name="alias")`
-    if let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = expr
-        && let Some(attr) = direct_register_helper(func)
-        && let Some(kind) = tag_decorator_kind(attr)
-    {
-        // Priority: name= kwarg > first positional string (for @register.tag only) > func_name
-        let name_override = kw_name_from(&arguments.keywords);
-
-        let positional_name = if attr == "tag" {
-            first_string_arg(&arguments.args)
-        } else {
-            None
-        };
-
-        let name = name_override
-            .or(positional_name)
-            .unwrap_or_else(|| func_name.to_string());
-
-        return Some((name, kind));
-    }
-
-    None
-}
-
-/// Extract a filter name from a decorator expression.
-///
-/// Returns `Some(name)` if the decorator is a filter registration.
-fn filter_name_from_decorator(expr: &Expr, func_name: &str) -> Option<String> {
-    // Bare decorator: `@register.filter`
-    if let Some(attr) = direct_register_helper(expr)
-        && FILTER_DECORATORS.contains(&attr)
-    {
-        return Some(func_name.to_string());
-    }
-
-    // Call decorator: `@register.filter(name="alias")` or `@register.filter("alias")`
-    if let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = expr
-        && let Some(attr) = direct_register_helper(func)
-        && FILTER_DECORATORS.contains(&attr)
-    {
-        let name_override = kw_name_from(&arguments.keywords);
-        let positional_name = first_string_arg(&arguments.args);
-        let name = name_override
-            .or(positional_name)
-            .unwrap_or_else(|| func_name.to_string());
-        return Some(name);
-    }
-
-    None
-}
-
 /// Extract registrations from a call expression statement.
-///
-/// Handles patterns like:
-/// - `register.tag("name", compile_func)`
-/// - `register.tag("name", SomeNode.handle)`
-/// - `register.filter("name", filter_func)`
-/// - `register.simple_tag(func, name="alias")`
 fn collect_from_call_statement(
     call: &ExprCall,
     transparent_decorated_functions: &BTreeMap<String, LocalFunctionSource>,
     python_facts: Option<&mut PythonSourceLookup<'_>>,
     analysis: &mut RegistrationSourceAnalysis,
 ) {
-    if !call_rooted_at_register(call) {
-        if call_escapes_register(call) {
-            analysis.open_inventory();
-        }
+    let lowered = if call_rooted_at_register(call) {
+        lower_registration_call(call, false)
+    } else if call.arguments.args.len() == 1 && call.arguments.keywords.is_empty() {
+        lower_registration_expression(
+            &call.func,
+            call.arguments.args.first().map(LoweredCallable::Expression),
+        )
+    } else {
+        None
+    };
+    if lowered.is_none() && !call_escapes_register(call) {
         return;
     }
     analysis.observe_register_use();
 
-    let Some(call) = lower_registration_call(call) else {
+    let Some(lowered) = lowered else {
         analysis.open_inventory();
         return;
     };
-    if let Some(python_facts) = python_facts
-        && let Some(registration) = resolved_python_registration(call, python_facts)
-    {
-        analysis.registrations.push(registration);
+    if lowered.callable.is_none() {
+        // Calling a decorator factory without applying the returned decorator does not
+        // mutate the library. This includes `filter(func=...)`, where `func` is only an
+        // ignored flag captured by `**flags`.
         return;
     }
-
-    let Some(registration) = unresolved_registration(call, transparent_decorated_functions) else {
+    let Some(registration) =
+        registration_from_lowered(lowered, transparent_decorated_functions, python_facts)
+    else {
         analysis.open_inventory();
         return;
     };
     analysis.registrations.push(registration);
 }
 
-fn resolved_python_registration(
-    call: LoweredRegistrationCall<'_>,
-    python_facts: &mut PythonSourceLookup<'_>,
-) -> Option<RegistrationInfo> {
-    let function = python_facts.function(call.callable?)?;
-    let name = call.name.map_or_else(
-        || Some(function.name().to_string()),
-        |expression| python_facts.exact_string(expression),
-    )?;
-    Some(RegistrationInfo {
-        name,
-        kind: call.kind,
-        callable: RegistrationCallable::ResolvedFunction(function),
-    })
-}
-
-fn unresolved_registration(
-    call: LoweredRegistrationCall<'_>,
-    transparent_decorated_functions: &BTreeMap<String, LocalFunctionSource>,
-) -> Option<RegistrationInfo> {
-    let function_name = call.callable.and_then(callable_name);
-    let local_source = function_name
-        .as_deref()
-        .and_then(|name| transparent_decorated_functions.get(name))
-        .copied();
-    let name = if let Some(name) = call.name {
-        name.string_literal()?.to_string()
-    } else {
-        local_source?;
-        function_name.clone()?
+fn resolved_registration_name(
+    kind: RegistrationKind,
+    name: Option<&Expr>,
+    callable_name: Option<&str>,
+    resolve_string: impl FnOnce(&Expr) -> Option<String>,
+) -> Option<String> {
+    let Some(name) = name else {
+        return callable_name.map(str::to_string);
     };
-    let callable = function_name.map_or(RegistrationCallable::Unresolved(None), |function_name| {
-        if let Some(navigation) = local_source {
-            RegistrationCallable::DecoratedLocal {
-                function_name,
-                navigation: Some(navigation),
+    if matches!(name, Expr::NoneLiteral(_)) {
+        return callable_name.map(str::to_string);
+    }
+    let resolved = resolve_string(name)?;
+    if resolved.is_empty()
+        && matches!(
+            kind,
+            RegistrationKind::SimpleTag
+                | RegistrationKind::InclusionTag
+                | RegistrationKind::SimpleBlockTag
+        )
+    {
+        callable_name.map(str::to_string)
+    } else {
+        Some(resolved)
+    }
+}
+
+fn registration_from_lowered(
+    lowered: LoweredRegistration<'_>,
+    transparent_decorated_functions: &BTreeMap<String, LocalFunctionSource>,
+    mut python_facts: Option<&mut PythonSourceLookup<'_>>,
+) -> Option<RegistrationInfo> {
+    let callable = lowered.callable?;
+    match callable {
+        LoweredCallable::Decorated {
+            function,
+            navigation,
+        } => {
+            let name = resolved_registration_name(
+                lowered.kind,
+                lowered.name,
+                Some(function.name.as_str()),
+                |expression| {
+                    python_facts
+                        .as_deref_mut()
+                        .and_then(|facts| facts.exact_string(expression))
+                        .or_else(|| expression.string_literal().map(str::to_string))
+                },
+            )?;
+            let options = RegistrationOptions::resolve(
+                lowered.kind,
+                lowered.takes_context,
+                lowered.end_name,
+                python_facts,
+            );
+            Some(RegistrationInfo {
+                name,
+                kind: lowered.kind,
+                callable: RegistrationCallable::DecoratedLocal {
+                    function_name: function.name.to_string(),
+                    navigation,
+                },
+                options,
+            })
+        }
+        LoweredCallable::Expression(expression) => {
+            if let Some(facts) = python_facts
+                && let Some(function) = facts.function(expression)
+            {
+                let name = resolved_registration_name(
+                    lowered.kind,
+                    lowered.name,
+                    Some(function.name()),
+                    |expression| facts.exact_string(expression),
+                )?;
+                let options = RegistrationOptions::resolve(
+                    lowered.kind,
+                    lowered.takes_context,
+                    lowered.end_name,
+                    Some(facts),
+                );
+                return Some(RegistrationInfo {
+                    name,
+                    kind: lowered.kind,
+                    callable: RegistrationCallable::ResolvedFunction(function),
+                    options,
+                });
             }
-        } else {
-            RegistrationCallable::Unresolved(Some(function_name))
-        }
-    });
-    Some(RegistrationInfo {
-        name,
-        kind: call.kind,
-        callable,
-    })
-}
 
-/// Map decorator attr name to `RegistrationKind`.
-fn tag_decorator_kind(attr: &str) -> Option<RegistrationKind> {
-    match attr {
-        "tag" => Some(RegistrationKind::Tag),
-        "simple_tag" => Some(RegistrationKind::SimpleTag),
-        "inclusion_tag" => Some(RegistrationKind::InclusionTag),
-        "simple_block_tag" => Some(RegistrationKind::SimpleBlockTag),
-        _ => None,
+            let function_name = callable_name(expression);
+            let navigation = function_name
+                .as_deref()
+                .and_then(|name| transparent_decorated_functions.get(name))
+                .copied();
+            let callable_name = navigation.and(function_name.as_deref());
+            let name = resolved_registration_name(
+                lowered.kind,
+                lowered.name,
+                callable_name,
+                |expression| expression.string_literal().map(str::to_string),
+            )?;
+            let callable =
+                function_name.map_or(RegistrationCallable::Unresolved(None), |function_name| {
+                    if let Some(navigation) = navigation {
+                        RegistrationCallable::DecoratedLocal {
+                            function_name,
+                            navigation: Some(navigation),
+                        }
+                    } else {
+                        RegistrationCallable::Unresolved(Some(function_name))
+                    }
+                });
+            Some(RegistrationInfo {
+                name,
+                kind: lowered.kind,
+                callable,
+                options: RegistrationOptions::resolve(
+                    lowered.kind,
+                    lowered.takes_context,
+                    lowered.end_name,
+                    None,
+                ),
+            })
+        }
     }
-}
-
-/// Extract the `name=` keyword argument value as a string.
-fn kw_name_from(keywords: &[Keyword]) -> Option<String> {
-    kw_constant_str(keywords, "name")
-}
-
-/// Extract a keyword argument's string constant value by argument name.
-fn kw_constant_str(keywords: &[Keyword], name: &str) -> Option<String> {
-    for kw in keywords {
-        let Some(arg) = &kw.arg else { continue };
-        if arg.as_str() != name {
-            continue;
-        }
-        if let Some(s) = kw.value.string_literal() {
-            return Some(s.to_string());
-        }
-    }
-    None
-}
-
-/// Extract the first positional argument's string value.
-fn first_string_arg(args: &[Expr]) -> Option<String> {
-    args.first()
-        .and_then(ExprExt::string_literal)
-        .map(str::to_string)
 }
 
 /// Best-effort callable name extraction for debugging / registration mapping.
@@ -1385,10 +1421,14 @@ fn template_library_source_analysis<'db>(
                 db,
                 imported.then_some(implementation_file),
                 func,
+                &registration.options,
             ) {
                 tag_rules.insert(symbol_key.clone(), rule.into());
             }
-            if let Some(block_spec) = registration.kind.extract_block_spec(func) {
+            if let Some(block_spec) = registration
+                .kind
+                .extract_block_spec(func, &registration.options)
+            {
                 let end_tag = match block_spec.end_tag {
                     EndTagEvidence::Literal(end_tag) => Some(end_tag),
                     EndTagEvidence::SelfNamed => Some(format!("end{}", symbol_key.name)),
@@ -1879,6 +1919,240 @@ register.simple_tag(my_func, name="alias")
     }
 
     #[test]
+    fn direct_and_curried_helpers_share_registration_options() {
+        let source = r#"
+from django import template
+register = template.Library()
+
+def direct(context, value): pass
+register.simple_tag(direct, takes_context=True, name="direct_alias")
+
+def curried(context, value): pass
+register.simple_tag(takes_context=True, name="curried_alias")(curried)
+"#;
+        let regs = collect_registrations(source);
+        for name in ["direct_alias", "curried_alias"] {
+            let registration = find_reg(&regs, name);
+            assert_eq!(registration.options.context, ContextProvision::Context);
+        }
+    }
+
+    #[test]
+    fn simple_block_options_retain_static_and_dynamic_end_names() {
+        let source = r#"
+from django import template
+register = template.Library()
+
+@register.simple_block_tag(name="panel", end_name="closepanel", takes_context=True)
+def panel_impl(context, content): pass
+
+@register.simple_block_tag(end_name=dynamic)
+def uncertain(content): pass
+
+@register.simple_block_tag(name="defaulted", end_name=None)
+def defaulted_impl(content): pass
+"#;
+        let regs = collect_registrations(source);
+        assert_eq!(
+            find_reg(&regs, "panel").options,
+            RegistrationOptions {
+                context: ContextProvision::Context,
+                block_end: Some(RegisteredEnd::Named("closepanel".to_string())),
+            }
+        );
+        assert_eq!(
+            find_reg(&regs, "uncertain").options.block_end,
+            Some(RegisteredEnd::Unknown)
+        );
+        assert_eq!(
+            find_reg(&regs, "defaulted").options.block_end,
+            Some(RegisteredEnd::Default)
+        );
+    }
+
+    #[test]
+    fn filter_registration_flags_work_in_decorator_and_direct_forms() {
+        let source = r#"
+from django import template
+register = template.Library()
+
+@register.filter(is_safe=True, needs_autoescape=True)
+def decorated(value, autoescape=None): pass
+
+def direct(value): pass
+register.filter("direct", direct, expects_localtime=True)
+"#;
+        let analysis = analyze_registrations(source);
+        assert!(!analysis.inventory_is_open());
+        assert_eq!(
+            analysis
+                .registrations
+                .iter()
+                .map(|registration| registration.name.as_str())
+                .collect::<Vec<_>>(),
+            ["decorated", "direct"]
+        );
+    }
+
+    #[test]
+    fn direct_filter_func_flag_is_a_known_noop() {
+        let source = r"
+from django import template
+register = template.Library()
+
+def unused(value): pass
+register.filter(func=unused)
+";
+        let analysis = analyze_registrations(source);
+        assert!(!analysis.inventory_is_open());
+        assert!(analysis.registrations.is_empty());
+    }
+
+    #[test]
+    fn filter_func_flag_is_not_a_callable_alias() {
+        let source = r#"
+from django import template
+register = template.Library()
+
+def ignored(value): pass
+
+def unused(value): pass
+register.filter(func=unused)
+
+@register.filter(func=ignored)
+def invalid(value): pass
+
+@register.filter(name="decorated", func=ignored)
+def decorated(value): pass
+"#;
+        let analysis = analyze_registrations(source);
+        assert!(analysis.inventory_is_open());
+        assert_eq!(analysis.registrations.len(), 1);
+        let registration = &analysis.registrations[0];
+        assert_eq!(registration.name, "decorated");
+        assert_eq!(registration.func_name(), Some("decorated"));
+    }
+
+    #[test]
+    fn tag_func_keyword_does_not_invent_a_callable_alias() {
+        let source = r"
+from django import template
+register = template.Library()
+
+def invented(parser, token): pass
+register.tag(func=invented)
+";
+        let analysis = analyze_registrations(source);
+        assert!(analysis.registrations.is_empty());
+        assert!(analysis.inventory_is_open());
+    }
+
+    #[test]
+    fn inclusion_func_argument_is_ignored_by_the_returned_decorator() {
+        let source = r#"
+from django import template
+register = template.Library()
+
+def ignored(value): pass
+register.inclusion_tag("unused.html", func=ignored)
+
+@register.inclusion_tag("included.html", func=ignored)
+def included(value): pass
+"#;
+        let analysis = analyze_registrations(source);
+        assert!(!analysis.inventory_is_open());
+        assert_eq!(analysis.registrations.len(), 1);
+        let registration = &analysis.registrations[0];
+        assert_eq!(registration.name, "included");
+        assert_eq!(registration.func_name(), Some("included"));
+    }
+
+    #[test]
+    fn django_name_fallbacks_keep_none_empty_and_dynamic_names_distinct() {
+        let source = r#"
+from django import template
+register = template.Library()
+
+@register.tag(name=None)
+def none_tag(parser, token): pass
+
+@register.filter(name=None)
+def none_filter(value): pass
+
+@register.simple_tag(name=None)
+def none_simple(): pass
+
+@register.inclusion_tag("included.html", name=None)
+def none_inclusion(): pass
+
+@register.simple_block_tag(name=None)
+def none_block(content): pass
+
+@register.tag(name="")
+def empty_tag(parser, token): pass
+
+@register.filter(name="")
+def empty_filter(value): pass
+
+@register.simple_tag(name="")
+def empty_simple(): pass
+
+@register.inclusion_tag("included.html", name="")
+def empty_inclusion(): pass
+
+@register.simple_block_tag(name="")
+def empty_block(content): pass
+
+@register.simple_tag(name=dynamic_name)
+def dynamic_simple(): pass
+"#;
+        let analysis = analyze_registrations(source);
+        assert!(analysis.inventory_is_open());
+        assert_eq!(
+            analysis
+                .registrations
+                .iter()
+                .map(|registration| registration.name.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "none_tag",
+                "none_filter",
+                "none_simple",
+                "none_inclusion",
+                "none_block",
+                "",
+                "",
+                "empty_simple",
+                "empty_inclusion",
+                "empty_block",
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_registration_decorators_open_inventory_without_symbols() {
+        for decorator in [
+            "@register.simple_tag(unsupported=True)",
+            "@register.inclusion_tag",
+            "@register.inclusion_tag()",
+            "@register.simple_tag(other)",
+        ] {
+            let source = format!(
+                "from django import template\nregister = template.Library()\n{decorator}\ndef invented(value): pass\n"
+            );
+            let analysis = analyze_registrations(&source);
+            assert!(
+                analysis.inventory_is_open(),
+                "malformed decorator should open inventory: {decorator}"
+            );
+            assert!(
+                analysis.registrations.is_empty(),
+                "malformed decorator must not invent a registration: {decorator}"
+            );
+        }
+    }
+
+    #[test]
     fn empty_source() {
         let regs = collect_registrations("");
         assert!(regs.is_empty());
@@ -1928,10 +2202,8 @@ register.filter(my_filter_func)
         assert!(analysis.inventory_is_open());
     }
 
-    // Edge case: name kwarg overrides positional string arg.
-    // Tests priority: name= kwarg wins over positional string.
     #[test]
-    fn name_kwarg_overrides_positional_for_tag() {
+    fn duplicate_positional_and_keyword_names_open_inventory() {
         let source = r#"
 from django import template
 register = template.Library()
@@ -1940,9 +2212,9 @@ register = template.Library()
 def my_tag(parser, token):
     pass
 "#;
-        let regs = collect_registrations(source);
-        assert_eq!(regs.len(), 1);
-        assert_eq!(regs[0].name, "kwarg_name");
+        let analysis = analyze_registrations(source);
+        assert!(analysis.registrations.is_empty());
+        assert!(analysis.inventory_is_open());
     }
 
     #[test]
@@ -2041,7 +2313,6 @@ def my_tag(parser, token):
             "register.tags.update(dynamic_tags)",
             "register.tags['dynamic'] = func",
             "del register.filters['dynamic']",
-            "register.tag()",
             "register.tag('invented', name=dynamic_name)",
             "register.filter('invented', name=dynamic_name)",
             "register.tag('invented', name='duplicate', compile_function=func)",

--- a/crates/djls-project/src/templates/tags/registry.rs
+++ b/crates/djls-project/src/templates/tags/registry.rs
@@ -5,10 +5,13 @@ use crate::templates::FilterArity;
 use crate::templates::RegistrationKind;
 use crate::templates::TemplateSymbolKind;
 use crate::templates::filters;
+use crate::templates::registrations::RegisteredEnd;
+use crate::templates::registrations::RegistrationOptions;
 use crate::templates::tags::analysis;
 use crate::templates::tags::blocks;
 use crate::templates::tags::signature;
 use crate::templates::tags::types::AsVar;
+use crate::templates::tags::types::BodyAnalysisEvidence;
 use crate::templates::tags::types::TagRule;
 
 impl RegistrationKind {
@@ -40,14 +43,20 @@ impl RegistrationKind {
         db: &dyn djls_source::Db,
         implementation_file: Option<File>,
         func: &StmtFunctionDef,
+        options: &RegistrationOptions,
     ) -> Option<Box<TagRule>> {
         match self {
             Self::Filter => None,
-            Self::SimpleTag | Self::InclusionTag => {
-                let rule = signature::extract_parse_bits_rule(func, self.var_assignment());
+            Self::SimpleTag | Self::InclusionTag | Self::SimpleBlockTag => {
+                let rule = signature::extract_parse_bits_rule(
+                    func,
+                    self,
+                    options.context,
+                    self.var_assignment(),
+                )?;
                 rule.has_content().then(|| Box::new(rule))
             }
-            Self::Tag | Self::SimpleBlockTag => {
+            Self::Tag => {
                 let mut rule = implementation_file.map_or_else(
                     || analysis::analyze_compile_function(func),
                     |file| analysis::analyze_compile_function_in_file(db, file, func),
@@ -63,12 +72,20 @@ impl RegistrationKind {
     pub(crate) fn extract_block_spec(
         self,
         func: &StmtFunctionDef,
+        options: &RegistrationOptions,
     ) -> Option<blocks::ExtractedBlockSpec> {
         match self {
             Self::Filter => None,
-            Self::Tag | Self::SimpleTag | Self::InclusionTag | Self::SimpleBlockTag => {
-                blocks::extract_block_spec(func)
-            }
+            Self::SimpleBlockTag => Some(blocks::ExtractedBlockSpec {
+                end_tag: match options.block_end.as_ref()? {
+                    RegisteredEnd::Default => blocks::EndTagEvidence::SelfNamed,
+                    RegisteredEnd::Named(name) => blocks::EndTagEvidence::Literal(name.clone()),
+                    RegisteredEnd::Unknown => blocks::EndTagEvidence::Unknown,
+                },
+                intermediates: Vec::new(),
+                body_analysis_evidence: BodyAnalysisEvidence::NotDetected,
+            }),
+            Self::Tag | Self::SimpleTag | Self::InclusionTag => blocks::extract_block_spec(func),
         }
     }
 }

--- a/crates/djls-project/src/templates/tags/signature.rs
+++ b/crates/djls-project/src/templates/tags/signature.rs
@@ -1,8 +1,7 @@
-use ruff_python_ast::Expr;
-use ruff_python_ast::ExprCall;
 use ruff_python_ast::StmtFunctionDef;
 
-use crate::ast::ExprExt;
+use crate::templates::RegistrationKind;
+use crate::templates::registrations::ContextProvision;
 use crate::templates::tags::types::ArgumentCountConstraint;
 use crate::templates::tags::types::AsVar;
 use crate::templates::tags::types::ParameterRequirement;
@@ -20,15 +19,41 @@ use crate::templates::tags::types::TagRule;
 /// `as_var` controls whether Django's framework strips trailing
 /// `as <varname>` before argument validation.
 #[must_use]
-pub(crate) fn extract_parse_bits_rule(func: &StmtFunctionDef, as_var: AsVar) -> TagRule {
+pub(crate) fn extract_parse_bits_rule(
+    func: &StmtFunctionDef,
+    kind: RegistrationKind,
+    context: ContextProvision,
+    as_var: AsVar,
+) -> Option<TagRule> {
     let params = &func.parameters;
-
-    let takes_context = has_takes_context(func);
-
-    let skip = usize::from(takes_context);
-
-    let effective_params: Vec<&ruff_python_ast::ParameterWithDefault> =
-        params.args.iter().skip(skip).collect();
+    let required_framework_names: &[&str] = match (kind, context) {
+        (_, ContextProvision::Unknown) | (RegistrationKind::Tag | RegistrationKind::Filter, _) => {
+            return None;
+        }
+        (RegistrationKind::SimpleTag | RegistrationKind::InclusionTag, ContextProvision::None) => {
+            &[]
+        }
+        (
+            RegistrationKind::SimpleTag | RegistrationKind::InclusionTag,
+            ContextProvision::Context,
+        ) => &["context"],
+        (RegistrationKind::SimpleBlockTag, ContextProvision::None) => &["content"],
+        (RegistrationKind::SimpleBlockTag, ContextProvision::Context) => &["context", "content"],
+    };
+    let combined: Vec<&ruff_python_ast::ParameterWithDefault> =
+        params.posonlyargs.iter().chain(&params.args).collect();
+    if !combined
+        .iter()
+        .zip(required_framework_names)
+        .all(|(parameter, required)| parameter.parameter.name.as_str() == *required)
+        || combined.len() < required_framework_names.len()
+    {
+        return None;
+    }
+    let effective_params: Vec<_> = combined
+        .into_iter()
+        .skip(required_framework_names.len())
+        .collect();
 
     let num_defaults = effective_params
         .iter()
@@ -93,7 +118,7 @@ pub(crate) fn extract_parse_bits_rule(func: &StmtFunctionDef, as_var: AsVar) -> 
         });
     }
 
-    TagRule {
+    Some(TagRule {
         arg_constraints,
         required_keywords: Vec::new(),
         choice_at_constraints: Vec::new(),
@@ -101,24 +126,7 @@ pub(crate) fn extract_parse_bits_rule(func: &StmtFunctionDef, as_var: AsVar) -> 
         diagnostic_messages: None,
         argument_syntax: TagArgumentSyntax::Parameters(extracted_args),
         as_var,
-    }
-}
-
-/// Check if a function's decorator includes `takes_context=True`.
-fn has_takes_context(func: &StmtFunctionDef) -> bool {
-    for decorator in &func.decorator_list {
-        if let Expr::Call(ExprCall { arguments, .. }) = &decorator.expression {
-            for kw in &arguments.keywords {
-                if let Some(arg) = &kw.arg
-                    && arg.as_str() == "takes_context"
-                    && kw.value.bool_literal() == Some(true)
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    })
 }
 
 #[cfg(test)]
@@ -133,7 +141,13 @@ mod tests {
     fn simple_tag_no_params() {
         let func = django_function("tests/template_tests/templatetags/custom.py", "no_params")
             .expect("expected Django fixture function should exist");
-        let rule = extract_parse_bits_rule(&func, AsVar::Strip);
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleTag,
+            ContextProvision::None,
+            AsVar::Strip,
+        )
+        .expect("simple tag signature should be trusted");
         assert!(
             rule.arg_constraints
                 .iter()
@@ -150,7 +164,13 @@ mod tests {
             "simple_two_params",
         )
         .expect("expected Django fixture function should exist");
-        let rule = extract_parse_bits_rule(&func, AsVar::Strip);
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleTag,
+            ContextProvision::None,
+            AsVar::Strip,
+        )
+        .expect("simple tag signature should be trusted");
         assert!(
             rule.arg_constraints
                 .contains(&ArgumentCountConstraint::Min(3))
@@ -166,7 +186,13 @@ mod tests {
             "simple_one_default",
         )
         .expect("expected Django fixture function should exist");
-        let rule = extract_parse_bits_rule(&func, AsVar::Strip);
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleTag,
+            ContextProvision::None,
+            AsVar::Strip,
+        )
+        .expect("simple tag signature should be trusted");
         assert!(
             rule.arg_constraints
                 .contains(&ArgumentCountConstraint::Min(2))
@@ -190,12 +216,64 @@ def concat(*args):
 ";
         let func = find_function_in_source(source, "concat")
             .expect("expected function should exist in test source");
-        let rule = extract_parse_bits_rule(&func, AsVar::Strip);
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleTag,
+            ContextProvision::None,
+            AsVar::Strip,
+        )
+        .expect("simple tag signature should be trusted");
         assert!(
             !rule
                 .arg_constraints
                 .iter()
                 .any(|c| matches!(c, ArgumentCountConstraint::Max(_)))
+        );
+    }
+
+    #[test]
+    fn block_tag_removes_framework_parameters() {
+        let source = r"
+def panel(context, content, title='Title'):
+    pass
+";
+        let func = find_function_in_source(source, "panel").expect("function should exist");
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleBlockTag,
+            ContextProvision::Context,
+            AsVar::Strip,
+        )
+        .expect("framework parameters should match");
+        let parameters = rule
+            .argument_syntax
+            .parameters()
+            .expect("signature parameters");
+        assert_eq!(parameters.len(), 1);
+        assert_eq!(parameters[0].name, "title");
+    }
+
+    #[test]
+    fn malformed_or_unknown_framework_parameters_have_no_rule() {
+        let source = "def panel(body, title): pass";
+        let func = find_function_in_source(source, "panel").expect("function should exist");
+        assert!(
+            extract_parse_bits_rule(
+                &func,
+                RegistrationKind::SimpleBlockTag,
+                ContextProvision::None,
+                AsVar::Strip,
+            )
+            .is_none()
+        );
+        assert!(
+            extract_parse_bits_rule(
+                &func,
+                RegistrationKind::SimpleBlockTag,
+                ContextProvision::Unknown,
+                AsVar::Strip,
+            )
+            .is_none()
         );
     }
 
@@ -209,7 +287,13 @@ def concat(*args):
             "add_preserved_filters",
         )
         .expect("expected Django fixture function should exist");
-        let rule = extract_parse_bits_rule(&func, AsVar::Strip);
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleTag,
+            ContextProvision::Context,
+            AsVar::Strip,
+        )
+        .expect("context simple tag signature should be trusted");
         assert!(
             rule.arg_constraints
                 .contains(&ArgumentCountConstraint::Min(2))

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -1086,7 +1086,7 @@ fn recovered_import_retains_positive_facts_but_opens_inventory_and_navigation() 
 fn literal_names_survive_unresolved_callables_across_call_shapes() {
     let (db, file, module) = imported_registration_fixture(
         "",
-        "from django import template\nfrom missing import implementation\nregister = template.Library()\nregister.tag('literal_tag', implementation.compile_tag)\nregister.filter('literal_filter', implementation.filter)\nregister.simple_tag(implementation.simple, name='literal_simple')\nregister.inclusion_tag('partial.html', func=implementation.inclusion, name='literal_inclusion')\nregister.simple_block_tag(name='literal_block', func=implementation.block)\n",
+        "from django import template\nfrom missing import implementation\nregister = template.Library()\nregister.tag('literal_tag', implementation.compile_tag)\nregister.filter('literal_filter', implementation.filter)\nregister.simple_tag(implementation.simple, name='literal_simple')\nregister.inclusion_tag('partial.html', name='literal_inclusion')(implementation.inclusion)\nregister.simple_block_tag(name='literal_block', func=implementation.block)\nregister.inclusion_tag('unused.html', name='unused_inclusion')\n",
         "",
     )
     .expect("unresolved-callable fixture should install");
@@ -1104,6 +1104,12 @@ fn literal_names_survive_unresolved_callables_across_call_shapes() {
             .unwrap_or_else(|| panic!("known Tag name `{name}` should survive"));
         assert_eq!(template_symbol_source(&db, symbol), None);
     }
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Tag, "unused_inclusion")
+            .is_none(),
+        "an unused inclusion_tag decorator must not register a Tag"
+    );
     let filter = facts
         .symbol(TemplateSymbolKind::Filter, "literal_filter")
         .expect("known Filter name should survive");
@@ -1120,25 +1126,116 @@ fn literal_names_survive_unresolved_callables_across_call_shapes() {
 fn imported_callable_only_registrations_use_resolved_function_names() {
     let (db, file, module) = imported_registration_fixture(
         "",
-        "from django import template\nfrom .implementation import compile_tag as tag_callable, imported_filter as filter_callable, keyword_tag, keyword_filter, simple, inclusion, block\nregister = template.Library()\nregister.tag(tag_callable)\nregister.filter(filter_callable)\nregister.tag(compile_function=keyword_tag)\nregister.filter(filter_func=keyword_filter)\nregister.simple_tag(func=simple)\nregister.inclusion_tag('partial.html', func=inclusion)\nregister.simple_block_tag(func=block)\n",
+        "from django import template\nfrom .implementation import compile_tag as tag_callable, imported_filter as filter_callable, keyword_tag, keyword_filter, simple, inclusion, block\nregister = template.Library()\nregister.tag(tag_callable)\nregister.filter(filter_callable)\nregister.tag(compile_function=keyword_tag)\nregister.filter(filter_func=keyword_filter)\nregister.simple_tag(func=simple)\nregister.inclusion_tag('partial.html')(inclusion)\nregister.simple_block_tag(func=block)\nregister.inclusion_tag('unused.html', name='unused_inclusion')\n",
         "def compile_tag(parser, token): pass\ndef imported_filter(value): return value\ndef keyword_tag(parser, token): pass\ndef keyword_filter(value): return value\ndef simple(): pass\ndef inclusion(): pass\ndef block(): pass\n",
     )
     .expect("callable-only fixture should install");
     let key = TemplateLibraryId::new(&db, Some(file), module);
     let facts = template_library_definition_facts(&db, key);
 
-    for name in ["compile_tag", "keyword_tag", "simple", "inclusion", "block"] {
+    for name in ["compile_tag", "simple", "inclusion", "block"] {
         assert!(
             facts.symbol(TemplateSymbolKind::Tag, name).is_some(),
             "resolved callable-only Tag `{name}` should use its function name"
         );
     }
-    for name in ["imported_filter", "keyword_filter"] {
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Filter, "imported_filter")
+            .is_some()
+    );
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Tag, "keyword_tag")
+            .is_none()
+    );
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Filter, "keyword_filter")
+            .is_none()
+    );
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Tag, "unused_inclusion")
+            .is_none(),
+        "an unused inclusion_tag decorator must not register a Tag"
+    );
+}
+
+#[test]
+fn project_backed_registration_options_resolve_without_inventing_count_facts() {
+    let (db, file, module) = imported_registration_fixture(
+        "",
+        r#"from django import template
+from . import implementation
+register = template.Library()
+
+register.simple_tag(
+    implementation.context_tag,
+    takes_context=implementation.TAKES_CONTEXT,
+    name="imported_context",
+)
+
+@register.simple_block_tag(
+    takes_context=implementation.TAKES_CONTEXT,
+    name=implementation.PANEL_NAME,
+    end_name=implementation.END_NAME,
+)
+def panel(context, content, title): pass
+
+@register.simple_tag(takes_context=UNKNOWN, name="unknown_context")
+def unknown_context(context, value): pass
+
+@register.simple_tag(name="malformed", unsupported=True)
+def malformed(value): pass
+"#,
+        "TAKES_CONTEXT = True\nPANEL_NAME = 'imported_panel'\nEND_NAME = 'finish_panel'\ndef context_tag(context, value): pass\n",
+    )
+    .expect("registration-option fixture should install");
+    let key = TemplateLibraryId::new(&db, Some(file), module);
+    let definitions = template_library_definition_facts(&db, key);
+    for name in ["imported_context", "imported_panel", "unknown_context"] {
         assert!(
-            facts.symbol(TemplateSymbolKind::Filter, name).is_some(),
-            "resolved callable-only Filter `{name}` should use its function name"
+            definitions.symbol(TemplateSymbolKind::Tag, name).is_some(),
+            "known registration `{name}` should survive"
         );
     }
+    assert!(
+        definitions
+            .symbol(TemplateSymbolKind::Tag, "malformed")
+            .is_none(),
+        "an unsupported decorator must not invent a registration"
+    );
+
+    let tag_facts = template_library_tag_facts(&db, key);
+    for name in ["imported_context", "imported_panel"] {
+        assert_eq!(
+            tag_facts.tag_rules()[&SymbolKey::tag("pkg.tags", name)].arg_constraints,
+            vec![
+                ArgumentCountConstraint::Min(2),
+                ArgumentCountConstraint::Max(2),
+            ],
+            "resolved takes_context must remove framework parameters for `{name}`"
+        );
+    }
+    assert_eq!(
+        tag_facts.block_specs().as_map()[&SymbolKey::tag("pkg.tags", "imported_panel")]
+            .end_tag
+            .as_deref(),
+        Some("finish_panel")
+    );
+    assert!(
+        !tag_facts
+            .tag_rules()
+            .contains_key(&SymbolKey::tag("pkg.tags", "unknown_context")),
+        "unknown options must not produce definite count facts"
+    );
+    assert!(
+        !tag_facts
+            .tag_rules()
+            .contains_key(&SymbolKey::tag("pkg.tags", "malformed")),
+        "malformed decorators must not produce count facts"
+    );
 }
 
 // The fixture deliberately keeps all released django-bird registration shapes together so the

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
@@ -21,7 +21,37 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::div":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: id
+          requirement: optional
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::div_custom_end":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
     arg_constraints:
       - Max: 1
     required_keywords: []
@@ -39,6 +69,15 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive":
     arg_constraints:
       - Max: 1
@@ -48,7 +87,29 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_naive_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
     arg_constraints:
       - Min: 2
       - Max: 2
@@ -92,7 +153,29 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::one_param_block":
     arg_constraints:
       - Min: 2
       - Max: 2
@@ -118,6 +201,19 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::params_and_context_block":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
     arg_constraints:
       - Max: 2
@@ -130,7 +226,31 @@ tag_rules:
           requirement: optional
           kind: Keyword
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: kwarg
+          requirement: optional
+          kind: Keyword
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: kwarg
+          requirement: required
+          kind: Keyword
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
     arg_constraints:
       - Max: 2
     required_keywords: []
@@ -158,6 +278,22 @@ tag_rules:
           requirement: optional
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
+    arg_constraints:
+      - Min: 2
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
     required_keywords: []
@@ -169,23 +305,16 @@ tag_rules:
           requirement: optional
           kind: VarArgs
     as_var: strip
-  "tests.template_tests.templatetags.custom::tag::simple_tag_takes_context_without_params":
-    arg_constraints:
-      - Max: 1
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
-    as_var: strip
-  "tests.template_tests.templatetags.custom::tag::simple_tag_without_context_parameter":
-    arg_constraints:
-      - Max: 1
-    required_keywords: []
-    choice_at_constraints: []
-    known_options: ~
-    argument_syntax:
-      Parameters: []
+      Parameters:
+        - name: args
+          requirement: optional
+          kind: VarArgs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
     arg_constraints:
@@ -203,7 +332,41 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: required
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
     arg_constraints:
       - Min: 2
     required_keywords: []
@@ -239,6 +402,24 @@ tag_rules:
           requirement: optional
           kind: VarArgs
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
     arg_constraints:
       - Max: 1
@@ -252,4 +433,92 @@ filter_arities:
   "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
   "tests.template_tests.templatetags.custom::filter::noop": optional_argument
   "tests.template_tests.templatetags.custom::filter::trim": required_argument
-block_specs: {}
+block_specs:
+  "tests.template_tests.templatetags.custom::tag::div":
+    body_analysis_evidence: not_detected
+    end_tag: enddiv
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::div_custom_end":
+    body_analysis_evidence: not_detected
+    end_tag: divend
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_explicit_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_format_html_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_naive_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_naive_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endexplicit_no_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endno_params_with_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::one_param_block":
+    body_analysis_evidence: not_detected
+    end_tag: endone_param_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::params_and_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endparams_and_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_block_tag_with_context_without_content":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_block_tag_with_context_without_content
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_block_tag_without_content":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_block_tag_without_content
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_block_tag_without_context_parameter":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_block_tag_without_context_parameter
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_keyword_only_default_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_keyword_only_param_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_one_default_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_only_unlimited_args_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_tag_takes_context_without_params_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_tag_takes_context_without_params_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_tag_with_context_without_content_parameter":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_tag_with_context_without_content_parameter
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_tag_without_content_parameter":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_tag_without_content_parameter
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_two_params_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_unlimited_args_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_unlimited_args_kwargs_block
+    intermediates: []

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__inclusion.py.snap
@@ -201,25 +201,7 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: keep
-  "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_takes_context_without_params":
-    arg_constraints:
-      - Max: 1
-    required_keywords: []
-    choice_at_constraints: []
-    known_options: ~
-    argument_syntax:
-      Parameters: []
-    as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
-    arg_constraints:
-      - Max: 1
-    required_keywords: []
-    choice_at_constraints: []
-    known_options: ~
-    argument_syntax:
-      Parameters: []
-    as_var: keep
-  "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_without_context_parameter":
     arg_constraints:
       - Max: 1
     required_keywords: []

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
@@ -21,7 +21,37 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::div":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: id
+          requirement: optional
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::div_custom_end":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
     arg_constraints:
       - Max: 1
     required_keywords: []
@@ -39,6 +69,15 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive":
     arg_constraints:
       - Max: 1
@@ -48,7 +87,29 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_naive_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
     arg_constraints:
       - Min: 2
       - Max: 2
@@ -92,7 +153,29 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::one_param_block":
     arg_constraints:
       - Min: 2
       - Max: 2
@@ -118,6 +201,19 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::params_and_context_block":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
     arg_constraints:
       - Max: 2
@@ -130,7 +226,31 @@ tag_rules:
           requirement: optional
           kind: Keyword
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: kwarg
+          requirement: optional
+          kind: Keyword
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: kwarg
+          requirement: required
+          kind: Keyword
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
     arg_constraints:
       - Max: 2
     required_keywords: []
@@ -158,6 +278,22 @@ tag_rules:
           requirement: optional
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
+    arg_constraints:
+      - Min: 2
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
     required_keywords: []
@@ -169,23 +305,16 @@ tag_rules:
           requirement: optional
           kind: VarArgs
     as_var: strip
-  "tests.template_tests.templatetags.custom::tag::simple_tag_takes_context_without_params":
-    arg_constraints:
-      - Max: 1
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
-    as_var: strip
-  "tests.template_tests.templatetags.custom::tag::simple_tag_without_context_parameter":
-    arg_constraints:
-      - Max: 1
-    required_keywords: []
-    choice_at_constraints: []
-    known_options: ~
-    argument_syntax:
-      Parameters: []
+      Parameters:
+        - name: args
+          requirement: optional
+          kind: VarArgs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
     arg_constraints:
@@ -203,7 +332,41 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: required
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
     arg_constraints:
       - Min: 2
     required_keywords: []
@@ -239,6 +402,24 @@ tag_rules:
           requirement: optional
           kind: VarArgs
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
     arg_constraints:
       - Max: 1
@@ -252,4 +433,92 @@ filter_arities:
   "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
   "tests.template_tests.templatetags.custom::filter::noop": optional_argument
   "tests.template_tests.templatetags.custom::filter::trim": required_argument
-block_specs: {}
+block_specs:
+  "tests.template_tests.templatetags.custom::tag::div":
+    body_analysis_evidence: not_detected
+    end_tag: enddiv
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::div_custom_end":
+    body_analysis_evidence: not_detected
+    end_tag: divend
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_explicit_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_format_html_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_naive_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_naive_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endexplicit_no_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endno_params_with_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::one_param_block":
+    body_analysis_evidence: not_detected
+    end_tag: endone_param_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::params_and_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endparams_and_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_block_tag_with_context_without_content":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_block_tag_with_context_without_content
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_block_tag_without_content":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_block_tag_without_content
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_block_tag_without_context_parameter":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_block_tag_without_context_parameter
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_keyword_only_default_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_keyword_only_param_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_one_default_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_only_unlimited_args_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_tag_takes_context_without_params_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_tag_takes_context_without_params_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_tag_with_context_without_content_parameter":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_tag_with_context_without_content_parameter
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_tag_without_content_parameter":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_tag_without_content_parameter
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_two_params_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_unlimited_args_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_unlimited_args_kwargs_block
+    intermediates: []

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__inclusion.py.snap
@@ -201,25 +201,7 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: keep
-  "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_takes_context_without_params":
-    arg_constraints:
-      - Max: 1
-    required_keywords: []
-    choice_at_constraints: []
-    known_options: ~
-    argument_syntax:
-      Parameters: []
-    as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
-    arg_constraints:
-      - Max: 1
-    required_keywords: []
-    choice_at_constraints: []
-    known_options: ~
-    argument_syntax:
-      Parameters: []
-    as_var: keep
-  "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_without_context_parameter":
     arg_constraints:
       - Max: 1
     required_keywords: []

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
@@ -21,7 +21,37 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::div":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: id
+          requirement: optional
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::div_custom_end":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
     arg_constraints:
       - Max: 1
     required_keywords: []
@@ -39,6 +69,15 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive":
     arg_constraints:
       - Max: 1
@@ -48,7 +87,29 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::escape_naive_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
     arg_constraints:
       - Min: 2
       - Max: 2
@@ -92,7 +153,29 @@ tag_rules:
     argument_syntax:
       Parameters: []
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::one_param_block":
     arg_constraints:
       - Min: 2
       - Max: 2
@@ -118,6 +201,19 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::params_and_context_block":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: arg
+          requirement: required
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
     arg_constraints:
       - Max: 2
@@ -130,7 +226,31 @@ tag_rules:
           requirement: optional
           kind: Keyword
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: kwarg
+          requirement: optional
+          kind: Keyword
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: kwarg
+          requirement: required
+          kind: Keyword
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
     arg_constraints:
       - Max: 2
     required_keywords: []
@@ -158,7 +278,34 @@ tag_rules:
           requirement: optional
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
+    arg_constraints:
+      - Min: 2
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
     arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
@@ -185,7 +332,41 @@ tag_rules:
           requirement: required
           kind: Variable
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
+    arg_constraints:
+      - Min: 3
+      - Max: 3
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: required
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
     arg_constraints:
       - Min: 2
     required_keywords: []
@@ -221,6 +402,24 @@ tag_rules:
           requirement: optional
           kind: VarArgs
     as_var: strip
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: one
+          requirement: required
+          kind: Variable
+        - name: two
+          requirement: optional
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
     arg_constraints:
       - Max: 1
@@ -234,4 +433,68 @@ filter_arities:
   "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument
   "tests.template_tests.templatetags.custom::filter::noop": optional_argument
   "tests.template_tests.templatetags.custom::filter::trim": required_argument
-block_specs: {}
+block_specs:
+  "tests.template_tests.templatetags.custom::tag::div":
+    body_analysis_evidence: not_detected
+    end_tag: enddiv
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::div_custom_end":
+    body_analysis_evidence: not_detected
+    end_tag: divend
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_explicit_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_format_html_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::escape_naive_block":
+    body_analysis_evidence: not_detected
+    end_tag: endescape_naive_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endexplicit_no_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endno_params_with_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::one_param_block":
+    body_analysis_evidence: not_detected
+    end_tag: endone_param_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::params_and_context_block":
+    body_analysis_evidence: not_detected
+    end_tag: endparams_and_context_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_keyword_only_default_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_keyword_only_param_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_one_default_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_only_unlimited_args_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_two_params_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_unlimited_args_block
+    intermediates: []
+  "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
+    body_analysis_evidence: not_detected
+    end_tag: endsimple_unlimited_args_kwargs_block
+    intermediates: []

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
@@ -3,6 +3,21 @@ source: crates/djls-project/tests/corpus.rs
 expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
+  "actstream.templatetags.activity_tags::tag::activity_stream":
+    arg_constraints:
+      - Min: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: stream_type
+          requirement: required
+          kind: Variable
+        - name: args
+          requirement: optional
+          kind: VarArgs
+    as_var: strip
   "actstream.templatetags.activity_tags::tag::actor_url":
     arg_constraints:
       - Exact: 2

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_tags.py.snap
@@ -34,16 +34,13 @@ tag_rules:
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_placeholder":
     arg_constraints:
-      - Min: 4
-      - Max: 7
+      - Min: 3
+      - Max: 6
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
       Parameters:
-        - name: context
-          requirement: required
-          kind: Variable
         - name: placeholder_name
           requirement: required
           kind: Variable
@@ -62,16 +59,13 @@ tag_rules:
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_placeholder_by_id":
     arg_constraints:
-      - Min: 4
-      - Max: 7
+      - Min: 3
+      - Max: 6
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
       Parameters:
-        - name: context
-          requirement: required
-          kind: Variable
         - name: placeholder_name
           requirement: required
           kind: Variable
@@ -89,31 +83,23 @@ tag_rules:
           kind: Variable
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_uncached_placeholder":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
       Parameters:
-        - name: context
-          requirement: required
-          kind: Variable
         - name: args
           requirement: optional
           kind: VarArgs
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_uncached_placeholder_by_id":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
       Parameters:
-        - name: context
-          requirement: required
-          kind: Variable
         - name: args
           requirement: optional
           kind: VarArgs

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__asciitable.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__asciitable.py.snap
@@ -1,10 +1,36 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
-tag_rules: {}
+tag_rules:
+  "hc.front.templatetags.asciitable::tag::cell":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
+  "hc.front.templatetags.asciitable::tag::row":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
 filter_arities: {}
 block_specs:
+  "hc.front.templatetags.asciitable::tag::cell":
+    body_analysis_evidence: not_detected
+    end_tag: endcell
+    intermediates: []
+  "hc.front.templatetags.asciitable::tag::row":
+    body_analysis_evidence: not_detected
+    end_tag: endrow
+    intermediates: []
   "hc.front.templatetags.asciitable::tag::table":
     body_analysis_evidence: not_detected
     end_tag: endtable

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__linemode.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__linemode.py.snap
@@ -1,10 +1,23 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
-tag_rules: {}
+tag_rules:
+  "hc.front.templatetags.linemode::tag::line":
+    arg_constraints:
+      - Max: 1
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters: []
+    as_var: strip
 filter_arities: {}
 block_specs:
+  "hc.front.templatetags.linemode::tag::line":
+    body_analysis_evidence: not_detected
+    end_tag: endline
+    intermediates: []
   "hc.front.templatetags.linemode::tag::linemode":
     body_analysis_evidence: not_detected
     end_tag: endlinemode

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__markup__templatetags__misago_editor.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__markup__templatetags__misago_editor.py.snap
@@ -1,7 +1,33 @@
 ---
 source: crates/djls-project/tests/corpus.rs
-expression: snapshot(result)
+expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
-tag_rules: {}
+tag_rules:
+  "misago.markup.templatetags.misago_editor::tag::editor_body":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: editor
+          requirement: required
+          kind: Variable
+    as_var: strip
+  "misago.markup.templatetags.misago_editor::tag::editor_js":
+    arg_constraints:
+      - Min: 2
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: editor
+          requirement: required
+          kind: Variable
+    as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_custom_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_custom_tags.snap
@@ -3,6 +3,18 @@ source: crates/djls-project/tests/extraction.rs
 expression: "sorted_snapshot(&result).expect(\"custom-tag extraction snapshot should serialize\")"
 ---
 tag_rules:
+  "tests.template_tests.templatetags.custom::tag::div":
+    arg_constraints:
+      - Max: 2
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Parameters:
+        - name: id
+          requirement: optional
+          kind: Variable
+    as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
     arg_constraints:
       - Max: 1
@@ -67,4 +79,8 @@ tag_rules:
           kind: Variable
     as_var: strip
 filter_arities: {}
-block_specs: {}
+block_specs:
+  "tests.template_tests.templatetags.custom::tag::div":
+    body_analysis_evidence: not_detected
+    end_tag: enddiv
+    intermediates: []

--- a/crates/djls-semantic/tests/django_compilation.rs
+++ b/crates/djls-semantic/tests/django_compilation.rs
@@ -12,8 +12,6 @@ use djls_testing::django_facts_project;
 
 /// Django compiles these templates; DJLS reports a diagnostic. Every entry is a bug.
 const FALSE_POSITIVES: &[&str] = &[
-    // direct registration loses takes_context, so context counts as a template argument
-    "direct_context_valid",
     // conditional argument pops are extracted as an unconditional count
     "lorem_no_arguments",
     "lorem_words",
@@ -29,16 +27,12 @@ const MISSED_DIAGNOSTICS: &[&str] = &[
     "authored_repeated_keyword",
     // class constructors are not resolved as parser functions for rule extraction
     "class_missing",
-    // curried registration leaves the library inventory open without an argument rule
-    "curried_context_missing",
     // split-sequence truthiness guards do not produce argument-count constraints
     "firstof_missing",
     // the conditional expression choosing the in-keyword index evaluates to Unknown
     "for_wrong_separator",
     // option extraction records names but not the assignments required after with
     "include_missing_assignment",
-    // simple_block_tag bodies use manual-parser analysis instead of signature extraction
-    "simple_block_missing",
     // registration is curried through functools.partial; there is no standard-library search root and no model of partial, so the library is open
     "stdlib_partial_context_invalid",
     // callable is wrapped by a functools.wraps decorator; the wrapper is unresolvable and the library is open

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -3096,18 +3096,10 @@ fn corpus_show_placeholder_gets_context_from_django() {
         .expect("template validation should run"),
         []
     );
-    // False positive: direct registration loses takes_context=True. Django
-    // supplies context to _show_placeholder_by_id, so this has no compile error.
+    // Django supplies context to _show_placeholder_by_id.
     let errors = collect_errors(&db, "/valid.html", "{% show_placeholder 'slot' page_id %}")
         .expect("template validation should run");
-    let [ValidationError::ExtractedRuleViolation { tag, message, .. }] = errors.as_slice() else {
-        panic!("expected the context-count gap, got {errors:?}");
-    };
-    assert_eq!(tag, "show_placeholder");
-    assert_eq!(
-        message,
-        "Tag 'show_placeholder' requires at least 3 arguments"
-    );
+    assert!(errors.is_empty(), "{errors:?}");
     let errors = collect_errors(&db, "/invalid.html", "{% show_placeholder %}")
         .expect("template validation should run");
     assert!(matches!(
@@ -3162,22 +3154,24 @@ fn corpus_activity_stream_curried_registration() {
     assert!(
         djls_project::template_library_definition_facts(&extraction_db, library)
             .symbol(TemplateSymbolKind::Tag, "activity_stream")
-            .is_none()
+            .is_some()
     );
     let (specs, _) =
         build_specs_from_extraction(&corpus, &root).expect("corpus specs should build");
     let db = TestDatabase::new().with_projectless_tag_specs(specs);
-    // False positive on the valid control: curried registration is absent.
-    // The invalid call should instead get Django parse_bits' missing
-    // 'stream_type' argument error, not an unknown-tag diagnostic.
-    for template in ["{% activity_stream 'actor' %}", "{% activity_stream %}"] {
-        let errors =
-            collect_errors(&db, "/case.html", template).expect("template validation should run");
-        let [ValidationError::UnknownTag { tag, .. }] = errors.as_slice() else {
-            panic!("expected the curried registration gap, got {errors:?}");
-        };
-        assert_eq!(tag, "activity_stream");
-    }
+    let errors = collect_errors(&db, "/valid.html", "{% activity_stream 'actor' %}")
+        .expect("template validation should run");
+    assert!(errors.is_empty(), "{errors:?}");
+    // Django's parse_bits rejects the missing stream_type argument.
+    let errors = collect_errors(&db, "/invalid.html", "{% activity_stream %}")
+        .expect("template validation should run");
+    assert!(
+        matches!(
+            errors.as_slice(),
+            [ValidationError::ExtractedRuleViolation { tag, .. }] if tag == "activity_stream"
+        ),
+        "{errors:?}"
+    );
 }
 
 #[test]

--- a/tests/compilation/compilation_tags.py
+++ b/tests/compilation/compilation_tags.py
@@ -25,6 +25,16 @@ def authored_default(one, two="default"):
     return f"{one}:{two}"
 
 
+@register.simple_tag(name=None)
+def none_named_simple(value):
+    return value
+
+
+@register.simple_tag(name="")
+def empty_named_simple(value):
+    return value
+
+
 @register.simple_tag(takes_context=True)
 def decorator_context(context, value):
     return value
@@ -46,6 +56,50 @@ register.simple_tag(takes_context=True)(curried_context)
 
 @register.simple_block_tag
 def authored_panel(content, title):
+    return f"{title}:{content}"
+
+
+@register.simple_block_tag(
+    takes_context=True,
+    name="context_panel",
+    end_name="close_context_panel",
+)
+def context_panel_impl(context, content, title):
+    return f"{title}:{content}"
+
+
+@register.simple_block_tag(name="default_panel", end_name=None)
+def default_panel_impl(content, title):
+    return f"{title}:{content}"
+
+
+def curried_inclusion(value):
+    return {"value": value}
+
+
+register.inclusion_tag("included.html", name="curried_inclusion")(curried_inclusion)
+
+
+@register.inclusion_tag("included.html", name="")
+def empty_named_inclusion(value):
+    return {"value": value}
+
+
+def ignored_inclusion(value):
+    return {"ignored": value}
+
+
+@register.inclusion_tag(
+    "included.html",
+    func=ignored_inclusion,
+    name="inclusion_func_is_ignored",
+)
+def inclusion_func_is_ignored(value):
+    return {"value": value}
+
+
+@register.simple_block_tag(name="")
+def empty_named_panel(content, title):
     return f"{title}:{content}"
 
 

--- a/tests/compilation/templates/context_simple_block_missing.html
+++ b/tests/compilation/templates/context_simple_block_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% context_panel %}content{% close_context_panel %}

--- a/tests/compilation/templates/context_simple_block_valid.html
+++ b/tests/compilation/templates/context_simple_block_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% context_panel title %}content{% close_context_panel %}

--- a/tests/compilation/templates/curried_inclusion_missing.html
+++ b/tests/compilation/templates/curried_inclusion_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% curried_inclusion %}

--- a/tests/compilation/templates/curried_inclusion_valid.html
+++ b/tests/compilation/templates/curried_inclusion_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% curried_inclusion value %}

--- a/tests/compilation/templates/empty_block_name_uses_function_name_missing.html
+++ b/tests/compilation/templates/empty_block_name_uses_function_name_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% empty_named_panel %}content{% endempty_named_panel %}

--- a/tests/compilation/templates/empty_block_name_uses_function_name_valid.html
+++ b/tests/compilation/templates/empty_block_name_uses_function_name_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% empty_named_panel title %}content{% endempty_named_panel %}

--- a/tests/compilation/templates/empty_inclusion_name_uses_function_name_missing.html
+++ b/tests/compilation/templates/empty_inclusion_name_uses_function_name_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% empty_named_inclusion %}

--- a/tests/compilation/templates/empty_inclusion_name_uses_function_name_valid.html
+++ b/tests/compilation/templates/empty_inclusion_name_uses_function_name_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% empty_named_inclusion value %}

--- a/tests/compilation/templates/empty_simple_name_uses_function_name_missing.html
+++ b/tests/compilation/templates/empty_simple_name_uses_function_name_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% empty_named_simple %}

--- a/tests/compilation/templates/empty_simple_name_uses_function_name_valid.html
+++ b/tests/compilation/templates/empty_simple_name_uses_function_name_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% empty_named_simple value %}

--- a/tests/compilation/templates/inclusion_func_is_ignored_missing.html
+++ b/tests/compilation/templates/inclusion_func_is_ignored_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% inclusion_func_is_ignored %}

--- a/tests/compilation/templates/inclusion_func_is_ignored_valid.html
+++ b/tests/compilation/templates/inclusion_func_is_ignored_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% inclusion_func_is_ignored value %}

--- a/tests/compilation/templates/none_end_name_uses_default_missing.html
+++ b/tests/compilation/templates/none_end_name_uses_default_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% default_panel %}content{% enddefault_panel %}

--- a/tests/compilation/templates/none_end_name_uses_default_valid.html
+++ b/tests/compilation/templates/none_end_name_uses_default_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% default_panel title %}content{% enddefault_panel %}

--- a/tests/compilation/templates/none_name_uses_function_name_missing.html
+++ b/tests/compilation/templates/none_name_uses_function_name_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% none_named_simple %}

--- a/tests/compilation/templates/none_name_uses_function_name_valid.html
+++ b/tests/compilation/templates/none_name_uses_function_name_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% none_named_simple value %}

--- a/tests/fixtures/django-facts/compilation-5.2.json
+++ b/tests/fixtures/django-facts/compilation-5.2.json
@@ -38,11 +38,25 @@
     "class_valid.html": {
       "result": "compiled"
     },
+    "context_simple_block_missing.html": {
+      "error": "'context_panel' did not receive value(s) for the argument(s): 'title'",
+      "result": "failed"
+    },
+    "context_simple_block_valid.html": {
+      "result": "compiled"
+    },
     "curried_context_missing.html": {
       "error": "'curried_context' did not receive value(s) for the argument(s): 'value'",
       "result": "failed"
     },
     "curried_context_valid.html": {
+      "result": "compiled"
+    },
+    "curried_inclusion_missing.html": {
+      "error": "'curried_inclusion' did not receive value(s) for the argument(s): 'value'",
+      "result": "failed"
+    },
+    "curried_inclusion_valid.html": {
       "result": "compiled"
     },
     "decorator_context_missing.html": {
@@ -57,6 +71,27 @@
       "result": "failed"
     },
     "direct_context_valid.html": {
+      "result": "compiled"
+    },
+    "empty_block_name_uses_function_name_missing.html": {
+      "error": "'empty_named_panel' did not receive value(s) for the argument(s): 'title'",
+      "result": "failed"
+    },
+    "empty_block_name_uses_function_name_valid.html": {
+      "result": "compiled"
+    },
+    "empty_inclusion_name_uses_function_name_missing.html": {
+      "error": "'empty_named_inclusion' did not receive value(s) for the argument(s): 'value'",
+      "result": "failed"
+    },
+    "empty_inclusion_name_uses_function_name_valid.html": {
+      "result": "compiled"
+    },
+    "empty_simple_name_uses_function_name_missing.html": {
+      "error": "'empty_named_simple' did not receive value(s) for the argument(s): 'value'",
+      "result": "failed"
+    },
+    "empty_simple_name_uses_function_name_valid.html": {
       "result": "compiled"
     },
     "firstof_missing.html": {
@@ -87,6 +122,13 @@
     "include_valid.html": {
       "result": "compiled"
     },
+    "inclusion_func_is_ignored_missing.html": {
+      "error": "'inclusion_func_is_ignored' did not receive value(s) for the argument(s): 'value'",
+      "result": "failed"
+    },
+    "inclusion_func_is_ignored_valid.html": {
+      "result": "compiled"
+    },
     "lorem_extra_arguments.html": {
       "error": "Incorrect format for 'lorem' tag",
       "result": "failed"
@@ -98,6 +140,20 @@
       "result": "compiled"
     },
     "lorem_words.html": {
+      "result": "compiled"
+    },
+    "none_end_name_uses_default_missing.html": {
+      "error": "'default_panel' did not receive value(s) for the argument(s): 'title'",
+      "result": "failed"
+    },
+    "none_end_name_uses_default_valid.html": {
+      "result": "compiled"
+    },
+    "none_name_uses_function_name_missing.html": {
+      "error": "'none_named_simple' did not receive value(s) for the argument(s): 'value'",
+      "result": "failed"
+    },
+    "none_name_uses_function_name_valid.html": {
       "result": "compiled"
     },
     "simple_block_missing.html": {


### PR DESCRIPTION
Preserve Django registration options for direct and curried calls, including context arguments, effective names, inclusion tags, and simple-block closing tags.

## Evidence

Django compilation and project-backed validation now agree on `direct_context_valid`, `curried_context_missing`, and `simple_block_missing`. Their disagreement entries were removed only after the comparison rejected them as stale. The valid `curried_context` template confirms project discovery finds the registration.

Eight added registrations cover absent/empty names, context-aware blocks, default closing names, and curried inclusion forms. Ordinary corpus tests now verify the corrected `show_placeholder` and `activity_stream` behavior. The open-library regressions inherited from #870 still assert unloaded-tag diagnostics. Their unresolved `globals()` callable keeps the inventory open; this PR does not change those fixture lines.

## Compilation fixtures

Adds 16 templates under `tests/compilation/templates/`. Django facts were regenerated through the existing fixtures session.

- `context_simple_block_missing`
- `context_simple_block_valid`
- `curried_inclusion_missing`
- `curried_inclusion_valid`
- `empty_block_name_uses_function_name_missing`
- `empty_block_name_uses_function_name_valid`
- `empty_inclusion_name_uses_function_name_missing`
- `empty_inclusion_name_uses_function_name_valid`
- `empty_simple_name_uses_function_name_missing`
- `empty_simple_name_uses_function_name_valid`
- `inclusion_func_is_ignored_missing`
- `inclusion_func_is_ignored_valid`
- `none_end_name_uses_default_missing`
- `none_end_name_uses_default_valid`
- `none_name_uses_function_name_missing`
- `none_name_uses_function_name_valid`

## Validation

Passed at this PR head:

- `cargo test -q` (includes the Django compilation comparison)
- `just clippy`
- `just fmt`
- `just lint`