### PR TITLE
Extract static tag choices and caught unpack arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
-- Fixed tag argument extraction from helper return paths, including nested helper calls and scalar `finally` overrides.
 - Fixed static validation of `simple_tag`, `inclusion_tag`, and `simple_block_tag` arguments to match Django's `parse_bits()` binding rules.
 - Fixed static validation for context-aware and curried tag registrations and for `simple_block_tag` block structure.
 - Fixed unloaded-tag diagnostics and load quick fixes disappearing when an unrelated template library has unknown registrations.
@@ -43,6 +42,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Fixed duplicate names and excess inclusion-tag arguments producing invented Template Library definitions.
 - Fixed false duplicate-option diagnostics for tag parsers that check membership without raising an error.
 - Fixed tag-rule extraction for conditional list mutations, truthiness guards, early returns, and `finally` validation.
+- Fixed tag argument extraction from helper return paths, including nested helper calls and scalar `finally` overrides.
+- Fixed tag argument extraction from unpacking assignments, including loop targets, starred targets, caught failures, and preceding mutations.
+- Fixed contradictory argument-count branches contributing impossible accepted forms.
+- Fixed argument validation for Pipeline's `stylesheet` and `javascript` tags, Compressor output modes, and Django's `templatetag` choices.
 - Fixed tag-rule extraction using incorrect argument positions after unsupported `pop()` calls.
 - Fixed custom tags with mixed body-parser paths suppressing diagnostics and references for bodies Django still parses.
 - Fixed manual tag extraction, validation, and completion losing correlated argument forms such as `widthratio ...` and `widthratio ... as variable`.

--- a/crates/djls-project/src/ast.rs
+++ b/crates/djls-project/src/ast.rs
@@ -128,11 +128,6 @@ pub(crate) trait ExprExt {
 
     /// Extract the magnitude from a negative integer literal.
     fn negative_integer(&self) -> Option<usize>;
-
-    /// Map elements of a collection expression (tuple, list, or set) through
-    /// a fallible function. Returns `None` if the expression is not a
-    /// collection or if any element mapping fails.
-    fn collection_map<T>(&self, f: impl Fn(&Expr) -> Option<T>) -> Option<Vec<T>>;
 }
 
 impl ExprExt for Expr {
@@ -203,23 +198,6 @@ impl ExprExt for Expr {
             return None;
         };
         operand.non_negative_integer()
-    }
-
-    fn collection_map<T>(&self, f: impl Fn(&Expr) -> Option<T>) -> Option<Vec<T>> {
-        let elements = if let Expr::Tuple(tuple) = self {
-            &tuple.elts
-        } else if let Expr::List(list) = self {
-            &list.elts
-        } else if let Expr::Set(set) = self {
-            &set.elts
-        } else {
-            return None;
-        };
-        let mut values = Vec::new();
-        for elt in elements {
-            values.push(f(elt)?);
-        }
-        Some(values)
     }
 }
 
@@ -328,29 +306,5 @@ mod tests {
     #[test]
     fn negative_integer_rejects_non_unary_expression() {
         assert_eq!(parse_expr("3").negative_integer(), None);
-    }
-
-    #[test]
-    fn collection_map_maps_set_elements() {
-        assert_eq!(
-            parse_expr("{1, 2}").collection_map(super::ExprExt::non_negative_integer),
-            Some(vec![1, 2])
-        );
-    }
-
-    #[test]
-    fn collection_map_accepts_empty_collections() {
-        assert_eq!(
-            parse_expr("()").collection_map(super::ExprExt::non_negative_integer),
-            Some(Vec::new())
-        );
-    }
-
-    #[test]
-    fn collection_map_rejects_mixed_collections() {
-        assert_eq!(
-            parse_expr("(1, 'two')").collection_map(super::ExprExt::non_negative_integer),
-            None
-        );
     }
 }

--- a/crates/djls-project/src/python/evaluation.rs
+++ b/crates/djls-project/src/python/evaluation.rs
@@ -12,7 +12,7 @@ mod evaluator;
 mod mapping;
 mod module_object;
 mod mutation;
-mod name_analysis;
+pub(crate) mod name_analysis;
 mod query;
 mod result;
 mod sequence;

--- a/crates/djls-project/src/python/evaluation/name_analysis.rs
+++ b/crates/djls-project/src/python/evaluation/name_analysis.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashSet;
 use crate::ast::ExprExt;
 use crate::python::evaluation::truthiness::Truthiness;
 
-pub(super) fn target_write_names(target: &ast::Expr) -> Vec<&str> {
+pub(crate) fn target_write_names(target: &ast::Expr) -> Vec<&str> {
     let mut names = Vec::new();
     collect_target_write_names(target, &mut names);
     names
@@ -280,7 +280,7 @@ impl<'a> ReadNameCollector<'a> {
     }
 }
 
-pub(super) fn pattern_bound_names(pattern: &ast::Pattern) -> Vec<&str> {
+pub(crate) fn pattern_bound_names(pattern: &ast::Pattern) -> Vec<&str> {
     let mut names = Vec::new();
     collect_pattern_bound_names(pattern, &mut names);
     names

--- a/crates/djls-project/src/templates/tags.rs
+++ b/crates/djls-project/src/templates/tags.rs
@@ -87,6 +87,11 @@ pub(crate) fn analyze_helper(db: &dyn djls_source::Db, call: HelperCall<'_>) -> 
     };
 
     let mut callee_env = Env::default();
+    analysis::constants::seed_static_bindings(
+        analysis::constants::module_static_bindings(db, call.file(db)),
+        callee,
+        &mut callee_env,
+    );
     for (i, param) in callee.parameters.args.iter().enumerate() {
         let value = args
             .get(i)

--- a/crates/djls-project/src/templates/tags/analysis.rs
+++ b/crates/djls-project/src/templates/tags/analysis.rs
@@ -1,4 +1,5 @@
 pub(crate) mod calls;
+pub(crate) mod constants;
 pub(crate) mod constraints;
 pub(crate) mod exceptions;
 pub(crate) mod expressions;
@@ -152,7 +153,16 @@ impl<'a> CompileFunction<'a> {
 /// (no database), helper calls evaluate to `Unknown`.
 #[must_use]
 pub(crate) fn analyze_compile_function(func: &StmtFunctionDef) -> TagRule {
-    analyze_compile_function_with_context(func, None, None)
+    analyze_compile_function_with_context(func, None, None, None)
+}
+
+#[cfg(test)]
+pub(crate) fn analyze_compile_function_in_module(
+    module: &[Stmt],
+    func: &StmtFunctionDef,
+) -> TagRule {
+    let bindings = constants::StaticBindings::from_module(module);
+    analyze_compile_function_with_context(func, None, None, Some(&bindings))
 }
 
 pub(crate) fn analyze_compile_function_in_file(
@@ -160,19 +170,28 @@ pub(crate) fn analyze_compile_function_in_file(
     file: File,
     func: &StmtFunctionDef,
 ) -> TagRule {
-    analyze_compile_function_with_context(func, Some(db), Some(file))
+    analyze_compile_function_with_context(
+        func,
+        Some(db),
+        Some(file),
+        Some(constants::module_static_bindings(db, file)),
+    )
 }
 
 fn analyze_compile_function_with_context(
     func: &StmtFunctionDef,
     db: Option<&dyn djls_source::Db>,
     file: Option<File>,
+    static_bindings: Option<&constants::StaticBindings>,
 ) -> TagRule {
     let Some(compile_fn) = CompileFunction::from_ast(func) else {
         return TagRule::default();
     };
 
     let mut env = state::Env::for_compile_function(compile_fn.parser_param, compile_fn.token_param);
+    if let Some(static_bindings) = static_bindings {
+        constants::seed_static_bindings(static_bindings, func, &mut env);
+    }
     let mut ctx = CallContext { db, file };
 
     let (result, _) = statements::process_statements(compile_fn.body, &mut env, &mut ctx);
@@ -467,16 +486,16 @@ mod tests {
         let module = parsed.into_syntax();
         let func = module
             .body
-            .into_iter()
-            .find_map(|s| {
-                if let Stmt::FunctionDef(f) = s {
-                    Some(f)
+            .iter()
+            .find_map(|statement| {
+                if let Stmt::FunctionDef(function) = statement {
+                    Some(function)
                 } else {
                     None
                 }
             })
             .expect("no function found");
-        analyze_compile_function(&func)
+        analyze_compile_function_in_module(&module.body, func)
     }
 
     #[test]

--- a/crates/djls-project/src/templates/tags/analysis/calls.rs
+++ b/crates/djls-project/src/templates/tags/analysis/calls.rs
@@ -31,7 +31,7 @@ impl From<&AbstractValue> for AbstractValueKey {
             AbstractValue::SplitLength(split) => AbstractValueKey::SplitLength(*split),
             AbstractValue::Int(n) => AbstractValueKey::Int(*n),
             AbstractValue::Str(s) => AbstractValueKey::Str(s.clone()),
-            AbstractValue::Tuple(_) => AbstractValueKey::Other,
+            AbstractValue::SplitPredicate(_) | AbstractValue::Tuple(_) => AbstractValueKey::Other,
         }
     }
 }

--- a/crates/djls-project/src/templates/tags/analysis/constants.rs
+++ b/crates/djls-project/src/templates/tags/analysis/constants.rs
@@ -1,0 +1,827 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::ops::ControlFlow;
+
+use ruff_python_ast::Expr;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtAssign;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::visitor::walk_expr;
+
+use crate::ast::ExprExt;
+use crate::ast::RangedExt;
+use crate::ast::Recurse;
+use crate::ast::walk_stmts;
+use crate::python::evaluation::name_analysis::pattern_bound_names;
+use crate::python::import::DirectImportClause;
+use crate::python::import::FromImportSyntax;
+use crate::templates::tags::analysis::state::AbstractValue;
+use crate::templates::tags::analysis::state::Env;
+
+const MAX_STATIC_VALUES: usize = 32;
+const MAX_RESOLUTION_DEPTH: usize = 16;
+
+/// Closed constants shared by every compile function in one source module.
+#[derive(Clone, Debug, Default, PartialEq, Eq, salsa::SalsaValue)]
+pub(crate) struct StaticBindings {
+    values: HashMap<String, AbstractValue>,
+    module_bound_names: HashSet<String>,
+    module_names_open: bool,
+}
+
+/// Resolve module constants once per file revision. Registered tags share this
+/// Salsa product rather than rescanning a large module for each function.
+#[salsa::tracked(returns(ref))]
+pub(crate) fn module_static_bindings(
+    db: &dyn djls_source::Db,
+    file: djls_source::File,
+) -> StaticBindings {
+    let Ok(Some(module)) = crate::python::RecoveredPythonModule::from_file(db, file) else {
+        return StaticBindings::default();
+    };
+    StaticBindings::from_module(module.body(db))
+}
+
+impl StaticBindings {
+    pub(crate) fn from_module(module: &[Stmt]) -> Self {
+        let resolver = StaticResolver::new(module);
+        let mut values = HashMap::new();
+        for name in resolver.assignments.keys() {
+            if let Some(value) = resolver.resolve_name(name) {
+                values.insert(name.clone(), value);
+            }
+        }
+        for (class_name, class) in &resolver.classes {
+            if !resolver
+                .bindings
+                .has_one_closed_write(class_name, class.span())
+                || class_is_dynamic(class)
+            {
+                continue;
+            }
+            for (attribute, value) in resolve_class_dict_keys(module, class_name, class) {
+                values.insert(format!("{class_name}.{attribute}"), value);
+            }
+        }
+        Self {
+            values,
+            module_bound_names: resolver.bindings.writes.keys().cloned().collect(),
+            module_names_open: resolver.bindings.has_unknown_star_import(),
+        }
+    }
+}
+
+/// Seed one function environment while applying Python's function-wide local
+/// shadowing rule.
+pub(crate) fn seed_static_bindings(
+    bindings: &StaticBindings,
+    function: &StmtFunctionDef,
+    env: &mut Env,
+) {
+    let function_bindings = FunctionBindings::collect(function);
+    for (path, value) in &bindings.values {
+        let root = path.split('.').next().unwrap_or(path);
+        if function_bindings.blocks_module_fallback(root) {
+            // Python decides local and nonlocal scope for the whole function,
+            // including reads that occur before the assignment. Preserve a
+            // known parameter value while still blocking static fallback.
+            env.shadow_static(root.to_string());
+        } else {
+            env.set_static(path.clone(), value.clone());
+        }
+    }
+
+    if !bindings.module_names_open && !function_bindings.names_open {
+        let mut shadowed_names = bindings.module_bound_names.clone();
+        shadowed_names.extend(function_bindings.bound_names);
+        env.set_builtin_name_scope(shadowed_names);
+    }
+}
+
+struct StaticResolver<'a> {
+    assignments: HashMap<String, &'a Expr>,
+    bindings: ScopeBindings,
+    classes: HashMap<String, &'a ruff_python_ast::StmtClassDef>,
+    mutated_names: HashSet<String>,
+}
+
+impl<'a> StaticResolver<'a> {
+    fn new(module: &'a [Stmt]) -> Self {
+        let mut assignments = HashMap::new();
+        let mut classes = HashMap::new();
+
+        for stmt in module {
+            if let Stmt::Assign(StmtAssign { targets, value, .. }) = stmt
+                && let [target] = targets.as_slice()
+                && let Some(name) = target.name_target()
+            {
+                assignments.insert(name.to_string(), value.as_ref());
+            }
+            if let Stmt::ClassDef(class) = stmt {
+                classes.insert(class.name.to_string(), class);
+            }
+        }
+
+        let mut bindings = ScopeBindings::collect(module);
+        collect_nested_global_effects(module, &mut bindings.writes);
+
+        let mut mutated_names = HashSet::new();
+        collect_mutated_roots(module, &mut mutated_names);
+        collect_nested_global_mutations(module, &mut mutated_names);
+
+        Self {
+            assignments,
+            bindings,
+            classes,
+            mutated_names,
+        }
+    }
+
+    fn resolve_name(&self, name: &str) -> Option<AbstractValue> {
+        self.resolve_name_inner(name, &mut Vec::new(), 0)
+    }
+
+    fn resolve_name_inner(
+        &self,
+        name: &str,
+        resolving: &mut Vec<String>,
+        depth: usize,
+    ) -> Option<AbstractValue> {
+        let expression = *self.assignments.get(name)?;
+        if depth >= MAX_RESOLUTION_DEPTH
+            || !self.bindings.has_one_closed_write(name, expression.span())
+            || self.mutated_names.contains(name)
+            || resolving.iter().any(|current| current == name)
+        {
+            return None;
+        }
+        resolving.push(name.to_string());
+        let value = self.resolve_expr(expression, resolving, depth + 1);
+        resolving.pop();
+        value
+    }
+
+    fn resolve_expr(
+        &self,
+        expr: &Expr,
+        resolving: &mut Vec<String>,
+        depth: usize,
+    ) -> Option<AbstractValue> {
+        if depth >= MAX_RESOLUTION_DEPTH {
+            return None;
+        }
+        if let Some(value) = expr.string_literal() {
+            return Some(AbstractValue::Str(value.to_string()));
+        }
+        if let Some(name) = expr.name_target() {
+            return self.resolve_name_inner(name, resolving, depth + 1);
+        }
+
+        // Module-level lists and sets remain mutable through aliases and
+        // arbitrary calls. Only tuples can retain exact collection evidence.
+        let Expr::Tuple(tuple) = expr else {
+            return None;
+        };
+        let elements = &tuple.elts;
+        if elements.is_empty() || elements.len() > MAX_STATIC_VALUES {
+            return None;
+        }
+        let mut values = Vec::with_capacity(elements.len());
+        for element in elements {
+            let value = self.resolve_expr(element, resolving, depth + 1)?;
+            if !matches!(value, AbstractValue::Str(_)) {
+                return None;
+            }
+            values.push(value);
+        }
+        Some(AbstractValue::Tuple(values))
+    }
+}
+
+fn class_is_dynamic(class: &ruff_python_ast::StmtClassDef) -> bool {
+    !class.decorator_list.is_empty()
+        || class.arguments.as_ref().is_some_and(|arguments| {
+            arguments.keywords.iter().any(|keyword| {
+                keyword.arg.is_none()
+                    || keyword.arg.as_ref().is_some_and(|name| name == "metaclass")
+            })
+        })
+}
+
+#[derive(Default)]
+struct ScopeBindings {
+    writes: HashMap<String, usize>,
+    globals: HashSet<String>,
+    nonlocals: HashSet<String>,
+    unknown_star_imports: Vec<djls_source::Span>,
+}
+
+impl ScopeBindings {
+    fn collect(body: &[Stmt]) -> Self {
+        let mut collector = Self::default();
+        collector.visit_body(body);
+        collector
+    }
+
+    fn record_name(&mut self, name: &str) {
+        *self.writes.entry(name.to_string()).or_insert(0) += 1;
+    }
+
+    fn record_target(&mut self, target: &Expr) {
+        record_target_writes(target, &mut self.writes);
+    }
+
+    fn record_unknown_star_import(&mut self, import: &ruff_python_ast::StmtImportFrom) {
+        self.unknown_star_imports.push(import.span());
+    }
+
+    fn has_unknown_star_import(&self) -> bool {
+        !self.unknown_star_imports.is_empty()
+    }
+
+    fn has_one_closed_write(&self, name: &str, write: djls_source::Span) -> bool {
+        self.writes.get(name) == Some(&1)
+            && self
+                .unknown_star_imports
+                .iter()
+                .all(|import| import.start() < write.start())
+    }
+
+    fn visit_definition_expressions(&mut self, function: &ruff_python_ast::StmtFunctionDef) {
+        for decorator in &function.decorator_list {
+            self.visit_expr(&decorator.expression);
+        }
+        for parameter in function
+            .parameters
+            .posonlyargs
+            .iter()
+            .chain(&function.parameters.args)
+            .chain(&function.parameters.kwonlyargs)
+        {
+            if let Some(default) = &parameter.default {
+                self.visit_expr(default);
+            }
+        }
+    }
+}
+
+impl<'a> Visitor<'a> for ScopeBindings {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::FunctionDef(function) => {
+                self.record_name(function.name.as_str());
+                self.visit_definition_expressions(function);
+                return;
+            }
+            Stmt::ClassDef(class) => {
+                self.record_name(class.name.as_str());
+                for decorator in &class.decorator_list {
+                    self.visit_expr(&decorator.expression);
+                }
+                if let Some(arguments) = &class.arguments {
+                    for argument in &arguments.args {
+                        self.visit_expr(argument);
+                    }
+                    for keyword in &arguments.keywords {
+                        self.visit_expr(&keyword.value);
+                    }
+                }
+                return;
+            }
+            Stmt::Assign(assign) => {
+                for target in &assign.targets {
+                    self.record_target(target);
+                }
+            }
+            Stmt::AnnAssign(assign) => self.record_target(&assign.target),
+            Stmt::AugAssign(assign) => self.record_target(&assign.target),
+            Stmt::Delete(delete) => {
+                for target in &delete.targets {
+                    self.record_target(target);
+                }
+            }
+            Stmt::For(statement) => self.record_target(&statement.target),
+            Stmt::With(statement) => {
+                for item in &statement.items {
+                    if let Some(target) = &item.optional_vars {
+                        self.record_target(target);
+                    }
+                }
+            }
+            Stmt::TypeAlias(alias) => self.record_target(&alias.name),
+            Stmt::Import(import) => {
+                for clause in DirectImportClause::lower(import) {
+                    self.record_name(clause.bound());
+                }
+            }
+            Stmt::ImportFrom(import) => {
+                let syntax = FromImportSyntax::lower(import);
+                if syntax.has_star() {
+                    self.record_unknown_star_import(import);
+                }
+                for clause in syntax.named_members() {
+                    self.record_name(clause.bound());
+                }
+            }
+            Stmt::Global(global) => {
+                self.globals
+                    .extend(global.names.iter().map(ToString::to_string));
+                return;
+            }
+            Stmt::Nonlocal(nonlocal) => {
+                self.nonlocals
+                    .extend(nonlocal.names.iter().map(ToString::to_string));
+                return;
+            }
+            Stmt::If(_)
+            | Stmt::While(_)
+            | Stmt::Try(_)
+            | Stmt::Match(_)
+            | Stmt::Expr(_)
+            | Stmt::Return(_)
+            | Stmt::Raise(_)
+            | Stmt::Assert(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => {}
+        }
+        ruff_python_ast::visitor::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Named(named) = expr {
+            self.record_target(&named.target);
+        }
+        if !matches!(expr, Expr::Lambda(_)) {
+            walk_expr(self, expr);
+        }
+    }
+
+    fn visit_except_handler(&mut self, exception: &'a ruff_python_ast::ExceptHandler) {
+        let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = exception;
+        if let Some(name) = &handler.name {
+            self.record_name(name.as_str());
+        }
+        ruff_python_ast::visitor::walk_except_handler(self, exception);
+    }
+
+    fn visit_pattern(&mut self, pattern: &'a ruff_python_ast::Pattern) {
+        for name in pattern_bound_names(pattern) {
+            self.record_name(name);
+        }
+    }
+}
+
+fn collect_nested_global_effects(body: &[Stmt], writes: &mut HashMap<String, usize>) {
+    walk_stmts(body, Recurse::IntoClasses, |stmt| {
+        if let Stmt::FunctionDef(function) = stmt {
+            let nested = ScopeBindings::collect(&function.body);
+            for name in &nested.globals {
+                if nested.writes.contains_key(name) {
+                    *writes.entry(name.clone()).or_insert(0) += 1;
+                }
+            }
+            collect_nested_global_effects(&function.body, writes);
+        }
+        ControlFlow::Continue(())
+    });
+}
+
+fn collect_nested_global_mutations(body: &[Stmt], mutated: &mut HashSet<String>) {
+    walk_stmts(body, Recurse::IntoClasses, |stmt| {
+        if let Stmt::FunctionDef(function) = stmt {
+            let globals = ScopeBindings::collect(&function.body).globals;
+            if !globals.is_empty() {
+                let mut nested_mutations = HashSet::new();
+                collect_mutated_roots(&function.body, &mut nested_mutations);
+                mutated.extend(
+                    nested_mutations
+                        .into_iter()
+                        .filter(|name| globals.contains(name)),
+                );
+            }
+            collect_nested_global_mutations(&function.body, mutated);
+        }
+        ControlFlow::Continue(())
+    });
+}
+
+fn resolve_class_dict_keys(
+    module: &[Stmt],
+    class_name: &str,
+    class: &ruff_python_ast::StmtClassDef,
+) -> Vec<(String, AbstractValue)> {
+    let bindings = ScopeBindings::collect(&class.body);
+    let mut direct = HashMap::<String, &Expr>::new();
+    for stmt in &class.body {
+        if let Stmt::Assign(assign) = stmt
+            && let [target] = assign.targets.as_slice()
+            && let Some(name) = target.name_target()
+        {
+            direct.insert(name.to_string(), assign.value.as_ref());
+        }
+    }
+
+    let candidates: Vec<_> = direct
+        .into_iter()
+        .filter_map(|(attribute, expression)| {
+            let Expr::Dict(dict) = expression else {
+                return None;
+            };
+            if !bindings.has_one_closed_write(&attribute, expression.span())
+                || class_local_mapping_is_mutated_or_escaped(&class.body, &attribute)
+            {
+                return None;
+            }
+            if dict.items.is_empty() || dict.items.len() > MAX_STATIC_VALUES {
+                return None;
+            }
+            let mut values = Vec::with_capacity(dict.items.len());
+            for item in &dict.items {
+                let key = item.key.as_ref()?.string_literal()?.to_string();
+                if !class_mapping_value_is_static(&item.value) {
+                    return None;
+                }
+                let value = AbstractValue::Str(key);
+                if !values.contains(&value) {
+                    values.push(value);
+                }
+            }
+            Some((attribute, AbstractValue::Tuple(values)))
+        })
+        .collect();
+    if !candidates.is_empty() && body_static_path_is_mutated(module, class_name) {
+        return Vec::new();
+    }
+    candidates
+}
+
+fn class_local_mapping_is_mutated_or_escaped(body: &[Stmt], name: &str) -> bool {
+    let mut unsafe_use = false;
+    walk_stmts(body, Recurse::ControlFlow, |stmt| {
+        let is_name = |expression: &Expr| expression.name_target() == Some(name);
+        let mutates = |target: &Expr| match target {
+            Expr::Attribute(attribute) => is_name(&attribute.value),
+            Expr::Subscript(subscript) => is_name(&subscript.value),
+            Expr::BoolOp(_)
+            | Expr::Named(_)
+            | Expr::BinOp(_)
+            | Expr::UnaryOp(_)
+            | Expr::Lambda(_)
+            | Expr::If(_)
+            | Expr::Dict(_)
+            | Expr::Set(_)
+            | Expr::ListComp(_)
+            | Expr::SetComp(_)
+            | Expr::DictComp(_)
+            | Expr::Generator(_)
+            | Expr::Await(_)
+            | Expr::Yield(_)
+            | Expr::YieldFrom(_)
+            | Expr::Compare(_)
+            | Expr::Call(_)
+            | Expr::FString(_)
+            | Expr::TString(_)
+            | Expr::StringLiteral(_)
+            | Expr::BytesLiteral(_)
+            | Expr::NumberLiteral(_)
+            | Expr::BooleanLiteral(_)
+            | Expr::NoneLiteral(_)
+            | Expr::EllipsisLiteral(_)
+            | Expr::Starred(_)
+            | Expr::Name(_)
+            | Expr::List(_)
+            | Expr::Tuple(_)
+            | Expr::Slice(_)
+            | Expr::IpyEscapeCommand(_) => false,
+        };
+        unsafe_use |= match stmt {
+            Stmt::Assign(assign) => assign.targets.iter().any(mutates) || is_name(&assign.value),
+            Stmt::AnnAssign(assign) => {
+                mutates(&assign.target) || assign.value.as_deref().is_some_and(is_name)
+            }
+            Stmt::AugAssign(assign) => mutates(&assign.target),
+            Stmt::Delete(delete) => delete.targets.iter().any(mutates),
+            Stmt::Expr(statement) => matches!(statement.value.as_ref(), Expr::Call(call) if
+                matches!(call.func.as_ref(), Expr::Attribute(attribute) if is_name(&attribute.value))
+                || call.arguments.args.iter().any(is_name)
+                || call.arguments.keywords.iter().any(|keyword| is_name(&keyword.value))),
+            Stmt::FunctionDef(_)
+            | Stmt::ClassDef(_)
+            | Stmt::Return(_)
+            | Stmt::TypeAlias(_)
+            | Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Raise(_)
+            | Stmt::Try(_)
+            | Stmt::Assert(_)
+            | Stmt::Import(_)
+            | Stmt::ImportFrom(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => false,
+        };
+        if unsafe_use {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    });
+    unsafe_use
+}
+
+fn class_mapping_value_is_static(value: &Expr) -> bool {
+    matches!(
+        value,
+        Expr::Name(_)
+            | Expr::StringLiteral(_)
+            | Expr::BytesLiteral(_)
+            | Expr::NumberLiteral(_)
+            | Expr::BooleanLiteral(_)
+            | Expr::NoneLiteral(_)
+            | Expr::EllipsisLiteral(_)
+    )
+}
+
+fn expression_contains_static_root(expression: &Expr, root: &str) -> bool {
+    struct RootObserver<'a> {
+        root: &'a str,
+        found: bool,
+    }
+
+    impl<'ast> Visitor<'ast> for RootObserver<'_> {
+        fn visit_expr(&mut self, expr: &'ast Expr) {
+            if expr
+                .path_segments()
+                .is_some_and(|path| path.first().is_some_and(|name| name == self.root))
+            {
+                self.found = true;
+                return;
+            }
+            if let Expr::Call(call) = expr {
+                // Calling the class constructs an instance; it does not expose
+                // the class object. Arguments may still contain an alias.
+                for argument in &call.arguments.args {
+                    self.visit_expr(argument);
+                }
+                for keyword in &call.arguments.keywords {
+                    self.visit_expr(&keyword.value);
+                }
+                return;
+            }
+            walk_expr(self, expr);
+        }
+    }
+
+    let mut observer = RootObserver { root, found: false };
+    observer.visit_expr(expression);
+    observer.found
+}
+
+fn body_static_path_is_mutated(body: &[Stmt], class_name: &str) -> bool {
+    let mut mutated = false;
+    walk_stmts(body, Recurse::WithinScope, |stmt| {
+        let target_mutates = |target: &Expr| {
+            target.path_segments().is_some_and(|path| {
+                path.first().is_some_and(|root| root == class_name) && path.len() > 1
+            }) || matches!(target, Expr::Subscript(subscript) if subscript.value.path_segments().is_some_and(|path| path.first().is_some_and(|root| root == class_name) && path.len() > 1))
+        };
+        let path_escapes =
+            |expression: &Expr| expression_contains_static_root(expression, class_name);
+        mutated |= match stmt {
+            Stmt::Assign(assign) => {
+                assign.targets.iter().any(target_mutates) || path_escapes(&assign.value)
+            }
+            Stmt::AnnAssign(assign) => {
+                target_mutates(&assign.target) || assign.value.as_deref().is_some_and(path_escapes)
+            }
+            Stmt::AugAssign(assign) => target_mutates(&assign.target),
+            Stmt::Delete(delete) => delete.targets.iter().any(target_mutates),
+            Stmt::Expr(expression) => {
+                matches!(expression.value.as_ref(), Expr::Call(call) if
+                    call.func.path_segments().is_some_and(|path| path.first().is_some_and(|root| root == class_name) && path.len() > 2)
+                    || call.arguments.args.iter().any(path_escapes)
+                    || call.arguments.keywords.iter().any(|keyword| path_escapes(&keyword.value)))
+            }
+            Stmt::Return(statement) => statement.value.as_deref().is_some_and(path_escapes),
+            Stmt::FunctionDef(function) => body_static_path_is_mutated(&function.body, class_name),
+            Stmt::ClassDef(class) => body_static_path_is_mutated(&class.body, class_name),
+            Stmt::TypeAlias(_)
+            | Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Try(_)
+            | Stmt::Raise(_)
+            | Stmt::Assert(_)
+            | Stmt::Import(_)
+            | Stmt::ImportFrom(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => false,
+        };
+        if mutated {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    });
+    mutated
+}
+
+fn collect_mutated_roots(body: &[Stmt], mutated: &mut HashSet<String>) {
+    walk_stmts(body, Recurse::WithinScope, |stmt| {
+        let mut record_target = |target: &Expr| {
+            let base = match target {
+                Expr::Subscript(subscript) => subscript.value.as_ref(),
+                Expr::Attribute(attribute) => attribute.value.as_ref(),
+                Expr::BoolOp(_)
+                | Expr::Named(_)
+                | Expr::BinOp(_)
+                | Expr::Compare(_)
+                | Expr::UnaryOp(_)
+                | Expr::Lambda(_)
+                | Expr::If(_)
+                | Expr::Dict(_)
+                | Expr::Set(_)
+                | Expr::ListComp(_)
+                | Expr::SetComp(_)
+                | Expr::DictComp(_)
+                | Expr::Generator(_)
+                | Expr::Await(_)
+                | Expr::Yield(_)
+                | Expr::YieldFrom(_)
+                | Expr::Call(_)
+                | Expr::FString(_)
+                | Expr::TString(_)
+                | Expr::StringLiteral(_)
+                | Expr::BytesLiteral(_)
+                | Expr::NumberLiteral(_)
+                | Expr::BooleanLiteral(_)
+                | Expr::NoneLiteral(_)
+                | Expr::EllipsisLiteral(_)
+                | Expr::Starred(_)
+                | Expr::Name(_)
+                | Expr::List(_)
+                | Expr::Tuple(_)
+                | Expr::Slice(_)
+                | Expr::IpyEscapeCommand(_) => return,
+            };
+            if let Some(root) = base.path_segments().and_then(|path| path.first().cloned()) {
+                mutated.insert(root);
+            }
+        };
+        match stmt {
+            Stmt::Assign(assign) => {
+                for target in &assign.targets {
+                    record_target(target);
+                }
+            }
+            Stmt::AnnAssign(assign) => record_target(&assign.target),
+            Stmt::AugAssign(assign) => record_target(&assign.target),
+            Stmt::Delete(delete) => {
+                for target in &delete.targets {
+                    record_target(target);
+                }
+            }
+            Stmt::Expr(expression) => {
+                if let Expr::Call(call) = expression.value.as_ref()
+                    && let Expr::Attribute(method) = call.func.as_ref()
+                    && let Some(root) = method
+                        .value
+                        .path_segments()
+                        .and_then(|path| path.first().cloned())
+                {
+                    mutated.insert(root);
+                }
+            }
+            Stmt::FunctionDef(_)
+            | Stmt::ClassDef(_)
+            | Stmt::TypeAlias(_)
+            | Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Try(_)
+            | Stmt::Return(_)
+            | Stmt::Raise(_)
+            | Stmt::Assert(_)
+            | Stmt::Import(_)
+            | Stmt::ImportFrom(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => {}
+        }
+        ControlFlow::Continue(())
+    });
+}
+
+struct FunctionBindings {
+    locals: HashSet<String>,
+    nonlocals: HashSet<String>,
+    bound_names: HashSet<String>,
+    names_open: bool,
+}
+
+impl FunctionBindings {
+    fn collect(function: &StmtFunctionDef) -> Self {
+        let scope = ScopeBindings::collect(&function.body);
+        let mut locals = scope.writes.keys().cloned().collect::<HashSet<_>>();
+        for parameter in function
+            .parameters
+            .posonlyargs
+            .iter()
+            .chain(&function.parameters.args)
+            .chain(&function.parameters.kwonlyargs)
+        {
+            locals.insert(parameter.parameter.name.to_string());
+        }
+        if let Some(parameter) = &function.parameters.vararg {
+            locals.insert(parameter.name.to_string());
+        }
+        if let Some(parameter) = &function.parameters.kwarg {
+            locals.insert(parameter.name.to_string());
+        }
+        locals.retain(|name| !scope.globals.contains(name) && !scope.nonlocals.contains(name));
+        let names_open = scope.has_unknown_star_import();
+        let mut bound_names = scope.writes.keys().cloned().collect::<HashSet<_>>();
+        bound_names.extend(locals.iter().cloned());
+        bound_names.extend(scope.nonlocals.iter().cloned());
+        Self {
+            locals,
+            nonlocals: scope.nonlocals,
+            bound_names,
+            names_open,
+        }
+    }
+
+    fn blocks_module_fallback(&self, name: &str) -> bool {
+        self.names_open || self.locals.contains(name) || self.nonlocals.contains(name)
+    }
+}
+
+fn record_target_writes(target: &Expr, writes: &mut HashMap<String, usize>) {
+    if let Some(name) = target.name_target() {
+        *writes.entry(name.to_string()).or_insert(0) += 1;
+        return;
+    }
+    match target {
+        Expr::Tuple(tuple) => {
+            for element in &tuple.elts {
+                record_target_writes(element, writes);
+            }
+        }
+        Expr::List(list) => {
+            for element in &list.elts {
+                record_target_writes(element, writes);
+            }
+        }
+        Expr::Starred(starred) => record_target_writes(&starred.value, writes),
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Attribute(_)
+        | Expr::Subscript(_)
+        | Expr::Name(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => {}
+    }
+}

--- a/crates/djls-project/src/templates/tags/analysis/exceptions.rs
+++ b/crates/djls-project/src/templates/tags/analysis/exceptions.rs
@@ -37,6 +37,9 @@ pub(super) fn extract_exception_message(
     if let Some(message) = first_arg.string_literal() {
         return Some(ExtractedMessageTemplate::Static(message.to_string()));
     }
+    if let AbstractValue::Str(message) = eval_expr(first_arg, &mut env.clone()) {
+        return Some(ExtractedMessageTemplate::Static(message));
+    }
 
     let Expr::BinOp(ExprBinOp {
         left,
@@ -48,7 +51,12 @@ pub(super) fn extract_exception_message(
         return None;
     };
 
-    let template = left.string_literal()?.to_string();
+    let template = left.string_literal().map(str::to_string).or_else(|| {
+        let AbstractValue::Str(value) = eval_expr(left, &mut env.clone()) else {
+            return None;
+        };
+        Some(value)
+    })?;
     let args = match right.as_ref() {
         Expr::Tuple(tuple) => tuple
             .elts
@@ -102,6 +110,7 @@ fn extract_message_arg(expr: &Expr, env: &Env) -> Option<ExtractedMessageArg> {
         | AbstractValue::Parser
         | AbstractValue::SplitResult(_)
         | AbstractValue::SplitLength(_)
+        | AbstractValue::SplitPredicate(_)
         | AbstractValue::Tuple(_) => None,
     }
 }

--- a/crates/djls-project/src/templates/tags/analysis/expressions.rs
+++ b/crates/djls-project/src/templates/tags/analysis/expressions.rs
@@ -1,4 +1,5 @@
 use ruff_python_ast::Arguments;
+use ruff_python_ast::CmpOp;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
@@ -15,6 +16,7 @@ use crate::templates::tags::analysis::calls::resolve_call;
 use crate::templates::tags::analysis::mutations::PopPosition;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
+use crate::templates::tags::analysis::state::SplitPredicate;
 use crate::templates::tags::analysis::state::TokenSplit;
 use crate::templates::tags::types::SplitPosition;
 
@@ -48,14 +50,17 @@ pub(super) fn eval_expr_with_ctx(
             AbstractValue::Str(value.to_string())
         }
 
-        Expr::Tuple(ExprTuple { elts, .. }) => {
-            let mut ctx = ctx;
-            let mut values = Vec::with_capacity(elts.len());
-            for e in elts {
-                values.push(eval_expr_with_ctx(e, env, ctx.as_deref_mut()));
-            }
-            AbstractValue::Tuple(values)
-        }
+        Expr::Tuple(ExprTuple { elts, .. }) => eval_collection(elts, env, ctx),
+
+        Expr::Attribute(attribute) => attribute
+            .value
+            .path_segments()
+            .map(|mut path| {
+                path.push(attribute.attr.to_string());
+                path
+            })
+            .and_then(|path| env.get_static_path(&path).cloned())
+            .unwrap_or(AbstractValue::Unknown),
 
         Expr::Call(call) => eval_call_with_ctx(call, env, ctx),
 
@@ -64,14 +69,43 @@ pub(super) fn eval_expr_with_ctx(
             eval_subscript(&base, slice, env)
         }
 
-        Expr::BoolOp(_)
+        Expr::Compare(compare) => eval_split_equality(compare, env),
+
+        Expr::UnaryOp(unary) if unary.op == ruff_python_ast::UnaryOp::USub => {
+            match eval_expr(&unary.operand, env) {
+                AbstractValue::Int(value) => value
+                    .checked_neg()
+                    .map_or(AbstractValue::Unknown, AbstractValue::Int),
+                AbstractValue::Unknown
+                | AbstractValue::Token
+                | AbstractValue::Parser
+                | AbstractValue::SplitResult(_)
+                | AbstractValue::SplitElement { .. }
+                | AbstractValue::SplitLength(_)
+                | AbstractValue::Str(_)
+                | AbstractValue::SplitPredicate(_)
+                | AbstractValue::Tuple(_) => AbstractValue::Unknown,
+            }
+        }
+
+        Expr::BinOp(binary) if binary.op == ruff_python_ast::Operator::Add => {
+            match (eval_expr(&binary.left, env), eval_expr(&binary.right, env)) {
+                (AbstractValue::Int(left), AbstractValue::Int(right)) => {
+                    AbstractValue::Int(left + right)
+                }
+                _ => AbstractValue::Unknown,
+            }
+        }
+
+        Expr::List(_)
+        | Expr::Set(_)
+        | Expr::BoolOp(_)
         | Expr::Named(_)
         | Expr::BinOp(_)
         | Expr::UnaryOp(_)
         | Expr::Lambda(_)
         | Expr::If(_)
         | Expr::Dict(_)
-        | Expr::Set(_)
         | Expr::ListComp(_)
         | Expr::SetComp(_)
         | Expr::DictComp(_)
@@ -79,7 +113,6 @@ pub(super) fn eval_expr_with_ctx(
         | Expr::Await(_)
         | Expr::Yield(_)
         | Expr::YieldFrom(_)
-        | Expr::Compare(_)
         | Expr::FString(_)
         | Expr::TString(_)
         | Expr::BytesLiteral(_)
@@ -87,12 +120,56 @@ pub(super) fn eval_expr_with_ctx(
         | Expr::BooleanLiteral(_)
         | Expr::NoneLiteral(_)
         | Expr::EllipsisLiteral(_)
-        | Expr::Attribute(_)
         | Expr::Starred(_)
         | Expr::Name(_)
-        | Expr::List(_)
         | Expr::Slice(_)
         | Expr::IpyEscapeCommand(_) => AbstractValue::Unknown,
+    }
+}
+
+fn eval_collection(
+    elements: &[Expr],
+    env: &mut Env,
+    mut ctx: Option<&mut CallContext<'_>>,
+) -> AbstractValue {
+    let mut values = Vec::with_capacity(elements.len());
+    for element in elements {
+        values.push(eval_expr_with_ctx(element, env, ctx.as_deref_mut()));
+    }
+    AbstractValue::Tuple(values)
+}
+
+/// A literal collection can be read at a membership test without keeping its
+/// mutable contents as an exact value in the environment.
+pub(super) fn eval_membership_collection(expr: &Expr, env: &mut Env) -> AbstractValue {
+    if let Expr::List(list) = expr {
+        eval_literal_collection(&list.elts, env, None)
+    } else if let Expr::Set(set) = expr {
+        eval_literal_collection(&set.elts, env, None)
+    } else {
+        eval_expr(expr, env)
+    }
+}
+
+fn eval_literal_collection(
+    elements: &[Expr],
+    env: &mut Env,
+    ctx: Option<&mut CallContext<'_>>,
+) -> AbstractValue {
+    if elements.is_empty() {
+        return AbstractValue::Unknown;
+    }
+    let value = eval_collection(elements, env, ctx);
+    let AbstractValue::Tuple(values) = &value else {
+        return AbstractValue::Unknown;
+    };
+    if values
+        .iter()
+        .all(|value| matches!(value, AbstractValue::Int(_) | AbstractValue::Str(_)))
+    {
+        value
+    } else {
+        AbstractValue::Unknown
     }
 }
 
@@ -160,8 +237,12 @@ fn eval_call_with_ctx(
 
     // Builtin calls: len(), list()
     if let Some(name) = call.func.name_target() {
-        // len() and list() with single argument
-        if let Some(arg) = call.arguments.args.first() {
+        // len() and list() with single argument. Bare names only identify
+        // builtins when module and function scope analysis proves they are
+        // visible.
+        if env.builtin_name_visible(name)
+            && let Some(arg) = call.arguments.args.first()
+        {
             let val = eval_expr_with_ctx(arg, env, ctx.as_deref_mut());
             match name {
                 "len" => {
@@ -200,6 +281,32 @@ fn eval_call_with_ctx(
     }
 
     AbstractValue::Unknown
+}
+
+fn eval_split_equality(compare: &ruff_python_ast::ExprCompare, env: &mut Env) -> AbstractValue {
+    let [CmpOp::Eq] = &*compare.ops else {
+        return AbstractValue::Unknown;
+    };
+    let [right] = &*compare.comparators else {
+        return AbstractValue::Unknown;
+    };
+    match (eval_expr(&compare.left, env), eval_expr(right, env)) {
+        (AbstractValue::SplitLength(split), AbstractValue::Int(length))
+        | (AbstractValue::Int(length), AbstractValue::SplitLength(split)) => {
+            usize::try_from(length)
+                .ok()
+                .map(|length| SplitPredicate::LengthEquals(split.resolve_length(length)))
+                .map_or(AbstractValue::Unknown, AbstractValue::SplitPredicate)
+        }
+        (AbstractValue::SplitElement { index }, AbstractValue::Str(value))
+        | (AbstractValue::Str(value), AbstractValue::SplitElement { index }) => {
+            AbstractValue::SplitPredicate(SplitPredicate::ElementEquals {
+                position: index,
+                value,
+            })
+        }
+        _ => AbstractValue::Unknown,
+    }
 }
 
 /// Handle `token.contents.split(...)` patterns.
@@ -246,6 +353,7 @@ fn eval_pop(receiver: &Expr, split: TokenSplit, args: &Arguments, env: &mut Env)
     };
     let original = AbstractValue::SplitResult(split);
     if let Some(name) = receiver.name_target() {
+        // A later argument may have changed the receiver already.
         if env.get(name) != &original {
             env.forget_aliases(&original);
             return AbstractValue::Unknown;
@@ -281,6 +389,23 @@ fn i64_to_index_element(n: i64, split: &TokenSplit) -> AbstractValue {
 
 /// Evaluate subscript access on an abstract value.
 fn eval_subscript(base: &AbstractValue, slice: &Expr, env: &mut Env) -> AbstractValue {
+    if let AbstractValue::Tuple(values) = base {
+        let AbstractValue::Int(index) = eval_expr(slice, env) else {
+            return AbstractValue::Unknown;
+        };
+        let index = if index < 0 {
+            usize::try_from(index.unsigned_abs())
+                .ok()
+                .and_then(|distance| values.len().checked_sub(distance))
+        } else {
+            usize::try_from(index).ok()
+        };
+        return index
+            .and_then(|index| values.get(index))
+            .cloned()
+            .unwrap_or(AbstractValue::Unknown);
+    }
+
     let AbstractValue::SplitResult(split) = base else {
         return AbstractValue::Unknown;
     };
@@ -332,16 +457,33 @@ fn eval_subscript(base: &AbstractValue, slice: &Expr, env: &mut Env) -> Abstract
                 .map_or(AbstractValue::Unknown, |n| {
                     AbstractValue::SplitResult(split.after_slice_from(n))
                 }),
+            // bits[N:-M] — retain the bounded middle of the original split.
+            (Some(lower_expr), Some(upper_expr)) => {
+                let Some(lower) = lower_expr.non_negative_integer() else {
+                    return AbstractValue::Unknown;
+                };
+                let AbstractValue::Int(upper) = eval_expr(upper_expr, env) else {
+                    return AbstractValue::Unknown;
+                };
+                if upper >= 0 {
+                    return AbstractValue::Unknown;
+                }
+                let Ok(back) = usize::try_from(upper.unsigned_abs()) else {
+                    return AbstractValue::Unknown;
+                };
+                let mut middle = split.after_slice_from(lower);
+                for _ in 0..back {
+                    middle = middle.after_pop_back();
+                }
+                AbstractValue::SplitResult(middle)
+            }
             // bits[:N], bits[:-N], or bits[:] — truncation, preserve offset
             (None, _) => AbstractValue::SplitResult(*split),
-            _ => AbstractValue::Unknown,
         };
     }
 
-    // bits[variable]
-    if slice.name_target().is_some()
-        && let AbstractValue::Int(n) = eval_expr(slice, env)
-    {
+    // bits[variable] or bits[tracked integer expression]
+    if let AbstractValue::Int(n) = eval_expr(slice, env) {
         return i64_to_index_element(n, split);
     }
 

--- a/crates/djls-project/src/templates/tags/analysis/guards.rs
+++ b/crates/djls-project/src/templates/tags/analysis/guards.rs
@@ -20,14 +20,85 @@ use crate::templates::tags::analysis::constraints::ExtractedTagConstraints;
 use crate::templates::tags::analysis::exceptions::direct_raise_exception;
 use crate::templates::tags::analysis::exceptions::extract_exception_message;
 use crate::templates::tags::analysis::expressions::eval_expr;
+use crate::templates::tags::analysis::expressions::eval_membership_collection;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
+use crate::templates::tags::analysis::state::SplitPredicate;
 use crate::templates::tags::types::ArgumentCountConstraint;
 use crate::templates::tags::types::ChoiceAt;
 use crate::templates::tags::types::ExtractedDiagnosticConstraint;
 use crate::templates::tags::types::ExtractedDiagnosticMessage;
 use crate::templates::tags::types::ExtractedMessageTemplate;
 use crate::templates::tags::types::RequiredKeyword;
+
+const MAX_EXACT_GUARD_VALUES: usize = 32;
+
+/// Normalize a supported condition into an equality predicate and the
+/// predicate value required for the condition to be true.
+pub(crate) fn split_predicate_condition(expr: &Expr, env: &Env) -> Option<(SplitPredicate, bool)> {
+    if let Expr::UnaryOp(ExprUnaryOp {
+        op: UnaryOp::Not,
+        operand,
+        ..
+    }) = expr
+    {
+        let (predicate, truth) = split_predicate_condition(operand, env)?;
+        return Some((predicate, !truth));
+    }
+
+    if expr.name_target().is_some()
+        && let AbstractValue::SplitPredicate(predicate) = eval_expr(expr, &mut env.clone())
+    {
+        return Some((predicate, true));
+    }
+
+    let Expr::Compare(ExprCompare {
+        left,
+        ops,
+        comparators,
+        ..
+    }) = expr
+    else {
+        return None;
+    };
+    let [operator] = &**ops else {
+        return None;
+    };
+    let truth = match operator {
+        CmpOp::Eq => true,
+        CmpOp::NotEq => false,
+        CmpOp::Lt
+        | CmpOp::LtE
+        | CmpOp::Gt
+        | CmpOp::GtE
+        | CmpOp::Is
+        | CmpOp::IsNot
+        | CmpOp::In
+        | CmpOp::NotIn => return None,
+    };
+    let [right] = &**comparators else {
+        return None;
+    };
+    let mut local_env = env.clone();
+    let predicate = match (
+        eval_expr(left, &mut local_env),
+        eval_expr(right, &mut local_env),
+    ) {
+        (AbstractValue::SplitLength(split), AbstractValue::Int(length))
+        | (AbstractValue::Int(length), AbstractValue::SplitLength(split)) => {
+            SplitPredicate::LengthEquals(split.resolve_length(usize::try_from(length).ok()?))
+        }
+        (AbstractValue::SplitElement { index }, AbstractValue::Str(value))
+        | (AbstractValue::Str(value), AbstractValue::SplitElement { index }) => {
+            SplitPredicate::ElementEquals {
+                position: index,
+                value,
+            }
+        }
+        _ => return None,
+    };
+    Some((predicate, truth))
+}
 
 /// Rule fragments contributed by one or more raising guards.
 #[derive(Debug, Clone, Default)]
@@ -424,7 +495,7 @@ fn eval_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagConstraints
     let comparator = &compare.comparators[0];
 
     let left_val = eval_expr(left, env);
-    let right_val = eval_expr(comparator, env);
+    let right_val = eval_comparator(*op, comparator, env);
 
     // len(split_result) vs integer
     if let AbstractValue::SplitLength(split) = &left_val {
@@ -449,7 +520,7 @@ fn eval_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagConstraints
 
         // `len(bits) not in (2, 3, 4)` → valid counts are {2+offset, 3+offset, 4+offset}
         if matches!(op, CmpOp::NotIn)
-            && let Some(values) = comparator.collection_map(ExprExt::non_negative_integer)
+            && let Some(values) = exact_integer_collection(&right_val)
         {
             return ExtractedTagConstraints::single_length(ArgumentCountConstraint::OneOf(
                 values
@@ -500,11 +571,9 @@ fn eval_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagConstraints
             return ExtractedTagConstraints::default();
         }
 
-        // SplitElement not in ("a", "b") → ChoiceAt constraint
+        // SplitElement not in a closed string collection → ChoiceAt constraint.
         if matches!(op, CmpOp::NotIn)
-            && let Some(values) =
-                comparator.collection_map(|expr| expr.string_literal().map(str::to_string))
-            && !values.is_empty()
+            && let Some(values) = exact_string_collection(&right_val)
         {
             let position = index;
             return ExtractedTagConstraints::single_choice(ChoiceAt { position, values });
@@ -529,6 +598,14 @@ fn eval_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagConstraints
     ExtractedTagConstraints::default()
 }
 
+fn eval_comparator(op: CmpOp, comparator: &Expr, env: &mut Env) -> AbstractValue {
+    if matches!(op, CmpOp::In | CmpOp::NotIn) {
+        eval_membership_collection(comparator, env)
+    } else {
+        eval_expr(comparator, env)
+    }
+}
+
 fn eval_negated_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagConstraints {
     // Range: `not (2 <= len(bits) <= 4)` → valid range is min..=max
     if compare.ops.len() == 2
@@ -544,9 +621,23 @@ fn eval_negated_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagCon
     // Simple negation: `not len(bits) == 3` → Exact(3)
     if compare.ops.len() == 1 && compare.comparators.len() == 1 {
         let left_val = eval_expr(&compare.left, env);
-        if let AbstractValue::SplitLength(split) = left_val
-            && let Some(n) = compare.comparators[0].non_negative_integer()
-        {
+        if let AbstractValue::SplitLength(split) = left_val {
+            if matches!(compare.ops[0], CmpOp::In)
+                && let Some(values) = exact_integer_collection(&eval_membership_collection(
+                    &compare.comparators[0],
+                    env,
+                ))
+            {
+                return ExtractedTagConstraints::single_length(ArgumentCountConstraint::OneOf(
+                    values
+                        .into_iter()
+                        .map(|value| split.resolve_length(value))
+                        .collect(),
+                ));
+            }
+            let Some(n) = compare.comparators[0].non_negative_integer() else {
+                return ExtractedTagConstraints::default();
+            };
             let constraint = match &compare.ops[0] {
                 CmpOp::Eq => Some(ArgumentCountConstraint::Exact(split.resolve_length(n))),
                 CmpOp::Lt if n > 0 => {
@@ -566,6 +657,45 @@ fn eval_negated_compare(compare: &ExprCompare, env: &mut Env) -> ExtractedTagCon
     }
 
     ExtractedTagConstraints::default()
+}
+
+fn exact_integer_collection(value: &AbstractValue) -> Option<Vec<usize>> {
+    let AbstractValue::Tuple(values) = value else {
+        return None;
+    };
+    if values.is_empty() || values.len() > MAX_EXACT_GUARD_VALUES {
+        return None;
+    }
+    let mut exact = Vec::with_capacity(values.len());
+    for value in values {
+        let AbstractValue::Int(value) = value else {
+            return None;
+        };
+        let value = usize::try_from(*value).ok()?;
+        if !exact.contains(&value) {
+            exact.push(value);
+        }
+    }
+    Some(exact)
+}
+
+fn exact_string_collection(value: &AbstractValue) -> Option<Vec<String>> {
+    let AbstractValue::Tuple(values) = value else {
+        return None;
+    };
+    if values.is_empty() || values.len() > MAX_EXACT_GUARD_VALUES {
+        return None;
+    }
+    let mut exact = Vec::with_capacity(values.len());
+    for value in values {
+        let AbstractValue::Str(value) = value else {
+            return None;
+        };
+        if !exact.contains(value) {
+            exact.push(value.clone());
+        }
+    }
+    Some(exact)
 }
 
 /// Extract range constraint from negated `not (CONST <=/<  len(var) <=/<  CONST)`.
@@ -672,6 +802,7 @@ mod tests {
             .map_or("token", |p| p.parameter.name.as_str());
 
         let mut env = Env::for_compile_function(parser_param, token_param);
+        env.set_builtin_name_scope(std::collections::HashSet::new());
         let mut ctx = CallContext {
             db: None,
             file: None,
@@ -963,6 +1094,39 @@ def do_tag(parser, token):
             c.arg_constraints,
             vec![ArgumentCountConstraint::OneOf(vec![2, 3, 4])]
         );
+    }
+
+    #[test]
+    fn negated_len_membership_matches_not_in_with_offsets() {
+        for condition in ["len(bits) not in (1, 2, 3)", "not len(bits) in (1, 2, 3)"] {
+            let c = extract_from_source(&format!(
+                "def do_tag(parser, token):\n    bits = token.split_contents()[1:]\n    if {condition}:\n        raise TemplateSyntaxError('err')\n"
+            ));
+            assert_eq!(
+                c.arg_constraints,
+                vec![ArgumentCountConstraint::OneOf(vec![2, 3, 4])],
+                "condition: {condition}"
+            );
+        }
+    }
+
+    #[test]
+    fn len_membership_rejects_unbounded_or_inexact_collections() {
+        let oversized = (0..=32)
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        for collection in [
+            "()".to_string(),
+            "(1, 'two')".to_string(),
+            "choices".to_string(),
+            format!("({oversized})"),
+        ] {
+            let c = extract_from_source(&format!(
+                "def do_tag(parser, token):\n    bits = token.split_contents()\n    if not len(bits) in {collection}:\n        raise TemplateSyntaxError('err')\n"
+            ));
+            assert!(c.arg_constraints.is_empty(), "collection: {collection}");
+        }
     }
 
     #[test]

--- a/crates/djls-project/src/templates/tags/analysis/mutations.rs
+++ b/crates/djls-project/src/templates/tags/analysis/mutations.rs
@@ -26,6 +26,12 @@ pub(super) struct PopInfo {
     position: PopPosition,
 }
 
+impl PopInfo {
+    pub(super) fn is_untracked(&self) -> bool {
+        self.position == PopPosition::Untracked
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum PopPosition {
     Front,

--- a/crates/djls-project/src/templates/tags/analysis/state.rs
+++ b/crates/djls-project/src/templates/tags/analysis/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use serde::Serialize;
 
@@ -118,6 +119,8 @@ pub(crate) enum AbstractValue {
     Int(i64),
     /// String constant
     Str(String),
+    /// A comparison over the original `split_contents()` result.
+    SplitPredicate(SplitPredicate),
     /// Tuple of tracked values (for function return/destructuring)
     Tuple(Vec<AbstractValue>),
 }
@@ -137,15 +140,30 @@ impl AbstractValue {
             | Self::SplitElement { .. }
             | Self::SplitLength(_)
             | Self::Int(_)
-            | Self::Str(_) => {}
+            | Self::Str(_)
+            | Self::SplitPredicate(_) => {}
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum SplitPredicate {
+    LengthEquals(usize),
+    LengthAtLeast(usize),
+    ElementEquals {
+        position: SplitPosition,
+        value: String,
+    },
 }
 
 /// The abstract environment: maps variable names to their abstract values.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct Env {
-    bindings: HashMap<String, AbstractValue>,
+    bindings: Arc<HashMap<String, AbstractValue>>,
+    static_bindings: Arc<HashMap<String, AbstractValue>>,
+    /// `None` means module name resolution is open. A closed set records names
+    /// that shadow their Python builtins in this function.
+    shadowed_builtin_names: Option<Arc<std::collections::HashSet<String>>>,
 }
 
 impl Env {
@@ -157,18 +175,67 @@ impl Env {
         let mut bindings = HashMap::new();
         bindings.insert(parser_param.to_string(), AbstractValue::Parser);
         bindings.insert(token_param.to_string(), AbstractValue::Token);
-        Self { bindings }
+        Self {
+            bindings: Arc::new(bindings),
+            static_bindings: Arc::new(HashMap::new()),
+            shadowed_builtin_names: None,
+        }
     }
 
-    /// Look up a variable's abstract value. Returns `Unknown` if not bound.
+    /// Look up a variable's abstract value. A local binding, including
+    /// `Unknown`, shadows a module constant.
     #[must_use]
     pub(crate) fn get(&self, name: &str) -> &AbstractValue {
-        self.bindings.get(name).unwrap_or(&AbstractValue::Unknown)
+        self.bindings
+            .get(name)
+            .or_else(|| self.static_bindings.get(name))
+            .unwrap_or(&AbstractValue::Unknown)
+    }
+
+    /// Look up a statically resolved dotted path unless its root is shadowed
+    /// by a function-local binding.
+    #[must_use]
+    pub(crate) fn get_static_path(&self, path: &[String]) -> Option<&AbstractValue> {
+        let [root, ..] = path else {
+            return None;
+        };
+        if self.bindings.contains_key(root) {
+            return None;
+        }
+        self.static_bindings.get(&path.join("."))
     }
 
     /// Bind a variable to an abstract value.
     pub(crate) fn set(&mut self, name: String, value: AbstractValue) {
-        self.bindings.insert(name, value);
+        Arc::make_mut(&mut self.bindings).insert(name, value);
+    }
+
+    /// Add a closed module or class constant. Local writes remain separate so
+    /// they cannot accidentally reveal the static value after control flow.
+    pub(crate) fn set_static(&mut self, name: String, value: AbstractValue) {
+        Arc::make_mut(&mut self.static_bindings).insert(name, value);
+    }
+
+    /// Block static fallback for a local name without replacing a value already
+    /// known at function entry, such as the parser or token parameter.
+    pub(crate) fn shadow_static(&mut self, name: String) {
+        Arc::make_mut(&mut self.bindings)
+            .entry(name)
+            .or_insert(AbstractValue::Unknown);
+    }
+
+    pub(crate) fn set_builtin_name_scope(
+        &mut self,
+        shadowed_names: std::collections::HashSet<String>,
+    ) {
+        self.shadowed_builtin_names = Some(Arc::new(shadowed_names));
+    }
+
+    #[must_use]
+    pub(crate) fn builtin_name_visible(&self, name: &str) -> bool {
+        self.shadowed_builtin_names
+            .as_ref()
+            .is_some_and(|shadowed| !shadowed.contains(name))
     }
 
     /// Mutate a variable's value in place (e.g., for `bits.pop(0)`).
@@ -177,17 +244,22 @@ impl Env {
     where
         F: FnOnce(&mut AbstractValue),
     {
-        if let Some(val) = self.bindings.get_mut(name) {
-            f(val);
-            true
-        } else {
-            false
+        if !self.bindings.contains_key(name) {
+            return false;
         }
+        let Some(value) = Arc::make_mut(&mut self.bindings).get_mut(name) else {
+            return false;
+        };
+        f(value);
+        true
     }
 
     /// Forget every binding that aliases a mutable abstract value.
     pub(crate) fn forget_aliases(&mut self, aliased: &AbstractValue) {
-        for value in self.bindings.values_mut() {
+        if !self.bindings.values().any(|value| value == aliased) {
+            return;
+        }
+        for value in Arc::make_mut(&mut self.bindings).values_mut() {
             if value == aliased {
                 *value = AbstractValue::Unknown;
             }
@@ -203,26 +275,73 @@ impl Env {
         };
         let mut joined = first.clone();
         for branch in branches {
-            joined
-                .bindings
-                .retain(|name, value| branch.bindings.get(name) == Some(value));
+            if !Arc::ptr_eq(&joined.bindings, &branch.bindings)
+                && joined
+                    .bindings
+                    .iter()
+                    .any(|(name, value)| branch.bindings.get(name) != Some(value))
+            {
+                Arc::make_mut(&mut joined.bindings)
+                    .retain(|name, value| branch.bindings.get(name) == Some(value));
+            }
+            if !joined.static_bindings.is_empty()
+                && branch.static_bindings != joined.static_bindings
+            {
+                joined.static_bindings = Arc::new(HashMap::new());
+            }
         }
         joined
     }
 
     /// Forget a binding that may have changed before an implicit exception.
     pub(crate) fn forget(&mut self, name: &str) {
-        if let Some(value) = self.bindings.get_mut(name) {
+        if !self.bindings.contains_key(name) {
+            return;
+        }
+        if let Some(value) = Arc::make_mut(&mut self.bindings).get_mut(name) {
             *value = AbstractValue::Unknown;
         }
     }
 
-    /// Forget every mutable token-derived sequence, including aliases.
-    pub(crate) fn forget_split_results(&mut self) {
-        for value in self.bindings.values_mut() {
-            if matches!(value, AbstractValue::SplitResult(_)) {
+    /// Forget every binding that identifies the source token.
+    pub(crate) fn forget_tokens(&mut self) {
+        if !self
+            .bindings
+            .values()
+            .any(|value| matches!(value, AbstractValue::Token))
+        {
+            return;
+        }
+        for value in Arc::make_mut(&mut self.bindings).values_mut() {
+            if matches!(value, AbstractValue::Token) {
                 *value = AbstractValue::Unknown;
             }
+        }
+    }
+
+    /// Forget every mutable token-derived sequence, including aliases nested
+    /// in a tuple or mutable literal container.
+    pub(crate) fn forget_split_results(&mut self) {
+        fn contains_split_result(value: &AbstractValue) -> bool {
+            match value {
+                AbstractValue::SplitResult(_) => true,
+                AbstractValue::Tuple(values) => values.iter().any(contains_split_result),
+                AbstractValue::Unknown
+                | AbstractValue::Token
+                | AbstractValue::Parser
+                | AbstractValue::SplitElement { .. }
+                | AbstractValue::SplitLength(_)
+                | AbstractValue::Int(_)
+                | AbstractValue::Str(_)
+                | AbstractValue::SplitPredicate(_) => false,
+            }
+        }
+
+        if !self.bindings.values().any(contains_split_result) {
+            return;
+        }
+        for value in Arc::make_mut(&mut self.bindings).values_mut() {
+            value.forget_mutable();
         }
     }
 
@@ -249,6 +368,18 @@ mod tests {
         let mut env = Env::default();
         env.set("x".to_string(), AbstractValue::Int(42));
         assert_eq!(env.get("x"), &AbstractValue::Int(42));
+    }
+
+    #[test]
+    fn env_clone_isolated_on_write() {
+        let mut original = Env::default();
+        original.set("x".to_string(), AbstractValue::Int(1));
+        let mut branch = original.clone();
+
+        branch.set("x".to_string(), AbstractValue::Int(2));
+
+        assert_eq!(original.get("x"), &AbstractValue::Int(1));
+        assert_eq!(branch.get("x"), &AbstractValue::Int(2));
     }
 
     #[test]

--- a/crates/djls-project/src/templates/tags/analysis/statements.rs
+++ b/crates/djls-project/src/templates/tags/analysis/statements.rs
@@ -2,9 +2,12 @@ use std::collections::BTreeSet;
 use std::ops::ControlFlow;
 
 use ruff_python_ast::Expr;
+use ruff_python_ast::ExprList;
 use ruff_python_ast::ExprTuple;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
+use ruff_python_ast::visitor;
+use ruff_python_ast::visitor::Visitor;
 
 use crate::ast::ExprExt;
 use crate::ast::Recurse;
@@ -13,13 +16,16 @@ use crate::templates::tags::analysis::AnalysisResult;
 use crate::templates::tags::analysis::CallContext;
 use crate::templates::tags::analysis::constraints::ExtractedTagConstraints;
 use crate::templates::tags::analysis::exceptions::direct_raise_exception;
+use crate::templates::tags::analysis::exceptions::extract_exception_message;
 use crate::templates::tags::analysis::expressions::eval_expr;
 use crate::templates::tags::analysis::expressions::eval_expr_with_ctx;
 use crate::templates::tags::analysis::match_arms::extract_match_constraints;
+use crate::templates::tags::analysis::mutations::PopInfo;
 use crate::templates::tags::analysis::mutations::try_extract_option_loop;
 use crate::templates::tags::analysis::mutations::try_extract_pop_call;
 use crate::templates::tags::analysis::state::AbstractValue;
 use crate::templates::tags::analysis::state::Env;
+use crate::templates::tags::analysis::state::SplitPredicate;
 use crate::templates::tags::types::ArgumentCountConstraint;
 use crate::templates::tags::types::ExtractedDiagnosticConstraint;
 use crate::templates::tags::types::ExtractedDiagnosticMessage;
@@ -29,23 +35,99 @@ use crate::templates::tags::types::TagArgumentSyntax;
 
 const MAX_EXEC_STATES: usize = 64;
 
-/// The control destination attached to one feasible execution state.
+/// One feasible path through a compile function. Facts stay attached to the
+/// environment that established them until all accepting paths are projected.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq)]
+enum PathAssumption {
+    LengthNotEquals(usize),
+    ElementNotEquals {
+        position: SplitPosition,
+        value: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltinException {
+    AssertionError,
+    AttributeError,
+    BaseException,
+    Exception,
+    ImportError,
+    IndexError,
+    KeyError,
+    NameError,
+    OSError,
+    RuntimeError,
+    StopIteration,
+    SyntaxError,
+    TypeError,
+    ValueError,
+}
+
+impl BuiltinException {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "AssertionError" => Some(Self::AssertionError),
+            "AttributeError" => Some(Self::AttributeError),
+            "BaseException" => Some(Self::BaseException),
+            "Exception" => Some(Self::Exception),
+            "ImportError" => Some(Self::ImportError),
+            "IndexError" => Some(Self::IndexError),
+            "KeyError" => Some(Self::KeyError),
+            "NameError" => Some(Self::NameError),
+            "OSError" => Some(Self::OSError),
+            "RuntimeError" => Some(Self::RuntimeError),
+            "StopIteration" => Some(Self::StopIteration),
+            "SyntaxError" => Some(Self::SyntaxError),
+            "TypeError" => Some(Self::TypeError),
+            "ValueError" => Some(Self::ValueError),
+            _ => None,
+        }
+    }
+
+    fn catches(self, pending: Self) -> bool {
+        matches!(self, Self::BaseException | Self::Exception) || self == pending
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum PendingException {
+    Builtin(BuiltinException),
+    Unpack(ArgumentCountConstraint),
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RaisedException {
+    kind: PendingException,
+    message: Option<ExtractedMessageTemplate>,
+}
+
+impl RaisedException {
+    fn implicit(kind: PendingException) -> Self {
+        Self {
+            kind,
+            message: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 enum ControlOutcome {
     Next,
     Return(AbstractValue),
-    Raise,
+    Raise(RaisedException),
     Break,
     Continue,
 }
 
-/// One feasible path through a compile function. Facts stay attached to the
-/// environment that established them until all accepting paths are projected.
 #[derive(Debug, Clone, PartialEq)]
 struct ExecutionState {
+    outcome: ControlOutcome,
     env: Env,
     result: AnalysisResult,
-    outcome: ControlOutcome,
+    exclusions: Vec<PathAssumption>,
 }
 
 impl ExecutionState {
@@ -53,21 +135,137 @@ impl ExecutionState {
         Self {
             env,
             result: AnalysisResult::default(),
+            exclusions: Vec::new(),
             outcome: ControlOutcome::Next,
         }
     }
 
-    fn attach_argument_syntax(&mut self, syntax: Option<&TagArgumentSyntax>) {
-        if let Some(syntax) = syntax {
-            self.result.extend(AnalysisResult {
-                argument_syntax: Some(syntax.clone()),
-                ..AnalysisResult::default()
-            });
+    fn assume(mut self, predicate: &SplitPredicate, truth: bool) -> Option<Self> {
+        match (predicate, truth) {
+            (SplitPredicate::LengthEquals(length), true) => {
+                self.result
+                    .constraints
+                    .extend(ExtractedTagConstraints::single_length(
+                        ArgumentCountConstraint::Exact(*length),
+                    ));
+            }
+            (SplitPredicate::LengthEquals(length), false) => {
+                self.exclusions
+                    .push(PathAssumption::LengthNotEquals(*length));
+            }
+            (SplitPredicate::LengthAtLeast(length), true) if *length > 1 => self
+                .result
+                .constraints
+                .extend(ExtractedTagConstraints::single_length(
+                    ArgumentCountConstraint::Min(*length),
+                )),
+            (SplitPredicate::LengthAtLeast(length), false) if *length > 0 => self
+                .result
+                .constraints
+                .extend(ExtractedTagConstraints::single_length(
+                    ArgumentCountConstraint::Max(length - 1),
+                )),
+            (SplitPredicate::ElementEquals { position, value }, true) => {
+                let keyword = crate::templates::tags::types::RequiredKeyword {
+                    position: *position,
+                    value: value.clone(),
+                };
+                if !self.result.constraints.required_keywords.contains(&keyword) {
+                    self.result.constraints.required_keywords.push(keyword);
+                }
+            }
+            (SplitPredicate::ElementEquals { position, value }, false) => {
+                self.exclusions.push(PathAssumption::ElementNotEquals {
+                    position: *position,
+                    value: value.clone(),
+                });
+            }
+            (SplitPredicate::LengthAtLeast(0), false) => return None,
+            (SplitPredicate::LengthAtLeast(_), _) => {}
         }
+
+        if !path_facts_are_feasible(&self.result.constraints, &self.exclusions) {
+            return None;
+        }
+        self.exclusions.dedup();
+        Some(self)
     }
 }
 
-/// Feasible control destinations at one statement boundary.
+fn path_facts_are_feasible(
+    constraints: &ExtractedTagConstraints,
+    exclusions: &[PathAssumption],
+) -> bool {
+    if finite_counts(&constraints.arg_constraints).is_some_and(|counts| counts.is_empty()) {
+        return false;
+    }
+    let lower = lower_bound(&constraints.arg_constraints).unwrap_or(1);
+    let upper = upper_bound(&constraints.arg_constraints);
+    if upper.is_some_and(|upper| lower > upper) {
+        return false;
+    }
+    if upper == Some(lower)
+        && exclusions.iter().any(
+            |assumption| matches!(assumption, PathAssumption::LengthNotEquals(length) if *length == lower),
+        )
+    {
+        return false;
+    }
+
+    let exact_length = finite_counts(&constraints.arg_constraints).and_then(|counts| {
+        let [length] = counts.as_slice() else {
+            return None;
+        };
+        Some(*length)
+    });
+    let exact_arguments_len = exact_length.and_then(|length| length.checked_sub(1));
+    if exact_length == Some(0)
+        || exact_arguments_len.is_some_and(|arguments_len| {
+            constraints
+                .required_keywords
+                .iter()
+                .map(|keyword| keyword.position)
+                .chain(exclusions.iter().filter_map(|assumption| match assumption {
+                    PathAssumption::ElementNotEquals { position, .. } => Some(*position),
+                    PathAssumption::LengthNotEquals(_) => None,
+                }))
+                .any(|position| position.to_bits_index(arguments_len).is_none())
+        })
+    {
+        return false;
+    }
+
+    for (index, left) in constraints.required_keywords.iter().enumerate() {
+        if constraints.required_keywords[index + 1..]
+            .iter()
+            .any(|right| {
+                positions_alias(left.position, right.position, exact_length)
+                    && left.value != right.value
+            })
+            || exclusions.iter().any(|assumption| match assumption {
+                PathAssumption::ElementNotEquals { position, value } => {
+                    positions_alias(left.position, *position, exact_length) && left.value == *value
+                }
+                PathAssumption::LengthNotEquals(_) => false,
+            })
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn positions_alias(left: SplitPosition, right: SplitPosition, exact_length: Option<usize>) -> bool {
+    left == right
+        || exact_length.is_some_and(|length| {
+            let arguments_len = length.saturating_sub(1);
+            left.to_bits_index(arguments_len).is_some()
+                && left.to_bits_index(arguments_len) == right.to_bits_index(arguments_len)
+        })
+}
+
+/// Feasible paths at one statement boundary. Each state owns one control
+/// destination, so environments and evidence cannot cross between exits.
 #[derive(Debug)]
 struct ExecutionStates(Vec<ExecutionState>);
 
@@ -105,11 +303,67 @@ impl ExecutionStates {
     }
 }
 
+fn normalize_state_destinations(destinations: &mut [&mut Vec<ExecutionState>]) {
+    for states in &mut *destinations {
+        deduplicate_states(states);
+    }
+    if destinations
+        .iter()
+        .map(|states| states.len())
+        .sum::<usize>()
+        <= MAX_EXEC_STATES
+    {
+        return;
+    }
+
+    let mut groups = Vec::new();
+    for (destination, states) in destinations.iter_mut().enumerate() {
+        let mut by_outcome = [const { Vec::new() }; 5];
+        for state in states.drain(..) {
+            by_outcome[outcome_index(&state.outcome)].push(state);
+        }
+        groups.extend(
+            by_outcome
+                .into_iter()
+                .filter(|group| !group.is_empty())
+                .map(|group| (destination, group)),
+        );
+    }
+    let mut budgets = vec![1; groups.len()];
+    let mut remaining = MAX_EXEC_STATES - groups.len();
+    while remaining > 0 {
+        let mut added = false;
+        for (budget, (_, group)) in budgets.iter_mut().zip(&groups) {
+            if *budget < group.len() {
+                *budget += 1;
+                remaining -= 1;
+                added = true;
+                if remaining == 0 {
+                    break;
+                }
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+
+    for ((destination, mut group), budget) in groups.into_iter().zip(budgets) {
+        if group.len() > budget
+            && let Some(summary) = summarize_states(&group)
+        {
+            group.truncate(budget - 1);
+            group.push(summary);
+        }
+        destinations[destination].append(&mut group);
+    }
+}
+
 fn outcome_index(outcome: &ControlOutcome) -> usize {
     match outcome {
         ControlOutcome::Next => 0,
         ControlOutcome::Return(_) => 1,
-        ControlOutcome::Raise => 2,
+        ControlOutcome::Raise(_) => 2,
         ControlOutcome::Break => 3,
         ControlOutcome::Continue => 4,
     }
@@ -130,84 +384,51 @@ fn deduplicate_states(states: &mut Vec<ExecutionState>) {
     states.truncate(unique_len);
 }
 
-fn normalize_state_destinations(destinations: &mut [&mut Vec<ExecutionState>]) {
-    for destination in destinations.iter_mut() {
-        deduplicate_states(destination);
-    }
-    if destinations
-        .iter()
-        .map(|states| states.len())
-        .sum::<usize>()
-        <= MAX_EXEC_STATES
-    {
-        return;
-    }
-
-    let mut groups = Vec::new();
-    for (destination_index, destination) in destinations.iter_mut().enumerate() {
-        let mut by_outcome = [const { Vec::new() }; 5];
-        for state in destination.drain(..) {
-            by_outcome[outcome_index(&state.outcome)].push(state);
+fn summarize_states(states: &[ExecutionState]) -> Option<ExecutionState> {
+    let mut summary = states.first()?.clone();
+    summary.env = Env::join_exact(states.iter().map(|state| &state.env));
+    summary.result = project_common_results(&states.iter().collect::<Vec<_>>());
+    summary.exclusions = summarize_exclusions(states);
+    summary.outcome = match &summary.outcome {
+        ControlOutcome::Return(first)
+            if states.iter().all(
+                |state| matches!(&state.outcome, ControlOutcome::Return(value) if value == first),
+            ) =>
+        {
+            ControlOutcome::Return(first.clone())
         }
-        groups.extend(
-            by_outcome
-                .into_iter()
-                .filter(|group| !group.is_empty())
-                .map(|group| (destination_index, group)),
-        );
-    }
-
-    let lengths = groups
-        .iter()
-        .map(|(_, group)| group.len())
-        .collect::<Vec<_>>();
-    let mut budgets = vec![1; groups.len()];
-    let mut remaining = MAX_EXEC_STATES - budgets.len();
-    while remaining > 0 {
-        let mut added = false;
-        for (budget, length) in budgets.iter_mut().zip(&lengths) {
-            if *budget < *length {
-                *budget += 1;
-                remaining -= 1;
-                added = true;
-                if remaining == 0 {
-                    break;
-                }
-            }
+        ControlOutcome::Return(_) => ControlOutcome::Return(AbstractValue::Unknown),
+        ControlOutcome::Raise(first)
+            if states.iter().all(
+                |state| matches!(&state.outcome, ControlOutcome::Raise(value) if value == first),
+            ) =>
+        {
+            ControlOutcome::Raise(first.clone())
         }
-        if !added {
-            break;
+        ControlOutcome::Raise(_) => {
+            ControlOutcome::Raise(RaisedException::implicit(PendingException::Unknown))
         }
-    }
-
-    let mut normalized = (0..destinations.len())
-        .map(|_| Vec::new())
-        .collect::<Vec<_>>();
-    for ((destination_index, mut group), budget) in groups.into_iter().zip(budgets) {
-        if group.len() > budget {
-            let summary = summarize_states(&group);
-            group.truncate(budget - 1);
-            group.push(summary);
-        }
-        normalized[destination_index].append(&mut group);
-    }
-    for (destination, mut states) in destinations.iter_mut().zip(normalized) {
-        destination.append(&mut states);
-    }
+        ControlOutcome::Next => ControlOutcome::Next,
+        ControlOutcome::Break => ControlOutcome::Break,
+        ControlOutcome::Continue => ControlOutcome::Continue,
+    };
+    Some(summary)
 }
 
-fn summarize_states(states: &[ExecutionState]) -> ExecutionState {
-    let mut summary = states[0].clone();
-    summary.env = Env::join_exact(states.iter().map(|state| &state.env));
-    summary.result = project_results(&states.iter().collect::<Vec<_>>());
-    if let ControlOutcome::Return(first) = &summary.outcome
-        && !states
-            .iter()
-            .all(|state| matches!(&state.outcome, ControlOutcome::Return(value) if value == first))
-    {
-        summary.outcome = ControlOutcome::Return(AbstractValue::Unknown);
-    }
-    summary
+fn summarize_exclusions(states: &[ExecutionState]) -> Vec<PathAssumption> {
+    let Some(first) = states.first() else {
+        return Vec::new();
+    };
+    first
+        .exclusions
+        .iter()
+        .filter(|exclusion| {
+            states
+                .iter()
+                .all(|state| state.exclusions.contains(exclusion))
+        })
+        .cloned()
+        .collect()
 }
 
 /// Process a function body and retain facts entailed by every accepting path.
@@ -233,7 +454,7 @@ pub(crate) fn process_statements(
     let values = accepting.iter().filter_map(|state| match &state.outcome {
         ControlOutcome::Return(value) => Some(value.clone()),
         ControlOutcome::Next => Some(AbstractValue::Unknown),
-        ControlOutcome::Raise | ControlOutcome::Break | ControlOutcome::Continue => None,
+        ControlOutcome::Raise(_) | ControlOutcome::Break | ControlOutcome::Continue => None,
     });
     (project_results(&accepting), join_return_values(values))
 }
@@ -262,10 +483,6 @@ fn process_statement_states(
         match stmt {
             Stmt::If(stmt_if) => states = branch_if(stmt_if, states, ctx),
             Stmt::Try(stmt_try) => states = branch_try(stmt_try, states, ctx),
-            Stmt::For(stmt_for) => states = branch_for(stmt_for, states, ctx),
-            Stmt::While(stmt_while) => states = branch_while(stmt_while, states, ctx),
-            Stmt::With(stmt_with) => states = branch_with(stmt_with, states, ctx),
-            Stmt::Match(stmt_match) => states = branch_match(stmt_match, states, ctx),
             Stmt::Return(returned) => {
                 for state in states.next_mut() {
                     let value = returned
@@ -277,9 +494,57 @@ fn process_statement_states(
                     state.outcome = ControlOutcome::Return(value);
                 }
             }
-            Stmt::Raise(_) => {
+            Stmt::Raise(raised) => {
                 for state in states.next_mut() {
-                    state.outcome = ControlOutcome::Raise;
+                    state.outcome = ControlOutcome::Raise(RaisedException {
+                        kind: raised_exception_kind(raised, &state.env),
+                        message: raised
+                            .exc
+                            .as_deref()
+                            .and_then(|exception| extract_exception_message(exception, &state.env)),
+                    });
+                }
+            }
+            Stmt::Assign(assign) => {
+                let incoming = states.take_next();
+                for state in incoming {
+                    if matches!(assign.value.as_ref(), Expr::If(_))
+                        && let Some(conditional) =
+                            analyze_conditional_assignment(assign, &state.env)
+                    {
+                        states
+                            .0
+                            .extend(branch_conditional_assignment(conditional, state));
+                    } else {
+                        states.0.extend(execute_assignment(assign, state, ctx));
+                    }
+                }
+            }
+            Stmt::For(stmt_for) => states = branch_for(stmt_for, states, ctx),
+            Stmt::With(stmt_with) => states = branch_with(stmt_with, states, ctx),
+            Stmt::Expr(stmt_expr) => {
+                for state in states.next_mut() {
+                    process_expression_statement(stmt_expr, &mut state.env);
+                }
+            }
+            Stmt::While(stmt_while) => states = branch_while(stmt_while, states, ctx),
+            Stmt::Match(stmt_match) => states = branch_match(stmt_match, states, ctx),
+            Stmt::Pass(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Assert(_)
+            | Stmt::IpyEscapeCommand(_) => {}
+            Stmt::AnnAssign(_)
+            | Stmt::FunctionDef(_)
+            | Stmt::ClassDef(_)
+            | Stmt::Delete(_)
+            | Stmt::TypeAlias(_)
+            | Stmt::AugAssign(_)
+            | Stmt::Import(_)
+            | Stmt::ImportFrom(_) => {
+                let changes = PotentialEnvChanges::collect(std::slice::from_ref(stmt));
+                for state in states.next_mut() {
+                    state.env = changes.apply(&state.env);
                 }
             }
             Stmt::Break(_) => {
@@ -292,111 +557,11 @@ fn process_statement_states(
                     state.outcome = ControlOutcome::Continue;
                 }
             }
-            Stmt::FunctionDef(_)
-            | Stmt::ClassDef(_)
-            | Stmt::Assign(_)
-            | Stmt::Delete(_)
-            | Stmt::TypeAlias(_)
-            | Stmt::AugAssign(_)
-            | Stmt::AnnAssign(_)
-            | Stmt::Assert(_)
-            | Stmt::Import(_)
-            | Stmt::ImportFrom(_)
-            | Stmt::Global(_)
-            | Stmt::Nonlocal(_)
-            | Stmt::Pass(_)
-            | Stmt::IpyEscapeCommand(_)
-            | Stmt::Expr(_) => {
-                for state in states.next_mut() {
-                    state
-                        .result
-                        .extend(process_statement(stmt, &mut state.env, ctx));
-                }
-            }
         }
         states.normalize();
     }
 
     states
-}
-
-fn branch_if(
-    stmt_if: &ruff_python_ast::StmtIf,
-    mut states: ExecutionStates,
-    ctx: &mut CallContext<'_>,
-) -> ExecutionStates {
-    let incoming = states.take_next();
-    let mut alternatives = states;
-
-    for mut state in incoming {
-        // Keep the original fixed-width syntax prepass until path-derived forms
-        // replace it in the later extraction change.
-        let argument_syntax = crate::templates::tags::analysis::forms::extract_if_argument_syntax(
-            stmt_if, &state.env, ctx,
-        );
-        state.attach_argument_syntax(argument_syntax.as_ref());
-
-        let mut unmatched = Some(state);
-        let mut clauses = Vec::with_capacity(stmt_if.elif_else_clauses.len() + 1);
-        clauses.push((Some(stmt_if.test.as_ref()), stmt_if.body.as_slice()));
-        clauses.extend(
-            stmt_if
-                .elif_else_clauses
-                .iter()
-                .map(|clause| (clause.test.as_ref(), clause.body.as_slice())),
-        );
-
-        for (test, body) in clauses {
-            let Some(state) = unmatched.take() else {
-                break;
-            };
-            let truth = test.and_then(static_truthiness);
-            if truth == Some(false) {
-                unmatched = Some(state);
-                continue;
-            }
-
-            let has_direct_raise = body.iter().any(|stmt| matches!(stmt, Stmt::Raise(_)));
-            let direct_guard =
-                test.filter(|_| direct_raise_exception(body).is_some())
-                    .map(|test| {
-                        crate::templates::tags::analysis::guards::extract_direct_guard(
-                            test, body, &state.env,
-                        )
-                    });
-
-            let mut taken = state.clone();
-            if let Some(test) = test.filter(|_| !has_direct_raise) {
-                taken.result.constraints.extend(
-                    crate::templates::tags::analysis::guards::extract_true_condition_constraints(
-                        test, &taken.env,
-                    ),
-                );
-            }
-            let mut branch = process_statement_states(body, ExecutionStates(vec![taken]), ctx);
-            alternatives.0.append(&mut branch.0);
-
-            if truth != Some(true) && test.is_some() {
-                let mut fallthrough = state;
-                if let Some(guard) = direct_guard {
-                    fallthrough.result.extend(guard.into());
-                } else if let Some(test) = test.filter(|_| !has_direct_raise) {
-                    fallthrough.result.constraints.extend(
-                        crate::templates::tags::analysis::guards::extract_false_condition_constraints(
-                            test, &fallthrough.env,
-                        ),
-                    );
-                }
-                unmatched = Some(fallthrough);
-            }
-        }
-
-        if let Some(state) = unmatched {
-            alternatives.0.push(state);
-        }
-    }
-
-    alternatives
 }
 
 fn branch_for(
@@ -410,38 +575,96 @@ fn branch_for(
         if let AbstractValue::Tuple(values) = iterator {
             let mut active = vec![state];
             for value in values {
-                let mut next_iteration = Vec::new();
-                for mut active_state in active {
-                    process_assignment_target(&stmt_for.target, &value, &mut active_state.env);
-                    let body = process_statement_states(
-                        &stmt_for.body,
-                        ExecutionStates(vec![active_state]),
-                        ctx,
+                let mut iteration = ExecutionStates(Vec::new());
+                for active_state in active {
+                    let assigned = execute_assignment_targets(
+                        std::slice::from_ref(stmt_for.target.as_ref()),
+                        &value,
+                        active_state,
                     );
-                    collect_loop_body(body, &mut states.0, &mut next_iteration);
+                    let mut branch =
+                        process_statement_states(&stmt_for.body, ExecutionStates(assigned), ctx);
+                    iteration.0.append(&mut branch.0);
                 }
-                normalize_state_destinations(&mut [&mut states.0, &mut next_iteration]);
-                active = next_iteration;
+                active = Vec::new();
+                for mut state in iteration.0 {
+                    match state.outcome {
+                        ControlOutcome::Next | ControlOutcome::Continue => {
+                            state.outcome = ControlOutcome::Next;
+                            active.push(state);
+                        }
+                        ControlOutcome::Break => {
+                            state.outcome = ControlOutcome::Next;
+                            states.0.push(state);
+                        }
+                        ControlOutcome::Return(_) | ControlOutcome::Raise(_) => {
+                            states.0.push(state);
+                        }
+                    }
+                }
+                normalize_state_destinations(&mut [&mut states.0, &mut active]);
                 if active.is_empty() {
                     break;
                 }
             }
-            let mut exhausted =
+            let mut after_loop =
                 process_statement_states(&stmt_for.orelse, ExecutionStates(active), ctx);
-            states.0.append(&mut exhausted.0);
+            states.0.append(&mut after_loop.0);
             continue;
         }
 
-        let mut body_entry = state;
+        let body_changes = PotentialEnvChanges::collect(&stmt_for.body);
+        let mut exhausted = vec![state.clone()];
         let mut target_changes = PotentialEnvChanges::default();
         target_changes.record_target(&stmt_for.target);
+        let mut body_entry = state;
         body_entry.env = target_changes.apply(&body_entry.env);
+        body_entry.outcome = ControlOutcome::Next;
         let body = process_statement_states(&stmt_for.body, ExecutionStates(vec![body_entry]), ctx);
-        let mut exhausted = Vec::new();
-        collect_loop_body(body, &mut states.0, &mut exhausted);
+        let mut repeatable = Vec::new();
+        for mut state in body.0 {
+            match state.outcome {
+                ControlOutcome::Next | ControlOutcome::Continue => {
+                    state.outcome = ControlOutcome::Next;
+                    repeatable.push(state);
+                }
+                ControlOutcome::Break => {
+                    state.outcome = ControlOutcome::Next;
+                    states.0.push(state);
+                }
+                ControlOutcome::Return(_) | ControlOutcome::Raise(_) => states.0.push(state),
+            }
+        }
+        for repeat_state in &repeatable {
+            let mut widened = repeat_state.clone();
+            widened.env = body_changes.apply(&widened.env);
+            exhausted.push(widened);
+        }
+        exhausted.append(&mut repeatable);
         let mut after_loop =
             process_statement_states(&stmt_for.orelse, ExecutionStates(exhausted), ctx);
         states.0.append(&mut after_loop.0);
+    }
+    states
+}
+
+fn branch_with(
+    stmt_with: &ruff_python_ast::StmtWith,
+    mut states: ExecutionStates,
+    ctx: &mut CallContext<'_>,
+) -> ExecutionStates {
+    let incoming = states.take_next();
+    for mut state in incoming {
+        let mut changes = PotentialEnvChanges::default();
+        for item in &stmt_with.items {
+            if let Some(target) = &item.optional_vars {
+                changes.record_target(target);
+            }
+        }
+        state.env = changes.apply(&state.env);
+        state.outcome = ControlOutcome::Next;
+        let mut body = process_statement_states(&stmt_with.body, ExecutionStates(vec![state]), ctx);
+        states.0.append(&mut body.0);
     }
     states
 }
@@ -459,54 +682,66 @@ fn branch_while(
             continue;
         }
 
-        // The original evaluator executes one representative loop iteration.
-        // Keep that bound while carrying exits as explicit outcomes.
+        let body_changes = PotentialEnvChanges::collect(&stmt_while.body);
+        let can_exhaust = static_truthiness(&stmt_while.test) != Some(true);
+        let mut exhausted = if can_exhaust {
+            vec![state.clone()]
+        } else {
+            Vec::new()
+        };
+        state.outcome = ControlOutcome::Next;
         let body = process_statement_states(&stmt_while.body, ExecutionStates(vec![state]), ctx);
-        let mut exhausted = Vec::new();
-        collect_loop_body(body, &mut states.0, &mut exhausted);
+        let mut repeatable = Vec::new();
+        for mut state in body.0 {
+            match state.outcome {
+                ControlOutcome::Next | ControlOutcome::Continue => {
+                    state.outcome = ControlOutcome::Next;
+                    repeatable.push(state);
+                }
+                ControlOutcome::Break => {
+                    state.outcome = ControlOutcome::Next;
+                    states.0.push(state);
+                }
+                ControlOutcome::Return(_) | ControlOutcome::Raise(_) => states.0.push(state),
+            }
+        }
+
+        // Execute one widened repeat. Its entry state summarizes all body
+        // changes, so another unroll cannot establish a sound hard fact.
+        let mut later = ExecutionStates(Vec::new());
+        for repeat_state in &repeatable {
+            let mut widened = repeat_state.clone();
+            widened.env = body_changes.apply(&widened.env);
+            if can_exhaust {
+                exhausted.push(widened.clone());
+            }
+            widened.outcome = ControlOutcome::Next;
+            let mut branch =
+                process_statement_states(&stmt_while.body, ExecutionStates(vec![widened]), ctx);
+            later.0.append(&mut branch.0);
+        }
+
+        for mut state in later.0 {
+            match state.outcome {
+                ControlOutcome::Next | ControlOutcome::Continue => {
+                    state.outcome = ControlOutcome::Next;
+                    if can_exhaust {
+                        exhausted.push(state);
+                    }
+                }
+                ControlOutcome::Break => {
+                    state.outcome = ControlOutcome::Next;
+                    states.0.push(state);
+                }
+                ControlOutcome::Return(_) | ControlOutcome::Raise(_) => states.0.push(state),
+            }
+        }
+        if can_exhaust {
+            exhausted.append(&mut repeatable);
+        }
         let mut after_loop =
             process_statement_states(&stmt_while.orelse, ExecutionStates(exhausted), ctx);
         states.0.append(&mut after_loop.0);
-    }
-    states
-}
-
-fn collect_loop_body(
-    body: ExecutionStates,
-    completed: &mut Vec<ExecutionState>,
-    repeatable: &mut Vec<ExecutionState>,
-) {
-    for mut state in body.0 {
-        match state.outcome {
-            ControlOutcome::Next | ControlOutcome::Continue => {
-                state.outcome = ControlOutcome::Next;
-                repeatable.push(state);
-            }
-            ControlOutcome::Break => {
-                state.outcome = ControlOutcome::Next;
-                completed.push(state);
-            }
-            ControlOutcome::Return(_) | ControlOutcome::Raise => completed.push(state),
-        }
-    }
-}
-
-fn branch_with(
-    stmt_with: &ruff_python_ast::StmtWith,
-    mut states: ExecutionStates,
-    ctx: &mut CallContext<'_>,
-) -> ExecutionStates {
-    let incoming = states.take_next();
-    for mut state in incoming {
-        let mut changes = PotentialEnvChanges::default();
-        for item in &stmt_with.items {
-            if let Some(target) = &item.optional_vars {
-                changes.record_target(target);
-            }
-        }
-        state.env = changes.apply(&state.env);
-        let mut body = process_statement_states(&stmt_with.body, ExecutionStates(vec![state]), ctx);
-        states.0.append(&mut body.0);
     }
     states
 }
@@ -521,9 +756,12 @@ fn branch_match(
         if let Some(constraints) = extract_match_constraints(stmt_match, &mut state.env) {
             state.result.constraints.extend(constraints);
         }
-        // Match exhaustiveness and pattern binding are handled by the later
-        // path-form change. Keep each original arm feasible here.
-        states.0.push(state.clone());
+
+        if stmt_match.cases.is_empty() {
+            states.0.push(state);
+            continue;
+        }
+
         for case in &stmt_match.cases {
             let mut branch =
                 process_statement_states(&case.body, ExecutionStates(vec![state.clone()]), ctx);
@@ -533,7 +771,170 @@ fn branch_match(
     states
 }
 
-#[derive(Default)]
+struct ConditionalAssignment<'a> {
+    target: &'a str,
+    predicate: SplitPredicate,
+    condition_truth: bool,
+    true_value: AbstractValue,
+    false_value: AbstractValue,
+}
+
+fn analyze_conditional_assignment<'a>(
+    assign: &'a StmtAssign,
+    env: &Env,
+) -> Option<ConditionalAssignment<'a>> {
+    let [target] = assign.targets.as_slice() else {
+        return None;
+    };
+    let Expr::If(conditional) = assign.value.as_ref() else {
+        return None;
+    };
+    let (predicate, condition_truth) =
+        crate::templates::tags::analysis::guards::split_predicate_condition(
+            &conditional.test,
+            env,
+        )?;
+    let true_value = eval_expr(&conditional.body, &mut env.clone());
+    let false_value = eval_expr(&conditional.orelse, &mut env.clone());
+    if !matches!(&true_value, AbstractValue::Int(_))
+        || !matches!(&false_value, AbstractValue::Int(_))
+    {
+        return None;
+    }
+    Some(ConditionalAssignment {
+        target: target.name_target()?,
+        predicate,
+        condition_truth,
+        true_value,
+        false_value,
+    })
+}
+
+fn branch_conditional_assignment(
+    conditional: ConditionalAssignment<'_>,
+    path: ExecutionState,
+) -> Vec<ExecutionState> {
+    let ConditionalAssignment {
+        target,
+        predicate,
+        condition_truth,
+        true_value,
+        false_value,
+    } = conditional;
+    let mut alternatives = Vec::with_capacity(2);
+    if let Some(mut taken) = path.clone().assume(&predicate, condition_truth) {
+        taken.env.set(target.to_string(), true_value);
+        alternatives.push(taken);
+    }
+    if let Some(mut path) = path.assume(&predicate, !condition_truth) {
+        path.env.set(target.to_string(), false_value);
+        alternatives.push(path);
+    }
+    alternatives
+}
+
+#[allow(clippy::too_many_lines)]
+fn branch_if(
+    stmt_if: &ruff_python_ast::StmtIf,
+    mut states: ExecutionStates,
+    ctx: &mut CallContext<'_>,
+) -> ExecutionStates {
+    let incoming = states.take_next();
+    let mut alternatives = states;
+
+    for mut path in incoming {
+        if let Some(argument_syntax) =
+            crate::templates::tags::analysis::forms::extract_if_argument_syntax(
+                stmt_if, &path.env, ctx,
+            )
+        {
+            path.result.extend(AnalysisResult {
+                argument_syntax: Some(argument_syntax),
+                ..AnalysisResult::default()
+            });
+        }
+
+        let mut unmatched = Some(path);
+        let mut clauses = Vec::with_capacity(stmt_if.elif_else_clauses.len() + 1);
+        clauses.push((Some(stmt_if.test.as_ref()), stmt_if.body.as_slice()));
+        clauses.extend(
+            stmt_if
+                .elif_else_clauses
+                .iter()
+                .map(|clause| (clause.test.as_ref(), clause.body.as_slice())),
+        );
+
+        for (test, body) in clauses {
+            let Some(path) = unmatched.take() else {
+                break;
+            };
+            let truth = test.and_then(static_truthiness);
+            if truth == Some(false) {
+                unmatched = Some(path);
+                continue;
+            }
+
+            let predicate = test.and_then(|test| {
+                crate::templates::tags::analysis::guards::split_predicate_condition(test, &path.env)
+            });
+            let has_direct_raise = body.iter().any(|stmt| matches!(stmt, Stmt::Raise(_)));
+            let direct_guard =
+                test.filter(|_| direct_raise_exception(body).is_some())
+                    .map(|test| {
+                        crate::templates::tags::analysis::guards::extract_direct_guard(
+                            test, body, &path.env,
+                        )
+                    });
+            let taken = path.clone();
+            let taken = match predicate.as_ref() {
+                Some((predicate, condition_truth)) => taken.assume(predicate, *condition_truth),
+                None => Some(taken),
+            };
+            if let Some(mut taken) = taken {
+                if let Some(test) = test.filter(|_| !has_direct_raise) {
+                    taken.result.constraints.extend(
+                        crate::templates::tags::analysis::guards::extract_true_condition_constraints(
+                            test, &taken.env,
+                        ),
+                    );
+                }
+                taken.outcome = ControlOutcome::Next;
+                let mut branch = process_statement_states(body, ExecutionStates(vec![taken]), ctx);
+                alternatives.0.append(&mut branch.0);
+            }
+
+            if truth != Some(true) && test.is_some() {
+                let fallthrough = path;
+                let fallthrough = match predicate.as_ref() {
+                    Some((predicate, condition_truth)) => {
+                        fallthrough.assume(predicate, !condition_truth)
+                    }
+                    None => Some(fallthrough),
+                };
+                if let Some(mut fallthrough) = fallthrough {
+                    if let Some(guard) = direct_guard {
+                        fallthrough.result.extend(guard.into());
+                    } else if let Some(test) = test.filter(|_| !has_direct_raise) {
+                        fallthrough.result.constraints.extend(
+                            crate::templates::tags::analysis::guards::extract_false_condition_constraints(
+                                test, &fallthrough.env,
+                            ),
+                        );
+                    }
+                    unmatched = Some(fallthrough);
+                }
+            }
+        }
+
+        if let Some(path) = unmatched {
+            alternatives.0.push(path);
+        }
+    }
+
+    alternatives
+}
+
+#[derive(Clone, Default)]
 struct PotentialEnvChanges {
     assigned_names: BTreeSet<String>,
     mutates_split_result: bool,
@@ -642,11 +1043,23 @@ impl PotentialEnvChanges {
             | Expr::BooleanLiteral(_)
             | Expr::NoneLiteral(_)
             | Expr::EllipsisLiteral(_)
-            | Expr::Attribute(_)
-            | Expr::Subscript(_)
             | Expr::Name(_)
             | Expr::Slice(_)
             | Expr::IpyEscapeCommand(_) => self.forget_all = true,
+            Expr::Attribute(attribute) => {
+                if let Some(name) = assignment_base_name(&attribute.value) {
+                    self.assigned_names.insert(name.to_string());
+                } else {
+                    self.forget_all = true;
+                }
+            }
+            Expr::Subscript(subscript) => {
+                if let Some(name) = assignment_base_name(&subscript.value) {
+                    self.assigned_names.insert(name.to_string());
+                } else {
+                    self.forget_all = true;
+                }
+            }
         }
     }
 
@@ -678,80 +1091,420 @@ impl PotentialEnvChanges {
     }
 }
 
+fn assignment_base_name(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Name(name) => Some(name.id.as_str()),
+        Expr::Attribute(attribute) => assignment_base_name(&attribute.value),
+        Expr::Subscript(subscript) => assignment_base_name(&subscript.value),
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Starred(_)
+        | Expr::List(_)
+        | Expr::Tuple(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => None,
+    }
+}
+
+fn raised_exception_kind(raised: &ruff_python_ast::StmtRaise, env: &Env) -> PendingException {
+    let Some(exception) = raised.exc.as_deref() else {
+        return PendingException::Unknown;
+    };
+    let exception_type = if let Expr::Call(call) = exception {
+        call.func.as_ref()
+    } else {
+        exception
+    };
+    let Some(name) = exception_type.name_target() else {
+        return PendingException::Unknown;
+    };
+    if !env.builtin_name_visible(name) {
+        return PendingException::Unknown;
+    }
+    BuiltinException::from_name(name).map_or(PendingException::Unknown, PendingException::Builtin)
+}
+
+#[derive(Clone, Copy)]
+enum HandlerMatch {
+    Always,
+    Maybe,
+    Never,
+}
+
+fn exception_handler_match(
+    pending: &PendingException,
+    handler_type: Option<&Expr>,
+    env: &Env,
+) -> HandlerMatch {
+    let Some(handler_type) = handler_type else {
+        return HandlerMatch::Always;
+    };
+    let pending = match pending {
+        PendingException::Builtin(kind) => kind,
+        PendingException::Unpack(_) => &BuiltinException::ValueError,
+        PendingException::Unknown => return HandlerMatch::Maybe,
+    };
+
+    match handler_type {
+        Expr::Name(name) => {
+            let name = name.id.as_str();
+            if !env.builtin_name_visible(name) {
+                return HandlerMatch::Maybe;
+            }
+            BuiltinException::from_name(name).map_or(HandlerMatch::Maybe, |handler| {
+                if handler.catches(*pending) {
+                    HandlerMatch::Always
+                } else {
+                    HandlerMatch::Never
+                }
+            })
+        }
+        Expr::Tuple(tuple) => {
+            let mut maybe = false;
+            for item in &tuple.elts {
+                match exception_handler_match(&PendingException::Builtin(*pending), Some(item), env)
+                {
+                    HandlerMatch::Always => return HandlerMatch::Always,
+                    HandlerMatch::Maybe => maybe = true,
+                    HandlerMatch::Never => {}
+                }
+            }
+            if maybe {
+                HandlerMatch::Maybe
+            } else {
+                HandlerMatch::Never
+            }
+        }
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Attribute(_)
+        | Expr::Subscript(_)
+        | Expr::Starred(_)
+        | Expr::List(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => HandlerMatch::Maybe,
+    }
+}
+
+#[allow(clippy::too_many_lines)]
 fn branch_try(
     stmt_try: &ruff_python_ast::StmtTry,
     mut states: ExecutionStates,
     ctx: &mut CallContext<'_>,
 ) -> ExecutionStates {
     let incoming = states.take_next();
-    // Outcomes completed before this try never enter its finalizer.
+    // Outcomes reached before this try do not enter its finalizer.
     let mut alternatives = ExecutionStates(Vec::new());
 
     for state in incoming {
         let body_changes = PotentialEnvChanges::collect(&stmt_try.body);
+        let body_may_raise_implicitly =
+            suite_may_raise_implicitly(&stmt_try.body, &state.env, &body_changes);
+        let mut body_entry = state.clone();
+        body_entry.outcome = ControlOutcome::Next;
         let mut body =
-            process_statement_states(&stmt_try.body, ExecutionStates(vec![state.clone()]), ctx);
-
-        let raised = body.take_outcome(|outcome| matches!(outcome, ControlOutcome::Raise));
+            process_statement_states(&stmt_try.body, ExecutionStates(vec![body_entry]), ctx);
+        let mut pending_exceptions =
+            body.take_outcome(|outcome| matches!(outcome, ControlOutcome::Raise(_)));
         let normal = ExecutionStates(body.take_next());
+        let mut completed = ExecutionStates(body.0);
         let mut success = process_statement_states(&stmt_try.orelse, normal, ctx);
-        alternatives.0.append(&mut body.0);
-        alternatives.0.append(&mut success.0);
-        // An explicit raise may escape the try or enter a matching handler.
-        alternatives.0.extend(raised.iter().cloned());
+        completed.0.append(&mut success.0);
 
+        if body_may_raise_implicitly {
+            let mut implicit_exception = state.clone();
+            implicit_exception.env = body_changes.apply(&state.env);
+            implicit_exception.outcome =
+                ControlOutcome::Raise(RaisedException::implicit(PendingException::Unknown));
+            pending_exceptions.push(implicit_exception);
+        }
         for exception in &stmt_try.handlers {
             let ruff_python_ast::ExceptHandler::ExceptHandler(clause) = exception;
-            for mut raised_state in raised.iter().cloned() {
-                raised_state.outcome = ControlOutcome::Next;
-                let mut handled = process_statement_states(
-                    &clause.body,
-                    ExecutionStates(vec![raised_state]),
-                    ctx,
-                );
-                alternatives.0.append(&mut handled.0);
+            let mut residual = Vec::new();
+            for mut raised in pending_exceptions {
+                let pending = match &raised.outcome {
+                    ControlOutcome::Raise(pending) => pending.clone(),
+                    ControlOutcome::Next
+                    | ControlOutcome::Return(_)
+                    | ControlOutcome::Break
+                    | ControlOutcome::Continue => {
+                        alternatives.0.push(raised);
+                        continue;
+                    }
+                };
+                let handler_match =
+                    exception_handler_match(&pending.kind, clause.type_.as_deref(), &raised.env);
+                if !matches!(handler_match, HandlerMatch::Always) {
+                    residual.push(raised.clone());
+                }
+                if !matches!(handler_match, HandlerMatch::Never) {
+                    let records_unpack_message = matches!(handler_match, HandlerMatch::Always)
+                        && handler_names_builtin_value_error(clause.type_.as_deref(), &raised.env);
+                    raised.outcome = ControlOutcome::Next;
+                    let mut handled =
+                        process_statement_states(&clause.body, ExecutionStates(vec![raised]), ctx);
+                    if records_unpack_message
+                        && let PendingException::Unpack(constraint) = pending.kind
+                        && let Some(message) = common_raised_message(&handled.0)
+                    {
+                        let diagnostic = ExtractedDiagnosticMessage {
+                            constraint: ExtractedDiagnosticConstraint::ArgumentCount(constraint),
+                            message,
+                        };
+                        for completed in &mut completed.0 {
+                            if !completed.result.diagnostic_messages.contains(&diagnostic) {
+                                completed
+                                    .result
+                                    .diagnostic_messages
+                                    .push(diagnostic.clone());
+                            }
+                        }
+                    }
+                    alternatives.0.append(&mut handled.0);
+                }
             }
-
-            // Any runtime operation may fail between changes. AST writes and
-            // mutations cover intermediate states that terminal environments
-            // cannot reveal when a later assignment restores the entry value.
-            let mut unknown_exception = state.clone();
-            unknown_exception.env = body_changes.apply(&state.env);
-            let mut handled = process_statement_states(
-                &clause.body,
-                ExecutionStates(vec![unknown_exception]),
-                ctx,
-            );
-            for handled_state in &mut handled.0 {
-                handled_state.result = state.result.clone();
+            pending_exceptions = residual;
+            if pending_exceptions.is_empty() {
+                break;
             }
-            alternatives.0.append(&mut handled.0);
         }
+        alternatives.0.append(&mut completed.0);
+        alternatives.0.append(&mut pending_exceptions);
 
         if !stmt_try.finalbody.is_empty() {
-            // An implicit exception also enters `finally` when no handler is
-            // present, or when it bypasses or arises within a handler.
             let mut finalizer_changes = body_changes;
             finalizer_changes.extend(&stmt_try.orelse);
             for handler in &stmt_try.handlers {
                 let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
                 finalizer_changes.extend(&handler.body);
+                if let Some(name) = &handler.name {
+                    finalizer_changes.assigned_names.insert(name.to_string());
+                }
             }
-            let mut implicit_raise = state.clone();
-            implicit_raise.env = finalizer_changes.apply(&state.env);
-            implicit_raise.outcome = ControlOutcome::Raise;
-            alternatives.0.push(implicit_raise);
+            let preceding_suite_may_raise = body_may_raise_implicitly
+                || suite_may_raise_implicitly(&stmt_try.orelse, &state.env, &finalizer_changes)
+                || stmt_try.handlers.iter().any(|handler| {
+                    let ruff_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    suite_may_raise_implicitly(&handler.body, &state.env, &finalizer_changes)
+                });
+            if preceding_suite_may_raise {
+                let mut implicit_raise = state.clone();
+                implicit_raise.env = finalizer_changes.apply(&state.env);
+                implicit_raise.outcome =
+                    ControlOutcome::Raise(RaisedException::implicit(PendingException::Unknown));
+                alternatives.0.push(implicit_raise);
+            }
         }
     }
 
+    alternatives.normalize();
     let mut result = if stmt_try.finalbody.is_empty() {
         alternatives
     } else {
         run_finally(&stmt_try.finalbody, alternatives, ctx)
     };
     result.0.append(&mut states.0);
-    result.normalize();
     result
+}
+
+fn suite_may_raise_implicitly(stmts: &[Stmt], env: &Env, changes: &PotentialEnvChanges) -> bool {
+    struct MayRaise<'env> {
+        env: &'env Env,
+        found: bool,
+    }
+
+    impl<'a> Visitor<'a> for MayRaise<'_> {
+        fn visit_stmt(&mut self, statement: &'a Stmt) {
+            match statement {
+                Stmt::Raise(_) => return,
+                Stmt::Import(_)
+                | Stmt::ImportFrom(_)
+                | Stmt::For(_)
+                | Stmt::While(_)
+                | Stmt::With(_)
+                | Stmt::Match(_)
+                | Stmt::Assert(_)
+                | Stmt::AugAssign(_)
+                | Stmt::Delete(_)
+                | Stmt::ClassDef(_) => {
+                    self.found = true;
+                    return;
+                }
+                Stmt::FunctionDef(_)
+                | Stmt::TypeAlias(_)
+                | Stmt::If(_)
+                | Stmt::Try(_)
+                | Stmt::Return(_)
+                | Stmt::Assign(_)
+                | Stmt::AnnAssign(_)
+                | Stmt::Expr(_)
+                | Stmt::Global(_)
+                | Stmt::Nonlocal(_)
+                | Stmt::Pass(_)
+                | Stmt::Break(_)
+                | Stmt::Continue(_)
+                | Stmt::IpyEscapeCommand(_) => {}
+            }
+            visitor::walk_stmt(self, statement);
+        }
+
+        fn visit_expr(&mut self, expression: &'a Expr) {
+            if let Expr::Call(call) = expression
+                && call.arguments.args.is_empty()
+                && call.arguments.keywords.is_empty()
+                && let Expr::Attribute(attribute) = call.func.as_ref()
+                && attribute.attr.as_str() == "split_contents"
+                && attribute
+                    .value
+                    .name_target()
+                    .is_some_and(|name| matches!(self.env.get(name), AbstractValue::Token))
+            {
+                // The normal evaluator models this intrinsic, including the
+                // unpack failure it can produce. Do not add a second unknown
+                // exception edge for its call or callee attribute.
+                return;
+            }
+            if matches!(
+                expression,
+                Expr::Call(_)
+                    | Expr::Attribute(_)
+                    | Expr::Subscript(_)
+                    | Expr::Named(_)
+                    | Expr::Await(_)
+                    | Expr::Yield(_)
+                    | Expr::YieldFrom(_)
+            ) {
+                self.found = true;
+                return;
+            }
+            visitor::walk_expr(self, expression);
+        }
+    }
+
+    let widened_env = changes.apply(env);
+    let mut may_raise = MayRaise {
+        env: &widened_env,
+        found: false,
+    };
+    for statement in stmts {
+        may_raise.visit_stmt(statement);
+        if may_raise.found {
+            return true;
+        }
+    }
+    false
+}
+
+fn handler_names_builtin_value_error(handler_type: Option<&Expr>, env: &Env) -> bool {
+    let Some(handler_type) = handler_type else {
+        return false;
+    };
+    match handler_type {
+        Expr::Name(name) => {
+            name.id.as_str() == "ValueError" && env.builtin_name_visible("ValueError")
+        }
+        Expr::Tuple(tuple) => {
+            tuple.elts.iter().all(|item| {
+                item.name_target().is_some_and(|name| {
+                    env.builtin_name_visible(name) && BuiltinException::from_name(name).is_some()
+                })
+            }) && tuple
+                .elts
+                .iter()
+                .any(|item| item.name_target() == Some("ValueError"))
+        }
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Attribute(_)
+        | Expr::Subscript(_)
+        | Expr::Starred(_)
+        | Expr::List(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => false,
+    }
+}
+
+fn common_raised_message(states: &[ExecutionState]) -> Option<ExtractedMessageTemplate> {
+    let mut messages = states.iter().map(|state| match &state.outcome {
+        ControlOutcome::Raise(raised) => raised.message.as_ref(),
+        ControlOutcome::Next
+        | ControlOutcome::Return(_)
+        | ControlOutcome::Break
+        | ControlOutcome::Continue => None,
+    });
+    let first = messages.next()??;
+    messages
+        .all(|message| message == Some(first))
+        .then(|| first.clone())
 }
 
 fn run_finally(
@@ -764,17 +1517,17 @@ fn run_finally(
         let mut saved = std::mem::replace(&mut state.outcome, ControlOutcome::Next);
         if let ControlOutcome::Return(value) = &mut saved {
             // Scalars are snapshots, but a returned list still shares its Python
-            // object with the finalizer. The evaluator cannot preserve that alias.
+            // object with the finalizer. We cannot preserve that alias here.
             value.forget_mutable();
         }
         let finalized = process_statement_states(finalbody, ExecutionStates(vec![state]), ctx);
         after_finally
             .0
-            .extend(finalized.0.into_iter().map(|mut finalized_state| {
-                if matches!(finalized_state.outcome, ControlOutcome::Next) {
-                    finalized_state.outcome = saved.clone();
+            .extend(finalized.0.into_iter().map(|mut state| {
+                if matches!(state.outcome, ControlOutcome::Next) {
+                    state.outcome = saved.clone();
                 }
-                finalized_state
+                state
             }));
     }
     after_finally.normalize();
@@ -782,11 +1535,25 @@ fn run_finally(
 }
 
 fn project_results(paths: &[&ExecutionState]) -> AnalysisResult {
+    let mut result = project_common_results(paths);
+    if matches!(
+        result.argument_syntax,
+        Some(TagArgumentSyntax::Forms {
+            coverage: crate::templates::tags::types::ArgumentFormCoverage::Complete,
+            ..
+        })
+    ) {
+        result.constraints = ExtractedTagConstraints::default();
+    }
+    result
+}
+
+fn project_common_results(paths: &[&ExecutionState]) -> AnalysisResult {
     let Some(first) = paths.first() else {
         return AnalysisResult::default();
     };
 
-    let mut constraints = project_constraints(paths);
+    let constraints = project_constraints(paths);
     let diagnostic_messages = project_diagnostics(paths, &constraints);
     let known_options = first.result.known_options.clone().filter(|options| {
         paths
@@ -806,12 +1573,6 @@ fn project_results(paths: &[&ExecutionState]) -> AnalysisResult {
     } else {
         None
     };
-    if matches!(argument_syntax, Some(TagArgumentSyntax::Forms { .. })) {
-        // Forms retain count/keyword correlation. Reapplying their branch-local
-        // facts as flat constraints both loses that correlation and duplicates
-        // diagnostics.
-        constraints = ExtractedTagConstraints::default();
-    }
 
     AnalysisResult {
         constraints,
@@ -980,8 +1741,9 @@ fn position_is_absent(position: SplitPosition, constraints: &[ArgumentCountConst
         return false;
     };
     match position {
-        SplitPosition::Forward(position) => maximum_count <= position,
-        SplitPosition::Backward(_) => maximum_count <= 1,
+        SplitPosition::Forward(position) | SplitPosition::Backward(position) => {
+            maximum_count <= position
+        }
     }
 }
 
@@ -1126,44 +1888,294 @@ fn static_truthiness(expr: &Expr) -> Option<bool> {
     }
 }
 
-fn process_statement(stmt: &Stmt, env: &mut Env, ctx: &mut CallContext<'_>) -> AnalysisResult {
-    match stmt {
-        Stmt::Assign(StmtAssign { targets, value, .. }) => {
-            let rhs = eval_expr_with_ctx(value, env, Some(ctx));
-            if let [target] = targets.as_slice() {
-                process_assignment_target(target, &rhs, env);
+fn execute_assignment(
+    assign: &StmtAssign,
+    mut state: ExecutionState,
+    ctx: &mut CallContext<'_>,
+) -> Vec<ExecutionState> {
+    let StmtAssign { targets, value, .. } = assign;
+    let pop_info = try_extract_pop_call(value);
+    let invalidates_split = expression_may_mutate_split(value, &state.env)
+        || unsupported_container_captures_split(value, &state.env)
+        || pop_info.as_ref().is_some_and(PopInfo::is_untracked);
+    let rhs = eval_expr_with_ctx(value, &mut state.env, Some(ctx));
+
+    if invalidates_split {
+        state.env.forget_split_results();
+    }
+    execute_assignment_targets(targets, &rhs, state)
+}
+
+fn execute_assignment_targets(
+    targets: &[Expr],
+    rhs: &AbstractValue,
+    state: ExecutionState,
+) -> Vec<ExecutionState> {
+    let mut active = vec![state];
+    let mut completed = Vec::new();
+    for target in targets {
+        let mut next = Vec::new();
+        for mut state in active {
+            let unpack_failure = if let Some(constraint) = split_unpack_constraint(target, rhs) {
+                let predicate = match &constraint {
+                    ArgumentCountConstraint::Exact(length) => SplitPredicate::LengthEquals(*length),
+                    ArgumentCountConstraint::Min(length) => SplitPredicate::LengthAtLeast(*length),
+                    ArgumentCountConstraint::Max(_) | ArgumentCountConstraint::OneOf(_) => {
+                        next.push(state);
+                        continue;
+                    }
+                };
+
+                let success = state.clone().assume(&predicate, true);
+                let failure = state.assume(&predicate, false).map(|mut state| {
+                    state.outcome = ControlOutcome::Raise(RaisedException {
+                        kind: PendingException::Unpack(constraint),
+                        message: None,
+                    });
+                    state
+                });
+                let Some(success) = success else {
+                    if let Some(failure) = failure {
+                        completed.push(failure);
+                    }
+                    continue;
+                };
+                state = success;
+                failure
+            } else {
+                None
+            };
+
+            let assignment = process_assignment_target(target, rhs, &mut state.env);
+            match assignment.failure {
+                AssignmentFailure::Never => next.push(state),
+                AssignmentFailure::Maybe => {
+                    let mut raised = state.clone();
+                    let mut changes = PotentialEnvChanges::default();
+                    changes.record_target(target);
+                    raised.env = changes.apply(&raised.env);
+                    raised.outcome =
+                        ControlOutcome::Raise(RaisedException::implicit(PendingException::Unknown));
+                    completed.push(raised);
+                    next.push(state);
+                }
+                AssignmentFailure::Definite => {
+                    state.outcome = ControlOutcome::Raise(RaisedException::implicit(
+                        PendingException::Builtin(BuiltinException::ValueError),
+                    ));
+                    completed.push(state);
+                }
+            }
+            if let Some(failure) = unpack_failure {
+                completed.push(failure);
             }
         }
-        Stmt::Expr(stmt_expr) => {
-            // Expression evaluation owns mutation effects such as `pop()`.
-            eval_expr_with_ctx(&stmt_expr.value, env, Some(ctx));
+        normalize_state_destinations(&mut [&mut completed, &mut next]);
+        active = next;
+        if active.is_empty() {
+            break;
         }
-        Stmt::FunctionDef(_)
-        | Stmt::ClassDef(_)
-        | Stmt::If(_)
-        | Stmt::With(_)
-        | Stmt::For(_)
-        | Stmt::While(_)
-        | Stmt::Match(_)
-        | Stmt::Try(_)
-        | Stmt::Return(_)
-        | Stmt::Delete(_)
-        | Stmt::TypeAlias(_)
-        | Stmt::AugAssign(_)
-        | Stmt::AnnAssign(_)
-        | Stmt::Raise(_)
-        | Stmt::Assert(_)
-        | Stmt::Import(_)
-        | Stmt::ImportFrom(_)
-        | Stmt::Global(_)
-        | Stmt::Nonlocal(_)
-        | Stmt::Pass(_)
-        | Stmt::Break(_)
-        | Stmt::Continue(_)
-        | Stmt::IpyEscapeCommand(_) => {}
+    }
+    completed.extend(active);
+    completed
+}
+
+fn assignment_sequence_elements(target: &Expr) -> Option<&[Expr]> {
+    match target {
+        Expr::Tuple(tuple) => Some(&tuple.elts),
+        Expr::List(list) => Some(&list.elts),
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Attribute(_)
+        | Expr::Subscript(_)
+        | Expr::Starred(_)
+        | Expr::Name(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => None,
+    }
+}
+
+fn split_unpack_constraint(
+    target: &Expr,
+    value: &AbstractValue,
+) -> Option<ArgumentCountConstraint> {
+    let AbstractValue::SplitResult(split) = value else {
+        return None;
+    };
+    let targets = assignment_sequence_elements(target)?;
+    if targets.is_empty() {
+        return None;
+    }
+    let fixed = targets
+        .iter()
+        .filter(|target| !matches!(target, Expr::Starred(_)))
+        .count();
+    Some(if fixed == targets.len() {
+        ArgumentCountConstraint::Exact(split.resolve_length(fixed))
+    } else {
+        ArgumentCountConstraint::Min(split.resolve_length(fixed))
+    })
+}
+
+fn process_expression_statement(stmt_expr: &ruff_python_ast::StmtExpr, env: &mut Env) {
+    let pop_info = try_extract_pop_call(&stmt_expr.value);
+    let invalidates_split = expression_may_mutate_split(&stmt_expr.value, env)
+        || pop_info.as_ref().is_some_and(PopInfo::is_untracked);
+    eval_expr(&stmt_expr.value, env);
+    if invalidates_split {
+        env.forget_split_results();
+    }
+}
+
+fn unsupported_container_captures_split(expr: &Expr, env: &Env) -> bool {
+    matches!(expr, Expr::List(_) | Expr::Set(_) | Expr::Dict(_))
+        && expression_contains_split(expr, env)
+}
+
+fn expression_may_mutate_split(expr: &Expr, env: &Env) -> bool {
+    struct EscapingSplit<'a> {
+        env: &'a Env,
+        found: bool,
     }
 
-    AnalysisResult::default()
+    impl<'a> Visitor<'a> for EscapingSplit<'_> {
+        fn visit_expr(&mut self, expression: &'a Expr) {
+            let Expr::Call(call) = expression else {
+                visitor::walk_expr(self, expression);
+                return;
+            };
+
+            if try_extract_pop_call(expression).is_none() {
+                let safe_builtin = call.func.name_target().is_some_and(|name| {
+                    matches!(name, "len" | "list") && self.env.builtin_name_visible(name)
+                });
+                let (split_receiver, read_only_method) =
+                    if let Expr::Attribute(attribute) = call.func.as_ref() {
+                        let receiver = eval_expr(&attribute.value, &mut self.env.clone());
+                        (
+                            matches!(receiver, AbstractValue::SplitResult(_)),
+                            matches!(receiver, AbstractValue::Str(_))
+                                && attribute.attr.as_str() == "join",
+                        )
+                    } else {
+                        (false, false)
+                    };
+                let split_argument =
+                    !safe_builtin
+                        && !read_only_method
+                        && (call
+                            .arguments
+                            .args
+                            .iter()
+                            .any(|argument| expression_contains_split(argument, self.env))
+                            || call.arguments.keywords.iter().any(|keyword| {
+                                expression_contains_split(&keyword.value, self.env)
+                            }));
+                if split_receiver || split_argument {
+                    self.found = true;
+                    return;
+                }
+            }
+            visitor::walk_expr(self, expression);
+        }
+    }
+
+    let mut escaping = EscapingSplit { env, found: false };
+    escaping.visit_expr(expr);
+    escaping.found
+}
+
+fn expression_contains_split(expr: &Expr, env: &Env) -> bool {
+    fn value_contains_split(value: &AbstractValue) -> bool {
+        match value {
+            AbstractValue::SplitResult(_) => true,
+            AbstractValue::Tuple(values) => values.iter().any(value_contains_split),
+            AbstractValue::Unknown
+            | AbstractValue::Token
+            | AbstractValue::Parser
+            | AbstractValue::SplitElement { .. }
+            | AbstractValue::SplitLength(_)
+            | AbstractValue::SplitPredicate(_)
+            | AbstractValue::Int(_)
+            | AbstractValue::Str(_) => false,
+        }
+    }
+
+    if value_contains_split(&eval_expr(expr, &mut env.clone())) {
+        return true;
+    }
+    match expr {
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .any(|element| expression_contains_split(element, env)),
+        Expr::List(list) => list
+            .elts
+            .iter()
+            .any(|element| expression_contains_split(element, env)),
+        Expr::Set(set) => set
+            .elts
+            .iter()
+            .any(|element| expression_contains_split(element, env)),
+        Expr::Starred(starred) => expression_contains_split(&starred.value, env),
+        Expr::Dict(dict) => dict.items.iter().any(|item| {
+            item.key
+                .as_ref()
+                .is_some_and(|key| expression_contains_split(key, env))
+                || expression_contains_split(&item.value, env)
+        }),
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Attribute(_)
+        | Expr::Subscript(_)
+        | Expr::Name(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => false,
+    }
 }
 
 /// Try to detect `token_kwargs(bits, parser)` calls and return the first
@@ -1183,105 +2195,195 @@ fn try_extract_token_kwargs_call(expr: &Expr) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Process an assignment target with the evaluated RHS value.
-fn process_assignment_target(target: &Expr, value: &AbstractValue, env: &mut Env) {
-    if let Some(name) = target.name_target() {
-        env.set(name.to_string(), value.clone());
-        return;
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AssignmentFailure {
+    Never,
+    Maybe,
+    Definite,
+}
+
+#[derive(Clone, Copy)]
+struct AssignmentTargetResult {
+    failure: AssignmentFailure,
+}
+
+impl AssignmentTargetResult {
+    fn applied() -> Self {
+        Self {
+            failure: AssignmentFailure::Never,
+        }
     }
 
-    if let Expr::Tuple(ExprTuple { elts, .. }) = target {
-        process_tuple_unpack(elts, value, env);
+    fn include(&mut self, result: Self) {
+        self.failure = match (self.failure, result.failure) {
+            (AssignmentFailure::Definite, _) | (_, AssignmentFailure::Definite) => {
+                AssignmentFailure::Definite
+            }
+            (AssignmentFailure::Maybe, _) | (_, AssignmentFailure::Maybe) => {
+                AssignmentFailure::Maybe
+            }
+            (AssignmentFailure::Never, AssignmentFailure::Never) => AssignmentFailure::Never,
+        };
     }
 }
 
-/// Handle tuple unpacking assignment.
-fn process_tuple_unpack(targets: &[Expr], value: &AbstractValue, env: &mut Env) {
+/// Process an assignment target with the evaluated RHS value.
+fn process_assignment_target(
+    target: &Expr,
+    value: &AbstractValue,
+    env: &mut Env,
+) -> AssignmentTargetResult {
+    if let Some(name) = target.name_target() {
+        env.set(name.to_string(), value.clone());
+        return AssignmentTargetResult::applied();
+    }
+
+    match target {
+        Expr::Tuple(ExprTuple { elts, .. }) | Expr::List(ExprList { elts, .. }) => {
+            process_tuple_unpack(elts, value, env)
+        }
+        Expr::Starred(starred) => process_assignment_target(&starred.value, value, env),
+        Expr::Attribute(attribute) => {
+            let mut target_env = env.clone();
+            match eval_expr(&attribute.value, &mut target_env) {
+                AbstractValue::SplitResult(_) => {
+                    env.forget_split_results();
+                    AssignmentTargetResult::applied()
+                }
+                AbstractValue::Token => {
+                    env.forget_tokens();
+                    AssignmentTargetResult::applied()
+                }
+                AbstractValue::Unknown
+                | AbstractValue::Parser
+                | AbstractValue::SplitElement { .. }
+                | AbstractValue::SplitLength(_)
+                | AbstractValue::Int(_)
+                | AbstractValue::Str(_)
+                | AbstractValue::SplitPredicate(_)
+                | AbstractValue::Tuple(_) => AssignmentTargetResult::applied(),
+            }
+        }
+        Expr::Subscript(subscript) => {
+            let mut target_env = env.clone();
+            let invalidates_split = matches!(
+                eval_expr(&subscript.value, &mut target_env),
+                AbstractValue::SplitResult(_)
+            );
+            if invalidates_split {
+                env.forget_split_results();
+            }
+            AssignmentTargetResult::applied()
+        }
+        Expr::BoolOp(_)
+        | Expr::Named(_)
+        | Expr::BinOp(_)
+        | Expr::Compare(_)
+        | Expr::UnaryOp(_)
+        | Expr::Lambda(_)
+        | Expr::If(_)
+        | Expr::Dict(_)
+        | Expr::Set(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_)
+        | Expr::Call(_)
+        | Expr::FString(_)
+        | Expr::TString(_)
+        | Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Name(_)
+        | Expr::Slice(_)
+        | Expr::IpyEscapeCommand(_) => AssignmentTargetResult::applied(),
+    }
+}
+
+/// Handle tuple unpacking assignment in Python's target order.
+fn process_tuple_unpack(
+    targets: &[Expr],
+    value: &AbstractValue,
+    env: &mut Env,
+) -> AssignmentTargetResult {
+    let star_index = targets
+        .iter()
+        .position(|target| matches!(target, Expr::Starred(_)));
+    let fixed = targets.len() - usize::from(star_index.is_some());
+    let mut result = AssignmentTargetResult::applied();
+
     match value {
         AbstractValue::Tuple(elements) => {
-            for (i, target) in targets.iter().enumerate() {
-                let elem = elements.get(i).cloned().unwrap_or(AbstractValue::Unknown);
-                if let Some(name) = target.name_target() {
-                    env.set(name.to_string(), elem);
+            if star_index.map_or(elements.len() != fixed, |_| elements.len() < fixed) {
+                result.failure = AssignmentFailure::Definite;
+                return result;
+            }
+            let after_star = star_index.map_or(0, |star| targets.len() - star - 1);
+            for (index, target) in targets.iter().enumerate() {
+                let element = match star_index {
+                    Some(star) if index == star => {
+                        AbstractValue::Tuple(elements[star..elements.len() - after_star].to_vec())
+                    }
+                    Some(star) if index > star => {
+                        elements[elements.len() - (targets.len() - index)].clone()
+                    }
+                    Some(_) | None => elements[index].clone(),
+                };
+                let assignment = process_assignment_target(target, &element, env);
+                let definite = assignment.failure == AssignmentFailure::Definite;
+                result.include(assignment);
+                if definite {
+                    break;
                 }
             }
         }
-
         AbstractValue::SplitResult(split) => {
             let split = *split;
-
-            // Find starred target index
-            let star_index = targets.iter().position(|t| matches!(t, Expr::Starred(_)));
-
-            if let Some(si) = star_index {
-                // Elements before the star
-                for (i, target) in targets[..si].iter().enumerate() {
-                    if let Some(name) = target.name_target() {
-                        env.set(
-                            name.to_string(),
-                            AbstractValue::SplitElement {
-                                index: split.resolve_index(i),
-                            },
-                        );
+            let after_star = star_index.map_or(0, |star| targets.len() - star - 1);
+            for (index, target) in targets.iter().enumerate() {
+                let element = match star_index {
+                    Some(star) if index == star => {
+                        let mut middle = split.after_slice_from(star);
+                        for _ in 0..after_star {
+                            middle = middle.after_pop_back();
+                        }
+                        AbstractValue::SplitResult(middle)
                     }
-                }
-
-                // Elements after the star (indexed from end)
-                let after_star = targets.len() - si - 1;
-
-                // The star target captures everything between pre-star and post-star elements.
-                // Its back_offset must include the trailing targets it doesn't contain.
-                if let Expr::Starred(starred) = &targets[si]
-                    && let Some(name) = starred.value.name_target()
-                {
-                    // Start from the current split sliced past the pre-star targets,
-                    // which preserves the original back_offset.
-                    let mut star_split = split.after_slice_from(si);
-                    // Add trailing targets as additional back pops
-                    for _ in 0..after_star {
-                        star_split = star_split.after_pop_back();
-                    }
-                    env.set(name.to_string(), AbstractValue::SplitResult(star_split));
-                }
-                for (j, target) in targets[si + 1..].iter().enumerate() {
-                    if let Some(name) = target.name_target() {
-                        env.set(
-                            name.to_string(),
-                            AbstractValue::SplitElement {
-                                index: SplitPosition::Backward(after_star - j),
-                            },
-                        );
-                    }
-                }
-            } else {
-                // No star: each target gets a SplitElement at its position
-                for (i, target) in targets.iter().enumerate() {
-                    if let Some(name) = target.name_target() {
-                        env.set(
-                            name.to_string(),
-                            AbstractValue::SplitElement {
-                                index: split.resolve_index(i),
-                            },
-                        );
-                    }
-                }
+                    Some(star) if index > star => AbstractValue::SplitElement {
+                        index: SplitPosition::Backward(targets.len() - index),
+                    },
+                    Some(_) | None => AbstractValue::SplitElement {
+                        index: split.resolve_index(index),
+                    },
+                };
+                result.include(process_assignment_target(target, &element, env));
             }
         }
-
         AbstractValue::Unknown
         | AbstractValue::Token
         | AbstractValue::Parser
         | AbstractValue::SplitElement { .. }
         | AbstractValue::SplitLength(_)
+        | AbstractValue::SplitPredicate(_)
         | AbstractValue::Int(_)
         | AbstractValue::Str(_) => {
             for target in targets {
-                if let Some(name) = target.name_target() {
-                    env.set(name.to_string(), AbstractValue::Unknown);
-                }
+                result.include(process_assignment_target(
+                    target,
+                    &AbstractValue::Unknown,
+                    env,
+                ));
             }
+            result.failure = AssignmentFailure::Maybe;
         }
     }
+    result
 }
 
 #[cfg(test)]
@@ -1322,6 +2424,7 @@ mod tests {
             .get(1)
             .map_or("token", |p| p.parameter.name.as_str());
         let mut env = Env::for_compile_function(parser_param, token_param);
+        env.set_builtin_name_scope(std::collections::HashSet::new());
         let mut ctx = CallContext {
             db: None,
             file: None,
@@ -1331,7 +2434,63 @@ mod tests {
     }
 
     #[test]
-    fn deduplicate_states_preserves_first_occurrence_order() {
+    fn normalization_caps_multiple_destinations_without_losing_an_outcome() {
+        let path = |marker, outcome| {
+            let mut env = Env::default();
+            env.set("marker".to_string(), AbstractValue::Int(marker));
+            let mut state = ExecutionState::from_env(env);
+            state.outcome = outcome;
+            state
+        };
+        let mut completed = (0_i64..16)
+            .flat_map(|marker| {
+                [
+                    ControlOutcome::Next,
+                    ControlOutcome::Return(AbstractValue::Int(marker)),
+                    ControlOutcome::Raise(RaisedException::implicit(PendingException::Unknown)),
+                    ControlOutcome::Break,
+                    ControlOutcome::Continue,
+                ]
+                .map(|outcome| path(marker, outcome))
+            })
+            .collect::<Vec<_>>();
+        let mut active = (80_i64..120)
+            .map(|marker| path(marker, ControlOutcome::Next))
+            .collect::<Vec<_>>();
+
+        normalize_state_destinations(&mut [&mut completed, &mut active]);
+
+        assert_eq!(completed.len() + active.len(), MAX_EXEC_STATES);
+        assert!(
+            completed
+                .iter()
+                .any(|state| matches!(state.outcome, ControlOutcome::Next))
+        );
+        assert!(!active.is_empty());
+        assert!(
+            completed
+                .iter()
+                .any(|state| matches!(state.outcome, ControlOutcome::Return(_)))
+        );
+        assert!(
+            completed
+                .iter()
+                .any(|state| matches!(state.outcome, ControlOutcome::Raise(_)))
+        );
+        assert!(
+            completed
+                .iter()
+                .any(|state| matches!(state.outcome, ControlOutcome::Break))
+        );
+        assert!(
+            completed
+                .iter()
+                .any(|state| matches!(state.outcome, ControlOutcome::Continue))
+        );
+    }
+
+    #[test]
+    fn deduplicate_paths_preserves_first_occurrence_order() {
         let path = |value| {
             let mut env = Env::default();
             env.set("value".to_string(), AbstractValue::Int(value));
@@ -1351,68 +2510,6 @@ mod tests {
         deduplicate_states(&mut paths);
 
         assert_eq!(paths, vec![first, second, third]);
-    }
-
-    #[test]
-    fn normalization_caps_multiple_destinations_without_losing_an_outcome() {
-        let outcomes = [
-            ControlOutcome::Next,
-            ControlOutcome::Return(AbstractValue::Int(1)),
-            ControlOutcome::Raise,
-            ControlOutcome::Break,
-            ControlOutcome::Continue,
-        ];
-        let mut completed = Vec::new();
-        let mut active = Vec::new();
-        for (index, outcome) in (0..100).zip(outcomes.iter().cycle()) {
-            let mut env = Env::default();
-            env.set("path".to_string(), AbstractValue::Int(index));
-            let state = ExecutionState {
-                env,
-                result: AnalysisResult::default(),
-                outcome: outcome.clone(),
-            };
-            if index % 2 == 0 {
-                completed.push(state);
-            } else {
-                active.push(state);
-            }
-        }
-
-        normalize_state_destinations(&mut [&mut completed, &mut active]);
-
-        assert_eq!(completed.len() + active.len(), MAX_EXEC_STATES);
-        for expected in outcomes {
-            assert!(
-                completed
-                    .iter()
-                    .chain(&active)
-                    .any(|state| outcome_index(&state.outcome) == outcome_index(&expected))
-            );
-        }
-    }
-
-    #[test]
-    fn return_expression_applies_pop_once() {
-        let function = parse_function(
-            "def compile(parser, token):\n    bits = token.split_contents()\n    return bits.pop(0)\n",
-        );
-        let mut env = Env::for_compile_function("parser", "token");
-        let mut ctx = CallContext {
-            db: None,
-            file: None,
-        };
-        let (_, value) = process_statements(&function.body, &mut env, &mut ctx);
-        assert_eq!(
-            value,
-            AbstractValue::SplitElement {
-                index: SplitPosition::Forward(0)
-            }
-        );
-        assert_eq!(
-            env.get("bits"),
-            &AbstractValue::SplitResult(TokenSplit::fresh().after_pop_front())
-        );
     }
 
     #[test]
@@ -2298,8 +3395,8 @@ def do_tag(parser, token):
     }
 
     #[test]
-    fn while_body_assignments_propagate() {
-        // Non-option while loop: body should be processed for env updates
+    fn unknown_while_body_assignments_are_widened() {
+        // A non-option loop may execute zero or many times.
         let env = eval_body(
             r"
 def do_tag(parser, token):
@@ -2309,23 +3406,13 @@ def do_tag(parser, token):
         val = remaining.pop(0)
 ",
         );
-        // The pop(0) assignment inside the while body should be processed
-        assert_eq!(
-            env.get("val"),
-            &AbstractValue::SplitElement {
-                index: SplitPosition::Forward(1)
-            }
-        );
-        // The pop(0) side effect should also mutate `remaining`
-        assert_eq!(
-            env.get("remaining"),
-            &AbstractValue::SplitResult(TokenSplit::fresh().after_slice_from(2))
-        );
+        assert_eq!(env.get("val"), &AbstractValue::Unknown);
+        assert_eq!(env.get("remaining"), &AbstractValue::Unknown);
     }
 
     #[test]
-    fn while_body_pop_side_effects() {
-        // Non-option while loop: pop side effects should be tracked
+    fn unknown_while_body_pop_side_effects_are_widened() {
+        // The loop count is unknown, so its final split offset is unknown.
         let env = eval_body(
             r"
 def do_tag(parser, token):
@@ -2335,11 +3422,7 @@ def do_tag(parser, token):
         remaining.pop(0)
 ",
         );
-        // The pop(0) inside the while body should mutate `remaining`
-        assert_eq!(
-            env.get("remaining"),
-            &AbstractValue::SplitResult(TokenSplit::fresh().after_slice_from(3))
-        );
+        assert_eq!(env.get("remaining"), &AbstractValue::Unknown);
     }
 
     #[test]
@@ -2387,6 +3470,77 @@ def do_tag(parser, token):
             env.get("result"),
             &AbstractValue::SplitResult(TokenSplit::fresh())
         );
+    }
+
+    #[test]
+    fn caught_flat_tuple_unpack_proves_exact_arity() {
+        let rule = analyze(
+            r#"
+def do_tag(parser, token):
+    try:
+        tag_name, name = token.split_contents()
+    except ValueError:
+        message = "requires exactly one argument"
+        raise TemplateSyntaxError(message)
+"#,
+        );
+        assert_eq!(
+            rule.arg_constraints,
+            vec![ArgumentCountConstraint::Exact(2)]
+        );
+        assert!(rule.diagnostic_messages.is_none());
+    }
+
+    #[test]
+    fn recovering_value_error_handler_does_not_prove_unpack_arity() {
+        let rule = analyze(
+            r"
+def do_tag(parser, token):
+    try:
+        tag_name, name = token.split_contents()
+    except ValueError:
+        name = None
+",
+        );
+        assert!(rule.arg_constraints.is_empty());
+    }
+
+    #[test]
+    fn runtime_operation_before_unpack_keeps_successful_arity_proof() {
+        let rule = analyze(
+            r#"
+def do_tag(parser, token):
+    try:
+        runtime_call()
+        tag_name, name = token.split_contents()
+    except ValueError:
+        raise TemplateSyntaxError("bad")
+"#,
+        );
+        assert_eq!(
+            rule.arg_constraints,
+            vec![ArgumentCountConstraint::Exact(2)]
+        );
+    }
+
+    #[test]
+    fn starred_and_nested_unpack_keep_their_outer_arity_proof() {
+        for (target, constraint) in [
+            ("tag_name, *names", vec![]),
+            (
+                "tag_name, first, *names",
+                vec![ArgumentCountConstraint::Min(2)],
+            ),
+            (
+                "tag_name, (first, second)",
+                vec![ArgumentCountConstraint::Exact(2)],
+            ),
+        ] {
+            let rule = analyze(&format!(
+                "def do_tag(parser, token):\n    try:\n        {target} = token.split_contents()\n    except ValueError:\n        raise TemplateSyntaxError('bad')\n"
+            ));
+            assert_eq!(rule.arg_constraints, constraint, "target: {target}");
+        }
     }
 
     #[test]

--- a/crates/djls-project/tests/extraction.rs
+++ b/crates/djls-project/tests/extraction.rs
@@ -2,6 +2,7 @@ use camino::Utf8Path;
 use djls_project::ArgumentCountConstraint;
 use djls_project::ArgumentFormCoverage;
 use djls_project::BodyAnalysisEvidence;
+use djls_project::ChoiceAt;
 use djls_project::FilterArity;
 use djls_project::ParameterRequirement;
 use djls_project::PythonModuleName;
@@ -79,6 +80,303 @@ fn execution_count(db: &TestDatabase, events: &[salsa::Event], query_name: &str)
             | salsa::EventKind::DidValidateInternedValue { .. } => false,
         })
         .count()
+}
+
+// Corpus: `no_params` in tests/template_tests/templatetags/custom.py —
+// `@register.simple_tag` with no user args, exercises simple_tag pipeline
+#[test]
+fn failed_known_for_target_skips_the_body_and_reaches_value_error() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    left = bits[1]
+    right = bits[2]
+    try:
+        for left, right in ((1,),):
+            return template.Node(left, right)
+    except ValueError:
+        if len(bits) != 3:
+            raise template.TemplateSyntaxError("expected two arguments")
+        return template.Node()
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "failed_for_target_tags").expect("fixture should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("failed_for_target_tags", "checked")];
+    assert_eq!(
+        rule.arg_constraints,
+        vec![ArgumentCountConstraint::Exact(3)]
+    );
+}
+
+#[test]
+fn maybe_failing_for_target_keeps_body_and_handler_paths() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    try:
+        for left, right in (runtime_value(),):
+            if len(bits) != 2:
+                raise template.TemplateSyntaxError("body count")
+            return template.Node(left, right)
+    except ValueError:
+        if len(bits) != 3:
+            raise template.TemplateSyntaxError("handler count")
+        return template.Node()
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "maybe_for_target_tags").expect("fixture should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("maybe_for_target_tags", "checked")];
+    assert_eq!(
+        rule.arg_constraints,
+        vec![ArgumentCountConstraint::OneOf(vec![2, 3])]
+    );
+}
+
+#[test]
+fn split_result_for_value_keeps_its_unpack_arity_provenance() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    try:
+        for tag_name, argument in (token.split_contents(),):
+            return template.Node(argument)
+    except ValueError:
+        raise template.TemplateSyntaxError("expected one argument")
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "split_for_target_tags").expect("fixture should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("split_for_target_tags", "checked")];
+    assert_eq!(
+        rule.arg_constraints,
+        vec![ArgumentCountConstraint::Exact(2)]
+    );
+}
+
+#[test]
+fn negative_length_facts_survive_untracked_branches() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    if len(bits) != 2:
+        if len(bits) == 2:
+            return template.Node()
+    assert runtime_condition()
+    if len(bits) == 3:
+        return template.Node()
+    raise template.TemplateSyntaxError("bad count")
+"#;
+    let result = extract_source(source, "negative_length_tags").expect("fixture should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("negative_length_tags", "checked")];
+    assert_eq!(
+        rule.arg_constraints,
+        vec![ArgumentCountConstraint::Exact(3)]
+    );
+}
+
+#[test]
+fn split_unpack_executes_at_its_statement_and_through_nested_control_flow() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def nested(parser, token):
+    try:
+        if runtime_condition():
+            tag, value = token.split_contents()
+        else:
+            tag, value = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError("nested needs one argument")
+    return Node(value)
+@register.tag
+def prefixed(parser, token):
+    bits = token.split_contents()
+    try:
+        bits.pop(0)
+        first, second = bits
+    except ValueError:
+        raise template.TemplateSyntaxError("prefixed needs two arguments")
+    return Node(first, second)
+@register.tag
+def starred(parser, token):
+    try:
+        tag, *middle, last = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError("starred needs an argument")
+    return Node(middle, last)
+"#;
+    let result = extract_source(source, "statement_unpack").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("statement_unpack", "nested")].arg_constraints,
+        vec![ArgumentCountConstraint::Exact(2)]
+    );
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("statement_unpack", "prefixed")].arg_constraints,
+        vec![ArgumentCountConstraint::Exact(3)]
+    );
+    let starred = &result.tag_rules[&SymbolKey::tag("statement_unpack", "starred")];
+    assert_eq!(
+        starred.arg_constraints,
+        vec![ArgumentCountConstraint::Min(2)]
+    );
+    assert_eq!(starred.diagnostic_messages.as_ref().map(Vec::len), Some(1));
+}
+
+#[test]
+fn failed_known_tuple_unpack_does_not_write_before_value_error() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    bits.pop(0)
+    try:
+        bits, missing = (token.split_contents(),)
+    except ValueError:
+        first, second = bits
+        return template.Node(first, second)
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "failed_unpack_tags").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("failed_unpack_tags", "checked")].arg_constraints,
+        vec![ArgumentCountConstraint::Exact(3)]
+    );
+}
+
+#[test]
+fn opaque_call_before_known_unpack_reaches_each_matching_handler() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    try:
+        callback()
+        left, right = (1,)
+    except IndexError:
+        if len(bits) != 4:
+            raise template.TemplateSyntaxError("index count")
+        return template.Node()
+    except ValueError:
+        if len(bits) != 3:
+            raise template.TemplateSyntaxError("value count")
+        return template.Node()
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "implicit_raise_tags").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("implicit_raise_tags", "checked")].arg_constraints,
+        vec![ArgumentCountConstraint::OneOf(vec![3, 4])]
+    );
+}
+
+#[test]
+fn rebound_token_method_call_retains_unknown_exception_edge() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    token = callback
+    try:
+        token.split_contents()
+        left, right = (1,)
+    except IndexError:
+        if len(bits) != 4:
+            raise template.TemplateSyntaxError("index count")
+        return template.Node()
+    except ValueError:
+        if len(bits) != 3:
+            raise template.TemplateSyntaxError("value count")
+        return template.Node()
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "rebound_token_tags").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("rebound_token_tags", "checked")].arg_constraints,
+        vec![ArgumentCountConstraint::OneOf(vec![3, 4])]
+    );
+}
+
+#[test]
+fn opaque_token_receiver_keeps_its_evaluation_exception() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def checked(parser, token):
+    bits = token.split_contents()
+    try:
+        (callback(), token)[1].split_contents()
+        left, right = (1,)
+    except IndexError:
+        if len(bits) != 4:
+            raise template.TemplateSyntaxError("index count")
+        return template.Node()
+    except ValueError:
+        if len(bits) != 3:
+            raise template.TemplateSyntaxError("value count")
+        return template.Node()
+    raise template.TemplateSyntaxError("unreachable")
+"#;
+    let result = extract_source(source, "receiver_tags").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("receiver_tags", "checked")].arg_constraints,
+        vec![ArgumentCountConstraint::OneOf(vec![3, 4])]
+    );
+}
+
+#[test]
+fn unpack_outcomes_respect_target_order_and_finally_override() {
+    let source = r#"
+from django import template
+register = template.Library()
+@register.tag
+def ordered(parser, token):
+    bits = token.split_contents()
+    try:
+        saved = first, second = bits
+    except ValueError:
+        if len(saved) == 3:
+            return Node()
+        raise template.TemplateSyntaxError("bad count")
+    return Node(first, second)
+@register.tag
+def finalized(parser, token):
+    bits = token.split_contents()
+    try:
+        tag, value = bits
+    except ValueError:
+        raise template.TemplateSyntaxError("bad count")
+    finally:
+        return Node()
+"#;
+    let result = extract_source(source, "unpack_control").expect("fixture should extract");
+    for tag in ["ordered", "finalized"] {
+        assert!(
+            result
+                .tag_rules
+                .get(&SymbolKey::tag("unpack_control", tag))
+                .is_none_or(|rule| !rule
+                    .arg_constraints
+                    .contains(&ArgumentCountConstraint::Exact(2)))
+        );
+    }
 }
 
 #[test]
@@ -185,14 +483,8 @@ def early(parser, token):
     return template.Node()
 "#;
     let result = extract_source(source, "helper_returns").expect("fixture should extract");
-    let key = SymbolKey::tag("helper_returns", "early");
-    assert!(
-        result.tag_rules.contains_key(&key),
-        "{:#?}",
-        result.tag_rules
-    );
     assert_eq!(
-        result.tag_rules[&key].arg_constraints,
+        result.tag_rules[&SymbolKey::tag("helper_returns", "early")].arg_constraints,
         vec![ArgumentCountConstraint::Exact(2)]
     );
 }
@@ -326,8 +618,6 @@ def nested(parser, token):
     );
 }
 
-// Corpus: `no_params` in tests/template_tests/templatetags/custom.py —
-// `@register.simple_tag` with no user args, exercises simple_tag pipeline
 #[test]
 fn extract_bundle_simple_tag() {
     let result = extract_source(CUSTOM_SOURCE, "tests.template_tests.templatetags.custom")
@@ -381,6 +671,578 @@ fn extract_bundle_block_tag() {
 }
 
 // (b) Edge case — empty source has no registrations
+#[test]
+fn pipeline_tuple_unpack_extracts_exact_arity_for_local_registrations() {
+    let source = r#"
+from django import template
+register = template.Library()
+
+@register.tag
+def stylesheet(parser, token):
+    try:
+        tag_name, name = token.split_contents()
+    except ValueError:
+        message = "%r requires exactly one argument"
+        raise template.TemplateSyntaxError(message % token.split_contents()[0])
+    return Node(name)
+
+@register.tag
+def javascript(parser, token):
+    try:
+        tag_name, name = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError("requires exactly one argument")
+    return Node(name)
+"#;
+    let result = extract_source(source, "pipeline_tags").expect("pipeline rules should extract");
+    for tag in ["stylesheet", "javascript"] {
+        let rule = &result.tag_rules[&SymbolKey::tag("pipeline_tags", tag)];
+        assert_eq!(
+            rule.arg_constraints,
+            vec![ArgumentCountConstraint::Exact(2)],
+            "tag: {tag}"
+        );
+        assert_eq!(rule.diagnostic_messages.as_ref().map(Vec::len), Some(1));
+    }
+}
+
+#[test]
+fn tuple_unpack_message_requires_reachable_builtin_value_error_handler() {
+    let cases = [
+        r#"
+def compile_tag(parser, token):
+    try:
+        tag_name, value = token.split_contents()
+    except Exception:
+        raise SyntaxError("broad handler")
+    except ValueError:
+        raise SyntaxError("dead value handler")
+register.tag("checked", compile_tag)
+"#,
+        r#"
+ValueError = RuntimeError
+def compile_tag(parser, token):
+    try:
+        tag_name, value = token.split_contents()
+    except ValueError:
+        raise SyntaxError("shadowed handler")
+register.tag("checked", compile_tag)
+"#,
+        r#"
+def compile_tag(parser, token):
+    try:
+        tag_name, value = token.split_contents()
+    except ValueError:
+        raise SyntaxError("possibly shadowed handler")
+register.tag("checked", compile_tag)
+from external import *
+"#,
+    ];
+    for declarations in cases {
+        let source =
+            format!("from django import template\nregister = template.Library()\n{declarations}");
+        let result = extract_source(&source, "handler_tags").expect("fixture should extract");
+        let rule = &result.tag_rules[&SymbolKey::tag("handler_tags", "checked")];
+        assert_eq!(
+            rule.arg_constraints,
+            vec![ArgumentCountConstraint::Exact(2)]
+        );
+        assert!(rule.diagnostic_messages.as_ref().is_none_or(Vec::is_empty));
+    }
+}
+
+#[test]
+fn tuple_unpack_recovering_broad_handler_accepts_wrong_arity() {
+    let source = r#"
+from django import template
+register = template.Library()
+def compile_tag(parser, token):
+    try:
+        tag_name, value = token.split_contents()
+    except:
+        return template.Node()
+    return template.Node()
+register.tag("checked", compile_tag)
+"#;
+    let result = extract_source(source, "recovering_handler_tags").expect("fixture should extract");
+    let key = SymbolKey::tag("recovering_handler_tags", "checked");
+    assert!(result.tag_rules.get(&key).is_none_or(|rule| {
+        !rule
+            .arg_constraints
+            .contains(&ArgumentCountConstraint::Exact(2))
+    }));
+}
+
+#[test]
+fn compressor_constants_and_negated_membership_extract_typed_constraints() {
+    let source = r#"
+from django import template
+register = template.Library()
+OUTPUT_FILE = "file"
+OUTPUT_INLINE = "inline"
+OUTPUT_PRELOAD = "preload"
+OUTPUT_MODES = (OUTPUT_FILE, OUTPUT_INLINE, OUTPUT_PRELOAD)
+
+@register.tag
+def compress(parser, token):
+    args = token.split_contents()
+    if not len(args) in (2, 3, 4):
+        raise template.TemplateSyntaxError("wrong count")
+    mode = args[2]
+    if mode not in OUTPUT_MODES:
+        raise template.TemplateSyntaxError("wrong mode")
+"#;
+    let result = extract_source(source, "compress_tags").expect("compress rule should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("compress_tags", "compress")];
+    assert_eq!(
+        rule.arg_constraints,
+        vec![ArgumentCountConstraint::OneOf(vec![2, 3, 4])]
+    );
+    assert_eq!(
+        rule.choice_at_constraints,
+        vec![ChoiceAt {
+            position: djls_project::SplitPosition::Forward(2),
+            values: vec![
+                "file".to_string(),
+                "inline".to_string(),
+                "preload".to_string()
+            ],
+        }]
+    );
+}
+
+#[test]
+fn class_literal_dictionary_keys_extract_as_choices() {
+    let source = r#"
+from django import template
+register = template.Library()
+OPEN = "{%"
+CLOSE = "%}"
+class TagNode:
+    mapping = {"open": OPEN, "close": CLOSE}
+
+@register.tag
+def templatetag(parser, token):
+    bits = token.contents.split()
+    tag = bits[1]
+    if tag not in TagNode.mapping:
+        raise template.TemplateSyntaxError("bad tag")
+"#;
+    let result = extract_source(source, "class_tags").expect("class choices should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("class_tags", "templatetag")];
+    assert_eq!(
+        rule.choice_at_constraints,
+        vec![ChoiceAt {
+            position: djls_project::SplitPosition::Forward(1),
+            values: vec!["open".to_string(), "close".to_string()],
+        }]
+    );
+}
+
+#[test]
+fn static_choices_reject_rebinding_local_shadowing_and_mutation() {
+    let cases = [
+        r#"
+VALUES = ("old", "other")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+VALUES = ("new",)
+"#,
+        r#"
+VALUES = ("old", "other")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+    VALUES = runtime_value()
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ["old", "other"]
+VALUES.append("new")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ("old", "other")
+def helper(value=(VALUES := ("new",))):
+    pass
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ("old", "other")
+from config import VALUES
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#,
+    ];
+    for declarations in cases {
+        let source =
+            format!("from django import template\nregister = template.Library()\n{declarations}");
+        let result = extract_source(&source, "shadow_tags").expect("fixture should extract");
+        let key = SymbolKey::tag("shadow_tags", "checked");
+        assert!(
+            result
+                .tag_rules
+                .get(&key)
+                .is_none_or(|rule| rule.choice_at_constraints.is_empty()),
+            "source:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn mutable_local_collections_do_not_become_persistent_exact_choices() {
+    for (assignment, mutation) in [
+        ("choices = ['a']", "choices.append('b')"),
+        ("choices: list[str] = ['a']", "choices.append('b')"),
+        ("choices, = (['a'],)", "choices.append('b')"),
+        ("choices: set[str] = {'a'}", "choices.add('b')"),
+    ] {
+        let source = format!(
+            r#"
+from django import template
+register = template.Library()
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    {assignment}
+    {mutation}
+    if bits[1] not in choices:
+        raise SyntaxError("bad")
+register.tag("mutable", compile_tag)
+
+def direct_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in {{"a", "b"}}:
+        raise SyntaxError("bad")
+register.tag("direct", direct_tag)
+"#
+        );
+        let result = extract_source(&source, "mutable_tags").expect("fixture should extract");
+        assert!(
+            result
+                .tag_rules
+                .get(&SymbolKey::tag("mutable_tags", "mutable"))
+                .is_none_or(|rule| rule.choice_at_constraints.is_empty()),
+            "source:\n{source}"
+        );
+        assert_eq!(
+            result.tag_rules[&SymbolKey::tag("mutable_tags", "direct")].choice_at_constraints,
+            vec![ChoiceAt {
+                position: djls_project::SplitPosition::Forward(1),
+                values: vec!["a".to_string(), "b".to_string()],
+            }],
+            "source:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn module_tuple_constants_preserve_repeated_positions() {
+    let source = r#"
+from django import template
+register = template.Library()
+VALUES = ("a", "a", "b")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    first, second, third = VALUES
+    if bits[1] not in (second,):
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#;
+    let result = extract_source(source, "tuple_tags").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("tuple_tags", "checked")].choice_at_constraints,
+        vec![ChoiceAt {
+            position: djls_project::SplitPosition::Forward(1),
+            values: vec!["a".to_string()],
+        }]
+    );
+}
+
+#[test]
+fn unresolved_star_import_only_invalidates_earlier_module_constants() {
+    for (declarations, expected_values) in [
+        (
+            r#"
+VALUES = ("old", "other")
+from external import *
+"#,
+            Vec::new(),
+        ),
+        (
+            r#"
+from external import *
+VALUES = ("new", "other")
+"#,
+            vec!["new".to_string(), "other".to_string()],
+        ),
+    ] {
+        let source = format!(
+            r#"
+from django import template
+register = template.Library()
+{declarations}
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#
+        );
+        let result = extract_source(&source, "star_tags").expect("fixture should extract");
+        let choices = result
+            .tag_rules
+            .get(&SymbolKey::tag("star_tags", "checked"))
+            .map_or(&[][..], |rule| rule.choice_at_constraints.as_slice());
+        let expected = if expected_values.is_empty() {
+            Vec::new()
+        } else {
+            vec![ChoiceAt {
+                position: djls_project::SplitPosition::Forward(1),
+                values: expected_values,
+            }]
+        };
+        assert_eq!(choices, expected, "source:\n{source}");
+    }
+}
+
+#[test]
+fn module_constants_do_not_replace_known_compile_parameters() {
+    let source = r#"
+from django import template
+register = template.Library()
+parser = "module parser"
+token = "module token"
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if len(bits) != 2:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#;
+    let result = extract_source(source, "parameter_tags").expect("fixture should extract");
+    assert_eq!(
+        result.tag_rules[&SymbolKey::tag("parameter_tags", "checked")].arg_constraints,
+        vec![ArgumentCountConstraint::Exact(2)]
+    );
+}
+
+#[test]
+fn static_choices_reject_nested_global_and_function_scope_bindings() {
+    let cases = [
+        r#"
+VALUES = ("old", "other")
+def replace():
+    global VALUES
+    VALUES = ("new",)
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ("old", "other")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+    import config as VALUES
+register.tag("checked", compile_tag)
+"#,
+        r#"
+package = ("old", "other")
+def replace():
+    global package
+    import package.child
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in package:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ("old", "other")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+    if (VALUES := runtime_value()):
+        pass
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ("old", "other")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+    try:
+        runtime_call()
+    except RuntimeError as VALUES:
+        pass
+register.tag("checked", compile_tag)
+"#,
+        r#"
+VALUES = ("old", "other")
+def compile_tag(parser, token):
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+    match runtime_value():
+        case [*VALUES]:
+            pass
+register.tag("checked", compile_tag)
+"#,
+    ];
+    for declarations in cases {
+        let source =
+            format!("from django import template\nregister = template.Library()\n{declarations}");
+        let result = extract_source(&source, "scope_tags").expect("fixture should extract");
+        let key = SymbolKey::tag("scope_tags", "checked");
+        assert!(
+            result
+                .tag_rules
+                .get(&key)
+                .is_none_or(|rule| rule.choice_at_constraints.is_empty()),
+            "source:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn unrelated_nested_writes_and_read_only_global_declarations_keep_tuple_choices() {
+    let source = r#"
+from django import template
+register = template.Library()
+VALUES = ("old", "other")
+UNRELATED = ("before",)
+def helper():
+    global VALUES, UNRELATED
+    UNRELATED = ("after",)
+    return VALUES
+
+def compile_tag(parser, token):
+    global VALUES
+    bits = token.split_contents()
+    if bits[1] not in VALUES:
+        raise SyntaxError("bad")
+register.tag("checked", compile_tag)
+"#;
+    let result = extract_source(source, "global_tags").expect("fixture should extract");
+    let rule = &result.tag_rules[&SymbolKey::tag("global_tags", "checked")];
+    assert_eq!(rule.choice_at_constraints[0].values, ["old", "other"]);
+}
+
+#[test]
+fn class_choices_reject_mutations_calls_and_dynamic_keys() {
+    let cases = [
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+TagNode.mapping["close"] = VALUE
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": make_value()}
+"#,
+        r"
+class TagNode:
+    mapping = {dynamic_key: VALUE}
+",
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+TagNode = replacement
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+alias = TagNode.mapping
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+consume(TagNode.mapping)
+"#,
+        r#"
+class TagNode(Base, metaclass=Meta):
+    mapping = {"open": VALUE}
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+    alias = mapping
+    alias["close"] = VALUE
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+Alias = TagNode
+Alias.mapping["close"] = VALUE
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+consume([TagNode])
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+def expose():
+    return {"node": TagNode}
+"#,
+        r#"
+@decorate
+class TagNode:
+    mapping = {"open": VALUE}
+"#,
+        r#"
+class TagNode(Base, **OPTIONS):
+    mapping = {"open": VALUE}
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+    for mapping in values:
+        pass
+"#,
+        r#"
+class TagNode:
+    mapping = {"open": VALUE}
+    import package.mapping as mapping
+"#,
+    ];
+    for declarations in cases {
+        let source = format!(
+            "from django import template\nregister = template.Library()\n{declarations}\n\ndef compile_tag(parser, token):\n    bits = token.split_contents()\n    if bits[1] not in TagNode.mapping:\n        raise SyntaxError('bad')\nregister.tag('checked', compile_tag)\n"
+        );
+        let result =
+            extract_source(&source, "class_negative_tags").expect("fixture should extract");
+        let key = SymbolKey::tag("class_negative_tags", "checked");
+        assert!(
+            result
+                .tag_rules
+                .get(&key)
+                .is_none_or(|rule| rule.choice_at_constraints.is_empty()),
+            "source:\n{source}"
+        );
+    }
+}
+
 #[test]
 fn extract_bundle_empty_source() {
     let result = extract_source("", "test.module").expect("empty extraction fixture should build");

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -11,6 +11,9 @@ tag_rules:
       - position:
           Backward: 2
         value: as
+      - position:
+          Backward: 4
+        value: for
     choice_at_constraints: []
     known_options: ~
     argument_syntax:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
@@ -235,7 +235,18 @@ tag_rules:
     arg_constraints:
       - Exact: 2
     required_keywords: []
-    choice_at_constraints: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - openblock
+          - closeblock
+          - openvariable
+          - closevariable
+          - openbrace
+          - closebrace
+          - opencomment
+          - closecomment
     known_options: ~
     diagnostic_messages:
       - constraint:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -11,6 +11,9 @@ tag_rules:
       - position:
           Backward: 2
         value: as
+      - position:
+          Backward: 4
+        value: for
     choice_at_constraints: []
     known_options: ~
     argument_syntax:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
@@ -268,7 +268,18 @@ tag_rules:
     arg_constraints:
       - Exact: 2
     required_keywords: []
-    choice_at_constraints: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - openblock
+          - closeblock
+          - openvariable
+          - closevariable
+          - openbrace
+          - closebrace
+          - opencomment
+          - closecomment
     known_options: ~
     diagnostic_messages:
       - constraint:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -11,6 +11,9 @@ tag_rules:
       - position:
           Backward: 2
         value: as
+      - position:
+          Backward: 4
+        value: for
     choice_at_constraints: []
     known_options: ~
     argument_syntax:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
@@ -282,7 +282,18 @@ tag_rules:
     arg_constraints:
       - Exact: 2
     required_keywords: []
-    choice_at_constraints: []
+    choice_at_constraints:
+      - position:
+          Forward: 1
+        values:
+          - openblock
+          - closeblock
+          - openvariable
+          - closevariable
+          - openbrace
+          - closebrace
+          - opencomment
+          - closecomment
     known_options: ~
     diagnostic_messages:
       - constraint:

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-compressor__compressor__templatetags__compress.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-compressor__compressor__templatetags__compress.py.snap
@@ -4,13 +4,58 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "compressor.templatetags.compress::tag::compress":
-    arg_constraints: []
+    arg_constraints:
+      - OneOf:
+          - 2
+          - 3
+          - 4
     required_keywords: []
-    choice_at_constraints: []
+    choice_at_constraints:
+      - position:
+          Forward: 2
+        values:
+          - file
+          - inline
+          - preload
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            OneOf:
+              - 2
+              - 3
+              - 4
+        message:
+          PercentFormat:
+            template: "%r tag requires either one, two or three arguments."
+            args:
+              - SplitElement:
+                  Forward: 0
+      - constraint:
+          ChoiceAt:
+            position:
+              Forward: 2
+            values:
+              - file
+              - inline
+              - preload
+        message:
+          PercentFormat:
+            template: "%r's second argument must be '%s' or '%s'."
+            args:
+              - SplitElement:
+                  Forward: 0
+              - String: file
+              - String: inline
     argument_syntax:
       Parameters:
         - name: kind
+          requirement: required
+          kind: Variable
+        - name: arg2
+          requirement: required
+          kind: Variable
+        - name: arg3
           requirement: required
           kind: Variable
     as_var: keep

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-oscar__src__oscar__templatetags__display_tags.py.snap
@@ -18,10 +18,21 @@ tag_rules:
         variadic_keyword: ~
     as_var: strip
   "src.oscar.templatetags.display_tags::tag::iffeature":
-    arg_constraints: []
+    arg_constraints:
+      - Exact: 2
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "%r tag requires a single argument"
+            args:
+              - SplitElement:
+                  Forward: 0
     argument_syntax:
       Parameters:
         - name: app_name

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-pipeline__pipeline__templatetags__pipeline.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-pipeline__pipeline__templatetags__pipeline.py.snap
@@ -4,10 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "pipeline.templatetags.pipeline::tag::javascript":
-    arg_constraints: []
+    arg_constraints:
+      - Exact: 2
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "%r requires exactly one argument: the name of a group in the PIPELINE.JAVASVRIPT setting"
+            args:
+              - SplitElement:
+                  Forward: 0
     argument_syntax:
       Parameters:
         - name: name
@@ -15,10 +26,21 @@ tag_rules:
           kind: Variable
     as_var: keep
   "pipeline.templatetags.pipeline::tag::stylesheet":
-    arg_constraints: []
+    arg_constraints:
+      - Exact: 2
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          PercentFormat:
+            template: "%r requires exactly one argument: the name of a group in the PIPELINE.STYLESHEETS setting"
+            args:
+              - SplitElement:
+                  Forward: 0
     argument_syntax:
       Parameters:
         - name: name

--- a/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__package__templatetags__package_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__djangopackages.org__package__templatetags__package_tags.py.snap
@@ -4,10 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "package.templatetags.package_tags::tag::participant_url":
-    arg_constraints: []
+    arg_constraints:
+      - Exact: 3
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 3
+        message:
+          PercentFormat:
+            template: "%r tag requires exactly two arguments"
+            args:
+              - SplitElement:
+                  Forward: 0
     argument_syntax:
       Parameters:
         - name: repo

--- a/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__linkding__bookmarks__templatetags__shared.py.snap
@@ -18,7 +18,8 @@ tag_rules:
         variadic_keyword: kwargs
     as_var: strip
   "bookmarks.templatetags.shared::tag::formhelp":
-    arg_constraints: []
+    arg_constraints:
+      - Exact: 2
     required_keywords: []
     choice_at_constraints: []
     known_options: ~

--- a/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__plugins__templatetags__misago_plugins.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__misago__misago__plugins__templatetags__misago_plugins.py.snap
@@ -9,6 +9,12 @@ tag_rules:
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          Static: "hasplugins tag syntax is \"hasplugins OUTLET_NAME\""
     argument_syntax:
       Parameters:
         - name: arg1
@@ -21,6 +27,12 @@ tag_rules:
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Exact: 2
+        message:
+          Static: "pluginoutlet tag syntax is \"pluginoutlet OUTLET_NAME\""
     argument_syntax:
       Parameters:
         - name: arg1

--- a/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__hierarkey_form.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__pretix__src__pretix__control__templatetags__hierarkey_form.py.snap
@@ -4,10 +4,21 @@ expression: "sorted_snapshot(&bundle).expect(\"corpus extraction snapshot should
 ---
 tag_rules:
   "src.pretix.control.templatetags.hierarkey_form::tag::propagated":
-    arg_constraints: []
+    arg_constraints:
+      - Min: 3
     required_keywords: []
     choice_at_constraints: []
     known_options: ~
+    diagnostic_messages:
+      - constraint:
+          ArgumentCount:
+            Min: 3
+        message:
+          PercentFormat:
+            template: "%r tag requires at least three arguments"
+            args:
+              - SplitElement:
+                  Forward: 0
     argument_syntax:
       Parameters:
         - name: event

--- a/crates/djls-semantic/tests/django_compilation.rs
+++ b/crates/djls-semantic/tests/django_compilation.rs
@@ -25,14 +25,14 @@ const MISSED_DIAGNOSTICS: &[&str] = &[
     "for_wrong_separator",
     // option extraction records names but not the assignments required after with
     "include_missing_assignment",
+    // the static choice list is mutated after assignment, so its value becomes Unknown
+    "mutated_choice_invalid_value",
     // unpropagated helper raises admit the later split reassignment while caught-exception fallback widens bits to unknown
     "restored_exception_state_missing",
     // registration is curried through functools.partial; there is no standard-library search root and no model of partial, so the library is open
     "stdlib_partial_context_invalid",
     // callable is wrapped by a functools.wraps decorator; the wrapper is unresolvable and the library is open
     "stdlib_wrapped_invalid",
-    // class-dictionary membership is not extracted as a set of allowed choices
-    "templatetag_invalid_choice",
     // implicit-exception fallback enters finally with unknown bits and its return makes that path accepting
     "unhandled_exception_finally_missing",
     // token_kwargs invalidates the remaining bits without modeling assignment parsing

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -3233,13 +3233,40 @@ fn corpus_stylesheet_requires_one_argument() {
             .expect("template validation should run"),
         []
     );
-    // Missed diagnostic: caught tuple-unpack errors do not constrain arity.
-    // pipeline.py raises "requires exactly one argument: the name of a group".
-    assert_eq!(
-        collect_errors(&db, "/invalid.html", "{% stylesheet %}")
-            .expect("template validation should run"),
-        []
+    let errors = collect_errors(&db, "/invalid.html", "{% stylesheet %}")
+        .expect("template validation should run");
+    assert!(
+        matches!(
+            errors.as_slice(),
+            [ValidationError::ExtractedRuleViolation { tag, message, .. }]
+                if tag == "stylesheet" && message.contains("requires exactly one argument")
+        ),
+        "{errors:?}"
     );
+}
+
+#[test]
+fn corpus_javascript_requires_one_argument() {
+    let corpus = Corpus::require().expect("synced corpus should be available");
+    let (specs, _) =
+        build_specs_from_extraction(&corpus, &corpus.root().join("repos/django-pipeline"))
+            .expect("corpus specs should build");
+    let db = TestDatabase::new().with_projectless_tag_specs(specs);
+    let errors = collect_errors(&db, "/valid.html", "{% javascript 'main' %}")
+        .expect("template validation should run");
+    assert!(errors.is_empty(), "{errors:?}");
+    for template in ["{% javascript %}", "{% javascript 'main' extra %}"] {
+        let errors =
+            collect_errors(&db, "/invalid.html", template).expect("template validation should run");
+        assert!(
+            matches!(
+                errors.as_slice(),
+                [ValidationError::ExtractedRuleViolation { tag, message, .. }]
+                    if tag == "javascript" && message.contains("requires exactly one argument")
+            ),
+            "{errors:?}"
+        );
+    }
 }
 
 #[test]
@@ -3258,16 +3285,19 @@ fn corpus_compress_requires_a_known_output_mode() {
         .expect("template validation should run"),
         []
     );
-    // Missed diagnostic: module constants are not extracted as choices.
-    // compress.py raises "second argument must be 'file' or 'inline'".
-    assert_eq!(
-        collect_errors(
-            &db,
-            "/invalid.html",
-            "{% compress css bogus %}x{% endcompress %}"
-        )
-        .expect("template validation should run"),
-        []
+    let errors = collect_errors(
+        &db,
+        "/invalid.html",
+        "{% compress css bogus %}x{% endcompress %}",
+    )
+    .expect("template validation should run");
+    assert!(
+        matches!(
+            errors.as_slice(),
+            [ValidationError::ExtractedRuleViolation { tag, message, .. }]
+                if tag == "compress" && message.contains("second argument must be 'file' or 'inline'")
+        ),
+        "{errors:?}"
     );
 }
 

--- a/tests/compilation/compilation_tags.py
+++ b/tests/compilation/compilation_tags.py
@@ -343,3 +343,76 @@ def unhandled_exception_finally(parser, token):
 
 
 register.tag("unhandled_exception_finally", unhandled_exception_finally)
+
+
+@register.tag
+def stylesheet(parser, token):
+    try:
+        tag_name, name = token.split_contents()
+    except ValueError:
+        message = "%r requires exactly one argument"
+        raise template.TemplateSyntaxError(message % token.split_contents()[0])
+    return template.Node()
+
+
+@register.tag
+def javascript(parser, token):
+    try:
+        tag_name, name = token.split_contents()
+    except ValueError:
+        message = "%r requires exactly one argument"
+        raise template.TemplateSyntaxError(message % token.split_contents()[0])
+    return template.Node()
+
+
+@register.tag
+def mutated_choice(parser, token):
+    bits = token.split_contents()
+    choices = ["old"]
+    choices.append("new")
+    if len(bits) != 2 or bits[1] not in choices:
+        raise template.TemplateSyntaxError("mutated_choice argument is invalid")
+    return template.Node()
+
+
+OUTPUT_FILE = "file"
+OUTPUT_INLINE = "inline"
+OUTPUT_PRELOAD = "preload"
+OUTPUT_MODES = (OUTPUT_FILE, OUTPUT_INLINE, OUTPUT_PRELOAD)
+
+
+@register.tag
+def compress(parser, token):
+    parser.parse(("endcompress",))
+    parser.delete_first_token()
+    args = token.split_contents()
+    if not len(args) in (2, 3, 4):
+        raise template.TemplateSyntaxError("compress expects one to three arguments")
+    if len(args) >= 3:
+        if args[2] not in OUTPUT_MODES:
+            raise template.TemplateSyntaxError("compress mode is invalid")
+    return template.Node()
+
+
+class DjangoTemplateTagNode(template.Node):
+    mapping = {
+        "openblock": "{%",
+        "closeblock": "%}",
+        "openvariable": "{{",
+        "closevariable": "}}",
+        "openbrace": "{",
+        "closebrace": "}",
+        "opencomment": "{#",
+        "closecomment": "#}",
+    }
+
+
+@register.tag
+def templatetag(parser, token):
+    bits = token.contents.split()
+    if len(bits) != 2:
+        raise template.TemplateSyntaxError("templatetag expects one argument")
+    tag = bits[1]
+    if tag not in DjangoTemplateTagNode.mapping:
+        raise template.TemplateSyntaxError("templatetag argument is invalid")
+    return DjangoTemplateTagNode()

--- a/tests/compilation/templates/authored_compress_default.html
+++ b/tests/compilation/templates/authored_compress_default.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress css %}x{% endcompress %}

--- a/tests/compilation/templates/authored_compress_empty.html
+++ b/tests/compilation/templates/authored_compress_empty.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress %}x{% endcompress %}

--- a/tests/compilation/templates/authored_compress_extra.html
+++ b/tests/compilation/templates/authored_compress_extra.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress css file bundle extra %}x{% endcompress %}

--- a/tests/compilation/templates/authored_compress_file.html
+++ b/tests/compilation/templates/authored_compress_file.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress css file %}x{% endcompress %}

--- a/tests/compilation/templates/authored_compress_inline.html
+++ b/tests/compilation/templates/authored_compress_inline.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress css inline %}x{% endcompress %}

--- a/tests/compilation/templates/authored_compress_invalid_mode.html
+++ b/tests/compilation/templates/authored_compress_invalid_mode.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress css bogus %}x{% endcompress %}

--- a/tests/compilation/templates/authored_compress_preload_name.html
+++ b/tests/compilation/templates/authored_compress_preload_name.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% compress css preload bundle %}x{% endcompress %}

--- a/tests/compilation/templates/authored_javascript_empty.html
+++ b/tests/compilation/templates/authored_javascript_empty.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% javascript %}

--- a/tests/compilation/templates/authored_javascript_extra.html
+++ b/tests/compilation/templates/authored_javascript_extra.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% javascript 'main' extra %}

--- a/tests/compilation/templates/authored_javascript_valid.html
+++ b/tests/compilation/templates/authored_javascript_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% javascript 'main' %}

--- a/tests/compilation/templates/authored_stylesheet_empty.html
+++ b/tests/compilation/templates/authored_stylesheet_empty.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% stylesheet %}

--- a/tests/compilation/templates/authored_stylesheet_extra.html
+++ b/tests/compilation/templates/authored_stylesheet_extra.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% stylesheet 'main' extra %}

--- a/tests/compilation/templates/authored_stylesheet_valid.html
+++ b/tests/compilation/templates/authored_stylesheet_valid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% stylesheet 'main' %}

--- a/tests/compilation/templates/authored_templatetag_closeblock.html
+++ b/tests/compilation/templates/authored_templatetag_closeblock.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag closeblock %}

--- a/tests/compilation/templates/authored_templatetag_closebrace.html
+++ b/tests/compilation/templates/authored_templatetag_closebrace.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag closebrace %}

--- a/tests/compilation/templates/authored_templatetag_closecomment.html
+++ b/tests/compilation/templates/authored_templatetag_closecomment.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag closecomment %}

--- a/tests/compilation/templates/authored_templatetag_closevariable.html
+++ b/tests/compilation/templates/authored_templatetag_closevariable.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag closevariable %}

--- a/tests/compilation/templates/authored_templatetag_invalid.html
+++ b/tests/compilation/templates/authored_templatetag_invalid.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag foo %}

--- a/tests/compilation/templates/authored_templatetag_openblock.html
+++ b/tests/compilation/templates/authored_templatetag_openblock.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag openblock %}

--- a/tests/compilation/templates/authored_templatetag_openbrace.html
+++ b/tests/compilation/templates/authored_templatetag_openbrace.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag openbrace %}

--- a/tests/compilation/templates/authored_templatetag_opencomment.html
+++ b/tests/compilation/templates/authored_templatetag_opencomment.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag opencomment %}

--- a/tests/compilation/templates/authored_templatetag_openvariable.html
+++ b/tests/compilation/templates/authored_templatetag_openvariable.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% templatetag openvariable %}

--- a/tests/compilation/templates/mutated_choice_appended_value.html
+++ b/tests/compilation/templates/mutated_choice_appended_value.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% mutated_choice new %}

--- a/tests/compilation/templates/mutated_choice_invalid_value.html
+++ b/tests/compilation/templates/mutated_choice_invalid_value.html
@@ -1,0 +1,2 @@
+{% load compilation_tags %}
+{% mutated_choice invalid %}

--- a/tests/compilation/templates/templatetag_closeblock.html
+++ b/tests/compilation/templates/templatetag_closeblock.html
@@ -1,0 +1,1 @@
+{% templatetag closeblock %}

--- a/tests/compilation/templates/templatetag_closebrace.html
+++ b/tests/compilation/templates/templatetag_closebrace.html
@@ -1,0 +1,1 @@
+{% templatetag closebrace %}

--- a/tests/compilation/templates/templatetag_closecomment.html
+++ b/tests/compilation/templates/templatetag_closecomment.html
@@ -1,0 +1,1 @@
+{% templatetag closecomment %}

--- a/tests/compilation/templates/templatetag_closevariable.html
+++ b/tests/compilation/templates/templatetag_closevariable.html
@@ -1,0 +1,1 @@
+{% templatetag closevariable %}

--- a/tests/compilation/templates/templatetag_openbrace.html
+++ b/tests/compilation/templates/templatetag_openbrace.html
@@ -1,0 +1,1 @@
+{% templatetag openbrace %}

--- a/tests/compilation/templates/templatetag_opencomment.html
+++ b/tests/compilation/templates/templatetag_opencomment.html
@@ -1,0 +1,1 @@
+{% templatetag opencomment %}

--- a/tests/compilation/templates/templatetag_openvariable.html
+++ b/tests/compilation/templates/templatetag_openvariable.html
@@ -1,0 +1,1 @@
+{% templatetag openvariable %}

--- a/tests/fixtures/django-facts/compilation-5.2.json
+++ b/tests/fixtures/django-facts/compilation-5.2.json
@@ -3,6 +3,30 @@
     "and_false_side_is_disjunction.html": {
       "result": "compiled"
     },
+    "authored_compress_default.html": {
+      "result": "compiled"
+    },
+    "authored_compress_empty.html": {
+      "error": "compress expects one to three arguments",
+      "result": "failed"
+    },
+    "authored_compress_extra.html": {
+      "error": "compress expects one to three arguments",
+      "result": "failed"
+    },
+    "authored_compress_file.html": {
+      "result": "compiled"
+    },
+    "authored_compress_inline.html": {
+      "result": "compiled"
+    },
+    "authored_compress_invalid_mode.html": {
+      "error": "compress mode is invalid",
+      "result": "failed"
+    },
+    "authored_compress_preload_name.html": {
+      "result": "compiled"
+    },
     "authored_default_duplicate_binding.html": {
       "result": "compiled"
     },
@@ -17,6 +41,17 @@
       "result": "failed"
     },
     "authored_empty_valid.html": {
+      "result": "compiled"
+    },
+    "authored_javascript_empty.html": {
+      "error": "'javascript' requires exactly one argument",
+      "result": "failed"
+    },
+    "authored_javascript_extra.html": {
+      "error": "'javascript' requires exactly one argument",
+      "result": "failed"
+    },
+    "authored_javascript_valid.html": {
       "result": "compiled"
     },
     "authored_keyword_only_missing.html": {
@@ -56,6 +91,45 @@
       "result": "failed"
     },
     "authored_required_valid.html": {
+      "result": "compiled"
+    },
+    "authored_stylesheet_empty.html": {
+      "error": "'stylesheet' requires exactly one argument",
+      "result": "failed"
+    },
+    "authored_stylesheet_extra.html": {
+      "error": "'stylesheet' requires exactly one argument",
+      "result": "failed"
+    },
+    "authored_stylesheet_valid.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_closeblock.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_closebrace.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_closecomment.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_closevariable.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_invalid.html": {
+      "error": "templatetag argument is invalid",
+      "result": "failed"
+    },
+    "authored_templatetag_openblock.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_openbrace.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_opencomment.html": {
+      "result": "compiled"
+    },
+    "authored_templatetag_openvariable.html": {
       "result": "compiled"
     },
     "authored_varargs_unexpected_keyword.html": {
@@ -228,6 +302,13 @@
     "lorem_words.html": {
       "result": "compiled"
     },
+    "mutated_choice_appended_value.html": {
+      "result": "compiled"
+    },
+    "mutated_choice_invalid_value.html": {
+      "error": "mutated_choice argument is invalid",
+      "result": "failed"
+    },
     "none_end_name_uses_default_missing.html": {
       "error": "'default_panel' did not receive value(s) for the argument(s): 'title'",
       "result": "failed"
@@ -284,9 +365,30 @@
     "stdlib_wrapped_valid.html": {
       "result": "compiled"
     },
+    "templatetag_closeblock.html": {
+      "result": "compiled"
+    },
+    "templatetag_closebrace.html": {
+      "result": "compiled"
+    },
+    "templatetag_closecomment.html": {
+      "result": "compiled"
+    },
+    "templatetag_closevariable.html": {
+      "result": "compiled"
+    },
     "templatetag_invalid_choice.html": {
       "error": "Invalid templatetag argument: 'foo'. Must be one of: ['openblock', 'closeblock', 'openvariable', 'closevariable', 'openbrace', 'closebrace', 'opencomment', 'closecomment']",
       "result": "failed"
+    },
+    "templatetag_openbrace.html": {
+      "result": "compiled"
+    },
+    "templatetag_opencomment.html": {
+      "result": "compiled"
+    },
+    "templatetag_openvariable.html": {
+      "result": "compiled"
     },
     "templatetag_valid.html": {
       "result": "compiled"


### PR DESCRIPTION
Extract tag argument choices from static containers and class dictionaries, and derive argument counts from unpacking guarded by caught exceptions. This fixes Pipeline's `stylesheet` and `javascript` validation, Compressor output modes, and Django's `templatetag` choices.

## Evidence

Removed `templatetag_invalid_choice` from the disagreement register after Django and project-backed validation both rejected it. `firstof_missing` was already resolved in the preceding change.

Five added parsers cover stylesheet/javascript counts, compression modes, class-dictionary choices, and a mutated choice list. Authored and builtin templates exercise every delimiter choice. Ordinary corpus regressions check stylesheet, compress, and javascript calls.

`mutated_choice_invalid_value` remains a missed diagnostic: local list contents and `append` mutations stay unknown during extraction. Its observed Django rejection is retained in the comparison.

## Compilation fixtures

Adds 31 templates under `tests/compilation/templates/`. Django facts were regenerated through the existing fixtures session.

- `authored_compress_default`
- `authored_compress_empty`
- `authored_compress_extra`
- `authored_compress_file`
- `authored_compress_inline`
- `authored_compress_invalid_mode`
- `authored_compress_preload_name`
- `authored_javascript_empty`
- `authored_javascript_extra`
- `authored_javascript_valid`
- `authored_stylesheet_empty`
- `authored_stylesheet_extra`
- `authored_stylesheet_valid`
- `authored_templatetag_closeblock`
- `authored_templatetag_closebrace`
- `authored_templatetag_closecomment`
- `authored_templatetag_closevariable`
- `authored_templatetag_invalid`
- `authored_templatetag_openblock`
- `authored_templatetag_openbrace`
- `authored_templatetag_opencomment`
- `authored_templatetag_openvariable`
- `mutated_choice_appended_value`
- `mutated_choice_invalid_value`
- `templatetag_closeblock`
- `templatetag_closebrace`
- `templatetag_closecomment`
- `templatetag_closevariable`
- `templatetag_openbrace`
- `templatetag_opencomment`
- `templatetag_openvariable`

## Validation

Passed at this PR head:

- `cargo test -q` (includes the Django compilation comparison)
- `just clippy`
- `just fmt`
- `just lint`