### PR TITLE
Validate helper arguments with Django signature binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Fixed static validation of `simple_tag`, `inclusion_tag`, and `simple_block_tag` arguments to match Django's `parse_bits()` binding rules.
 - Fixed static validation for context-aware and curried tag registrations and for `simple_block_tag` block structure.
 - Fixed unloaded-tag diagnostics and load quick fixes disappearing when an unrelated template library has unknown registrations.
 - Fixed explicit `false` and empty LSP initialization options failing to override project configuration.

--- a/crates/djls-ide/src/snippets.rs
+++ b/crates/djls-ide/src/snippets.rs
@@ -50,7 +50,8 @@ fn generate_snippet_from_args(args: &[TagArgument]) -> String {
 #[must_use]
 fn generate_snippet_for_tag(tag_name: &str, spec: &TagSpec) -> String {
     let arguments = match spec.argument_syntax() {
-        TagArgumentSyntax::Parameters(arguments) => Some(arguments.as_slice()),
+        TagArgumentSyntax::Signature { parameters, .. }
+        | TagArgumentSyntax::Parameters(parameters) => Some(parameters.as_slice()),
         TagArgumentSyntax::Forms {
             forms,
             coverage: ArgumentFormCoverage::Complete,
@@ -76,7 +77,8 @@ fn generate_snippet_for_tag(tag_name: &str, spec: &TagSpec) -> String {
 #[must_use]
 pub(crate) fn has_full_argument_snippet(spec: &TagSpec) -> bool {
     match spec.argument_syntax() {
-        TagArgumentSyntax::Parameters(arguments) => !arguments.is_empty(),
+        TagArgumentSyntax::Signature { parameters, .. }
+        | TagArgumentSyntax::Parameters(parameters) => !parameters.is_empty(),
         TagArgumentSyntax::Forms {
             forms,
             coverage: ArgumentFormCoverage::Complete,
@@ -121,7 +123,8 @@ pub(crate) fn compatible_arguments_at<'a>(
 ) -> Vec<&'a TagArgument> {
     let sequences: Vec<&[TagArgument]> = match spec.argument_syntax() {
         TagArgumentSyntax::Unknown => Vec::new(),
-        TagArgumentSyntax::Parameters(arguments) => vec![arguments],
+        TagArgumentSyntax::Signature { parameters, .. }
+        | TagArgumentSyntax::Parameters(parameters) => vec![parameters],
         TagArgumentSyntax::Forms { forms, .. } => {
             forms.iter().map(|form| form.arguments.as_slice()).collect()
         }
@@ -149,7 +152,8 @@ pub(crate) fn generate_partial_snippet(
 ) -> String {
     let sequence = match spec.argument_syntax() {
         TagArgumentSyntax::Unknown => None,
-        TagArgumentSyntax::Parameters(arguments) => Some(arguments.as_slice()),
+        TagArgumentSyntax::Signature { parameters, .. }
+        | TagArgumentSyntax::Parameters(parameters) => Some(parameters.as_slice()),
         TagArgumentSyntax::Forms { forms, .. } => forms
             .iter()
             .filter(|form| {

--- a/crates/djls-project/src/python/source_occurrences.rs
+++ b/crates/djls-project/src/python/source_occurrences.rs
@@ -81,6 +81,14 @@ impl PythonFunctionDefinition {
     }
 
     #[must_use]
+    pub(crate) fn source_is_exact(&self, db: &dyn ProjectDb) -> bool {
+        RecoveredPythonModule::from_file(db, self.file)
+            .ok()
+            .flatten()
+            .is_some_and(|module| !module.has_ordinary_syntax_errors(db))
+    }
+
+    #[must_use]
     pub(crate) fn statement<'db>(&self, db: &'db dyn ProjectDb) -> Option<&'db StmtFunctionDef> {
         let module = RecoveredPythonModule::from_file(db, self.file)
             .ok()
@@ -118,7 +126,7 @@ pub(crate) struct PythonSourceLookup<'db> {
     module: Option<PythonSourceModule>,
     file: File,
     consulted_files: Vec<File>,
-    recovered_source: bool,
+    recovered_source_lookups: usize,
 }
 
 impl<'db> PythonSourceLookup<'db> {
@@ -129,7 +137,7 @@ impl<'db> PythonSourceLookup<'db> {
             module: None,
             file,
             consulted_files: Vec::new(),
-            recovered_source: false,
+            recovered_source_lookups: 0,
         }
     }
 
@@ -144,7 +152,7 @@ impl<'db> PythonSourceLookup<'db> {
             file: module.file(),
             module: Some(module),
             consulted_files: Vec::new(),
-            recovered_source: false,
+            recovered_source_lookups: 0,
         }
     }
 
@@ -188,7 +196,12 @@ impl<'db> PythonSourceLookup<'db> {
 
     #[must_use]
     pub(crate) fn has_recovered_source(&self) -> bool {
-        self.recovered_source
+        self.recovered_source_lookups != 0
+    }
+
+    #[must_use]
+    pub(crate) fn recovered_source_lookups(&self) -> usize {
+        self.recovered_source_lookups
     }
 
     fn lookup(&mut self, expression: &Expr) -> Option<PythonOccurrenceValue> {
@@ -199,7 +212,7 @@ impl<'db> PythonSourceLookup<'db> {
             self.file,
             expression.span(),
         );
-        self.recovered_source |= occurrence.recovered_source;
+        self.recovered_source_lookups += usize::from(occurrence.recovered_source);
         for file in &occurrence.consulted_files {
             if !self.consulted_files.contains(file) {
                 self.consulted_files.push(*file);

--- a/crates/djls-project/src/templates/registrations.rs
+++ b/crates/djls-project/src/templates/registrations.rs
@@ -44,6 +44,7 @@ pub(crate) struct RegistrationInfo {
 pub(crate) struct RegistrationOptions {
     pub(crate) context: ContextProvision,
     pub(crate) block_end: Option<RegisteredEnd>,
+    source_is_exact: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +68,9 @@ impl RegistrationOptions {
         end_name: Option<&Expr>,
         mut python_facts: Option<&mut PythonSourceLookup<'_>>,
     ) -> Self {
+        let recovered_lookups_before = python_facts
+            .as_deref()
+            .map_or(0, PythonSourceLookup::recovered_source_lookups);
         let context = match takes_context {
             None | Some(Expr::NoneLiteral(_)) => ContextProvision::None,
             Some(value) => match value.bool_literal().or_else(|| {
@@ -82,11 +86,19 @@ impl RegistrationOptions {
         let block_end = matches!(kind, RegistrationKind::SimpleBlockTag).then(|| match end_name {
             None | Some(Expr::NoneLiteral(_)) => RegisteredEnd::Default,
             Some(value) => python_facts
+                .as_deref_mut()
                 .and_then(|facts| facts.exact_string(value))
                 .or_else(|| value.string_literal().map(str::to_string))
                 .map_or(RegisteredEnd::Unknown, RegisteredEnd::Named),
         });
-        Self { context, block_end }
+        let source_is_exact = python_facts
+            .as_deref()
+            .is_none_or(|facts| facts.recovered_source_lookups() == recovered_lookups_before);
+        Self {
+            context,
+            block_end,
+            source_is_exact,
+        }
     }
 }
 
@@ -96,7 +108,10 @@ enum RegistrationCallable {
         function_name: String,
         navigation: Option<LocalFunctionSource>,
     },
-    ResolvedFunction(PythonFunctionDefinition),
+    ResolvedFunction {
+        definition: PythonFunctionDefinition,
+        resolution_is_exact: bool,
+    },
     Unresolved(Option<String>),
 }
 
@@ -105,7 +120,7 @@ impl RegistrationInfo {
     fn func_name(&self) -> Option<&str> {
         match &self.callable {
             RegistrationCallable::DecoratedLocal { function_name, .. } => Some(function_name),
-            RegistrationCallable::ResolvedFunction(_) => None,
+            RegistrationCallable::ResolvedFunction { .. } => None,
             RegistrationCallable::Unresolved(function_name) => function_name.as_deref(),
         }
     }
@@ -114,7 +129,9 @@ impl RegistrationInfo {
     fn local_source(&self) -> Option<LocalFunctionSource> {
         match self.callable {
             RegistrationCallable::DecoratedLocal { navigation, .. } => navigation,
-            RegistrationCallable::ResolvedFunction(_) | RegistrationCallable::Unresolved(_) => None,
+            RegistrationCallable::ResolvedFunction { .. } | RegistrationCallable::Unresolved(_) => {
+                None
+            }
         }
     }
 }
@@ -654,7 +671,7 @@ fn for_each_registration<'db>(
                 })
                 .copied()
                 .map(|function| (function, registration_file, false)),
-            RegistrationCallable::ResolvedFunction(definition) => {
+            RegistrationCallable::ResolvedFunction { definition, .. } => {
                 definition.statement(db).map(|function| {
                     let file = definition.file();
                     (function, file, file != registration_file)
@@ -1057,27 +1074,33 @@ fn registration_from_lowered(
             })
         }
         LoweredCallable::Expression(expression) => {
-            if let Some(facts) = python_facts
-                && let Some(function) = facts.function(expression)
-            {
-                let name = resolved_registration_name(
-                    lowered.kind,
-                    lowered.name,
-                    Some(function.name()),
-                    |expression| facts.exact_string(expression),
-                )?;
-                let options = RegistrationOptions::resolve(
-                    lowered.kind,
-                    lowered.takes_context,
-                    lowered.end_name,
-                    Some(facts),
-                );
-                return Some(RegistrationInfo {
-                    name,
-                    kind: lowered.kind,
-                    callable: RegistrationCallable::ResolvedFunction(function),
-                    options,
-                });
+            if let Some(facts) = python_facts {
+                let recovered_lookups_before = facts.recovered_source_lookups();
+                if let Some(function) = facts.function(expression) {
+                    let resolution_is_exact =
+                        facts.recovered_source_lookups() == recovered_lookups_before;
+                    let name = resolved_registration_name(
+                        lowered.kind,
+                        lowered.name,
+                        Some(function.name()),
+                        |expression| facts.exact_string(expression),
+                    )?;
+                    let options = RegistrationOptions::resolve(
+                        lowered.kind,
+                        lowered.takes_context,
+                        lowered.end_name,
+                        Some(facts),
+                    );
+                    return Some(RegistrationInfo {
+                        name,
+                        kind: lowered.kind,
+                        callable: RegistrationCallable::ResolvedFunction {
+                            definition: function,
+                            resolution_is_exact,
+                        },
+                        options,
+                    });
+                }
             }
 
             let function_name = callable_name(expression);
@@ -1382,7 +1405,7 @@ fn template_library_source_analysis<'db>(
                     && !used_recovered_source
                     && !registration_analysis.inventory_is_open())
                 .then(|| match &registration.callable {
-                    RegistrationCallable::ResolvedFunction(_) => {
+                    RegistrationCallable::ResolvedFunction { .. } => {
                         func.map(|(function, implementation_file, _)| {
                             TemplateSymbolSource::new(
                                 implementation_file,
@@ -1417,11 +1440,22 @@ fn template_library_source_analysis<'db>(
             let Some((func, implementation_file, imported)) = func else {
                 return;
             };
+            let trusted_callable = parse_quality == TemplateLibraryParseQuality::Exact
+                && registration.options.source_is_exact
+                && match &registration.callable {
+                    RegistrationCallable::DecoratedLocal { navigation, .. } => navigation.is_some(),
+                    RegistrationCallable::ResolvedFunction {
+                        definition,
+                        resolution_is_exact,
+                    } => *resolution_is_exact && definition.source_is_exact(db),
+                    RegistrationCallable::Unresolved(_) => false,
+                };
             if let Some(rule) = registration.kind.extract_tag_rule(
                 db,
                 imported.then_some(implementation_file),
                 func,
                 &registration.options,
+                trusted_callable,
             ) {
                 tag_rules.insert(symbol_key.clone(), rule.into());
             }
@@ -1958,6 +1992,7 @@ def defaulted_impl(content): pass
             RegistrationOptions {
                 context: ContextProvision::Context,
                 block_end: Some(RegisteredEnd::Named("closepanel".to_string())),
+                source_is_exact: true,
             }
         );
         assert_eq!(

--- a/crates/djls-project/src/templates/tags/registry.rs
+++ b/crates/djls-project/src/templates/tags/registry.rs
@@ -44,16 +44,26 @@ impl RegistrationKind {
         implementation_file: Option<File>,
         func: &StmtFunctionDef,
         options: &RegistrationOptions,
+        trusted_callable: bool,
     ) -> Option<Box<TagRule>> {
         match self {
             Self::Filter => None,
             Self::SimpleTag | Self::InclusionTag | Self::SimpleBlockTag => {
-                let rule = signature::extract_parse_bits_rule(
+                let mut rule = signature::extract_parse_bits_rule(
                     func,
                     self,
                     options.context,
                     self.var_assignment(),
                 )?;
+                if !trusted_callable
+                    && let crate::templates::tags::types::TagArgumentSyntax::Signature {
+                        parameters,
+                        ..
+                    } = rule.argument_syntax
+                {
+                    rule.argument_syntax =
+                        crate::templates::tags::types::TagArgumentSyntax::Parameters(parameters);
+                }
                 rule.has_content().then(|| Box::new(rule))
             }
             Self::Tag => {

--- a/crates/djls-project/src/templates/tags/signature.rs
+++ b/crates/djls-project/src/templates/tags/signature.rs
@@ -2,7 +2,6 @@ use ruff_python_ast::StmtFunctionDef;
 
 use crate::templates::RegistrationKind;
 use crate::templates::registrations::ContextProvision;
-use crate::templates::tags::types::ArgumentCountConstraint;
 use crate::templates::tags::types::AsVar;
 use crate::templates::tags::types::ParameterRequirement;
 use crate::templates::tags::types::TagArgument;
@@ -10,11 +9,10 @@ use crate::templates::tags::types::TagArgumentKind;
 use crate::templates::tags::types::TagArgumentSyntax;
 use crate::templates::tags::types::TagRule;
 
-/// Extract rules from a `simple_tag` or `inclusion_tag` function signature.
+/// Extract a trusted callable contract for a Django tag helper.
 ///
-/// These tags use Django's `parse_bits` for argument validation, so we derive
-/// constraints from the function signature (required params, optional params,
-/// `*args`, `**kwargs`).
+/// Django validates these helpers with `parse_bits()`. The signature variant
+/// retains that boundary instead of turning it into coarse count constraints.
 ///
 /// `as_var` controls whether Django's framework strips trailing
 /// `as <varname>` before argument validation.
@@ -55,32 +53,10 @@ pub(crate) fn extract_parse_bits_rule(
         .skip(required_framework_names.len())
         .collect();
 
-    let num_defaults = effective_params
-        .iter()
-        .filter(|p| p.default.is_some())
-        .count();
-    let num_required = effective_params.len().saturating_sub(num_defaults);
-
-    let has_varargs = params.vararg.is_some();
-    let has_kwargs = params.kwarg.is_some();
-
-    let mut arg_constraints = Vec::new();
-
-    if !has_varargs {
-        if num_required > 0 {
-            arg_constraints.push(ArgumentCountConstraint::Min(num_required + 1));
-        }
-        if !has_kwargs {
-            let max_positional = effective_params.len();
-            let kwonly_count = params.kwonlyargs.len();
-            arg_constraints.push(ArgumentCountConstraint::Max(
-                max_positional + kwonly_count + 1,
-            ));
-        }
-    } else if num_required > 0 {
-        arg_constraints.push(ArgumentCountConstraint::Min(num_required + 1));
-    }
-
+    let positional_only = params
+        .posonlyargs
+        .len()
+        .saturating_sub(required_framework_names.len());
     let mut extracted_args = Vec::new();
     for param in effective_params {
         let name = param.parameter.name.to_string();
@@ -96,7 +72,7 @@ pub(crate) fn extract_parse_bits_rule(
         });
     }
 
-    if has_varargs && let Some(vararg) = &params.vararg {
+    if let Some(vararg) = &params.vararg {
         extracted_args.push(TagArgument {
             name: vararg.name.to_string(),
             requirement: ParameterRequirement::Optional,
@@ -119,13 +95,13 @@ pub(crate) fn extract_parse_bits_rule(
     }
 
     Some(TagRule {
-        arg_constraints,
-        required_keywords: Vec::new(),
-        choice_at_constraints: Vec::new(),
-        known_options: None,
-        diagnostic_messages: None,
-        argument_syntax: TagArgumentSyntax::Parameters(extracted_args),
+        argument_syntax: TagArgumentSyntax::Signature {
+            parameters: extracted_args,
+            positional_only,
+            variadic_keyword: params.kwarg.as_ref().map(|kwarg| kwarg.name.to_string()),
+        },
         as_var,
+        ..TagRule::default()
     })
 }
 
@@ -148,10 +124,13 @@ mod tests {
             AsVar::Strip,
         )
         .expect("simple tag signature should be trusted");
-        assert!(
-            rule.arg_constraints
-                .iter()
-                .all(|c| matches!(c, ArgumentCountConstraint::Max(_)))
+        assert_eq!(
+            rule.argument_syntax,
+            TagArgumentSyntax::Signature {
+                parameters: Vec::new(),
+                positional_only: 0,
+                variadic_keyword: None,
+            }
         );
     }
 
@@ -171,9 +150,15 @@ mod tests {
             AsVar::Strip,
         )
         .expect("simple tag signature should be trusted");
+        let parameters = rule
+            .argument_syntax
+            .parameters()
+            .expect("simple tag should expose signature parameters");
+        assert_eq!(parameters.len(), 2);
         assert!(
-            rule.arg_constraints
-                .contains(&ArgumentCountConstraint::Min(3))
+            parameters
+                .iter()
+                .all(|parameter| parameter.requirement == ParameterRequirement::Required)
         );
     }
 
@@ -193,10 +178,6 @@ mod tests {
             AsVar::Strip,
         )
         .expect("simple tag signature should be trusted");
-        assert!(
-            rule.arg_constraints
-                .contains(&ArgumentCountConstraint::Min(2))
-        );
         let parameters = rule
             .argument_syntax
             .parameters()
@@ -223,12 +204,13 @@ def concat(*args):
             AsVar::Strip,
         )
         .expect("simple tag signature should be trusted");
-        assert!(
-            !rule
-                .arg_constraints
-                .iter()
-                .any(|c| matches!(c, ArgumentCountConstraint::Max(_)))
-        );
+        assert!(matches!(
+            rule.argument_syntax.parameters(),
+            Some([TagArgument {
+                kind: TagArgumentKind::VarArgs,
+                ..
+            }])
+        ));
     }
 
     #[test]
@@ -294,9 +276,72 @@ def panel(context, content, title='Title'):
             AsVar::Strip,
         )
         .expect("context simple tag signature should be trusted");
-        assert!(
-            rule.arg_constraints
-                .contains(&ArgumentCountConstraint::Min(2))
+        let parameters = rule
+            .argument_syntax
+            .parameters()
+            .expect("context tag should expose signature parameters");
+        assert_eq!(
+            parameters
+                .iter()
+                .map(|parameter| parameter.name.as_str())
+                .collect::<Vec<_>>(),
+            ["url", "popup", "to_field"]
+        );
+    }
+
+    #[test]
+    fn preserves_positional_only_keyword_only_and_variadic_keyword_shape() {
+        let source = "def shaped(first, /, second='x', *, required, optional=None, **extra): pass";
+        let func = find_function_in_source(source, "shaped").expect("function should exist");
+        let rule = extract_parse_bits_rule(
+            &func,
+            RegistrationKind::SimpleTag,
+            ContextProvision::None,
+            AsVar::Strip,
+        )
+        .expect("signature should be trusted");
+
+        let TagArgumentSyntax::Signature {
+            parameters,
+            positional_only,
+            variadic_keyword,
+        } = rule.argument_syntax
+        else {
+            panic!("expected trusted signature syntax");
+        };
+        assert_eq!(positional_only, 1);
+        assert_eq!(variadic_keyword.as_deref(), Some("extra"));
+        assert_eq!(
+            parameters
+                .iter()
+                .map(|parameter| (
+                    parameter.name.as_str(),
+                    parameter.requirement,
+                    &parameter.kind
+                ))
+                .collect::<Vec<_>>(),
+            [
+                (
+                    "first",
+                    ParameterRequirement::Required,
+                    &TagArgumentKind::Variable
+                ),
+                (
+                    "second",
+                    ParameterRequirement::Optional,
+                    &TagArgumentKind::Variable
+                ),
+                (
+                    "required",
+                    ParameterRequirement::Required,
+                    &TagArgumentKind::Keyword
+                ),
+                (
+                    "optional",
+                    ParameterRequirement::Optional,
+                    &TagArgumentKind::Keyword
+                ),
+            ]
         );
     }
 }

--- a/crates/djls-project/src/templates/tags/types.rs
+++ b/crates/djls-project/src/templates/tags/types.rs
@@ -111,6 +111,7 @@ impl TagRule {
                 .as_ref()
                 .is_some_and(|messages| !messages.is_empty())
             || match &self.argument_syntax {
+                TagArgumentSyntax::Signature { .. } => true,
                 TagArgumentSyntax::Parameters(parameters) => !parameters.is_empty(),
                 TagArgumentSyntax::Forms { forms, .. } => !forms.is_empty(),
                 TagArgumentSyntax::Unknown => false,
@@ -299,7 +300,19 @@ pub enum TagArgumentSyntax {
     /// No useful argument syntax was found.
     #[default]
     Unknown,
-    /// A signature or configured parameter sequence, including optional parameters.
+    /// A trusted callable contract consumed by Django's `parse_bits()`.
+    ///
+    /// `parameters` is the single source for both completion presentation and
+    /// binding. Positional parameters come first, followed by an optional
+    /// `VarArgs` parameter and keyword-only parameters. `positional_only`
+    /// preserves the Python source distinction even though `parse_bits()`
+    /// accepts those names as template keywords.
+    Signature {
+        parameters: Vec<TagArgument>,
+        positional_only: usize,
+        variadic_keyword: Option<String>,
+    },
+    /// A configured or manually inferred parameter sequence used as a hint.
     Parameters(Vec<TagArgument>),
     /// Correlated fixed-length forms found in a manual compile function.
     Forms {
@@ -312,7 +325,7 @@ impl TagArgumentSyntax {
     #[must_use]
     pub fn parameters(&self) -> Option<&[TagArgument]> {
         match self {
-            Self::Parameters(parameters) => Some(parameters),
+            Self::Signature { parameters, .. } | Self::Parameters(parameters) => Some(parameters),
             Self::Unknown | Self::Forms { .. } => None,
         }
     }
@@ -321,7 +334,7 @@ impl TagArgumentSyntax {
     pub fn forms(&self) -> Option<(&[TagArgumentForm], ArgumentFormCoverage)> {
         match self {
             Self::Forms { forms, coverage } => Some((forms, *coverage)),
-            Self::Unknown | Self::Parameters(_) => None,
+            Self::Unknown | Self::Signature { .. } | Self::Parameters(_) => None,
         }
     }
 }

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -3,9 +3,11 @@ use djls_project::ArgumentCountConstraint;
 use djls_project::ArgumentFormCoverage;
 use djls_project::BodyAnalysisEvidence;
 use djls_project::FilterArity;
+use djls_project::ParameterRequirement;
 use djls_project::PythonModuleName;
 use djls_project::SymbolKey;
 use djls_project::TagArgumentKind;
+use djls_project::TagArgumentSyntax;
 use djls_project::TemplateLibraryId;
 use djls_project::TemplateSymbolKind;
 use djls_project::template_library_definition_facts;
@@ -1061,8 +1063,8 @@ fn imported_module_attribute_mutation_invalidates_later_resolution() {
 fn recovered_import_retains_positive_facts_but_opens_inventory_and_navigation() {
     let (db, file, module) = imported_registration_fixture(
         "",
-        "from django import template\nfrom . import implementation\nregister = template.Library()\n@register.simple_tag\ndef retained(): pass\nregister.tag(implementation.TAG, implementation.compile_tag)\n",
-        "TAG = 'recovered'\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 1: raise ValueError()\ndef broken(\n",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\n@register.simple_tag\ndef retained(): pass\nregister.tag(implementation.TAG, implementation.compile_tag)\nregister.simple_tag(implementation.simple, name='recovered_simple')\n",
+        "TAG = 'recovered'\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if len(bits) != 1: raise ValueError()\ndef simple(value): return value\ndef broken(\n",
     )
     .expect("recovered-import fixture should install");
     let key = TemplateLibraryId::new(&db, Some(file), module);
@@ -1073,13 +1075,57 @@ fn recovered_import_retains_positive_facts_but_opens_inventory_and_navigation() 
     let retained = facts
         .symbol(TemplateSymbolKind::Tag, "retained")
         .expect("other exact registrations should survive");
+    assert!(
+        facts
+            .symbol(TemplateSymbolKind::Tag, "recovered_simple")
+            .is_some(),
+        "a recovered callable keeps its positive Tag Definition"
+    );
     assert_eq!(template_symbol_source(&db, imported), None);
     assert_eq!(template_symbol_source(&db, retained), None);
-    assert!(
-        template_library_tag_facts(&db, key)
-            .tag_rules()
-            .contains_key(&SymbolKey::tag("pkg.tags", "recovered"))
-    );
+    let tag_rules = template_library_tag_facts(&db, key).tag_rules();
+    assert!(tag_rules.contains_key(&SymbolKey::tag("pkg.tags", "recovered")));
+    assert!(matches!(
+        &tag_rules[&SymbolKey::tag("pkg.tags", "retained")].argument_syntax,
+        TagArgumentSyntax::Signature {
+            parameters,
+            variadic_keyword: None,
+            ..
+        } if parameters.is_empty()
+    ));
+    assert!(matches!(
+        &tag_rules[&SymbolKey::tag("pkg.tags", "recovered_simple")].argument_syntax,
+        TagArgumentSyntax::Parameters(parameters)
+            if parameters.len() == 1 && parameters[0].name == "value"
+    ));
+}
+
+#[test]
+fn recovered_registration_options_do_not_taint_independent_signatures() {
+    let (db, file, module) = imported_registration_fixture(
+        "",
+        "from django import template\nfrom . import implementation\nregister = template.Library()\n@register.simple_tag(takes_context=implementation.TAKES_CONTEXT, name='first')\ndef first(context, value): return value\n@register.simple_tag(takes_context=implementation.TAKES_CONTEXT, name='second')\ndef second(context, value): return value\n@register.simple_tag\ndef retained(value): return value\n",
+        "TAKES_CONTEXT = True\ndef broken(\n",
+    )
+    .expect("recovered registration-option fixture should install");
+    let key = TemplateLibraryId::new(&db, Some(file), module);
+    let rules = template_library_tag_facts(&db, key).tag_rules();
+
+    for name in ["first", "second"] {
+        assert!(matches!(
+            &rules[&SymbolKey::tag("pkg.tags", name)].argument_syntax,
+            TagArgumentSyntax::Parameters(parameters)
+                if parameters.len() == 1 && parameters[0].name == "value"
+        ));
+    }
+    assert!(matches!(
+        &rules[&SymbolKey::tag("pkg.tags", "retained")].argument_syntax,
+        TagArgumentSyntax::Signature {
+            parameters,
+            variadic_keyword: None,
+            ..
+        } if parameters.len() == 1 && parameters[0].name == "value"
+    ));
 }
 
 #[test]
@@ -1210,11 +1256,20 @@ def malformed(value): pass
     let tag_facts = template_library_tag_facts(&db, key);
     for name in ["imported_context", "imported_panel"] {
         assert_eq!(
-            tag_facts.tag_rules()[&SymbolKey::tag("pkg.tags", name)].arg_constraints,
-            vec![
-                ArgumentCountConstraint::Min(2),
-                ArgumentCountConstraint::Max(2),
-            ],
+            tag_facts.tag_rules()[&SymbolKey::tag("pkg.tags", name)].argument_syntax,
+            TagArgumentSyntax::Signature {
+                parameters: vec![djls_project::TagArgument {
+                    name: if name == "imported_context" {
+                        "value".to_string()
+                    } else {
+                        "title".to_string()
+                    },
+                    requirement: ParameterRequirement::Required,
+                    kind: TagArgumentKind::Variable,
+                }],
+                positional_only: 0,
+                variadic_keyword: None,
+            },
             "resolved takes_context must remove framework parameters for `{name}`"
         );
     }

--- a/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__config_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__config_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "archivebox.core.templatetags.config_tags::tag::get_config":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: key
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: key
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__core_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__archivebox__archivebox__core__templatetags__core_tags.py.snap
@@ -4,99 +4,121 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "archivebox.core.templatetags.core_tags::tag::admin_base_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::api_token":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::plugin_card":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: result
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: result
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::plugin_full":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: result
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: result
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::plugin_icon":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: plugin
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: plugin
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::snapshot_base_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: snapshot
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: snapshot
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::snapshot_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: snapshot
-          requirement: required
-          kind: Variable
-        - name: path
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: snapshot
+            requirement: required
+            kind: Variable
+          - name: path
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "archivebox.core.templatetags.core_tags::tag::url_replace":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "archivebox.core.templatetags.core_tags::tag::web_base_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "archivebox.core.templatetags.core_tags::filter::file_size": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__babybuddy__templatetags__babybuddy.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__babybuddy__templatetags__babybuddy.py.snap
@@ -4,130 +4,146 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "babybuddy.templatetags.babybuddy::tag::axes_lockout_message":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::confirm_delete_text":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: object
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: object
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::confirm_unlock_text":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: object
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: object
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::get_child_count":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::get_current_locale":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::get_current_timezone":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::make_absolute_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::relative_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field_name
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field_name
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::user_is_locked":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::user_is_read_only":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "babybuddy.templatetags.babybuddy::tag::version_string":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__breadcrumb.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__breadcrumb.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "core.templatetags.breadcrumb::tag::child_quick_switch":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: current_child
-          requirement: required
-          kind: Variable
-        - name: target_url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: current_child
+            requirement: required
+            kind: Variable
+          - name: target_url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__timers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__core__templatetags__timers.py.snap
@@ -4,35 +4,40 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "core.templatetags.timers::tag::instance_add_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "core.templatetags.timers::tag::quick_timer_nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "core.templatetags.timers::tag::timer_nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__dashboard__templatetags__cards.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__babybuddy__dashboard__templatetags__cards.py.snap
@@ -4,203 +4,218 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "dashboard.templatetags.cards::tag::card_breastfeeding":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
-        - name: date
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+          - name: date
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_diaperchange_last":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_diaperchange_types":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
-        - name: date
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+          - name: date
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_feeding_last":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_feeding_last_method":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_feeding_recent":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
-        - name: end_date
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+          - name: end_date
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_pumping_last":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_sleep_last":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_sleep_naps_day":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
-        - name: date
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+          - name: date
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_sleep_recent":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
-        - name: end_date
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+          - name: end_date
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_statistics":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_timer_list":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_tummytime_day":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
-        - name: date
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+          - name: date
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "dashboard.templatetags.cards::tag::card_tummytime_last":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: child
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: child
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_list.py.snap
@@ -4,36 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_list::tag::admin_list_filter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: spec
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: spec
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_urls::tag::add_preserved_filters":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: popup
-          requirement: optional
-          kind: Variable
-        - name: to_field
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: popup
+            requirement: optional
+            kind: Variable
+          - name: to_field
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
@@ -134,10 +134,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: query_dict
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: query_dict
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__bad_tag.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__bad_tag.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.bad_tag::tag::badsimpletag":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__custom.py.snap
@@ -4,295 +4,338 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.custom::tag::context_stack_length":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::current_app":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::div":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: id
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: id
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::div_custom_end":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_format_html":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::minustwo":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: required
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: required
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: required
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: required
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
@@ -300,10 +343,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
     arg_constraints: []
@@ -311,123 +357,138 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__inclusion.py.snap
@@ -4,154 +4,174 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends2":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_keyword_only_default":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_from_template":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context_from_template":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
     arg_constraints: []
@@ -159,10 +179,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
     arg_constraints: []
@@ -170,131 +193,146 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.subpackage.echo::tag::echo2":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__view_tests__templatetags__debugtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__tests__view_tests__templatetags__debugtags.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.view_tests.templatetags.debugtags::tag::go_boom":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_list.py.snap
@@ -4,36 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_list::tag::admin_list_filter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: spec
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: spec
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_urls::tag::add_preserved_filters":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: popup
-          requirement: optional
-          kind: Variable
-        - name: to_field
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: popup
+            requirement: optional
+            kind: Variable
+          - name: to_field
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__auth__templatetags__auth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__auth__templatetags__auth.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.auth.templatetags.auth::tag::render_password_as_hash":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
@@ -167,10 +167,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__bad_tag.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__bad_tag.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.bad_tag::tag::badsimpletag":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__custom.py.snap
@@ -4,295 +4,338 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.custom::tag::context_stack_length":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::current_app":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::div":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: id
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: id
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::div_custom_end":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_format_html":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::minustwo":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: required
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: required
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: required
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: required
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
@@ -300,10 +343,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
     arg_constraints: []
@@ -311,123 +357,138 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__inclusion.py.snap
@@ -4,154 +4,174 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends2":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_keyword_only_default":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_from_template":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context_from_template":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
     arg_constraints: []
@@ -159,10 +179,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
     arg_constraints: []
@@ -170,131 +193,146 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.subpackage.echo::tag::echo2":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__view_tests__templatetags__debugtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__tests__view_tests__templatetags__debugtags.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.view_tests.templatetags.debugtags::tag::go_boom":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_list.py.snap
@@ -4,36 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_list::tag::admin_list_filter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: spec
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: spec
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "django.contrib.admin.templatetags.admin_list::tag::paginator_number":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__admin__templatetags__admin_urls.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_urls::tag::add_preserved_filters":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: popup
-          requirement: optional
-          kind: Variable
-        - name: to_field
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: popup
+            requirement: optional
+            kind: Variable
+          - name: to_field
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "django.contrib.admin.templatetags.admin_urls::filter::admin_urlname": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__auth__templatetags__auth.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__auth__templatetags__auth.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django.contrib.auth.templatetags.auth::tag::render_password_as_hash":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
@@ -36,16 +36,18 @@ tag_rules:
           kind: Variable
     as_var: keep
   "django.template.defaulttags::tag::csp_nonce_attr":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: media
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: media
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "django.template.defaulttags::tag::cycle":
     arg_constraints:
@@ -179,10 +181,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__bad_tag.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__bad_tag.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.bad_tag::tag::badsimpletag":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__custom.py.snap
@@ -4,295 +4,338 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.custom::tag::context_stack_length":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::current_app":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::div":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: id
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: id
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::div_custom_end":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_explicit_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_format_html":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_format_html_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::escape_naive_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::explicit_no_context_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::minustwo":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context_block":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::params_and_context_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_default_block":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: required
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: required
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_keyword_only_param_block":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: required
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: required
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default_block":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args":
     arg_constraints: []
@@ -300,10 +343,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_only_unlimited_args_block":
     arg_constraints: []
@@ -311,123 +357,138 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params_block":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_block":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_unlimited_args_kwargs_block":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::use_l10n":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "tests.template_tests.templatetags.custom::filter::make_data_div": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__inclusion.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__inclusion.py.snap
@@ -4,154 +4,174 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_explicit_no_context_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends1":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_extends2":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_keyword_only_default":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: kwarg
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: kwarg
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_from_template":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context_from_template":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args":
     arg_constraints: []
@@ -159,10 +179,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_only_unlimited_args_from_template":
     arg_constraints: []
@@ -170,131 +193,146 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_params_and_context_from_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_tag_use_l10n":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_two_params_from_template":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_from_template":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_unlimited_args_kwargs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__subpackage__echo.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__template_tests__templatetags__subpackage__echo.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.template_tests.templatetags.subpackage.echo::tag::echo2":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__view_tests__templatetags__debugtags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__tests__view_tests__templatetags__debugtags.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "tests.view_tests.templatetags.debugtags::tag::go_boom":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-activity-stream__actstream__templatetags__activity_tags.py.snap
@@ -4,19 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "actstream.templatetags.activity_tags::tag::activity_stream":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: stream_type
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: stream_type
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "actstream.templatetags.activity_tags::tag::actor_url":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__account__templatetags__account.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__account__templatetags__account.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "allauth.account.templatetags.account::tag::user_display":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__socialaccount__templatetags__socialaccount.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-allauth__allauth__socialaccount__templatetags__socialaccount.py.snap
@@ -4,47 +4,54 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "allauth.socialaccount.templatetags.socialaccount::tag::get_providers":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "allauth.socialaccount.templatetags.socialaccount::tag::get_social_accounts":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "allauth.socialaccount.templatetags.socialaccount::tag::provider_login_url":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: provider
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: provider
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: params
     as_var: strip
   "allauth.socialaccount.templatetags.socialaccount::tag::providers_media_js":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-avatar__avatar__templatetags__avatar_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-avatar__avatar__templatetags__avatar_tags.py.snap
@@ -4,79 +4,84 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "avatar.templatetags.avatar_tags::tag::avatar":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: width
-          requirement: optional
-          kind: Variable
-        - name: height
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: width
+            requirement: optional
+            kind: Variable
+          - name: height
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "avatar.templatetags.avatar_tags::tag::avatar_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: width
-          requirement: optional
-          kind: Variable
-        - name: height
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: width
+            requirement: optional
+            kind: Variable
+          - name: height
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "avatar.templatetags.avatar_tags::tag::primary_avatar":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: width
-          requirement: optional
-          kind: Variable
-        - name: height
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: width
+            requirement: optional
+            kind: Variable
+          - name: height
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "avatar.templatetags.avatar_tags::tag::render_avatar":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: avatar
-          requirement: required
-          kind: Variable
-        - name: width
-          requirement: optional
-          kind: Variable
-        - name: height
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: avatar
+            requirement: required
+            kind: Variable
+          - name: width
+            requirement: optional
+            kind: Variable
+          - name: height
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "avatar.templatetags.avatar_tags::filter::has_avatar": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-baton__baton__templatetags__baton_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-baton__baton__templatetags__baton_tags.py.snap
@@ -4,53 +4,73 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "baton.templatetags.baton_tags::tag::baton_ai_stats":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "baton.templatetags.baton_tags::tag::baton_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "baton.templatetags.baton_tags::tag::baton_config_value":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: key
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: key
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "baton.templatetags.baton_tags::tag::baton_theme":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
-  "baton.templatetags.baton_tags::tag::footer":
-    arg_constraints:
-      - Max: 1
+  "baton.templatetags.baton_tags::tag::call_model_admin_method":
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "baton.templatetags.baton_tags::tag::footer":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "baton.templatetags.baton_tags::filter::to_json": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-bootstrap3__src__bootstrap3__templatetags__bootstrap3.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_alert":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: content
-          requirement: required
-          kind: Variable
-        - name: alert_type
-          requirement: optional
-          kind: Variable
-        - name: dismissable
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: content
+            requirement: required
+            kind: Variable
+          - name: alert_type
+            requirement: optional
+            kind: Variable
+          - name: dismissable
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_button":
     arg_constraints: []
@@ -28,28 +29,35 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_css":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_css_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_field":
     arg_constraints: []
@@ -57,10 +65,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_form":
     arg_constraints: []
@@ -68,10 +79,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_form_errors":
     arg_constraints: []
@@ -79,10 +93,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_formset":
     arg_constraints: []
@@ -90,10 +107,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_formset_errors":
     arg_constraints: []
@@ -101,52 +121,63 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_icon":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: icon
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: icon
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_javascript":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: jquery
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: jquery
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_javascript_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_jquery_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_label":
     arg_constraints: []
@@ -154,10 +185,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_messages":
     arg_constraints: []
@@ -165,50 +199,58 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_pagination":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_theme_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.bootstrap3.templatetags.bootstrap3::tag::bootstrap_url_replace_param":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: name
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: name
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "src.bootstrap3.templatetags.bootstrap3::filter::bootstrap_message_classes": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_admin.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_admin.py.snap
@@ -4,67 +4,74 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "cms.templatetags.cms_admin::tag::admin_static_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_admin::tag::get_page_display_name":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cms_page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cms_page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_admin::tag::render_filter_field":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "cms.templatetags.cms_admin::tag::show_admin_menu_for_pages":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: descendants
-          requirement: required
-          kind: Variable
-        - name: depth
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: descendants
+            requirement: required
+            kind: Variable
+          - name: depth
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_admin::tag::submit_row_plugin":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "cms.templatetags.cms_admin::filter::boolean_icon": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_alias_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_alias_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "cms.templatetags.cms_alias_tags::tag::render_alias_plugin":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_js_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_js_tags.py.snap
@@ -4,33 +4,35 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "cms.templatetags.cms_js_tags::tag::render_cms_structure_js":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: renderer
-          requirement: required
-          kind: Variable
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: renderer
+            requirement: required
+            kind: Variable
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_js_tags::tag::render_plugin_init_js":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: plugin
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: plugin
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "cms.templatetags.cms_js_tags::filter::bool": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-cms__cms__templatetags__cms_tags.py.snap
@@ -4,83 +4,87 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "cms.templatetags.cms_tags::tag::render_extra_menu_items":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: template
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: template
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_tags::tag::render_plugin":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: plugin
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: plugin
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_placeholder":
-    arg_constraints:
-      - Min: 3
-      - Max: 6
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: placeholder_name
-          requirement: required
-          kind: Variable
-        - name: reverse_id
-          requirement: required
-          kind: Variable
-        - name: lang
-          requirement: optional
-          kind: Variable
-        - name: site
-          requirement: optional
-          kind: Variable
-        - name: use_cache
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: placeholder_name
+            requirement: required
+            kind: Variable
+          - name: reverse_id
+            requirement: required
+            kind: Variable
+          - name: lang
+            requirement: optional
+            kind: Variable
+          - name: site
+            requirement: optional
+            kind: Variable
+          - name: use_cache
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_placeholder_by_id":
-    arg_constraints:
-      - Min: 3
-      - Max: 6
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: placeholder_name
-          requirement: required
-          kind: Variable
-        - name: reverse_id
-          requirement: required
-          kind: Variable
-        - name: lang
-          requirement: optional
-          kind: Variable
-        - name: site
-          requirement: optional
-          kind: Variable
-        - name: use_cache
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: placeholder_name
+            requirement: required
+            kind: Variable
+          - name: reverse_id
+            requirement: required
+            kind: Variable
+          - name: lang
+            requirement: optional
+            kind: Variable
+          - name: site
+            requirement: optional
+            kind: Variable
+          - name: use_cache
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_uncached_placeholder":
     arg_constraints: []
@@ -88,10 +92,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "cms.templatetags.cms_tags::tag::show_uncached_placeholder_by_id":
     arg_constraints: []
@@ -99,10 +106,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_field.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crispy-forms__crispy_forms__templatetags__crispy_forms_field.py.snap
@@ -4,26 +4,27 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "crispy_forms.templatetags.crispy_forms_field::tag::crispy_addon":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: append
-          requirement: optional
-          kind: Variable
-        - name: prepend
-          requirement: optional
-          kind: Variable
-        - name: form_show_labels
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: append
+            requirement: optional
+            kind: Variable
+          - name: prepend
+            requirement: optional
+            kind: Variable
+          - name: form_show_labels
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "crispy_forms.templatetags.crispy_forms_field::filter::classes": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crm__common__templatetags__crm_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crm__common__templatetags__crm_list.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "common.templatetags.crm_list::tag::paginator_number":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-crm__massmail__templatetags__mailbuilder.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-crm__massmail__templatetags__mailbuilder.py.snap
@@ -4,30 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "massmail.templatetags.mailbuilder::tag::cid_media":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: file_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: file_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "massmail.templatetags.mailbuilder::tag::cid_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: file_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: file_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-grappelli__grappelli__templatetags__grp_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-grappelli__grappelli__templatetags__grp_tags.py.snap
@@ -4,110 +4,131 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "grappelli.templatetags.grp_tags::tag::admin_list_filter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: spec
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: spec
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_admin_title":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_admin_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_date_format":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_datetime_format":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_lang":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_site_title":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::get_time_format":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::grappelli_admin_title":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::grappelli_clean_input_types":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "grappelli.templatetags.grp_tags::tag::switch_user_dropdown":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "grappelli.templatetags.grp_tags::filter::classname": optional_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-htmx__src__django_htmx__templatetags__django_htmx.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-htmx__src__django_htmx__templatetags__django_htmx.py.snap
@@ -4,25 +4,29 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.django_htmx.templatetags.django_htmx::tag::django_htmx_script":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.django_htmx.templatetags.django_htmx::tag::htmx_script":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: minified
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: minified
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-import-export__import_export__templatetags__import_export_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-import-export__import_export__templatetags__import_export_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "import_export.templatetags.import_export_tags::tag::compare_values":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value1
-          requirement: required
-          kind: Variable
-        - name: value2
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value1
+            requirement: required
+            kind: Variable
+          - name: value2
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-jazzmin__jazzmin__templatetags__jazzmin.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-jazzmin__jazzmin__templatetags__jazzmin.py.snap
@@ -4,224 +4,243 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "jazzmin.templatetags.jazzmin::tag::action_message_to_list":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::admin_extra_filters":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_changeform_template":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: adminform
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: adminform
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_jazzmin_settings":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_jazzmin_ui_tweaks":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_jazzmin_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_sections":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: admin_form
-          requirement: required
-          kind: Variable
-        - name: inline_admin_formsets
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: admin_form
+            requirement: required
+            kind: Variable
+          - name: inline_admin_formsets
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_side_menu":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: using
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: using
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_top_menu":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: admin_site
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: admin_site
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_user_avatar":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::get_user_menu":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: admin_site
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: admin_site
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::header_class":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: header
-          requirement: required
-          kind: Variable
-        - name: forloop
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: header
+            requirement: required
+            kind: Variable
+          - name: forloop
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::jazzmin_list_filter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: spec
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: spec
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::jazzmin_paginator_number":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: change_list
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: change_list
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::jazzy_admin_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: admin_site
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: admin_site
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "jazzmin.templatetags.jazzmin::tag::sidebar_status":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "jazzmin.templatetags.jazzmin::filter::app_is_installed": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__basket_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__basket_tags.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.basket_tags::tag::basket_form":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: product
-          requirement: required
-          kind: Variable
-        - name: quantity_type
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: product
+            requirement: required
+            kind: Variable
+          - name: quantity_type
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__category_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__category_tags.py.snap
@@ -4,19 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.category_tags::tag::category_tree":
-    arg_constraints:
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: depth
-          requirement: optional
-          kind: Variable
-        - name: parent
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: depth
+            requirement: optional
+            kind: Variable
+          - name: parent
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__dashboard_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__dashboard_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.dashboard_tags::tag::dashboard_navigation":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.display_tags::tag::get_parameters":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: except_field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: except_field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.oscar.templatetags.display_tags::tag::iffeature":
     arg_constraints: []

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__history_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__history_tags.py.snap
@@ -4,25 +4,29 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.history_tags::tag::get_back_button":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.oscar.templatetags.history_tags::tag::recently_viewed_products":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: current_product
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: current_product
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__product_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__product_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.product_tags::tag::render_product":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: product
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: product
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__purchase_info_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__purchase_info_tags.py.snap
@@ -4,36 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.purchase_info_tags::tag::purchase_info_for_line":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: line
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: line
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.oscar.templatetags.purchase_info_tags::tag::purchase_info_for_product":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: product
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: product
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__shipping_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__shipping_tags.py.snap
@@ -4,52 +4,55 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.shipping_tags::tag::shipping_charge":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: method
-          requirement: required
-          kind: Variable
-        - name: basket
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: method
+            requirement: required
+            kind: Variable
+          - name: basket
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.oscar.templatetags.shipping_tags::tag::shipping_charge_discount":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: method
-          requirement: required
-          kind: Variable
-        - name: basket
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: method
+            requirement: required
+            kind: Variable
+          - name: basket
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.oscar.templatetags.shipping_tags::tag::shipping_charge_excl_discount":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: method
-          requirement: required
-          kind: Variable
-        - name: basket
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: method
+            requirement: required
+            kind: Variable
+          - name: basket
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__sorting_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__sorting_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.sorting_tags::tag::anchor":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__url_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__url_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.url_tags::tag::absolute_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: domain
-          requirement: required
-          kind: Variable
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: domain
+            requirement: required
+            kind: Variable
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__wishlist_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__wishlist_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.oscar.templatetags.wishlist_tags::tag::wishlists_containing_product":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: wishlists
-          requirement: required
-          kind: Variable
-        - name: product
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: wishlists
+            requirement: required
+            kind: Variable
+          - name: product
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-qr-code__qr_code__templatetags__qr_code.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-qr-code__qr_code__templatetags__qr_code.py.snap
@@ -4,433 +4,529 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "qr_code.templatetags.qr_code::tag::qr_for_contact":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: contact_detail
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: contact_detail
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_email":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: email
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: email
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_epc":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: epc_data
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: epc_data
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_event":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: event
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: event
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "qr_code.templatetags.qr_code::tag::qr_for_geolocation":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "qr_code.templatetags.qr_code::tag::qr_for_google_maps":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_google_play":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: package_id
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: package_id
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_mecard":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: mecard
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: mecard
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_sms":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: phone_number
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: phone_number
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_tel":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: phone_number
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: phone_number
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_vcard":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: vcard
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: vcard
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_wifi":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: wifi_config
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: wifi_config
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_for_youtube":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: video_id
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: video_id
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_from_data":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_from_text":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: text
-          requirement: required
-          kind: Variable
-        - name: use_data_uri_for_svg
-          requirement: optional
-          kind: Variable
-        - name: alt_text
-          requirement: optional
-          kind: Variable
-        - name: class_names
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: text
+            requirement: required
+            kind: Variable
+          - name: use_data_uri_for_svg
+            requirement: optional
+            kind: Variable
+          - name: alt_text
+            requirement: optional
+            kind: Variable
+          - name: class_names
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_contact":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: contact_detail
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: contact_detail
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_email":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: email
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: email
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_epc":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: epc_data
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: epc_data
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_event":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: event
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: event
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "qr_code.templatetags.qr_code::tag::qr_url_for_geolocation":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "qr_code.templatetags.qr_code::tag::qr_url_for_google_maps":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_google_play":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: package_id
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: package_id
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_mecard":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: mecard
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: mecard
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_sms":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: phone_number
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: phone_number
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_tel":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: phone_number
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: phone_number
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_vcard":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: vcard
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: vcard
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_wifi":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: wifi_config
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: wifi_config
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_for_youtube":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: video_id
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: video_id
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_from_data":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "qr_code.templatetags.qr_code::tag::qr_url_from_text":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: text
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: text
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-statici18n__src__statici18n__templatetags__statici18n.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-statici18n__src__statici18n__templatetags__statici18n.py.snap
@@ -4,30 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.statici18n.templatetags.statici18n::tag::inlinei18n":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: locale
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: locale
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.statici18n.templatetags.statici18n::tag::statici18n":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: locale
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: locale
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-tables2__django_tables2__templatetags__django_tables2.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-tables2__django_tables2__templatetags__django_tables2.py.snap
@@ -4,32 +4,35 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "django_tables2.templatetags.django_tables2::tag::export_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: export_format
-          requirement: required
-          kind: Variable
-        - name: export_trigger_param
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: export_format
+            requirement: required
+            kind: Variable
+          - name: export_trigger_param
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "django_tables2.templatetags.django_tables2::tag::render_attrs":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: attrs
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: attrs
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities:
   "django_tables2.templatetags.django_tables2::filter::table_page_range": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold.py.snap
@@ -4,42 +4,46 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.unfold.templatetags.unfold::tag::action_item_classes":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::action_list":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::admin_object_app_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: object
-          requirement: required
-          kind: Variable
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: object
+            requirement: required
+            kind: Variable
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::capture":
     arg_constraints:
@@ -105,168 +109,186 @@ tag_rules:
           kind: Variable
     as_var: keep
   "src.unfold.templatetags.unfold::tag::element_classes":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: key
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: key
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::elided_page_range":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: paginator
-          requirement: required
-          kind: Variable
-        - name: number
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: paginator
+            requirement: required
+            kind: Variable
+          - name: number
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::fieldset_line_classes":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::fieldset_row_classes":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::fieldset_rows_classes":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::has_nav_item_active":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::header_title":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::infinite_paginator_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::preserve_filters":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "src.unfold.templatetags.unfold::tag::querystring_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: query_key
-          requirement: required
-          kind: Variable
-        - name: query_value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: query_key
+            requirement: required
+            kind: Variable
+          - name: query_value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::render_section":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: section_class
-          requirement: required
-          kind: Variable
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: section_class
+            requirement: required
+            kind: Variable
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::tab_list":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: opts
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: opts
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::tabs_primary_active":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: inlines
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: inlines
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.unfold.templatetags.unfold::tag::unfold_querystring":
     arg_constraints: []
@@ -274,10 +296,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities:
   "src.unfold.templatetags.unfold::filter::add_css_class": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold_list.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-unfold__src__unfold__templatetags__unfold_list.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.unfold.templatetags.unfold_list::tag::paginator_number":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: cl
-          requirement: required
-          kind: Variable
-        - name: i
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: cl
+            requirement: required
+            kind: Variable
+          - name: i
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__core__templatetags__page_metadata_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__core__templatetags__page_metadata_tags.py.snap
@@ -4,25 +4,27 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "core.templatetags.page_metadata_tags::tag::page_metadata":
-    arg_constraints:
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page_title
-          requirement: optional
-          kind: Variable
-        - name: page_description
-          requirement: optional
-          kind: Variable
-        - name: page_keywords
-          requirement: optional
-          kind: Variable
-        - name: og_image_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page_title
+            requirement: optional
+            kind: Variable
+          - name: page_description
+            requirement: optional
+            kind: Variable
+          - name: page_keywords
+            requirement: optional
+            kind: Variable
+          - name: og_image_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__homepage__templatetags__grid_of_the_week_tag.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__homepage__templatetags__grid_of_the_week_tag.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "homepage.templatetags.grid_of_the_week_tag::tag::grid_of_the_week":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__homepage__templatetags__psa_tag.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__homepage__templatetags__psa_tag.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "homepage.templatetags.psa_tag::tag::psa":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__blog__templatetags__weblog.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__blog__templatetags__weblog.py.snap
@@ -4,35 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "blog.templatetags.weblog::tag::render_latest_blog_entries":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: num
-          requirement: required
-          kind: Variable
-        - name: summary_first
-          requirement: optional
-          kind: Variable
-        - name: hide_readmore
-          requirement: optional
-          kind: Variable
-        - name: header_tag
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: num
+            requirement: required
+            kind: Variable
+          - name: summary_first
+            requirement: optional
+            kind: Variable
+          - name: hide_readmore
+            requirement: optional
+            kind: Variable
+          - name: header_tag
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.weblog::tag::render_month_links":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__docs__templatetags__docs.py.snap
@@ -4,41 +4,46 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "docs.templatetags.docs::tag::code_links":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: searched_python_objects
-          requirement: required
-          kind: Variable
-        - name: python_objects
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: searched_python_objects
+            requirement: required
+            kind: Variable
+          - name: python_objects
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "docs.templatetags.docs::tag::get_all_doc_versions":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "docs.templatetags.docs::tag::search_form":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "docs.templatetags.docs::filter::fragment": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__foundation__templatetags__meetings.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__foundation__templatetags__meetings.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "foundation.templatetags.meetings::tag::render_latest_meeting_minute_entries":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: num
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: num
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__fundraising__templatetags__fundraising_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__fundraising__templatetags__fundraising_extras.py.snap
@@ -4,31 +4,37 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "fundraising.templatetags.fundraising_extras::tag::display_django_heroes":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "fundraising.templatetags.fundraising_extras::tag::donation_form_with_heart":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "fundraising.templatetags.fundraising_extras::tag::donation_snippet":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "fundraising.templatetags.fundraising_extras::tag::top_corporate_members":
     arg_constraints: []
@@ -36,13 +42,16 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: levels
-          requirement: optional
-          kind: VarArgs
-        - name: header
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: levels
+            requirement: optional
+            kind: VarArgs
+          - name: header
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "fundraising.templatetags.fundraising_extras::filter::as_percentage": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__date_format.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__date_format.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "releases.templatetags.date_format::tag::isodate":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: datestr
-          requirement: required
-          kind: Variable
-        - name: dateformat
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: datestr
+            requirement: required
+            kind: Variable
+          - name: dateformat
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__release_notes.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangoproject.com__releases__templatetags__release_notes.py.snap
@@ -4,33 +4,35 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "releases.templatetags.release_notes::tag::get_latest_micro_release":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: version
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: version
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "releases.templatetags.release_notes::tag::release_notes":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: version
-          requirement: required
-          kind: Variable
-        - name: show_version
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: version
+            requirement: required
+            kind: Variable
+          - name: show_version
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__base_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__base_tags.py.snap
@@ -4,121 +4,133 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.base.templatetags.base_tags::tag::display_change_perms_button":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: resource
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: perms
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: resource
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: perms
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::display_edit_request_button":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: resource
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: perms
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: resource
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: perms
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::facets":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::fullurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::get_context_resourcetype":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::get_current_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::get_menu":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: placeholder_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: placeholder_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.base_tags::tag::get_visibile_resources":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "geonode.base.templatetags.base_tags::tag::render_nav_menu":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: placeholder_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: placeholder_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "geonode.base.templatetags.base_tags::filter::get_item": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__user_messages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__base__templatetags__user_messages.py.snap
@@ -4,77 +4,83 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.base.templatetags.user_messages::tag::format_senders":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: thread
-          requirement: required
-          kind: Variable
-        - name: current_user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: thread
+            requirement: required
+            kind: Variable
+          - name: current_user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::get_item":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dictionary
-          requirement: required
-          kind: Variable
-        - name: key
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dictionary
+            requirement: required
+            kind: Variable
+          - name: key
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::is_unread":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: thread
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: thread
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::random_uuid":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.base.templatetags.user_messages::tag::show_notification":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: notice_type_label
-          requirement: required
-          kind: Variable
-        - name: current_user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: notice_type_label
+            requirement: required
+            kind: Variable
+          - name: current_user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__client__templatetags__client_lib_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__client__templatetags__client_lib_tags.py.snap
@@ -4,119 +4,137 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.client.templatetags.client_lib_tags::tag::dataset_detail_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: layer
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: layer
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::dataset_list_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::dataset_upload_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::document_detail_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: document
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: document
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::document_list_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::geoapp_detail_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: geoapp
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: geoapp
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::geoapp_list_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::google_api_key":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::map_detail_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: map
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: map
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::map_list_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.client.templatetags.client_lib_tags::tag::mapbox_access_token":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__groups__templatetags__groups_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__groups__templatetags__groups_tags.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.groups.templatetags.groups_tags::tag::group_profile_image":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: group_profile
-          requirement: required
-          kind: Variable
-        - name: css_classes
-          requirement: optional
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: group_profile
+            requirement: required
+            kind: Variable
+          - name: css_classes
+            requirement: optional
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__contact_roles.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__contact_roles.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.layers.templatetags.contact_roles::tag::getattribute":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: form
-          requirement: required
-          kind: Variable
-        - name: contact
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: form
+            requirement: required
+            kind: Variable
+          - name: contact
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "geonode.layers.templatetags.contact_roles::filter::get_contact_role_id": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__dataset_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__layers__templatetags__dataset_tags.py.snap
@@ -4,43 +4,46 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.layers.templatetags.dataset_tags::tag::get_all_resource_styles":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: resource
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: resource
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.layers.templatetags.dataset_tags::tag::get_sld_name_from_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: sld_url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: sld_url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.layers.templatetags.dataset_tags::tag::get_style_name_from_legend_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: legend_url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: legend_url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "geonode.layers.templatetags.dataset_tags::filter::camelize": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__people__templatetags__socialaccount_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__people__templatetags__socialaccount_extra.py.snap
@@ -4,56 +4,60 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.people.templatetags.socialaccount_extra::tag::get_number_unconnected_providers":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.people.templatetags.socialaccount_extra::tag::get_other_social_providers":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.people.templatetags.socialaccount_extra::tag::get_user_social_providers":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "geonode.people.templatetags.socialaccount_extra::tag::user_providers":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__proxy__templatetags__proxy_lib_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__proxy__templatetags__proxy_lib_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.proxy.templatetags.proxy_lib_tags::tag::original_link_available":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: resourceid
-          requirement: required
-          kind: Variable
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: resourceid
+            requirement: required
+            kind: Variable
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__services__templatetags__services_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__services__templatetags__services_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.services.templatetags.services_tags::tag::get_dataset_count_by_services":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: service_id
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: service_id
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__social__templatetags__social_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__geonode__geonode__social__templatetags__social_tags.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "geonode.social.templatetags.social_tags::tag::activity_item":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__asciitable.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__asciitable.py.snap
@@ -4,22 +4,26 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "hc.front.templatetags.asciitable::tag::cell":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.asciitable::tag::row":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__hc_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__hc_extras.py.snap
@@ -4,89 +4,106 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "hc.front.templatetags.hc_extras::tag::absolute_site_logo_url":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::debug_warning":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::now_isoformat":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::site_hostname":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::site_name":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::site_root":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::site_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::sort_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: sort
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: sort
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hc.front.templatetags.hc_extras::tag::support_email":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "hc.front.templatetags.hc_extras::filter::add6days": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__linemode.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__healthchecks__hc__front__templatetags__linemode.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "hc.front.templatetags.linemode::tag::line":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__angular.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__angular.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "horizon.templatetags.angular::tag::angular_templates":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "horizon.templatetags.angular::filter::angular_escapes": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__bootstrap.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__bootstrap.py.snap
@@ -9,10 +9,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__branding.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__branding.py.snap
@@ -4,22 +4,26 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "horizon.templatetags.branding::tag::site_branding":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "horizon.templatetags.branding::tag::site_branding_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__breadcrumb_nav.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__breadcrumb_nav.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "horizon.templatetags.breadcrumb_nav::tag::breadcrumb_nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__horizon__templatetags__horizon.py.snap
@@ -4,74 +4,87 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "horizon.templatetags.horizon::tag::datepicker_locale":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "horizon.templatetags.horizon::tag::horizon_dashboard_nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "horizon.templatetags.horizon::tag::horizon_main_nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "horizon.templatetags.horizon::tag::horizon_nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "horizon.templatetags.horizon::tag::load_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "horizon.templatetags.horizon::tag::quotapercent":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: used
-          requirement: required
-          kind: Variable
-        - name: limit
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: used
+            requirement: required
+            kind: Variable
+          - name: limit
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "horizon.templatetags.horizon::tag::template_cache_age":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "horizon.templatetags.horizon::filter::has_permissions": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__openstack_dashboard__templatetags__context_selection.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__openstack_dashboard__templatetags__context_selection.py.snap
@@ -4,85 +4,103 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "openstack_dashboard.templatetags.context_selection::tag::iframe_embed_settings":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "openstack_dashboard.templatetags.context_selection::tag::is_multi_region":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "openstack_dashboard.templatetags.context_selection::tag::is_multidomain":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "openstack_dashboard.templatetags.context_selection::tag::show_domain_list":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "openstack_dashboard.templatetags.context_selection::tag::show_overview":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "openstack_dashboard.templatetags.context_selection::tag::show_project_list":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "openstack_dashboard.templatetags.context_selection::tag::show_region_list":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "openstack_dashboard.templatetags.context_selection::tag::show_system_list":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "openstack_dashboard.templatetags.context_selection::tag::show_systems":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__horizon__openstack_dashboard__templatetags__themes.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__horizon__openstack_dashboard__templatetags__themes.py.snap
@@ -4,53 +4,62 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "openstack_dashboard.templatetags.themes::tag::current_theme":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "openstack_dashboard.templatetags.themes::tag::themable_asset":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: asset
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: asset
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "openstack_dashboard.templatetags.themes::tag::theme_cookie":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "openstack_dashboard.templatetags.themes::tag::theme_dir":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "openstack_dashboard.templatetags.themes::tag::themes":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_generic.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__hyperkitty__hyperkitty__templatetags__hk_generic.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "hyperkitty.templatetags.hk_generic::tag::export_allowed":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hyperkitty.templatetags.hk_generic::tag::gravatar":
     arg_constraints: []
@@ -18,39 +20,44 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kw
     as_var: strip
   "hyperkitty.templatetags.hk_generic::tag::is_message_new":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: refdate
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: refdate
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "hyperkitty.templatetags.hk_generic::tag::settings_value_equals":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "hyperkitty.templatetags.hk_generic::filter::date_with_senders_timezone": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__InvenTree__templatetags__inventree_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__InvenTree__templatetags__inventree_extras.py.snap
@@ -4,34 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::decimal":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::define":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_commit_date":
     arg_constraints: []
@@ -39,10 +43,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_commit_hash":
     arg_constraints: []
@@ -50,25 +57,30 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_customize":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: reference
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: reference
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_installer":
     arg_constraints: []
@@ -76,10 +88,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_instance_name":
     arg_constraints: []
@@ -87,10 +102,24 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_logo":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_title":
     arg_constraints: []
@@ -98,10 +127,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::inventree_version":
     arg_constraints: []
@@ -109,71 +141,81 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: shortstring
-          requirement: optional
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: shortstring
+            requirement: optional
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::render_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date_object
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date_object
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::setting_object":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: key
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: key
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::settings_value":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: key
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: key
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::str2bool":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::tag::to_list":
     arg_constraints: []
@@ -181,10 +223,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "src.backend.InvenTree.InvenTree.templatetags.inventree_extras::filter::keyvalue": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__plugin__templatetags__plugin_extras.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__plugin__templatetags__plugin_extras.py.snap
@@ -9,43 +9,50 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::mixin_available":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: mixin
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: mixin
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::mixin_enabled":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: plugin
-          requirement: required
-          kind: Variable
-        - name: key
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: plugin
+            requirement: required
+            kind: Variable
+          - name: key
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::plugin_list":
     arg_constraints: []
@@ -53,40 +60,47 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::plugin_settings":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: plugin
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: plugin
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.plugin.templatetags.plugin_extras::tag::safe_url":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: view_name
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: view_name
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__barcode.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__barcode.py.snap
@@ -4,56 +4,63 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.backend.InvenTree.report.templatetags.barcode::tag::barcode":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
-        - name: barcode_class
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+          - name: barcode_class
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.barcode::tag::clean_barcode":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.barcode::tag::datamatrix":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.barcode::tag::qrcode":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__report.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__report__templatetags__report.py.snap
@@ -4,460 +4,510 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.backend.InvenTree.report.templatetags.report::tag::add":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: y
-          requirement: required
-          kind: Variable
-        - name: cast
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: y
+            requirement: required
+            kind: Variable
+          - name: cast
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::asset":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: filename
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: filename
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::company_image":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: company
-          requirement: required
-          kind: Variable
-        - name: preview
-          requirement: optional
-          kind: Variable
-        - name: thumbnail
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: company
+            requirement: required
+            kind: Variable
+          - name: preview
+            requirement: optional
+            kind: Variable
+          - name: thumbnail
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::convert_currency":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: money
-          requirement: required
-          kind: Variable
-        - name: currency
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: money
+            requirement: required
+            kind: Variable
+          - name: currency
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::create_currency":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: amount
-          requirement: required
-          kind: Variable
-        - name: currency
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: amount
+            requirement: required
+            kind: Variable
+          - name: currency
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::divide":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: y
-          requirement: required
-          kind: Variable
-        - name: cast
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: y
+            requirement: required
+            kind: Variable
+          - name: cast
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::encode_svg_image":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: filename
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: filename
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::filter_db_model":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::filter_queryset":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: queryset
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: queryset
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::format_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dt
-          requirement: required
-          kind: Variable
-        - name: timezone
-          requirement: optional
-          kind: Variable
-        - name: fmt
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dt
+            requirement: required
+            kind: Variable
+          - name: timezone
+            requirement: optional
+            kind: Variable
+          - name: fmt
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::format_datetime":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dt
-          requirement: required
-          kind: Variable
-        - name: timezone
-          requirement: optional
-          kind: Variable
-        - name: fmt
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dt
+            requirement: required
+            kind: Variable
+          - name: timezone
+            requirement: optional
+            kind: Variable
+          - name: fmt
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::format_number":
-    arg_constraints:
-      - Min: 2
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: number
-          requirement: required
-          kind: Variable
-        - name: decimal_places
-          requirement: optional
-          kind: Variable
-        - name: multiplier
-          requirement: optional
-          kind: Variable
-        - name: integer
-          requirement: optional
-          kind: Variable
-        - name: leading
-          requirement: optional
-          kind: Variable
-        - name: separator
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: number
+            requirement: required
+            kind: Variable
+          - name: decimal_places
+            requirement: optional
+            kind: Variable
+          - name: multiplier
+            requirement: optional
+            kind: Variable
+          - name: integer
+            requirement: optional
+            kind: Variable
+          - name: leading
+            requirement: optional
+            kind: Variable
+          - name: separator
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::getindex":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: container
-          requirement: required
-          kind: Variable
-        - name: index
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: container
+            requirement: required
+            kind: Variable
+          - name: index
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::getkey":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: container
-          requirement: required
-          kind: Variable
-        - name: key
-          requirement: required
-          kind: Variable
-        - name: backup_value
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: container
+            requirement: required
+            kind: Variable
+          - name: key
+            requirement: required
+            kind: Variable
+          - name: backup_value
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::icon":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::include_icon_fonts":
-    arg_constraints:
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: ttf
-          requirement: optional
-          kind: Variable
-        - name: woff
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: ttf
+            requirement: optional
+            kind: Variable
+          - name: woff
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::internal_link":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: link
-          requirement: required
-          kind: Variable
-        - name: text
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: link
+            requirement: required
+            kind: Variable
+          - name: text
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "src.backend.InvenTree.report.templatetags.report::tag::logo_image":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::modulo":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: y
-          requirement: required
-          kind: Variable
-        - name: cast
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: y
+            requirement: required
+            kind: Variable
+          - name: cast
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::multiply":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: y
-          requirement: required
-          kind: Variable
-        - name: cast
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: y
+            requirement: required
+            kind: Variable
+          - name: cast
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::order_queryset":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: queryset
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: queryset
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::parameter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
-        - name: parameter_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+          - name: parameter_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::part_image":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: part
-          requirement: required
-          kind: Variable
-        - name: preview
-          requirement: optional
-          kind: Variable
-        - name: thumbnail
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: part
+            requirement: required
+            kind: Variable
+          - name: preview
+            requirement: optional
+            kind: Variable
+          - name: thumbnail
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::part_parameter":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
-        - name: parameter_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+          - name: parameter_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::render_currency":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: money
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: money
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::render_html_text":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: text
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: text
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::subtract":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: x
-          requirement: required
-          kind: Variable
-        - name: y
-          requirement: required
-          kind: Variable
-        - name: cast
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: x
+            requirement: required
+            kind: Variable
+          - name: y
+            requirement: required
+            kind: Variable
+          - name: cast
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.report.templatetags.report::tag::uploaded_image":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: filename
-          requirement: required
-          kind: Variable
-        - name: replace_missing
-          requirement: optional
-          kind: Variable
-        - name: replacement_file
-          requirement: optional
-          kind: Variable
-        - name: validate
-          requirement: optional
-          kind: Variable
-        - name: width
-          requirement: optional
-          kind: Variable
-        - name: height
-          requirement: optional
-          kind: Variable
-        - name: rotate
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: filename
+            requirement: required
+            kind: Variable
+          - name: replace_missing
+            requirement: optional
+            kind: Variable
+          - name: replacement_file
+            requirement: optional
+            kind: Variable
+          - name: validate
+            requirement: optional
+            kind: Variable
+          - name: width
+            requirement: optional
+            kind: Variable
+          - name: height
+            requirement: optional
+            kind: Variable
+          - name: rotate
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__web__templatetags__spa_helper.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__inventree__src__backend__InvenTree__web__templatetags__spa_helper.py.snap
@@ -4,28 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.backend.InvenTree.web.templatetags.spa_helper::tag::spa_bundle":
-    arg_constraints:
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: manifest_path
-          requirement: optional
-          kind: Variable
-        - name: app
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: manifest_path
+            requirement: optional
+            kind: Variable
+          - name: app
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.backend.InvenTree.web.templatetags.spa_helper::tag::spa_settings":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__bookmarks.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__bookmarks.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "bookmarks.templatetags.bookmarks::tag::bookmark_search":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: search
-          requirement: required
-          kind: Variable
-        - name: mode
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: search
+            requirement: required
+            kind: Variable
+          - name: mode
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__pagination.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__pagination.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "bookmarks.templatetags.pagination::tag::pagination":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "bookmarks.templatetags.shared::tag::formfield":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "bookmarks.templatetags.shared::tag::formhelp":
     arg_constraints: []
@@ -27,33 +29,57 @@ tag_rules:
           kind: Variable
     as_var: keep
   "bookmarks.templatetags.shared::tag::formlabel":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: label_text
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: label_text
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "bookmarks.templatetags.shared::tag::markdown":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: markdown_text
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: markdown_text
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "bookmarks.templatetags.shared::tag::replace_query_param":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: strip
+  "bookmarks.templatetags.shared::tag::update_query_string":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities:
   "bookmarks.templatetags.shared::filter::first_char": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__admin__templatetags__misago_admin_form.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__admin__templatetags__misago_admin_form.py.snap
@@ -4,137 +4,144 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.admin.templatetags.misago_admin_form::tag::form_checkbox_row":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: label_class
-          requirement: optional
-          kind: Variable
-        - name: field_class
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: label_class
+            requirement: optional
+            kind: Variable
+          - name: field_class
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_dimensions_row":
-    arg_constraints:
-      - Min: 3
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field_width
-          requirement: required
-          kind: Variable
-        - name: field_height
-          requirement: required
-          kind: Variable
-        - name: label_class
-          requirement: optional
-          kind: Variable
-        - name: field_class
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field_width
+            requirement: required
+            kind: Variable
+          - name: field_height
+            requirement: required
+            kind: Variable
+          - name: label_class
+            requirement: optional
+            kind: Variable
+          - name: field_class
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_image_row":
-    arg_constraints:
-      - Min: 2
-      - Max: 8
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: label_class
-          requirement: optional
-          kind: Variable
-        - name: field_class
-          requirement: optional
-          kind: Variable
-        - name: image_class
-          requirement: optional
-          kind: Variable
-        - name: delete_field
-          requirement: optional
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: dimensions
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: label_class
+            requirement: optional
+            kind: Variable
+          - name: field_class
+            requirement: optional
+            kind: Variable
+          - name: image_class
+            requirement: optional
+            kind: Variable
+          - name: delete_field
+            requirement: optional
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: dimensions
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_input":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::form_row":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: label_class
-          requirement: optional
-          kind: Variable
-        - name: field_class
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: label_class
+            requirement: optional
+            kind: Variable
+          - name: field_class
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "misago.admin.templatetags.misago_admin_form::tag::render_attrs":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: attrs
-          requirement: required
-          kind: Variable
-        - name: class_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: attrs
+            requirement: required
+            kind: Variable
+          - name: class_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "misago.admin.templatetags.misago_admin_form::tag::render_bool_attrs":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: attrs
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: attrs
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "misago.admin.templatetags.misago_admin_form::filter::get_options": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__components__templatetags__misago_component.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__components__templatetags__misago_component.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.components.templatetags.misago_component::tag::includecomponent":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: data
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: data
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_absoluteurl.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_absoluteurl.py.snap
@@ -4,19 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.core.templatetags.misago_absoluteurl::tag::absoluteurl":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url_or_name
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: url_or_name
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_pagetitle.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__core__templatetags__misago_pagetitle.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.core.templatetags.misago_pagetitle::tag::pagetitle":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: title
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: title
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__markup__templatetags__misago_editor.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__markup__templatetags__misago_editor.py.snap
@@ -4,30 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.markup.templatetags.misago_editor::tag::editor_body":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: editor
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: editor
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "misago.markup.templatetags.misago_editor::tag::editor_js":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: editor
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: editor
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__parser__templatetags__misago_rich_text.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__parser__templatetags__misago_rich_text.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.parser.templatetags.misago_rich_text::tag::rich_text":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: html
-          requirement: required
-          kind: Variable
-        - name: data
-          requirement: optional
-          kind: Variable
-        - name: thread
-          requirement: optional
-          kind: Keyword
+      Signature:
+        parameters:
+          - name: html
+            requirement: required
+            kind: Variable
+          - name: data
+            requirement: optional
+            kind: Variable
+          - name: thread
+            requirement: optional
+            kind: Keyword
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__threads__templatetags__misago_poststags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__threads__templatetags__misago_poststags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "misago.threads.templatetags.misago_poststags::tag::likes_label":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: post
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: post
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__custom_links.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__custom_links.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.extras.templatetags.custom_links::tag::custom_links":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__dashboard.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__dashboard.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.extras.templatetags.dashboard::tag::render_widget":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: widget
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: widget
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__log_levels.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__extras__templatetags__log_levels.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.extras.templatetags.log_levels::tag::log_level":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: level
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: level
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__builtins__tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__builtins__tags.py.snap
@@ -4,148 +4,160 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.builtins.tags::tag::badge":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: bg_color
-          requirement: optional
-          kind: Variable
-        - name: show_empty
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: bg_color
+            requirement: optional
+            kind: Variable
+          - name: show_empty
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::checkmark":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: show_false
-          requirement: optional
-          kind: Variable
-        - name: "true"
-          requirement: optional
-          kind: Variable
-        - name: "false"
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: show_false
+            requirement: optional
+            kind: Variable
+          - name: "true"
+            requirement: optional
+            kind: Variable
+          - name: "false"
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::copy_content":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: target
-          requirement: required
-          kind: Variable
-        - name: prefix
-          requirement: optional
-          kind: Variable
-        - name: color
-          requirement: optional
-          kind: Variable
-        - name: classes
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: target
+            requirement: required
+            kind: Variable
+          - name: prefix
+            requirement: optional
+            kind: Variable
+          - name: color
+            requirement: optional
+            kind: Variable
+          - name: classes
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::customfield_value":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: customfield
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: customfield
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::formaction":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.builtins.tags::tag::htmx_table":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: viewname
-          requirement: required
-          kind: Variable
-        - name: return_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: viewname
+            requirement: required
+            kind: Variable
+          - name: return_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
   "netbox.utilities.templatetags.builtins.tags::tag::render":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: component
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: component
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.builtins.tags::tag::static_with_params":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: params
     as_var: strip
   "netbox.utilities.templatetags.builtins.tags::tag::tag":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: viewname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: viewname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__buttons.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__buttons.py.snap
@@ -4,186 +4,199 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.buttons::tag::action_buttons":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: actions
-          requirement: required
-          kind: Variable
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: multi
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: actions
+            requirement: required
+            kind: Variable
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: multi
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "netbox.utilities.templatetags.buttons::tag::add_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: optional
-          kind: Variable
-        - name: return_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: optional
+            kind: Variable
+          - name: return_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::bookmark_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::bulk_delete_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: optional
-          kind: Variable
-        - name: query_params
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: optional
+            kind: Variable
+          - name: query_params
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::bulk_edit_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: optional
-          kind: Variable
-        - name: query_params
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: optional
+            kind: Variable
+          - name: query_params
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::clone_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::delete_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::edit_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::export_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::import_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::subscribe_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.buttons::tag::sync_button":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__form_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__form_helpers.py.snap
@@ -4,78 +4,83 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.form_helpers::tag::render_custom_fields":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: form
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: form
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_errors":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: form
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: form
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_field":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: bulk_nullable
-          requirement: optional
-          kind: Variable
-        - name: label
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: bulk_nullable
+            requirement: optional
+            kind: Variable
+          - name: label
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_fieldset":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: form
-          requirement: required
-          kind: Variable
-        - name: fieldset
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: form
+            requirement: required
+            kind: Variable
+          - name: fieldset
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.form_helpers::tag::render_form":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: form
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: form
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "netbox.utilities.templatetags.form_helpers::filter::getfield": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__helpers.py.snap
@@ -19,70 +19,75 @@ tag_rules:
           kind: Variable
     as_var: strip
   "netbox.utilities.templatetags.helpers::tag::applied_filters":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
-        - name: form
-          requirement: required
-          kind: Variable
-        - name: query_params
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+          - name: form
+            requirement: required
+            kind: Variable
+          - name: query_params
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.helpers::tag::querystring":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "netbox.utilities.templatetags.helpers::tag::table_config_form":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: table
-          requirement: required
-          kind: Variable
-        - name: table_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: table
+            requirement: required
+            kind: Variable
+          - name: table_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "netbox.utilities.templatetags.helpers::tag::utilization_graph":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: utilization
-          requirement: required
-          kind: Variable
-        - name: warning_threshold
-          requirement: optional
-          kind: Variable
-        - name: danger_threshold
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: utilization
+            requirement: required
+            kind: Variable
+          - name: warning_threshold
+            requirement: optional
+            kind: Variable
+          - name: danger_threshold
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "netbox.utilities.templatetags.helpers::filter::as_range": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__mptt.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__mptt.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.mptt::tag::nested_tree":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__navigation.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__navigation.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.navigation::tag::nav":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__plugins.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__plugins.py.snap
@@ -4,100 +4,110 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.plugins::tag::plugin_alerts":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_buttons":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_full_width_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_head":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_left_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_list_buttons":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: model
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: model
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_navbar":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "netbox.utilities.templatetags.plugins::tag::plugin_right_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__tabs.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__netbox__netbox__utilities__templatetags__tabs.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "netbox.utilities.templatetags.tabs::tag::model_view_tabs":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: instance
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: instance
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__nomnom__src__nomnom__nominate__templatetags__nomnom_styles.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__nomnom__src__nomnom__nominate__templatetags__nomnom_styles.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.nomnom.nominate.templatetags.nomnom_styles::tag::site_stylesheet":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__eventsignal.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__eventsignal.py.snap
@@ -4,34 +4,38 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.base.templatetags.eventsignal::tag::eventsignal":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: event
-          requirement: required
-          kind: Variable
-        - name: signame
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: event
+            requirement: required
+            kind: Variable
+          - name: signame
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.pretix.base.templatetags.eventsignal::tag::signal":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: signame
-          requirement: required
-          kind: Variable
-        - name: request
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: signame
+            requirement: required
+            kind: Variable
+          - name: request
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__html_time.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__html_time.py.snap
@@ -4,19 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.base.templatetags.html_time::tag::html_time":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: dt_format
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: dt_format
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__icon.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__icon.py.snap
@@ -4,19 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.base.templatetags.icon::tag::icon":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: key
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: key
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__safelink.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__safelink.py.snap
@@ -4,33 +4,35 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.base.templatetags.safelink::tag::answer_token":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: answer
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: answer
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.pretix.base.templatetags.safelink::tag::safelink":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__textbubble.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__textbubble.py.snap
@@ -4,28 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.base.templatetags.textbubble::tag::endtextbubble":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.pretix.base.templatetags.textbubble::tag::textbubble":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: type
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: type
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__urlreplace.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__base__templatetags__urlreplace.py.snap
@@ -4,19 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.base.templatetags.urlreplace::tag::url_replace":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: pairs
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: pairs
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__emaildigest__templatetags__emaildigest_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__emaildigest__templatetags__emaildigest_extra.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "emaildigest.templatetags.emaildigest_extra::tag::digest_subscription_form":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__news__templatetags__news_extra.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pythonic-news__news__templatetags__news_extra.py.snap
@@ -3,55 +3,83 @@ source: crates/djls-project/tests/corpus.rs
 expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should serialize\")"
 ---
 tag_rules:
-  "news.templatetags.news_extra::tag::link_user":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+  "news.templatetags.news_extra::tag::item_content":
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: keep
+  "news.templatetags.news_extra::tag::item_control":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
+    as_var: keep
+  "news.templatetags.news_extra::tag::link_user":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "news.templatetags.news_extra::tag::more_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "news.templatetags.news_extra::tag::news_item":
-    arg_constraints:
-      - Min: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: item
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: item
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: keep
   "news.templatetags.news_extra::tag::user_arrows":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: item
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: item
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "news.templatetags.news_extra::filter::comment_markdown": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__core_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__core_tags.py.snap
@@ -4,53 +4,58 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "readthedocs.core.templatetags.core_tags::tag::doc_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: project
-          requirement: required
-          kind: Variable
-        - name: version
-          requirement: optional
-          kind: Variable
-        - name: page
-          requirement: optional
-          kind: Variable
-        - name: path
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: project
+            requirement: required
+            kind: Variable
+          - name: version
+            requirement: optional
+            kind: Variable
+          - name: page
+            requirement: optional
+            kind: Variable
+          - name: path
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "readthedocs.core.templatetags.core_tags::tag::readthedocs_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "readthedocs.core.templatetags.core_tags::tag::url_replace":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: field
-          requirement: required
-          kind: Variable
-        - name: values
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: field
+            requirement: required
+            kind: Variable
+          - name: values
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "readthedocs.core.templatetags.core_tags::filter::escapejson": optional_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__privacy_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__readthedocs.org__readthedocs__core__templatetags__privacy_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "readthedocs.core.templatetags.privacy_tags::tag::get_public_projects":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "readthedocs.core.templatetags.privacy_tags::filter::is_admin": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_api.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_api.py.snap
@@ -4,59 +4,63 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_api::tag::convert_to_json":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_api::tag::get_recipient_context":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: request
-          requirement: required
-          kind: Variable
-        - name: escape
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: request
+            requirement: required
+            kind: Variable
+          - name: escape
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_api::tag::serialize":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_api::tag::serialize_detailed_org":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_assets.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_assets.py.snap
@@ -4,38 +4,43 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_assets::tag::absolute_asset_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: module
-          requirement: required
-          kind: Variable
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: module
+            requirement: required
+            kind: Variable
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_assets::tag::crossorigin":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_assets::tag::injected_script_assets":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_avatars.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_avatars.py.snap
@@ -4,112 +4,118 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_avatars::tag::avatar":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "src.sentry.templatetags.sentry_avatars::tag::avatar_for_email":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "src.sentry.templatetags.sentry_avatars::tag::email_avatar":
-    arg_constraints:
-      - Min: 3
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: display_name
-          requirement: required
-          kind: Variable
-        - name: identifier
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: try_gravatar
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: display_name
+            requirement: required
+            kind: Variable
+          - name: identifier
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: try_gravatar
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_avatars::tag::gravatar_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: email
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: required
-          kind: Variable
-        - name: default
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: email
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: required
+            kind: Variable
+          - name: default
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_avatars::tag::letter_avatar_svg":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: display_name
-          requirement: required
-          kind: Variable
-        - name: identifier
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: display_name
+            requirement: required
+            kind: Variable
+          - name: identifier
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_avatars::tag::profile_photo_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user_id
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user_id
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_helpers.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_helpers.py.snap
@@ -4,110 +4,133 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_helpers::tag::get_sentry_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::loading_message":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::org_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: organization
-          requirement: required
-          kind: Variable
-        - name: path
-          requirement: required
-          kind: Variable
-        - name: query
-          requirement: optional
-          kind: Variable
-        - name: fragment
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: organization
+            requirement: required
+            kind: Variable
+          - name: path
+            requirement: required
+            kind: Variable
+          - name: query
+            requirement: optional
+            kind: Variable
+          - name: fragment
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::percent":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
-        - name: total
-          requirement: required
-          kind: Variable
-        - name: format
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+          - name: total
+            requirement: required
+            kind: Variable
+          - name: format
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "src.sentry.templatetags.sentry_helpers::tag::querystring":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::random_int":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: a
-          requirement: required
-          kind: Variable
-        - name: b
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: a
+            requirement: required
+            kind: Variable
+          - name: b
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::security_contact":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::serialize":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_helpers::tag::system_origin":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "src.sentry.templatetags.sentry_helpers::filter::absolute_value": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_platforms.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_platforms.py.snap
@@ -4,42 +4,44 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_platforms::tag::letter_platform_svg":
-    arg_constraints:
-      - Min: 3
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: display_name
-          requirement: required
-          kind: Variable
-        - name: identifier
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: rounded
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: display_name
+            requirement: required
+            kind: Variable
+          - name: identifier
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: rounded
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_platforms::tag::platform_avatar":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: display_name
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: display_name
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_react.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_react.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_react::tag::get_react_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_status.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_status.py.snap
@@ -4,13 +4,15 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_status::tag::show_system_status":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_trace.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__sentry__src__sentry__templatetags__sentry_trace.py.snap
@@ -4,22 +4,26 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.sentry.templatetags.sentry_trace::tag::get_sentry_baggage":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "src.sentry.templatetags.sentry_trace::tag::get_sentry_trace":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_calendar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_calendar.py.snap
@@ -4,30 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "blog.templatetags.blog_calendar::tag::render_calendar":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.blog_calendar::tag::render_calendar_month_only":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__blog_tags.py.snap
@@ -4,135 +4,145 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "blog.templatetags.blog_tags::tag::add_qsarg":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "blog.templatetags.blog_tags::tag::blog_mixed_list":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.blog_tags::tag::blog_mixed_list_with_dates":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
-        - name: year_headers
-          requirement: optional
-          kind: Variable
-        - name: day_headers
-          requirement: optional
-          kind: Variable
-        - name: day_links
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+          - name: year_headers
+            requirement: optional
+            kind: Variable
+          - name: day_headers
+            requirement: optional
+            kind: Variable
+          - name: day_links
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.blog_tags::tag::comments_list":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: comments
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: comments
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.blog_tags::tag::comments_list_with_headers":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: comments
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: comments
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.blog_tags::tag::page_href":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "blog.templatetags.blog_tags::tag::remove_id_filters":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "blog.templatetags.blog_tags::tag::remove_qsarg":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "blog.templatetags.blog_tags::tag::replace_qsarg":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: required
-          kind: Variable
-        - name: value
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: required
+            kind: Variable
+          - name: value
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "blog.templatetags.blog_tags::filter::markdownify": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__entry_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__entry_tags.py.snap
@@ -4,30 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "blog.templatetags.entry_tags::tag::entry_footer":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: entry
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: entry
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.entry_tags::tag::entry_footer_no_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: entry
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: entry
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities:
   "blog.templatetags.entry_tags::filter::break_up_long_words": required_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__tag_cloud.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__simonwillison.net__blog__templatetags__tag_cloud.py.snap
@@ -4,26 +4,29 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "blog.templatetags.tag_cloud::tag::tag_cloud":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "blog.templatetags.tag_cloud::tag::tag_cloud_for_tags":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: tags
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: tags
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -4,150 +4,163 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_edit_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_url_name":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: tooltip
-          requirement: optional
-          kind: Variable
-        - name: tooltip_html
-          requirement: optional
-          kind: Variable
-        - name: edit_link
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: tooltip
+            requirement: optional
+            kind: Variable
+          - name: tooltip_html
+            requirement: optional
+            kind: Variable
+          - name: edit_link
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: gravatar_only
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: gravatar_only
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: default
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: default
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: app_label
-          requirement: required
-          kind: Variable
-        - name: model_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: app_label
+            requirement: required
+            kind: Variable
+          - name: model_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -155,541 +168,602 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: classes
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: classes
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dialog_id
-          requirement: required
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: text
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dialog_id
+            requirement: required
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: text
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
-    arg_constraints:
-      - Max: 13
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: optional
-          kind: Variable
-        - name: rendered_field
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: show_label
-          requirement: optional
-          kind: Variable
-        - name: id_for_label
-          requirement: optional
-          kind: Variable
-        - name: sr_only_label
-          requirement: optional
-          kind: Variable
-        - name: icon
-          requirement: optional
-          kind: Variable
-        - name: help_text
-          requirement: optional
-          kind: Variable
-        - name: help_text_id
-          requirement: optional
-          kind: Variable
-        - name: show_add_comment_button
-          requirement: optional
-          kind: Variable
-        - name: label_text
-          requirement: optional
-          kind: Variable
-        - name: error_message_id
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: optional
+            kind: Variable
+          - name: rendered_field
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: show_label
+            requirement: optional
+            kind: Variable
+          - name: id_for_label
+            requirement: optional
+            kind: Variable
+          - name: sr_only_label
+            requirement: optional
+            kind: Variable
+          - name: icon
+            requirement: optional
+            kind: Variable
+          - name: help_text
+            requirement: optional
+            kind: Variable
+          - name: help_text_id
+            requirement: optional
+            kind: Variable
+          - name: show_add_comment_button
+            requirement: optional
+            kind: Variable
+          - name: label_text
+            requirement: optional
+            kind: Variable
+          - name: error_message_id
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::get_comments_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::hook_output":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: hook_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: hook_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date
-          requirement: required
-          kind: Variable
-        - name: description
-          requirement: optional
-          kind: Variable
-        - name: placement
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date
+            requirement: required
+            kind: Variable
+          - name: description
+            requirement: optional
+            kind: Variable
+          - name: placement
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::icon":
-    arg_constraints:
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: wrapped
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: wrapped
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::js_translation_strings":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::latest_str":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: locale_id
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: locale_id
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locales":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: serialize
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: serialize
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::notification_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
-    arg_constraints:
-      - Min: 3
-      - Max: 10
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: url_root_name
-          requirement: optional
-          kind: Variable
-        - name: include_self
-          requirement: optional
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: querystring_value
-          requirement: optional
-          kind: Variable
-        - name: trailing_breadcrumb_title
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: url_root_name
+            requirement: optional
+            kind: Variable
+          - name: include_self
+            requirement: optional
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: querystring_value
+            requirement: optional
+            kind: Variable
+          - name: trailing_breadcrumb_title
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: view_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: view_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: next_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: next_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: base_url
-          requirement: optional
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: base_url
+            requirement: optional
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page_number
-          requirement: required
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page_number
+            requirement: required
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "wagtail.admin.templatetags.wagtailadmin_tags::tag::querystring":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: current
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: current
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_props":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::status":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: label
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: url
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: hidden_label
-          requirement: optional
-          kind: Variable
-        - name: attrs
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: label
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: url
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: hidden_label
+            requirement: optional
+            kind: Variable
+          - name: attrs
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: collection
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: collection
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: last_update
-          requirement: required
-          kind: Variable
-        - name: show_time_prefix
-          requirement: optional
-          kind: Variable
-        - name: user_display_name
-          requirement: optional
-          kind: Variable
-        - name: use_shorthand
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: last_update
+            requirement: required
+            kind: Variable
+          - name: show_time_prefix
+            requirement: optional
+            kind: Variable
+          - name: user_display_name
+            requirement: optional
+            kind: Variable
+          - name: use_shorthand
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::workflow_status_with_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: workflow_state
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: workflow_state
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailuserbar::tag::wagtailuserbar":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: position
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: position
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -4,22 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags::tag::routablepageurl":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags::tag::get_search_promotions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: search_query
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: search_query
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -4,61 +4,64 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_classname":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.embeds.templatetags.wagtailembeds_tags::tag::embed":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: max_width
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: max_width
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.images.templatetags.wagtailimages_tags::tag::image_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: image
-          requirement: required
-          kind: Variable
-        - name: filter_spec
-          requirement: required
-          kind: Variable
-        - name: viewname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: image
+            requirement: required
+            kind: Variable
+          - name: filter_spec
+            requirement: required
+            kind: Variable
+          - name: viewname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.templatetags.wagtailcore_tags::tag::fullpageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -31,87 +32,101 @@ tag_rules:
           kind: Variable
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: slug
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: slug
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_editor_guide_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_whats_new_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_release_notes_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_site":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-6.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -4,30 +4,32 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.users.templatetags.wagtailusers_tags::tag::format_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: permission_bound_field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: permission_bound_field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.users.templatetags.wagtailusers_tags::tag::user_listing_buttons":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -4,159 +4,174 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_edit_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_color_scheme":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_url_name":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: tooltip
-          requirement: optional
-          kind: Variable
-        - name: tooltip_html
-          requirement: optional
-          kind: Variable
-        - name: edit_link
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: tooltip
+            requirement: optional
+            kind: Variable
+          - name: tooltip_html
+            requirement: optional
+            kind: Variable
+          - name: edit_link
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: gravatar_only
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: gravatar_only
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: default
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: default
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: app_label
-          requirement: required
-          kind: Variable
-        - name: model_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: app_label
+            requirement: required
+            kind: Variable
+          - name: model_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -164,520 +179,577 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: classes
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: classes
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dialog_id
-          requirement: required
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: text
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dialog_id
+            requirement: required
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: text
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
-    arg_constraints:
-      - Max: 13
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: optional
-          kind: Variable
-        - name: rendered_field
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: show_label
-          requirement: optional
-          kind: Variable
-        - name: id_for_label
-          requirement: optional
-          kind: Variable
-        - name: sr_only_label
-          requirement: optional
-          kind: Variable
-        - name: icon
-          requirement: optional
-          kind: Variable
-        - name: help_text
-          requirement: optional
-          kind: Variable
-        - name: help_text_id
-          requirement: optional
-          kind: Variable
-        - name: show_add_comment_button
-          requirement: optional
-          kind: Variable
-        - name: label_text
-          requirement: optional
-          kind: Variable
-        - name: error_message_id
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: optional
+            kind: Variable
+          - name: rendered_field
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: show_label
+            requirement: optional
+            kind: Variable
+          - name: id_for_label
+            requirement: optional
+            kind: Variable
+          - name: sr_only_label
+            requirement: optional
+            kind: Variable
+          - name: icon
+            requirement: optional
+            kind: Variable
+          - name: help_text
+            requirement: optional
+            kind: Variable
+          - name: help_text_id
+            requirement: optional
+            kind: Variable
+          - name: show_add_comment_button
+            requirement: optional
+            kind: Variable
+          - name: label_text
+            requirement: optional
+            kind: Variable
+          - name: error_message_id
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::get_comments_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::hook_output":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: hook_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: hook_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date
-          requirement: required
-          kind: Variable
-        - name: description
-          requirement: optional
-          kind: Variable
-        - name: placement
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date
+            requirement: required
+            kind: Variable
+          - name: description
+            requirement: optional
+            kind: Variable
+          - name: placement
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::icon":
-    arg_constraints:
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: wrapped
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: wrapped
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::latest_str":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: locale_id
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: locale_id
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::notification_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
-    arg_constraints:
-      - Min: 3
-      - Max: 10
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: url_root_name
-          requirement: optional
-          kind: Variable
-        - name: include_self
-          requirement: optional
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: querystring_value
-          requirement: optional
-          kind: Variable
-        - name: trailing_breadcrumb_title
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: url_root_name
+            requirement: optional
+            kind: Variable
+          - name: include_self
+            requirement: optional
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: querystring_value
+            requirement: optional
+            kind: Variable
+          - name: trailing_breadcrumb_title
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: view_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: view_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: next_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: next_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: base_url
-          requirement: optional
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: base_url
+            requirement: optional
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page_number
-          requirement: required
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page_number
+            requirement: required
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "wagtail.admin.templatetags.wagtailadmin_tags::tag::querystring":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: current
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: current
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_props":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::status":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: label
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: url
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: hidden_label
-          requirement: optional
-          kind: Variable
-        - name: attrs
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: label
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: url
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: hidden_label
+            requirement: optional
+            kind: Variable
+          - name: attrs
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: collection
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: collection
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: last_update
-          requirement: required
-          kind: Variable
-        - name: show_time_prefix
-          requirement: optional
-          kind: Variable
-        - name: user_display_name
-          requirement: optional
-          kind: Variable
-        - name: use_shorthand
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: last_update
+            requirement: required
+            kind: Variable
+          - name: show_time_prefix
+            requirement: optional
+            kind: Variable
+          - name: user_display_name
+            requirement: optional
+            kind: Variable
+          - name: use_shorthand
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::workflow_status_with_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: workflow_state
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: workflow_state
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailuserbar::tag::wagtailuserbar":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: position
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: position
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -4,22 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags::tag::routablepageurl":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags::tag::get_search_promotions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: search_query
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: search_query
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -4,61 +4,64 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_classname":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.embeds.templatetags.wagtailembeds_tags::tag::embed":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: max_width
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: max_width
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.images.templatetags.wagtailimages_tags::tag::image_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: image
-          requirement: required
-          kind: Variable
-        - name: filter_spec
-          requirement: required
-          kind: Variable
-        - name: viewname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: image
+            requirement: required
+            kind: Variable
+          - name: filter_spec
+            requirement: required
+            kind: Variable
+          - name: viewname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.templatetags.wagtailcore_tags::tag::fullpageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -31,87 +32,101 @@ tag_rules:
           kind: Variable
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: slug
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: slug
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_editor_guide_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_whats_new_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_release_notes_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_site":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.0__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.users.templatetags.wagtailusers_tags::tag::format_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: permission_bound_field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: permission_bound_field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -4,185 +4,202 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::absolute_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_edit_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_color_scheme":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_url_name":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: tooltip
-          requirement: optional
-          kind: Variable
-        - name: tooltip_html
-          requirement: optional
-          kind: Variable
-        - name: edit_link
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: tooltip
+            requirement: optional
+            kind: Variable
+          - name: tooltip_html
+            requirement: optional
+            kind: Variable
+          - name: edit_link
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: gravatar_only
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: gravatar_only
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: default
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: default
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::build_absolute_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: app_label
-          requirement: required
-          kind: Variable
-        - name: model_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: app_label
+            requirement: required
+            kind: Variable
+          - name: model_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -190,513 +207,569 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: classes
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: classes
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dialog_id
-          requirement: required
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: text
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dialog_id
+            requirement: required
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: text
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
-    arg_constraints:
-      - Max: 15
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: optional
-          kind: Variable
-        - name: rendered_field
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: show_label
-          requirement: optional
-          kind: Variable
-        - name: id_for_label
-          requirement: optional
-          kind: Variable
-        - name: sr_only_label
-          requirement: optional
-          kind: Variable
-        - name: icon
-          requirement: optional
-          kind: Variable
-        - name: help_text
-          requirement: optional
-          kind: Variable
-        - name: help_text_id
-          requirement: optional
-          kind: Variable
-        - name: show_add_comment_button
-          requirement: optional
-          kind: Variable
-        - name: label_text
-          requirement: optional
-          kind: Variable
-        - name: error_message_id
-          requirement: optional
-          kind: Variable
-        - name: wrapper_id
-          requirement: optional
-          kind: Variable
-        - name: attrs
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: optional
+            kind: Variable
+          - name: rendered_field
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: show_label
+            requirement: optional
+            kind: Variable
+          - name: id_for_label
+            requirement: optional
+            kind: Variable
+          - name: sr_only_label
+            requirement: optional
+            kind: Variable
+          - name: icon
+            requirement: optional
+            kind: Variable
+          - name: help_text
+            requirement: optional
+            kind: Variable
+          - name: help_text_id
+            requirement: optional
+            kind: Variable
+          - name: show_add_comment_button
+            requirement: optional
+            kind: Variable
+          - name: label_text
+            requirement: optional
+            kind: Variable
+          - name: error_message_id
+            requirement: optional
+            kind: Variable
+          - name: wrapper_id
+            requirement: optional
+            kind: Variable
+          - name: attrs
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::get_comments_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::hook_output":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: hook_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: hook_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date
-          requirement: required
-          kind: Variable
-        - name: description
-          requirement: optional
-          kind: Variable
-        - name: placement
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date
+            requirement: required
+            kind: Variable
+          - name: description
+            requirement: optional
+            kind: Variable
+          - name: placement
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::icon":
-    arg_constraints:
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: wrapped
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: wrapped
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::latest_str":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: locale_id
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: locale_id
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
-    arg_constraints:
-      - Min: 3
-      - Max: 10
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: url_root_name
-          requirement: optional
-          kind: Variable
-        - name: include_self
-          requirement: optional
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: querystring_value
-          requirement: optional
-          kind: Variable
-        - name: trailing_breadcrumb_title
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: url_root_name
+            requirement: optional
+            kind: Variable
+          - name: include_self
+            requirement: optional
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: querystring_value
+            requirement: optional
+            kind: Variable
+          - name: trailing_breadcrumb_title
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: view_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: view_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: next_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: next_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: base_url
-          requirement: optional
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: base_url
+            requirement: optional
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page_number
-          requirement: required
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page_number
+            requirement: required
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "wagtail.admin.templatetags.wagtailadmin_tags::tag::querystring":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: current
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: current
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_props":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::status":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: label
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: url
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: hidden_label
-          requirement: optional
-          kind: Variable
-        - name: attrs
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: label
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: url
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: hidden_label
+            requirement: optional
+            kind: Variable
+          - name: attrs
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: collection
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: collection
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: last_update
-          requirement: required
-          kind: Variable
-        - name: show_time_prefix
-          requirement: optional
-          kind: Variable
-        - name: user_display_name
-          requirement: optional
-          kind: Variable
-        - name: use_shorthand
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: last_update
+            requirement: required
+            kind: Variable
+          - name: show_time_prefix
+            requirement: optional
+            kind: Variable
+          - name: user_display_name
+            requirement: optional
+            kind: Variable
+          - name: use_shorthand
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::workflow_status_with_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: workflow_state
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: workflow_state
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailuserbar::tag::wagtailuserbar":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: position
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: position
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -4,22 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags::tag::routablepageurl":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags::tag::get_search_promotions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: search_query
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: search_query
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -4,61 +4,64 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_classname":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.embeds.templatetags.wagtailembeds_tags::tag::embed":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: max_width
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: max_width
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.images.templatetags.wagtailimages_tags::tag::image_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: image
-          requirement: required
-          kind: Variable
-        - name: filter_spec
-          requirement: required
-          kind: Variable
-        - name: viewname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: image
+            requirement: required
+            kind: Variable
+          - name: filter_spec
+            requirement: required
+            kind: Variable
+          - name: viewname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.templatetags.wagtailcore_tags::tag::fullpageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -31,87 +32,101 @@ tag_rules:
           kind: Variable
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: slug
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: slug
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_editor_guide_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_whats_new_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_release_notes_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_site":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.2__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.users.templatetags.wagtailusers_tags::tag::format_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: permission_bound_field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: permission_bound_field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailadmin_tags.py.snap
@@ -4,185 +4,202 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::absolute_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_edit_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_classname":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_theme_color_scheme":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::admin_url_name":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
-        - name: action
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+          - name: action
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::allow_unicode_slugs":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: tooltip
-          requirement: optional
-          kind: Variable
-        - name: tooltip_html
-          requirement: optional
-          kind: Variable
-        - name: edit_link
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: tooltip
+            requirement: optional
+            kind: Variable
+          - name: tooltip_html
+            requirement: optional
+            kind: Variable
+          - name: edit_link
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::avatar_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: size
-          requirement: optional
-          kind: Variable
-        - name: gravatar_only
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: size
+            requirement: optional
+            kind: Variable
+          - name: gravatar_only
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::base_url_setting":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: default
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: default
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::breadcrumbs":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: items
-          requirement: required
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: items
+            requirement: required
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::build_absolute_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::bulk_action_choices":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: app_label
-          requirement: required
-          kind: Variable
-        - name: model_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: app_label
+            requirement: required
+            kind: Variable
+          - name: model_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::classnames":
     arg_constraints: []
@@ -190,513 +207,569 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: classes
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: classes
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::dialog_toggle":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: dialog_id
-          requirement: required
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: text
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: dialog_id
+            requirement: required
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: text
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfield":
-    arg_constraints:
-      - Max: 15
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: field
-          requirement: optional
-          kind: Variable
-        - name: rendered_field
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: show_label
-          requirement: optional
-          kind: Variable
-        - name: id_for_label
-          requirement: optional
-          kind: Variable
-        - name: sr_only_label
-          requirement: optional
-          kind: Variable
-        - name: icon
-          requirement: optional
-          kind: Variable
-        - name: help_text
-          requirement: optional
-          kind: Variable
-        - name: help_text_id
-          requirement: optional
-          kind: Variable
-        - name: show_add_comment_button
-          requirement: optional
-          kind: Variable
-        - name: label_text
-          requirement: optional
-          kind: Variable
-        - name: error_message_id
-          requirement: optional
-          kind: Variable
-        - name: wrapper_id
-          requirement: optional
-          kind: Variable
-        - name: attrs
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: field
+            requirement: optional
+            kind: Variable
+          - name: rendered_field
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: show_label
+            requirement: optional
+            kind: Variable
+          - name: id_for_label
+            requirement: optional
+            kind: Variable
+          - name: sr_only_label
+            requirement: optional
+            kind: Variable
+          - name: icon
+            requirement: optional
+            kind: Variable
+          - name: help_text
+            requirement: optional
+            kind: Variable
+          - name: help_text_id
+            requirement: optional
+            kind: Variable
+          - name: show_add_comment_button
+            requirement: optional
+            kind: Variable
+          - name: label_text
+            requirement: optional
+            kind: Variable
+          - name: error_message_id
+            requirement: optional
+            kind: Variable
+          - name: wrapper_id
+            requirement: optional
+            kind: Variable
+          - name: attrs
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::formattedfieldfromcontext":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::get_comments_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::hook_output":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: hook_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: hook_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::human_readable_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: date
-          requirement: required
-          kind: Variable
-        - name: description
-          requirement: optional
-          kind: Variable
-        - name: placement
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: date
+            requirement: required
+            kind: Variable
+          - name: description
+            requirement: optional
+            kind: Variable
+          - name: placement
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::i18n_enabled":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::icon":
-    arg_constraints:
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: name
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: wrapped
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: name
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: wrapped
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::is_page":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::keyboard_shortcuts_dialog":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::latest_str":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: obj
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: obj
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::locale_label_from_id":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: locale_id
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: locale_id
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_level_tag":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::message_tags":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: message
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: message
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_breadcrumbs":
-    arg_constraints:
-      - Min: 3
-      - Max: 10
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: url_root_name
-          requirement: optional
-          kind: Variable
-        - name: include_self
-          requirement: optional
-          kind: Variable
-        - name: is_expanded
-          requirement: optional
-          kind: Variable
-        - name: querystring_value
-          requirement: optional
-          kind: Variable
-        - name: trailing_breadcrumb_title
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: icon_name
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: url_root_name
+            requirement: optional
+            kind: Variable
+          - name: include_self
+            requirement: optional
+            kind: Variable
+          - name: is_expanded
+            requirement: optional
+            kind: Variable
+          - name: querystring_value
+            requirement: optional
+            kind: Variable
+          - name: trailing_breadcrumb_title
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: icon_name
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_header_buttons":
-    arg_constraints:
-      - Min: 4
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: view_name
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: view_name
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_listing_buttons":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: user
-          requirement: required
-          kind: Variable
-        - name: next_url
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: user
+            requirement: required
+            kind: Variable
+          - name: next_url
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::page_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::paginate":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: base_url
-          requirement: optional
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: base_url
+            requirement: optional
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::pagination_querystring":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page_number
-          requirement: required
-          kind: Variable
-        - name: page_key
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page_number
+            requirement: required
+            kind: Variable
+          - name: page_key
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
+    as_var: strip
+  "wagtail.admin.templatetags.wagtailadmin_tags::tag::querystring":
+    arg_constraints: []
+    required_keywords: []
+    choice_at_constraints: []
+    known_options: ~
+    argument_syntax:
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::resolve_url":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::search_other":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: current
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: current
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_collapsed":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::sidebar_props":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::status":
-    arg_constraints:
-      - Max: 7
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: label
-          requirement: optional
-          kind: Variable
-        - name: classname
-          requirement: optional
-          kind: Variable
-        - name: url
-          requirement: optional
-          kind: Variable
-        - name: title
-          requirement: optional
-          kind: Variable
-        - name: hidden_label
-          requirement: optional
-          kind: Variable
-        - name: attrs
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: label
+            requirement: optional
+            kind: Variable
+          - name: classname
+            requirement: optional
+            kind: Variable
+          - name: url
+            requirement: optional
+            kind: Variable
+          - name: title
+            requirement: optional
+            kind: Variable
+          - name: hidden_label
+            requirement: optional
+            kind: Variable
+          - name: attrs
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_collection_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: collection
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: collection
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::test_page_is_public":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::timesince_last_update":
-    arg_constraints:
-      - Min: 2
-      - Max: 5
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: last_update
-          requirement: required
-          kind: Variable
-        - name: show_time_prefix
-          requirement: optional
-          kind: Variable
-        - name: user_display_name
-          requirement: optional
-          kind: Variable
-        - name: use_shorthand
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: last_update
+            requirement: required
+            kind: Variable
+          - name: show_time_prefix
+            requirement: optional
+            kind: Variable
+          - name: user_display_name
+            requirement: optional
+            kind: Variable
+          - name: use_shorthand
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::versioned_static":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: path
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: path
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::wagtail_config":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.admin.templatetags.wagtailadmin_tags::tag::workflow_status_with_date":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: workflow_state
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: workflow_state
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.admin.templatetags.wagtailadmin_tags::filter::abs": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__admin__templatetags__wagtailuserbar.py.snap
@@ -4,16 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.admin.templatetags.wagtailuserbar::tag::wagtailuserbar":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: position
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: position
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__routable_page__templatetags__wagtailroutablepage_tags.py.snap
@@ -4,22 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags::tag::routablepageurl":
-    arg_constraints:
-      - Min: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: url_name
-          requirement: required
-          kind: Variable
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: url_name
+            requirement: required
+            kind: Variable
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__search_promotions__templatetags__wagtailsearchpromotions_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags::tag::get_search_promotions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: search_query
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: search_query
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__contrib__table_block__templatetags__table_block_tags.py.snap
@@ -4,61 +4,64 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_classname":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_hidden":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.contrib.table_block.templatetags.table_block_tags::tag::cell_span":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: row_index
-          requirement: required
-          kind: Variable
-        - name: col_index
-          requirement: required
-          kind: Variable
-        - name: table_header
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: row_index
+            requirement: required
+            kind: Variable
+          - name: col_index
+            requirement: required
+            kind: Variable
+          - name: table_header
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__embeds__templatetags__wagtailembeds_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.embeds.templatetags.wagtailembeds_tags::tag::embed":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: max_width
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: max_width
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__images__templatetags__wagtailimages_tags.py.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.images.templatetags.wagtailimages_tags::tag::image_url":
-    arg_constraints:
-      - Min: 3
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: image
-          requirement: required
-          kind: Variable
-        - name: filter_spec
-          requirement: required
-          kind: Variable
-        - name: viewname
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: image
+            requirement: required
+            kind: Variable
+          - name: filter_spec
+            requirement: required
+            kind: Variable
+          - name: viewname
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__templatetags__wagtailcore_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__templatetags__wagtailcore_tags.py.snap
@@ -4,20 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.templatetags.wagtailcore_tags::tag::fullpageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::include_block":
     arg_constraints: []
@@ -31,87 +32,101 @@ tag_rules:
           kind: Variable
     as_var: keep
   "wagtail.templatetags.wagtailcore_tags::tag::pageurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: page
-          requirement: required
-          kind: Variable
-        - name: fallback
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: page
+            requirement: required
+            kind: Variable
+          - name: fallback
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::slugurl":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: slug
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: slug
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_documentation_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_editor_guide_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_feature_release_whats_new_link":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_release_notes_path":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_site":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "wagtail.templatetags.wagtailcore_tags::tag::wagtail_version":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities:
   "wagtail.templatetags.wagtailcore_tags::filter::richtext": no_argument

--- a/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__wagtail-7.3__wagtail__users__templatetags__wagtailusers_tags.py.snap
@@ -4,17 +4,18 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "wagtail.users.templatetags.wagtailusers_tags::tag::format_permissions":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: permission_bound_field
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: permission_bound_field
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_custom_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_custom_tags.snap
@@ -4,79 +4,88 @@ expression: "sorted_snapshot(&result).expect(\"custom-tag extraction snapshot sh
 ---
 tag_rules:
   "tests.template_tests.templatetags.custom::tag::div":
-    arg_constraints:
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: id
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: id
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
   "tests.template_tests.templatetags.custom::tag::simple_two_params":
-    arg_constraints:
-      - Min: 3
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs:

--- a/crates/djls-project/tests/snapshots/extraction__golden_defaulttags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_defaulttags.snap
@@ -139,10 +139,13 @@ tag_rules:
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: args
-          requirement: optional
-          kind: VarArgs
+      Signature:
+        parameters:
+          - name: args
+            requirement: optional
+            kind: VarArgs
+        positional_only: 0
+        variadic_keyword: kwargs
     as_var: strip
   "django.template.defaulttags::tag::regroup":
     arg_constraints:

--- a/crates/djls-project/tests/snapshots/extraction__golden_django_admin_urls.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_django_admin_urls.snap
@@ -4,23 +4,24 @@ expression: "sorted_snapshot(&result).expect(\"Django admin URL extraction snaps
 ---
 tag_rules:
   "django.contrib.admin.templatetags.admin_urls::tag::add_preserved_filters":
-    arg_constraints:
-      - Min: 2
-      - Max: 4
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: url
-          requirement: required
-          kind: Variable
-        - name: popup
-          requirement: optional
-          kind: Variable
-        - name: to_field
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: url
+            requirement: required
+            kind: Variable
+          - name: popup
+            requirement: optional
+            kind: Variable
+          - name: to_field
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: strip
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-project/tests/snapshots/extraction__golden_inclusion_tags.snap
+++ b/crates/djls-project/tests/snapshots/extraction__golden_inclusion_tags.snap
@@ -4,51 +4,57 @@ expression: "sorted_snapshot(&result).expect(\"inclusion-tag extraction snapshot
 ---
 tag_rules:
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_no_params_with_context":
-    arg_constraints:
-      - Max: 1
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters: []
+      Signature:
+        parameters: []
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_default":
-    arg_constraints:
-      - Min: 2
-      - Max: 3
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: one
-          requirement: required
-          kind: Variable
-        - name: two
-          requirement: optional
-          kind: Variable
+      Signature:
+        parameters:
+          - name: one
+            requirement: required
+            kind: Variable
+          - name: two
+            requirement: optional
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
   "tests.template_tests.templatetags.inclusion::tag::inclusion_one_param":
-    arg_constraints:
-      - Min: 2
-      - Max: 2
+    arg_constraints: []
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
     argument_syntax:
-      Parameters:
-        - name: arg
-          requirement: required
-          kind: Variable
+      Signature:
+        parameters:
+          - name: arg
+            requirement: required
+            kind: Variable
+        positional_only: 0
+        variadic_keyword: ~
     as_var: keep
 filter_arities: {}
 block_specs: {}

--- a/crates/djls-semantic/resources/mdtest/diagnostics/tag-rules.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/tag-rules.md
@@ -7,7 +7,7 @@
 ```
 
 ```snapshot
-error[S117]: Tag 'one_arg_tag' requires at least 1 argument
+error[S117]: 'one_arg_tag' did not receive value(s) for the argument(s): 'value'
  --> test.html:1:1
   |
 1 | {% one_arg_tag %}
@@ -21,7 +21,7 @@ error[S117]: Tag 'one_arg_tag' requires at least 1 argument
 ```
 
 ```snapshot
-error[S117]: Tag 'one_arg_tag' accepts at most 1 argument
+error[S117]: 'one_arg_tag' received too many positional arguments
  --> test.html:1:1
   |
 1 | {% one_arg_tag first second %}

--- a/crates/djls-semantic/src/tags/rules.rs
+++ b/crates/djls-semantic/src/tags/rules.rs
@@ -172,17 +172,15 @@ pub(crate) fn evaluate_tag_rules(
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
 
-    // Django's simple_tag supports `{% tag args... as varname %}` syntax.
-    // The framework strips `as varname` before validating arguments, so we
-    // do the same: if the last two bits are ["as", <something>], strip them.
-    let effective_bits =
-        if rules.as_var.strips_suffix() && bits.len() >= 2 && bits[bits.len() - 2] == "as" {
-            &bits[..bits.len() - 2]
-        } else {
-            bits
-        };
+    let effective_bits = effective_tag_bits(bits, rules.as_var.strips_suffix());
 
     let diagnostic_messages = rules.diagnostic_messages.as_deref().unwrap_or(&[]);
+
+    if let Some(error) =
+        validate_signature_syntax(tag_name, &rules.argument_syntax, effective_bits, span)
+    {
+        return vec![error];
+    }
 
     if let TagArgumentSyntax::Forms { forms, coverage } = &rules.argument_syntax
         && !forms.iter().any(|form| form_matches(form, effective_bits))
@@ -281,6 +279,148 @@ pub(crate) fn evaluate_tag_rules(
     }
 
     errors
+}
+
+fn effective_tag_bits(bits: &[String], strips_as_var: bool) -> &[String] {
+    if strips_as_var && bits.len() >= 2 && bits[bits.len() - 2] == "as" {
+        &bits[..bits.len() - 2]
+    } else {
+        bits
+    }
+}
+
+fn validate_signature_syntax(
+    tag_name: &str,
+    syntax: &TagArgumentSyntax,
+    bits: &[String],
+    span: Span,
+) -> Option<ValidationError> {
+    let TagArgumentSyntax::Signature {
+        parameters,
+        variadic_keyword,
+        ..
+    } = syntax
+    else {
+        return None;
+    };
+    validate_django_signature(
+        tag_name,
+        parameters,
+        variadic_keyword.as_deref(),
+        bits,
+        span,
+    )
+}
+
+fn validate_django_signature(
+    tag_name: &str,
+    parameters: &[djls_project::TagArgument],
+    variadic_keyword: Option<&str>,
+    bits: &[String],
+    span: Span,
+) -> Option<ValidationError> {
+    bind_django_signature(parameters, variadic_keyword, bits)
+        .err()
+        .map(|message| ValidationError::ExtractedRuleViolation {
+            tag: tag_name.to_string(),
+            message: format!("'{tag_name}' {message}"),
+            span,
+        })
+}
+
+fn bind_django_signature(
+    parameters: &[djls_project::TagArgument],
+    variadic_keyword: Option<&str>,
+    bits: &[String],
+) -> Result<(), String> {
+    let mut unhandled_positional = parameters
+        .iter()
+        .take_while(|parameter| matches!(parameter.kind, TagArgumentKind::Variable))
+        .map(|parameter| parameter.name.as_str())
+        .collect::<Vec<_>>();
+    let positional_names = unhandled_positional.clone();
+    let has_varargs = parameters
+        .iter()
+        .any(|parameter| matches!(parameter.kind, TagArgumentKind::VarArgs));
+    let keyword_only = parameters
+        .iter()
+        .filter(|parameter| matches!(parameter.kind, TagArgumentKind::Keyword))
+        .collect::<Vec<_>>();
+    let mut unhandled_keyword_only = keyword_only
+        .iter()
+        .filter(|parameter| parameter.requirement.is_required())
+        .map(|parameter| parameter.name.as_str())
+        .collect::<Vec<_>>();
+    let default_count = parameters
+        .iter()
+        .take_while(|parameter| matches!(parameter.kind, TagArgumentKind::Variable))
+        .filter(|parameter| !parameter.requirement.is_required())
+        .count();
+    let mut seen_keywords = Vec::new();
+
+    for bit in bits {
+        if let Some(name) = django_keyword_name(bit) {
+            let known = positional_names.contains(&name)
+                || keyword_only.iter().any(|parameter| parameter.name == name);
+            if !known && variadic_keyword.is_none() {
+                return Err(format!("received unexpected keyword argument '{name}'"));
+            }
+            if seen_keywords.contains(&name) {
+                return Err(format!(
+                    "received multiple values for keyword argument '{name}'"
+                ));
+            }
+            seen_keywords.push(name);
+            if let Some(index) = unhandled_positional
+                .iter()
+                .position(|parameter| *parameter == name)
+            {
+                unhandled_positional.remove(index);
+            } else if let Some(index) = unhandled_keyword_only
+                .iter()
+                .position(|parameter| *parameter == name)
+            {
+                unhandled_keyword_only.remove(index);
+            }
+        } else if !seen_keywords.is_empty() {
+            return Err(
+                "received some positional argument(s) after some keyword argument(s)".to_string(),
+            );
+        } else if unhandled_positional.is_empty() {
+            if !has_varargs {
+                return Err("received too many positional arguments".to_string());
+            }
+        } else {
+            unhandled_positional.remove(0);
+        }
+    }
+
+    if default_count > 0 {
+        unhandled_positional.truncate(unhandled_positional.len().saturating_sub(default_count));
+    }
+    if unhandled_positional.is_empty() && unhandled_keyword_only.is_empty() {
+        return Ok(());
+    }
+
+    let missing = unhandled_positional
+        .into_iter()
+        .chain(unhandled_keyword_only)
+        .map(|name| format!("'{name}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(format!(
+        "did not receive value(s) for the argument(s): {missing}"
+    ))
+}
+
+fn django_keyword_name(bit: &str) -> Option<&str> {
+    let (name, value) = bit.split_once('=')?;
+    (!name.is_empty()
+        && !value.is_empty()
+        && name
+            .chars()
+            .all(|character| character == '_' || character.is_alphanumeric()))
+    .then_some(name)
 }
 
 fn form_matches(form: &TagArgumentForm, bits: &[String]) -> bool {
@@ -586,6 +726,121 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    #[test]
+    fn django_signature_binder_matches_parse_bits_order_and_default_quirks() {
+        let parameters = vec![
+            TagArgument {
+                name: "one".to_string(),
+                requirement: ParameterRequirement::Required,
+                kind: TagArgumentKind::Variable,
+            },
+            TagArgument {
+                name: "two".to_string(),
+                requirement: ParameterRequirement::Optional,
+                kind: TagArgumentKind::Variable,
+            },
+        ];
+
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&[])),
+            Err("did not receive value(s) for the argument(s): 'one'".to_string())
+        );
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&["two=value"])),
+            Ok(())
+        );
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&["first", "one=second"]),),
+            Ok(())
+        );
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&["one=first", "one=second"]),),
+            Err("received multiple values for keyword argument 'one'".to_string())
+        );
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&["one=first", "second"]),),
+            Err("received some positional argument(s) after some keyword argument(s)".to_string())
+        );
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&["unknown=value"])),
+            Err("received unexpected keyword argument 'unknown'".to_string())
+        );
+        assert_eq!(
+            bind_django_signature(&parameters, None, &make_bits(&["first", "second", "third"]),),
+            Err("received too many positional arguments".to_string())
+        );
+    }
+
+    #[test]
+    fn django_signature_binder_handles_keyword_only_varargs_and_kwargs_independently() {
+        let keyword_parameters = vec![
+            TagArgument {
+                name: "values".to_string(),
+                requirement: ParameterRequirement::Optional,
+                kind: TagArgumentKind::VarArgs,
+            },
+            TagArgument {
+                name: "required".to_string(),
+                requirement: ParameterRequirement::Required,
+                kind: TagArgumentKind::Keyword,
+            },
+            TagArgument {
+                name: "optional".to_string(),
+                requirement: ParameterRequirement::Optional,
+                kind: TagArgumentKind::Keyword,
+            },
+        ];
+        assert_eq!(
+            bind_django_signature(&keyword_parameters, None, &make_bits(&["first"])),
+            Err("did not receive value(s) for the argument(s): 'required'".to_string())
+        );
+        assert_eq!(
+            bind_django_signature(
+                &keyword_parameters,
+                None,
+                &make_bits(&["first", "second", "required=value"]),
+            ),
+            Ok(())
+        );
+
+        let kwargs_parameters = vec![TagArgument {
+            name: "one".to_string(),
+            requirement: ParameterRequirement::Required,
+            kind: TagArgumentKind::Variable,
+        }];
+        let variadic_keyword = Some("extra".to_string());
+        assert_eq!(
+            bind_django_signature(
+                &kwargs_parameters,
+                variadic_keyword.as_deref(),
+                &make_bits(&["one=value", "unknown=value"]),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            bind_django_signature(
+                &kwargs_parameters,
+                variadic_keyword.as_deref(),
+                &make_bits(&["first", "second"]),
+            ),
+            Err("received too many positional arguments".to_string())
+        );
+    }
+
+    #[test]
+    fn manual_parameter_hints_are_not_bound() {
+        let rule = TagRule {
+            argument_syntax: TagArgumentSyntax::Parameters(vec![TagArgument {
+                name: "required_hint".to_string(),
+                requirement: ParameterRequirement::Required,
+                kind: TagArgumentKind::Keyword,
+            }]),
+            ..TagRule::default()
+        };
+
+        assert!(evaluate_tag_rules("manual", &[], &rule, Span::new(0, 1)).is_empty());
     }
 
     // --- ArgumentCountConstraint tests ---

--- a/crates/djls-semantic/src/tags/specs.rs
+++ b/crates/djls-semantic/src/tags/specs.rs
@@ -163,8 +163,34 @@ impl TagSpecs {
                         existing.intermediate_tags = fallback_spec.intermediate_tags;
                     }
 
-                    if existing.extracted_rules.is_none() {
-                        existing.extracted_rules = fallback_spec.extracted_rules;
+                    let kwargs_only_signature_as_var = existing
+                        .extracted_rules
+                        .as_deref()
+                        .and_then(|rules| match &rules.argument_syntax {
+                            TagArgumentSyntax::Signature {
+                                parameters,
+                                variadic_keyword: Some(_),
+                                ..
+                            } if parameters.is_empty() => Some(rules.as_var),
+                            TagArgumentSyntax::Unknown
+                            | TagArgumentSyntax::Signature { .. }
+                            | TagArgumentSyntax::Parameters(_)
+                            | TagArgumentSyntax::Forms { .. } => None,
+                        });
+                    match (
+                        existing.extracted_rules.is_none(),
+                        fallback_spec.extracted_rules.take(),
+                        kwargs_only_signature_as_var,
+                    ) {
+                        (true, configured_rules, _) => {
+                            existing.extracted_rules = configured_rules;
+                        }
+                        (false, Some(configured_rules), Some(as_var)) => {
+                            let mut configured_rules = configured_rules.as_ref().clone();
+                            configured_rules.as_var = as_var;
+                            existing.extracted_rules = Some(configured_rules.into());
+                        }
+                        (false, None | Some(_), None) | (false, None, Some(_)) => {}
                     }
                 }
             }

--- a/crates/djls-semantic/tests/django_compilation.rs
+++ b/crates/djls-semantic/tests/django_compilation.rs
@@ -19,12 +19,6 @@ const FALSE_POSITIVES: &[&str] = &[
 
 /// Django rejects these templates; DJLS reports nothing. Every entry is a bug.
 const MISSED_DIAGNOSTICS: &[&str] = &[
-    // parameter syntax is extracted but validation does not bind required keyword-only arguments
-    "authored_keyword_only_missing",
-    // parameter syntax is extracted but validation does not check argument ordering
-    "authored_positional_after_keyword",
-    // parameter syntax is extracted but validation does not reject repeated keywords
-    "authored_repeated_keyword",
     // class constructors are not resolved as parser functions for rule extraction
     "class_missing",
     // split-sequence truthiness guards do not produce argument-count constraints

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -17,6 +17,7 @@ use djls_project::TemplateSymbolKind;
 use djls_project::template_library_catalog;
 use djls_semantic::Db as SemanticDb;
 use djls_semantic::TagArgumentKind;
+use djls_semantic::TagArgumentSyntax;
 use djls_semantic::TagRole;
 use djls_semantic::TagSpec;
 use djls_semantic::TagSpecs;
@@ -28,6 +29,8 @@ use djls_semantic::semantic_grammar_vocabulary;
 use djls_semantic::tag_spec_at;
 use djls_semantic::tag_specs_for_file;
 use djls_semantic::validate_template_file;
+use djls_source::ChangeEvent;
+use djls_source::SourceChanges;
 use djls_templates::parse_template;
 use djls_testing::ProjectFixture;
 use djls_testing::TestDatabase;
@@ -777,7 +780,10 @@ fn configured_arguments_fill_a_kwargs_only_simple_tag() {
             "/proj/dynamic_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef configured(**kwargs):\n    return ''\n",
         )
-        .file("/proj/templates/page.html", "{% load dynamic %}")
+        .file(
+            "/proj/templates/page.html",
+            "{% load dynamic %}{% configured small as selected %}",
+        )
         .install(&mut db)
         .expect("configured kwargs project fixture should install");
 
@@ -796,10 +802,194 @@ fn configured_arguments_fill_a_kwargs_only_simple_tag() {
         .parameters()
         .expect("configured arguments should replace empty signature evidence");
 
+    assert!(matches!(
+        spec.argument_syntax(),
+        TagArgumentSyntax::Parameters(_)
+    ));
     assert_eq!(parameters.len(), 1);
     assert_eq!(
         parameters[0].kind,
         TagArgumentKind::Choice(vec!["small".to_string(), "large".to_string()])
+    );
+    assert!(
+        collect_file_errors(&db, "/proj/templates/page.html")
+            .expect("configured fallback template should validate")
+            .is_empty()
+    );
+}
+
+#[test]
+fn configured_fallback_does_not_weaken_empty_trusted_signatures() {
+    let mut db = TestDatabase::new();
+    let tag_specs: TagSpecDef = serde_json::from_value(serde_json::json!({
+        "libraries": [{
+            "module": "strict_tags",
+            "tags": [
+                {
+                    "name": "empty_helper",
+                    "type": "standalone",
+                    "args": [{"name": "invented", "kind": "variable"}]
+                },
+                {
+                    "name": "kwargs_helper",
+                    "type": "standalone",
+                    "args": []
+                }
+            ]
+        }]
+    }))
+    .expect("strict configured fallback fixture should deserialize");
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("project.settings")
+        .tag_specs(tag_specs)
+        .file(
+            "/proj/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'strict': 'strict_tags'}}}]\n",
+        )
+        .file(
+            "/proj/strict_tags.py",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef empty_helper(): return ''\n@register.simple_tag\ndef kwargs_helper(**options): return options\n",
+        )
+        .file(
+            "/proj/templates/page.html",
+            "{% load strict %}{% empty_helper invented %}{% kwargs_helper positional %}",
+        )
+        .install(&mut db)
+        .expect("strict configured fallback project should install");
+
+    let library =
+        ScopedTemplateLibraries::from_project_inventory(template_library_catalog(&db, project))
+            .resolved_libraries()
+            .into_iter()
+            .find(|library| library.module_name_str() == "strict_tags")
+            .expect("strict Template Library should resolve");
+    let specs = library_tag_specs(&db, project, library.id());
+    assert!(matches!(
+        specs
+            .get("empty_helper")
+            .expect("empty helper should have a spec")
+            .argument_syntax(),
+        TagArgumentSyntax::Signature {
+            parameters,
+            variadic_keyword: None,
+            ..
+        } if parameters.is_empty()
+    ));
+    assert!(matches!(
+        specs
+            .get("kwargs_helper")
+            .expect("kwargs helper should have a spec")
+            .argument_syntax(),
+        TagArgumentSyntax::Signature {
+            parameters,
+            variadic_keyword: Some(name),
+            ..
+        } if parameters.is_empty() && name == "options"
+    ));
+
+    let errors = collect_file_errors(&db, "/proj/templates/page.html")
+        .expect("strict configured fallback template should validate");
+    assert!(errors.iter().any(|error| matches!(
+        error,
+        ValidationError::ExtractedRuleViolation { tag, message, .. }
+            if tag == "empty_helper" && message.contains("too many positional")
+    )));
+    assert!(errors.iter().any(|error| matches!(
+        error,
+        ValidationError::ExtractedRuleViolation { tag, message, .. }
+            if tag == "kwargs_helper" && message.contains("too many positional")
+    )));
+}
+
+#[test]
+fn loaded_imported_signature_rebinds_after_source_invalidation() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("project.settings")
+        .file(
+            "/proj/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'authored': 'app.templatetags.authored'}}}]\n",
+        )
+        .file(
+            "/proj/app/templatetags/authored.py",
+            "from django import template\nfrom app.implementation import imported\nregister = template.Library()\nregister.simple_tag(imported, name='loaded_imported')\n",
+        )
+        .file(
+            "/proj/app/implementation.py",
+            "def imported(value): return value\n",
+        )
+        .file(
+            "/proj/templates/page.html",
+            "{% load authored %}{% loaded_imported %}",
+        )
+        .install(&mut db)
+        .expect("loaded imported signature fixture should install");
+
+    let library =
+        ScopedTemplateLibraries::from_project_inventory(template_library_catalog(&db, project))
+            .resolved_libraries()
+            .into_iter()
+            .find(|library| library.module_name_str() == "app.templatetags.authored")
+            .expect("authored Template Library should resolve");
+    let before = library_tag_specs(&db, project, library.id())
+        .get("loaded_imported")
+        .cloned()
+        .expect("imported tag should have a semantic spec");
+    assert!(matches!(
+        before.argument_syntax(),
+        TagArgumentSyntax::Signature { parameters, variadic_keyword: None, .. }
+            if parameters.len() == 1
+                && parameters[0].name == "value"
+                && parameters[0].requirement.is_required()
+    ));
+    assert!(
+        collect_file_errors(&db, "/proj/templates/page.html")
+            .expect("missing imported argument should validate")
+            .iter()
+            .any(|error| matches!(
+                error,
+                ValidationError::ExtractedRuleViolation { tag, message, .. }
+                    if tag == "loaded_imported" && message.contains("'value'")
+            ))
+    );
+    drop(before);
+
+    let implementation_path = Utf8Path::new("/proj/app/implementation.py");
+    db.add_file(
+        implementation_path.as_str(),
+        "def imported(value=None, **options): return value, options\n",
+    )
+    .expect("updated imported callable should be written");
+    SourceChanges::new([ChangeEvent::ContentChanged(
+        implementation_path.to_path_buf(),
+    )])
+    .apply(&mut db);
+
+    let updated_library =
+        ScopedTemplateLibraries::from_project_inventory(template_library_catalog(&db, project))
+            .resolved_libraries()
+            .into_iter()
+            .find(|library| library.module_name_str() == "app.templatetags.authored")
+            .expect("updated authored Template Library should resolve");
+    let after = library_tag_specs(&db, project, updated_library.id())
+        .get("loaded_imported")
+        .cloned()
+        .expect("updated imported tag should keep its semantic spec");
+    assert!(matches!(
+        after.argument_syntax(),
+        TagArgumentSyntax::Signature {
+            parameters,
+            variadic_keyword: Some(name),
+            ..
+        } if parameters.len() == 1
+            && parameters[0].name == "value"
+            && !parameters[0].requirement.is_required()
+            && name == "options"
+    ));
+    assert!(
+        collect_file_errors(&db, "/proj/templates/page.html")
+            .expect("updated imported argument should validate")
+            .is_empty()
     );
 }
 
@@ -3123,16 +3313,20 @@ fn corpus_eventsignal_rejects_extra_positional_arguments() {
         .expect("template validation should run"),
         []
     );
-    // Missed diagnostic: **kwargs erases the positional maximum. Django's
-    // parse_bits raises "received too many positional arguments".
-    assert_eq!(
-        collect_errors(
-            &db,
-            "/invalid.html",
-            "{% eventsignal event 'signal.name' extra %}"
-        )
-        .expect("template validation should run"),
-        []
+    // Django's parse_bits rejects extra positional arguments even with **kwargs.
+    let errors = collect_errors(
+        &db,
+        "/invalid.html",
+        "{% eventsignal event 'signal.name' extra %}",
+    )
+    .expect("template validation should run");
+    assert!(
+        matches!(
+            errors.as_slice(),
+            [ValidationError::ExtractedRuleViolation { tag, message, .. }]
+                if tag == "eventsignal" && message.contains("received too many positional arguments")
+        ),
+        "{errors:?}"
     );
 }
 

--- a/crates/djls/tests/check.rs
+++ b/crates/djls/tests/check.rs
@@ -476,7 +476,8 @@ fn check_multi_backend_stdin_uses_inventory_while_concrete_path_uses_backend() {
     let concrete_stdout = String::from_utf8_lossy(&concrete.stdout);
     assert!(concrete_stdout.contains("error[S117]"), "{concrete_stdout}");
     assert!(
-        concrete_stdout.contains("Tag 'shared_tag' requires at least 1 argument"),
+        concrete_stdout
+            .contains("'shared_tag' did not receive value(s) for the argument(s): 'value'"),
         "{concrete_stdout}"
     );
 

--- a/tests/compilation/compilation_tags.py
+++ b/tests/compilation/compilation_tags.py
@@ -16,6 +16,11 @@ def authored_required(value):
 
 
 @register.simple_tag
+def authored_empty():
+    return ""
+
+
+@register.simple_tag
 def authored_keyword_only(*, required):
     return required
 
@@ -23,6 +28,21 @@ def authored_keyword_only(*, required):
 @register.simple_tag
 def authored_default(one, two="default"):
     return f"{one}:{two}"
+
+
+@register.simple_tag
+def authored_positional_only(value, /):
+    return value
+
+
+@register.simple_tag
+def authored_varargs(*values):
+    return values
+
+
+@register.simple_tag
+def authored_kwargs(one, **options):
+    return one, options
 
 
 @register.simple_tag(name=None)

--- a/tests/compilation/templates/authored_empty_extra.html
+++ b/tests/compilation/templates/authored_empty_extra.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_empty value %}

--- a/tests/compilation/templates/authored_empty_valid.html
+++ b/tests/compilation/templates/authored_empty_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_empty %}

--- a/tests/compilation/templates/authored_kwargs_extra_positional.html
+++ b/tests/compilation/templates/authored_kwargs_extra_positional.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_kwargs first second %}

--- a/tests/compilation/templates/authored_kwargs_valid.html
+++ b/tests/compilation/templates/authored_kwargs_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_kwargs first extra=value %}

--- a/tests/compilation/templates/authored_positional_only_keyword_valid.html
+++ b/tests/compilation/templates/authored_positional_only_keyword_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_positional_only value=first %}

--- a/tests/compilation/templates/authored_positional_only_missing.html
+++ b/tests/compilation/templates/authored_positional_only_missing.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_positional_only %}

--- a/tests/compilation/templates/authored_required_as_valid.html
+++ b/tests/compilation/templates/authored_required_as_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_required value as saved %}

--- a/tests/compilation/templates/authored_varargs_unexpected_keyword.html
+++ b/tests/compilation/templates/authored_varargs_unexpected_keyword.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_varargs value=first %}

--- a/tests/compilation/templates/authored_varargs_valid.html
+++ b/tests/compilation/templates/authored_varargs_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% authored_varargs first second third %}

--- a/tests/fixtures/django-facts/compilation-5.2.json
+++ b/tests/fixtures/django-facts/compilation-5.2.json
@@ -9,6 +9,13 @@
     "authored_default_valid.html": {
       "result": "compiled"
     },
+    "authored_empty_extra.html": {
+      "error": "'authored_empty' received too many positional arguments",
+      "result": "failed"
+    },
+    "authored_empty_valid.html": {
+      "result": "compiled"
+    },
     "authored_keyword_only_missing.html": {
       "error": "'authored_keyword_only' did not receive value(s) for the argument(s): 'required'",
       "result": "failed"
@@ -16,19 +23,43 @@
     "authored_keyword_only_valid.html": {
       "result": "compiled"
     },
+    "authored_kwargs_extra_positional.html": {
+      "error": "'authored_kwargs' received too many positional arguments",
+      "result": "failed"
+    },
+    "authored_kwargs_valid.html": {
+      "result": "compiled"
+    },
     "authored_positional_after_keyword.html": {
       "error": "'authored_default' received some positional argument(s) after some keyword argument(s)",
+      "result": "failed"
+    },
+    "authored_positional_only_keyword_valid.html": {
+      "result": "compiled"
+    },
+    "authored_positional_only_missing.html": {
+      "error": "'authored_positional_only' did not receive value(s) for the argument(s): 'value'",
       "result": "failed"
     },
     "authored_repeated_keyword.html": {
       "error": "'authored_default' received multiple values for keyword argument 'one'",
       "result": "failed"
     },
+    "authored_required_as_valid.html": {
+      "result": "compiled"
+    },
     "authored_required_missing.html": {
       "error": "'authored_required' did not receive value(s) for the argument(s): 'value'",
       "result": "failed"
     },
     "authored_required_valid.html": {
+      "result": "compiled"
+    },
+    "authored_varargs_unexpected_keyword.html": {
+      "error": "'authored_varargs' received unexpected keyword argument 'value'",
+      "result": "failed"
+    },
+    "authored_varargs_valid.html": {
       "result": "compiled"
     },
     "class_missing.html": {


### PR DESCRIPTION
Validate helper arguments using Django's compile-time signature-binding rules: required keyword-only parameters, positional/keyword ordering, repeated keywords, empty signatures, and excess positional arguments in functions accepting `**kwargs`.

## Evidence

Removed the disagreement entries for `authored_keyword_only_missing`, `authored_positional_after_keyword`, and `authored_repeated_keyword` after Django compilation and project-backed validation agreed on all three rejected calls.

Four added helper signatures cover empty parameters, positional-only parameters, `*args`, and `**kwargs`. Ordinary tests retain configured-rule fallback and imported-signature invalidation coverage. The `eventsignal` corpus regression now requires an excess-positional diagnostic. CLI, diagnostic markdown, snippet, and extraction tests remain in this change.

## Compilation fixtures

Adds 9 templates under `tests/compilation/templates/`. Django facts were regenerated through the existing fixtures session.

- `authored_empty_extra`
- `authored_empty_valid`
- `authored_kwargs_extra_positional`
- `authored_kwargs_valid`
- `authored_positional_only_keyword_valid`
- `authored_positional_only_missing`
- `authored_required_as_valid`
- `authored_varargs_unexpected_keyword`
- `authored_varargs_valid`

## Validation

Passed at this PR head:

- `cargo test -q` (includes the Django compilation comparison)
- `just clippy`
- `just fmt`
- `just lint`