### PR TITLE
Reduce Python settings branch identity overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Added a "Why a language server?" docs page.
 - **Internal**: Compare DJLS template tag validation against Django's template compilation on a dedicated fixture project.
 - **Internal**: Extraction snapshots now record library symbol inventories and whether they are open; a corpus census counts registration sites and records candidates that cannot be matched to extracted definitions.
+- **Internal**: Added cold settings-analysis benchmarks for conditional bindings and corpus projects.
 
 ### Changed
 
+- Reduced analysis time for Django settings with many conditional branches.
 - Removed eager Django Model scanning and Model Graph construction from project discovery and cache warm-up.
 - Swapped the order of environments when automatically finding a project's Python interpreter, preferring the project venv dirs to `VIRTUAL_ENV`, to account for pre-commit isolated environments.
 

--- a/crates/djls-bench/benches/extraction.rs
+++ b/crates/djls-bench/benches/extraction.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use camino::Utf8PathBuf;
 use divan::Bencher;
 use djls_bench::Db;
@@ -5,10 +7,20 @@ use djls_bench::Fixture;
 use djls_bench::REPEATED_INNER_ITERS;
 use djls_bench::python_fixtures;
 use djls_bench::require;
+use djls_project::Interpreter;
 use djls_project::InvalidModuleName;
+use djls_project::Project;
 use djls_project::PythonModuleName;
+use djls_project::SearchPaths;
+use djls_project::testing::django_settings;
+use djls_project::testing::settings_module_file;
+use djls_source::Db as _;
 use djls_source::File;
 use djls_source::FileError;
+use djls_testing::Corpus;
+use djls_testing::OsTestDatabase;
+use djls_testing::ProjectFixture;
+use djls_testing::TestDatabase;
 use djls_testing::extract_bundle;
 
 struct ExtractionFile {
@@ -73,6 +85,96 @@ fn tags(bencher: Bencher) {
                 divan::black_box(bundle);
             }
             divan::black_box(extracted);
+        });
+}
+
+/// Fresh settings parsing, evaluation, and projection with growing independent
+/// conditional bindings. Source generation and database setup are not timed.
+#[divan::bench(args = [8, 32, 64])]
+fn settings_cold_branches(bencher: Bencher, branches: usize) {
+    let mut source = String::from("INSTALLED_APPS = ['core']\n");
+    for index in 0..branches {
+        require(
+            "write conditional settings fixture",
+            writeln!(
+                source,
+                "if FLAG_{index}:\n    SETTING_{index} = 'enabled'\nelse:\n    SETTING_{index} = 'disabled'"
+            ),
+        );
+    }
+    bencher
+        .with_inputs(|| {
+            let mut db = TestDatabase::new();
+            let project = require(
+                "prepare cold conditional settings input",
+                ProjectFixture::new("/corpus/repos/settings-project/src/project")
+                    .django_settings_module("settings")
+                    .file(
+                        "/corpus/repos/settings-project/src/project/settings.py",
+                        source.as_str(),
+                    )
+                    .install(&mut db),
+            );
+            (db, project)
+        })
+        .bench_local_values(|(db, project)| {
+            divan::black_box(django_settings(&db, project));
+        });
+}
+
+/// Real settings source and imports, with no installed dependencies and fresh
+/// evaluation queries. Corpus metadata, search paths, and entry resolution are setup;
+/// source reads, parsing, evaluation, and settings projection are timed.
+#[divan::bench(args = ["healthchecks", "netbox", "pretix"], sample_count = 10)]
+fn settings_cold_corpus(bencher: Bencher, name: &str) {
+    let corpus = require("load settings corpus", Corpus::require());
+    let declaration = require(
+        "find settings corpus project",
+        require(
+            "load corpus project declarations",
+            corpus.repo_settings_projects(),
+        )
+        .into_iter()
+        .find(|project| project.repo_name == name)
+        .ok_or("benchmark repository must declare settings metadata"),
+    );
+    let [settings_module] = declaration.django_settings_modules.as_slice() else {
+        djls_bench::fail("settings corpus benchmark requires exactly one settings module");
+    };
+    let settings_module = require(
+        "parse corpus settings module",
+        PythonModuleName::parse(settings_module),
+    );
+    bencher
+        .with_inputs(|| {
+            let mut db = OsTestDatabase::new();
+            let interpreter = Interpreter::VenvPath(corpus.root().join("hermetic-no-venv"));
+            let search_paths = SearchPaths::from_project_settings(
+                db.file_system(),
+                &declaration.project_root,
+                &interpreter,
+                &[],
+            );
+            search_paths.register_roots(&db);
+            let project = Project::new(
+                &db,
+                declaration.project_root.clone(),
+                search_paths,
+                interpreter,
+                Some(settings_module.clone()),
+                Vec::new(),
+                Vec::new(),
+                djls_conf::Settings::default().tagspecs().clone(),
+            );
+            db.set_project(project);
+            require(
+                "resolve corpus settings entry",
+                settings_module_file(&db, project).ok_or("settings module must resolve"),
+            );
+            (db, project)
+        })
+        .bench_local_values(|(db, project)| {
+            divan::black_box(django_settings(&db, project));
         });
 }
 

--- a/crates/djls-bench/notes/settings-evaluator.md
+++ b/crates/djls-bench/notes/settings-evaluator.md
@@ -1,0 +1,87 @@
+# Python settings evaluator measurements
+
+Recorded 2026-09-09. Baseline: `1fd95c3d` (the corpus demo script, before evaluator changes). Both CLI binaries used the normal Cargo release profile on an AMD Ryzen 7 PRO 5850U, Linux, 16 logical CPUs. The machine was shared with other work; timings varied substantially.
+
+## CLI workload
+
+`uv run tools/demo_check.py --binary <binary> healthchecks netbox pretix` ran each repository in a fresh process, sequentially, with its manifest settings module and project root. Each check received the repository directory as an explicit input. Timings include discovery, template analysis, rendering, and log I/O. Builds and downloads were outside the timer. Filesystem caches were not cleared.
+
+The dependency-free `uv` script environment supplied no installed Django packages. This workload does not measure LSP readiness or a fully installed Pretix environment.
+
+Corpus revisions:
+
+| Repository | Commit |
+| --- | --- |
+| Healthchecks | `b9eac590c6cbc7ba1417175bebe4f15c51b54f4f` |
+| NetBox | `7300104cea5d658324b9aba4873e9b867de0b9c1` |
+| pretix | `fbd8bbbeaaa2564c3e29bd4447ae5a8b17fe0cf3` |
+
+Three interleaved baseline/changed runs, seconds:
+
+| Repository | Baseline runs | Changed runs | Baseline median | Changed median |
+| --- | --- | --- | --- | --- |
+| Healthchecks | 0.378, 0.382, 0.822 | 0.272, 0.532, 0.294 | 0.382 | 0.294 |
+| NetBox | 3.271, 3.162, 6.935 | 0.966, 2.261, 1.059 | 3.271 | 1.059 |
+| pretix | 8.156, 13.221, 9.145 | 1.839, 4.622, 2.088 | 9.145 | 2.088 |
+
+Earlier baseline Pretix runs took 7.8–8.4s. Changing only identity lookup equality produced 1.8–2.5s. The additional borrowing and full-equality changes had smaller effects that these noisy CLI runs do not isolate reliably.
+
+Diagnostics matched byte-for-byte in the compared logs. Healthchecks and NetBox reported none. Pretix reported two findings in Sphinx/Jinja documentation templates included by the repository-wide scan; these are not Django template errors. No files or diagnostic codes were excluded to improve the timings.
+
+## Changes measured
+
+`BranchJoin::identity_cmp` orders branches by kind, module identity, origin, and discriminator. The old duplicate lookup in `ConstraintNode::collect_joins` used that full ordering even though it needed only equality. Most candidates have different origins, but the comparison walked module paths before reaching the origin.
+
+`same_identity` now compares cheap fields first and module identity last. Full join equality uses that check plus `arm_count`. Canonical structural ordering is unchanged. This matters because ordering determines which predicates and exact alternatives survive the existing precision limits.
+
+Join collection now borrows identities. Domain validation clones none; predicate widening clones only the excess predicates it must forget before consuming the original tree. The full domain checks still run, including checks for inconsistent domains under disjoint branches.
+
+## Regression benchmarks
+
+The `extraction` target now includes two additional workloads. Existing tag benchmarks remain unchanged.
+
+- `settings_cold_branches`: 8, 32, or 64 independent conditional assignments. Source generation and in-memory database construction are setup. Parsing, evaluation, and settings projection use a fresh database for every input.
+- `settings_cold_corpus`: Healthchecks, NetBox, and pretix settings, including first-party imports. Metadata loading, search-path construction, and entry-module resolution are setup. Source reads, parsing, evaluation, and projection are measured. An explicit nonexistent virtual environment prevents caller-installed packages from changing this workload.
+
+Command: `cargo bench -p djls-bench --bench extraction -- settings_ --sample-count 5`.
+
+The synthetic 64-branch median was 11.19ms before the changes (10 samples), 9.396ms with equality lookup alone (10 samples), and 8.761ms with all changes (5 samples). Different sample counts and machine contention limit conclusions about the smaller changes.
+
+The new corpus settings-only medians after the changes were 149.8ms, 799.8ms, and 1.365s respectively (5 samples). These exclude template checking and are not interchangeable with the CLI measurements.
+
+## Profiles and remaining costs
+
+Baseline Pretix profiling attributed about 97% of sampled CPU to settings discovery and 72–74% to path comparison. Much of it passed through guarded branch merging and repeated domain checks.
+
+A second profile, after equality lookup and borrowed collection but before the full join equality change, moved the costs to:
+
+| Call path | Inclusive sampled CPU |
+| --- | ---: |
+| `PythonModuleEffects::join_guarded_branches` | 39% |
+| `BranchConstraints::intersection` | 29% |
+| `PythonBinding::normalize` | 28% |
+| `ConstraintNode::clone` | 17% |
+| `BranchJoin::identity_cmp` | 16% |
+| `ConstraintNode::collect_joins` | 6% |
+
+These percentages overlap. They identify calls worth inspecting, not independent savings that can be added together.
+
+The profiling binary used `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only RUSTFLAGS='-C force-frame-pointers=yes' cargo build --release -p djls --target-dir target/pretix-profile`. Sampling used `perf record --call-graph fp`. CLI timings above used the ordinary release binary instead.
+
+An additional run inherited the development checkout's `VIRTUAL_ENV`. It exceeded a 30-second limit even after these changes. A 12-second sampled run of the equality/borrowing build spent more than 99% of CPU in settings evaluation; dictionary binding combination, normalization, and module-effect branch merging were prominent. It did not complete, so that profile describes only the sampled prefix. The dependency or import responsible for the difference has not been isolated. No project Python code was executed.
+
+Candidates for the next experiments, not implemented here:
+
+1. Minimize the installed-dependency case and give it a fixed fixture. The dependency-free benchmarks do not cover this much slower behavior.
+2. Share immutable constraint subtrees and module identities to reduce deep clones. Any compact identity must preserve module executions under overlapping search roots and must not make canonical ordering depend on insertion order.
+3. Avoid reconstructing unchanged module effects at every guarded join. A shortcut must account for the guards, unbound alternatives, and origin evidence; equal-looking values alone do not prove that the inputs cover the same feasible cases.
+4. Answer constraint compatibility without constructing a complete intersection. A direct overlap query would still need the domain checks and an equivalence test against the existing intersection result.
+5. Revisit linear join deduplication if it becomes significant again. Hashing full paths can cost more than the current cheap rejection on small trees. Predicate widening also collects control joins it later discards.
+
+## Validation
+
+- `cargo test -q`: full workspace suite passed.
+- `cargo test --release -p djls-project --test settings_extraction --test corpus_settings`: 315 settings tests and 3 corpus tests passed before the final equality refinement; the full workspace run covered that refinement afterward.
+- All existing settings snapshots remained unchanged.
+- A new test checks identity equality against canonical comparison and checks full equality against structural comparison across different origins, kinds, discriminators, domains, and module search roots.
+- `just fmt` and all-target/all-feature Clippy passed.

--- a/crates/djls-project/src/python/evaluation/constraints.rs
+++ b/crates/djls-project/src/python/evaluation/constraints.rs
@@ -69,7 +69,7 @@ impl StructuralOrd for PredicateIdentity {
 
 /// One finite decision join. The module identity, source origin, and kind name
 /// one coordinate; `arm_count` records its complete modeled domain.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub(super) struct BranchJoin {
     module: PythonSourceModule,
     origin: Origin,
@@ -125,6 +125,15 @@ impl BranchJoin {
             })
     }
 
+    fn same_identity(&self, other: &Self) -> bool {
+        // Equality can reject distinct source sites before comparing module
+        // paths. Canonical ordering must still compare modules first.
+        self.kind == other.kind
+            && self.origin == other.origin
+            && self.predicate_discriminator == other.predicate_discriminator
+            && self.module == other.module
+    }
+
     fn assert_same_domain(&self, other: &Self) {
         assert_eq!(
             self.arm_count, other.arm_count,
@@ -156,6 +165,12 @@ impl BranchJoin {
             origin,
             arm_count,
         )
+    }
+}
+
+impl PartialEq for BranchJoin {
+    fn eq(&self, other: &Self) -> bool {
+        self.arm_count == other.arm_count && self.same_identity(other)
     }
 }
 
@@ -211,17 +226,14 @@ impl ConstraintNode {
         Self::Branch { join, arms }
     }
 
-    fn collect_joins(&self, joins: &mut Vec<BranchJoin>) {
+    fn collect_joins<'a>(&'a self, joins: &mut Vec<&'a BranchJoin>) {
         let Self::Branch { join, arms } = self else {
             return;
         };
-        if let Some(existing) = joins
-            .iter()
-            .find(|existing| existing.identity_cmp(join) == Ordering::Equal)
-        {
+        if let Some(existing) = joins.iter().find(|existing| existing.same_identity(join)) {
             existing.assert_same_domain(join);
         } else {
-            joins.push(join.clone());
+            joins.push(join);
         }
         for arm in arms {
             arm.collect_joins(joins);
@@ -241,10 +253,14 @@ impl ConstraintNode {
             .into_iter()
             .filter(|join| join.kind == BranchJoinKind::Predicate)
             .collect::<Vec<_>>();
-        predicates.sort_by(BranchJoin::structural_cmp);
-        predicates
-            .iter()
+        predicates.sort_by(|left, right| left.structural_cmp(right));
+        let forgotten = predicates
+            .into_iter()
             .skip(MAX_TRACKED_PREDICATES)
+            .cloned()
+            .collect::<Vec<_>>();
+        forgotten
+            .iter()
             .fold(self, |constraints, join| constraints.forget(join))
     }
 
@@ -517,6 +533,55 @@ mod tests {
     fn impossible() -> BranchConstraints {
         BranchConstraints {
             root: Box::new(ConstraintNode::Impossible),
+        }
+    }
+
+    #[test]
+    fn identity_equality_matches_canonical_order_without_including_arm_count() {
+        use camino::Utf8PathBuf;
+
+        use crate::python::PythonModuleName;
+        use crate::python::SearchPath;
+
+        let base = BranchJoin::for_test(origin(0, 1), 2);
+        let different_domain = BranchJoin {
+            arm_count: 3,
+            ..base.clone()
+        };
+        assert!(base.same_identity(&different_domain));
+        let joins = [
+            base.clone(),
+            different_domain,
+            BranchJoin::for_test(origin(0, 2), 2),
+            BranchJoin::for_test(origin(1, 1), 2),
+            BranchJoin::predicate_for_test(base.origin),
+            BranchJoin::binding_choice(base.module.clone(), base.origin, "first"),
+            BranchJoin::binding_choice(base.module.clone(), base.origin, "second"),
+            BranchJoin::new(
+                PythonSourceModule::file_module(
+                    PythonModuleName::parse("test").expect("valid test module"),
+                    Utf8PathBuf::from("/test.py"),
+                    base.origin.file,
+                    SearchPath::FirstParty(Utf8PathBuf::from("/different-root")),
+                ),
+                base.origin,
+                2,
+            ),
+        ];
+
+        for left in &joins {
+            for right in &joins {
+                assert_eq!(
+                    left.same_identity(right),
+                    left.identity_cmp(right) == Ordering::Equal,
+                    "identity equality must preserve every canonical identity field"
+                );
+                assert_eq!(
+                    left == right,
+                    left.structural_cmp(right) == Ordering::Equal,
+                    "full equality must also include the arm domain"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Reduce the work spent comparing Python settings branch identities while preserving branch equality and ordering behavior. Add cold settings-analysis benchmarks for conditional bindings and corpus projects, with evaluator notes describing the measured paths. Existing benchmark names and measurements remain intact; this update makes no new performance claim.

No compilation templates or disagreement entries change. Across the completed stack's 153 templates, the comparison reports zero false positives and nine known missed diagnostics.

## Verification

Passed `cargo test -q`, `just clippy`, `just fmt`, and `just lint` at this head. Final stack checks passed all 44 E2E tests and a subsequent full workspace test run.