### PR TITLE
Preserve unloaded-tag diagnostics beside open libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Fixed unloaded-tag diagnostics and load quick fixes disappearing when an unrelated template library has unknown registrations.
 - Fixed explicit `false` and empty LSP initialization options failing to override project configuration.
 - Fixed `djls check` scanning the project root when template settings branches differ only in context processors.
 - Fixed duplicate names and excess inclusion-tag arguments producing invented Template Library definitions.

--- a/crates/djls-ide/src/completions.rs
+++ b/crates/djls-ide/src/completions.rs
@@ -701,7 +701,7 @@ fn scope_has_definite_symbols(
     scoped_libraries.inventory_symbol_names(kind).any(|name| {
         matches!(
             scoped_libraries.symbol(name, kind),
-            ScopedTemplateSymbolLookup::Builtin | ScopedTemplateSymbolLookup::RequiresLoad(_)
+            ScopedTemplateSymbolLookup::Builtin | ScopedTemplateSymbolLookup::RequiresLoad { .. }
         )
     })
 }

--- a/crates/djls-project/src/templates/libraries.rs
+++ b/crates/djls-project/src/templates/libraries.rs
@@ -436,7 +436,13 @@ pub enum AppTemplateSymbolLookup {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScopedTemplateSymbolLookup {
     Builtin,
-    RequiresLoad(Vec<LibraryName>),
+    RequiresLoad {
+        /// Libraries whose inventories definitely provide the name.
+        required: Vec<LibraryName>,
+        /// Open loadable inventories that did not show the name. A matching
+        /// load can make occurrence availability inconclusive.
+        open: Vec<LibraryName>,
+    },
     Inconclusive,
     Absent,
 }
@@ -1129,7 +1135,11 @@ impl<'db> TemplateLibraryCatalog<'db> {
             return candidates;
         }
 
-        let ScopedTemplateSymbolLookup::RequiresLoad(required_names) = lookup else {
+        let ScopedTemplateSymbolLookup::RequiresLoad {
+            required: required_names,
+            ..
+        } = lookup
+        else {
             return candidates;
         };
         for library in libraries
@@ -1201,6 +1211,7 @@ impl<'db> TemplateLibraryCatalog<'db> {
         }
 
         let mut required = Vec::new();
+        let mut open_libraries = Vec::new();
         for load_name in Self::completion_library_names_in_view(view) {
             let mut present = false;
             let mut absent = false;
@@ -1222,16 +1233,21 @@ impl<'db> TemplateLibraryCatalog<'db> {
             }
             if present && !absent && !open {
                 required.push(load_name);
-            } else if present || open {
+            } else if present {
                 inconclusive = true;
+            } else if open {
+                open_libraries.push(load_name);
             }
         }
 
         if inconclusive {
             ScopedTemplateSymbolLookup::Inconclusive
         } else if !required.is_empty() {
-            ScopedTemplateSymbolLookup::RequiresLoad(required)
-        } else if view.has_omissions() {
+            ScopedTemplateSymbolLookup::RequiresLoad {
+                required,
+                open: open_libraries,
+            }
+        } else if !open_libraries.is_empty() || view.has_omissions() {
             ScopedTemplateSymbolLookup::Inconclusive
         } else {
             ScopedTemplateSymbolLookup::Absent

--- a/crates/djls-project/tests/template_libraries.rs
+++ b/crates/djls-project/tests/template_libraries.rs
@@ -274,9 +274,10 @@ fn symbol_join_distinguishes_unanimous_and_partial_ambiguous_libraries() {
 
     assert_eq!(
         project_inventory(&libraries).symbol("all_tag", TemplateSymbolKind::Tag),
-        ScopedTemplateSymbolLookup::RequiresLoad(vec![
-            library_name("shared").expect("test library name should be valid")
-        ])
+        ScopedTemplateSymbolLookup::RequiresLoad {
+            required: vec![library_name("shared").expect("test library name should be valid")],
+            open: Vec::new(),
+        }
     );
     assert_eq!(
         project_inventory(&libraries).symbol("one_tag", TemplateSymbolKind::Tag),
@@ -284,13 +285,36 @@ fn symbol_join_distinguishes_unanimous_and_partial_ambiguous_libraries() {
     );
     assert_eq!(
         project_inventory(&libraries).symbol("all_filter", TemplateSymbolKind::Filter),
-        ScopedTemplateSymbolLookup::RequiresLoad(vec![
-            library_name("shared").expect("test library name should be valid")
-        ])
+        ScopedTemplateSymbolLookup::RequiresLoad {
+            required: vec![library_name("shared").expect("test library name should be valid")],
+            open: Vec::new(),
+        }
     );
     assert_eq!(
         project_inventory(&libraries).symbol("one_filter", TemplateSymbolKind::Filter),
         ScopedTemplateSymbolLookup::Inconclusive
+    );
+}
+
+#[test]
+fn symbol_lookup_keeps_known_providers_beside_open_loadable_libraries() {
+    let mut db = TestDatabase::new();
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("settings")
+        .file("/proj/settings.py", "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'OPTIONS': {'libraries': {'known': 'known_tags', 'open': 'open_tags'}}}]\n")
+        .file("/proj/known_tags.py", "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known_tag(): pass\n")
+        .file("/proj/open_tags.py", "from django import template\nregister = template.Library()\ndef other_tag(context): pass\nregister.simple_tag(takes_context=True)(globals()['other_tag'])\n")
+        .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/templates/page.html", "{% known_tag %}")
+        .install(&mut db)
+        .expect("open-library fixture should install");
+    let catalog = template_library_catalog(&db, project);
+    assert_eq!(
+        project_inventory(catalog).symbol("known_tag", TemplateSymbolKind::Tag),
+        ScopedTemplateSymbolLookup::RequiresLoad {
+            required: vec![library_name("known").expect("library name should parse")],
+            open: vec![library_name("open").expect("library name should parse")],
+        }
     );
 }
 

--- a/crates/djls-semantic/src/scoping.rs
+++ b/crates/djls-semantic/src/scoping.rs
@@ -290,15 +290,20 @@ pub(crate) fn template_analysis_projection_for_file_in_scope<'db>(
                         TagOccurrenceKey::from_name_span(tag.name_span),
                         ScopedTagFact {
                             spec: spec.cloned(),
-                            availability: contextual_fact.availability,
                             structure_accepts_spelling: matches!(
                                 tag.structural_meaning,
                                 StructuralOccurrenceMeaning::CapturedIntermediate
                                     | StructuralOccurrenceMeaning::CapturedCloser
-                            ) || matches!(
+                            ) || (matches!(
                                 grammar_fact.classification,
                                 TagClassification::Inconclusive
-                            ),
+                            ) && !matches!(
+                                // An open grammar does not waive a proven load requirement.
+                                contextual_fact.availability,
+                                SymbolAvailability::Unloaded { .. }
+                                    | SymbolAvailability::AmbiguousUnloaded { .. }
+                            )),
+                            availability: contextual_fact.availability,
                             unknown_load_can_shadow: contextual_fact.unknown_load_can_shadow,
                             loader_arguments,
                         },

--- a/crates/djls-semantic/src/scoping/symbols.rs
+++ b/crates/djls-semantic/src/scoping/symbols.rs
@@ -35,7 +35,13 @@ pub(crate) fn resolve_occurrence_availability(
 ) -> SymbolAvailability {
     match scoped_libraries.symbol(name, kind) {
         ScopedTemplateSymbolLookup::Builtin => SymbolAvailability::Available,
-        ScopedTemplateSymbolLookup::RequiresLoad(required) => {
+        ScopedTemplateSymbolLookup::RequiresLoad { required, open } => {
+            if open
+                .iter()
+                .any(|library| load_state.is_symbol_available(library.as_str(), name))
+            {
+                return SymbolAvailability::Inconclusive;
+            }
             if required
                 .iter()
                 .any(|library| load_state.is_symbol_available(library.as_str(), name))

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -2923,6 +2923,41 @@ fn imported_register_keeps_known_symbols_and_makes_only_symbol_misses_inconclusi
 }
 
 #[test]
+fn unloaded_tag_diagnostic_depends_on_whether_the_open_library_is_loaded() {
+    let mut db = TestDatabase::new();
+    ProjectFixture::new("/proj")
+        .django_settings_module("settings")
+        .file("/proj/settings.py", "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'OPTIONS': {'libraries': {'known': 'known_tags', 'open': 'open_tags'}}}]\n")
+        .file("/proj/known_tags.py", "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known_tag(): pass\n")
+        .file("/proj/open_tags.py", "from django import template\nregister = template.Library()\ndef other_tag(context): pass\nregister.simple_tag(takes_context=True)(globals()['other_tag'])\n")
+        .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
+        .file("/proj/templates/unloaded.html", "{% known_tag %}")
+        .file("/proj/templates/open.html", "{% load open %}{% known_tag %}")
+        .file("/proj/templates/known.html", "{% load known %}{% known_tag %}")
+        .install(&mut db)
+        .expect("open-library fixture should install");
+
+    let errors = collect_file_errors(&db, "/proj/templates/unloaded.html")
+        .expect("unloaded template should validate");
+    assert!(
+        matches!(errors.as_slice(), [ValidationError::UnloadedTag { tag, library, .. }]
+        if tag == "known_tag" && library == "known"),
+        "{errors:?}"
+    );
+
+    let errors = collect_file_errors(&db, "/proj/templates/open.html")
+        .expect("open-library template should validate");
+    assert!(!errors.iter().any(|error| matches!(
+        error,
+        ValidationError::UnloadedTag { .. } | ValidationError::UnknownTag { .. }
+    )));
+
+    let errors = collect_file_errors(&db, "/proj/templates/known.html")
+        .expect("known-library template should validate");
+    assert!(errors.is_empty(), "{errors:?}");
+}
+
+#[test]
 fn closed_registration_source_still_produces_symbol_negatives() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")


### PR DESCRIPTION
## What changes

DJLS treats a library's symbol inventory as open when it cannot read every registration. Previously, an unrelated open library could suppress the S109 unloaded-tag diagnostic and its load quick fix, even when DJLS knew another library supplied the tag.

Keep known providers separate from open libraries. A known tag still needs a load when none of its possible providers has been loaded. If the template loads an open library that could supply the name, keep the result inconclusive. Selective loads count only for the selected name.

The project lookup now returns both lists. Semantic scoping checks load state before resolving the known providers, and grammar uncertainty no longer overrides a proven load requirement. Unknown names, open builtins, and disagreements between template backends keep their existing treatment.

## Tests

A project lookup regression checks both provider lists. A semantic regression checks three templates: no loads produces the unloaded diagnostic, loading the open library leaves the name inconclusive, and loading the known provider produces no diagnostics. Both fixtures use `register.simple_tag(takes_context=True)(globals()['other_tag'])` so the inventory stays open even when curried registration support improves.

Passed:

- `cargo test -q -p djls-project`
- `cargo test -q -p djls-semantic`
- `cargo test -q`
- `just clippy`, `just fmt`, and `just lint`
- `just e2e`: 44 passed with the stacked verdict tests, without changing E2E assertions
