### PR TITLE
Render test project settings from a typed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - **Internal**: Compare DJLS template tag validation against Django's template compilation on a dedicated fixture project.
 - **Internal**: Validated markdown diagnostic snapshots against the pinned Django corpus source.
 - **Internal**: Added `py` and `toml` mdtest fences for scenario-owned tag libraries and settings.
+- **Internal**: Test fixtures now render `settings.py` from a typed `ProjectSettings` value.
 - **Internal**: Extraction snapshots now record library symbol inventories and whether they are open; a corpus census counts registration sites and records candidates that cannot be matched to extracted definitions.
 - **Internal**: Added cold settings-analysis benchmarks for conditional bindings and corpus projects.
 

--- a/crates/djls-bench/src/specs.rs
+++ b/crates/djls-bench/src/specs.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -18,6 +19,7 @@ use djls_semantic::FilterAritySpecs;
 use djls_semantic::TagSpecs;
 use djls_source::Db as SourceDb;
 use djls_source::FileError;
+use djls_testing::ProjectSettings;
 use djls_testing::extract_bundle;
 
 use crate::Db;
@@ -155,7 +157,6 @@ fn install_template_library_fixture(
 ) -> Result<(), BenchmarkSetupError> {
     // Canonical builtin identities make extracted source facts fuse with semantic's hardcoded
     // Django roles and fallback grammar, matching production project analysis.
-    const SETTINGS: &str = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'i18n': 'django.templatetags.i18n', 'static': 'django.templatetags.static'}}}]\n";
     const DEFAULTFILTERS: &str = concat!(
         "from django import template\nregister = template.Library()\n",
         "@register.filter\ndef title(value): pass\n",
@@ -178,9 +179,23 @@ fn install_template_library_fixture(
         "@register.tag\ndef include(parser, token): pass\n",
     );
 
+    db.add_fixture_source("/project/__init__.py", "");
+    db.add_fixture_source(
+        "/project/settings.py",
+        ProjectSettings {
+            libraries: BTreeMap::from([
+                ("i18n".to_string(), "django.templatetags.i18n".to_string()),
+                (
+                    "static".to_string(),
+                    "django.templatetags.static".to_string(),
+                ),
+            ]),
+            ..ProjectSettings::default()
+        }
+        .settings_py(),
+    );
+
     for (path, source) in [
-        ("/project/__init__.py", ""),
-        ("/project/settings.py", SETTINGS),
         ("/django/__init__.py", ""),
         ("/django/template/__init__.py", ""),
         ("/django/template/defaultfilters.py", DEFAULTFILTERS),

--- a/crates/djls-ide/tests/code_actions.rs
+++ b/crates/djls-ide/tests/code_actions.rs
@@ -194,13 +194,21 @@ fn unloaded_tag_action_inserts_load_at_top_without_header() {
 #[test]
 fn unloaded_filter_action_inserts_required_library() {
     let source = "{{ value|intcomma }}\n";
-    let db = db_with_source(source).expect("validation fixture should build");
+    let settings = ProjectSettings {
+        installed_apps: vec!["django.contrib.humanize".into()],
+        ..ProjectSettings::default()
+    };
+    let mut db = validation_db(&settings).expect("validation fixture should build");
+    db.add_file(TEMPLATE_PATH, source)
+        .expect("template fixture should be added");
     let actions = collect_actions(&db, request_at(source, "intcomma"))
         .expect("unloaded filter should produce a code action response");
     let action = only_action(actions).expect("unloaded filter should produce one action");
     let edit = only_edit(&action).expect("unloaded filter action should contain one edit");
-    let edited_db =
-        db_with_source(&apply_edit(source, edit)).expect("edited validation fixture should build");
+    let mut edited_db = validation_db(&settings).expect("edited validation fixture should build");
+    edited_db
+        .add_file(TEMPLATE_PATH, &apply_edit(source, edit))
+        .expect("edited template fixture should be added");
 
     assert_eq!(action.title, "Add '{% load humanize %}'");
     assert_eq!(edit.range.start, ls_types::Position::new(0, 0));
@@ -353,11 +361,11 @@ fn unreadable_library_action_reports_resolved_module_and_first_statement() {
     let library_path = "/test/project/open_tags.py";
     let mut db = TestDatabase::new();
     ProjectFixture::new("/test/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/test/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'open': 'open_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            libraries: BTreeMap::from([("open".into(), "open_tags".into())]),
+            ..ProjectSettings::default()
+        })
         .file(
             library_path,
             concat!(

--- a/crates/djls-ide/tests/completions.rs
+++ b/crates/djls-ide/tests/completions.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 
@@ -22,6 +23,7 @@ use djls_source::Offset;
 use djls_source::PositionEncoding;
 use djls_testing::Corpus;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
@@ -43,11 +45,13 @@ fn install_template_completion_project(
     source: &str,
 ) -> TestResult<()> {
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/app/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec![
+                "/test/project/templates".into(),
+                "/test/project/app/templates".into(),
+            ],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file("/test/project/templates/base.html", "base")
         .file("/test/project/templates/shared.html", "primary")
@@ -180,11 +184,12 @@ fn shadowed_normal_tag_named_load_gets_no_library_completion() {
     let (symbol_source, symbol_offset) = source_and_offset("{% load custom_§ from custom %}")
         .expect("symbol completion fixture should contain a valid cursor marker");
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['custom_load'], 'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            builtins: vec!["custom_load".into()],
+            libraries: BTreeMap::from([("custom".into(), "custom_tags".into())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_load.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='load')\ndef custom_load(value): pass\n",
@@ -495,11 +500,11 @@ fn project_backed_widthratio_completes_correlated_django_forms() {
         .collect::<Vec<_>>();
 
     let mut fixture = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['django.template.defaulttags']}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            builtins: vec!["django.template.defaulttags".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/django/__init__.py", "")
         .file("/test/project/django/template/__init__.py", "")
         .file(
@@ -580,11 +585,11 @@ fn project_backed_for_completes_correlated_django_forms() {
         })
         .collect::<Vec<_>>();
     let mut fixture = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['django.template.defaulttags']}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            builtins: vec!["django.template.defaulttags".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/django/__init__.py", "")
         .file("/test/project/django/template/__init__.py", "")
         .file(

--- a/crates/djls-ide/tests/diagnostics.rs
+++ b/crates/djls-ide/tests/diagnostics.rs
@@ -1,7 +1,10 @@
+use std::collections::BTreeMap;
+
 use camino::Utf8Path;
 use djls_ide::collect_diagnostics;
 use djls_source::PositionEncoding;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
 
@@ -15,11 +18,11 @@ fn unreadable_library_diagnostic_is_a_hint_with_python_source_information() {
         "register.simple_tag(takes_context=True)(globals()['other_tag'])\n",
     );
     ProjectFixture::new("/proj")
-        .django_settings_module("project.settings")
-        .file(
-            "/proj/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'open': 'open_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".into()],
+            libraries: BTreeMap::from([("open".into(), "open_tags".into())]),
+            ..ProjectSettings::default()
+        })
         .file("/proj/open_tags.py", library_source)
         .file("/proj/templates/page.html", "{% load open %}")
         .install(&mut db)

--- a/crates/djls-ide/tests/document_links.rs
+++ b/crates/djls-ide/tests/document_links.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use camino::Utf8Path;
 use djls_conf::TagDef;
 use djls_conf::TagLibraryDef;
@@ -7,6 +9,7 @@ use djls_ide::document_links as ide_document_links;
 use djls_source::File;
 use djls_source::PositionEncoding;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
 
@@ -38,11 +41,10 @@ fn document_links_resolve_absolute_references_from_originless_files() {
     let source = "{% include 'card.html' %}\n{% include './card.html' %}";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/scratch.html", source)
         .file("/test/project/templates/card.html", "card")
         .install(&mut db)
@@ -66,11 +68,10 @@ fn document_link_ranges_follow_position_encoding() {
     let template_path = "/test/project/templates/page.html";
     let source = "é😀 {% include \"card.html\" %}";
     ProjectFixture::new("/test/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/test/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(template_path, source)
         .file("/test/project/templates/card.html", "card")
         .install(&mut db)
@@ -114,11 +115,10 @@ fn document_links_resolve_template_references_with_interior_ranges() {
     );
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file(base_path, "base")
         .file(partial_path, "partial")
@@ -194,7 +194,6 @@ fn document_links_do_not_invent_origin_for_source_less_configured_library() {
     let mut db = TestDatabase::new();
     let template_path = "/test/project/templates/load.html";
     ProjectFixture::new("/test/project")
-        .django_settings_module("project.settings")
         .tag_specs(TagSpecDef {
             libraries: vec![TagLibraryDef {
                 module: "missing.panel_tags".to_string(),
@@ -211,10 +210,11 @@ fn document_links_do_not_invent_origin_for_source_less_configured_library() {
             }],
             ..TagSpecDef::default()
         })
-        .file(
-            "/test/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'panels': 'missing.panel_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            libraries: BTreeMap::from([("panels".into(), "missing.panel_tags".into())]),
+            ..ProjectSettings::default()
+        })
         .file(template_path, "{% load panels %}")
         .install(&mut db)
         .expect("configured-library project fixture should install");
@@ -257,11 +257,10 @@ fn document_links_resolve_relative_include_to_sibling_template() {
     let source = "{% include \"./x.html\" %}\n";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file(target_path, "target")
         .install(&mut db)
@@ -299,11 +298,17 @@ fn document_links_resolve_load_libraries_with_argument_ranges() {
         "{% load djls_greeting from djls_app_tags %}\n",
     );
     ProjectFixture::new("/test/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/test/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'djls_app_tags': 'djls_app.templatetags.djls_app_tags', 'extras': 'project.templatetags.extras'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            libraries: BTreeMap::from([
+                (
+                    "djls_app_tags".into(),
+                    "djls_app.templatetags.djls_app_tags".into(),
+                ),
+                ("extras".into(), "project.templatetags.extras".into()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/djls_app/templatetags/djls_app_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef djls_greeting(): pass\n",

--- a/crates/djls-ide/tests/hover.rs
+++ b/crates/djls-ide/tests/hover.rs
@@ -1,9 +1,12 @@
+use std::collections::BTreeMap;
+
 use camino::Utf8Path;
 use djls_ide::hover as ide_hover;
 use djls_source::File;
 use djls_source::Offset;
 use djls_source::PositionEncoding;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
 
@@ -20,15 +23,22 @@ fn hover_markdown(hover: ls_types::Hover) -> Option<String> {
 
 fn collision_fixture(source: &str) -> Result<(TestDatabase, File), Box<dyn std::error::Error>> {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['builtin_tags'], 'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}}]\n";
+    let settings = ProjectSettings {
+        dirs: vec!["/test/project/templates".into()],
+        builtins: vec!["builtin_tags".into()],
+        libraries: BTreeMap::from([
+            ("alpha".into(), "alpha_tags".into()),
+            ("beta".into(), "beta_tags".into()),
+        ]),
+        ..ProjectSettings::default()
+    };
     let library_source = |doc: &str| {
         format!(
             "from django import template\nregister = template.Library()\n\n@register.simple_tag(name='shared')\ndef shared_tag():\n    \"\"\"{doc} tag.\"\"\"\n    return ''\n\n@register.filter(name='shared_filter')\ndef shared_filter(value):\n    \"\"\"{doc} filter.\"\"\"\n    return value\n"
         )
     };
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&settings)
         .file(
             "/test/project/builtin_tags.py",
             library_source("Builtin definition"),
@@ -116,11 +126,11 @@ fn captured_if_else_does_not_hover_a_colliding_custom_definition() {
     let mut db = TestDatabase::new();
     let source = "{% load custom %}{% if condition %}{% else %}{% endif %}{% else %}";
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            libraries: BTreeMap::from([("custom".into(), "custom_tags".into())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_tags.py",
             "from django import template\nregister = template.Library()\n\n@register.simple_tag(name='else')\ndef custom_else():\n    \"\"\"Custom else definition.\"\"\"\n    return ''\n",
@@ -283,11 +293,10 @@ fn template_hover_resolves_absolute_reference_from_originless_file() {
     let source = r#"{% extends "base.html" %}"#;
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/scratch.html", source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
@@ -325,11 +334,10 @@ fn missing_template_hover_says_template_not_found() {
     let child_path = "/test/project/templates/child.html";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .install(&mut db)
         .expect("missing-template project fixture should install");

--- a/crates/djls-ide/tests/navigation.rs
+++ b/crates/djls-ide/tests/navigation.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use camino::Utf8Path;
 use djls_ide::find_references;
 use djls_ide::goto_definition as ide_goto_definition;
@@ -5,6 +7,7 @@ use djls_source::File;
 use djls_source::Offset;
 use djls_source::PositionEncoding;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use tower_lsp_server::ls_types;
 
@@ -41,11 +44,11 @@ fn custom_symbol_navigation_fixture(
 ) -> Result<(TestDatabase, File), Box<dyn std::error::Error>> {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            libraries: BTreeMap::from([("custom".into(), "custom_tags".into())]),
+            ..ProjectSettings::default()
+        })
         .file("/test/project/custom_tags.py", library_source)
         .file("/test/project/templates/page.html", template_source)
         .install(&mut db)?;
@@ -94,11 +97,10 @@ fn goto_definition_reports_location_link_with_origin_range() {
     let child_path = "/test/project/templates/child.html";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
@@ -144,11 +146,10 @@ fn goto_definition_encodes_existing_template_reference_origins() {
     let source = "😀{% extends \"base.html\" %}";
     let child_path = "/test/project/templates/child.html";
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
@@ -184,11 +185,10 @@ fn goto_definition_resolves_absolute_reference_from_originless_file() {
     let source = r#"{% extends "base.html" %}"#;
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/scratch.html", source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
@@ -230,11 +230,10 @@ fn goto_definition_leaves_relative_reference_from_originless_file_unresolved() {
     let source = r#"{% extends "./base.html" %}"#;
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/scratch.html", source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
@@ -268,11 +267,10 @@ fn goto_definition_falls_back_to_location_without_link_support() {
     let child_path = "/test/project/templates/child.html";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
@@ -412,11 +410,10 @@ fn goto_definition_resolves_template_block_to_nearest_parent() {
     let parent_source = "{% block title %}Parent{% endblock %}";
     let child_source = "{% extends \"base.html\" %}\n{% block title %}Child{% endblock %}";
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/templates/base.html", parent_source)
         .file("/test/project/templates/child.html", child_source)
         .install(&mut db)
@@ -536,11 +533,10 @@ fn goto_definition_encodes_template_block_targets_for_link_and_plain_clients() {
     let parent_source = "😀{% block title %}Parent{% endblock %}";
     let child_source = "{% extends \"base.html\" %}\n😀{% block title %}Child{% endblock %}";
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file("/test/project/templates/base.html", parent_source)
         .file("/test/project/templates/child.html", child_source)
         .install(&mut db)
@@ -677,11 +673,10 @@ fn find_references_keeps_an_originless_local_override() {
     let mut db = TestDatabase::new();
     let source = "{% extends \"base.html\" %}\n{% block title %}Scratch{% endblock %}";
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/templates/base.html",
             "{% block title %}Base{% endblock %}",
@@ -738,11 +733,15 @@ fn goto_definition_resolves_django_load_and_static_tags() {
     let source = "{% load static %}\n{% static 'asset.css' %}";
     let mut db = TestDatabase::new();
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['django.template.defaulttags'], 'libraries': {'static': 'django.templatetags.static'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            builtins: vec!["django.template.defaulttags".into()],
+            libraries: BTreeMap::from([(
+                "static".into(),
+                "django.templatetags.static".into(),
+            )]),
+            ..ProjectSettings::default()
+        })
         .file("/test/project/django/__init__.py", "")
         .file("/test/project/django/template/__init__.py", "")
         .file(
@@ -962,11 +961,15 @@ fn goto_definition_follows_source_order_shadowing() {
         )
     };
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['builtin_tags'], 'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            builtins: vec!["builtin_tags".into()],
+            libraries: BTreeMap::from([
+                ("alpha".into(), "alpha_tags".into()),
+                ("beta".into(), "beta_tags".into()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file("/test/project/builtin_tags.py", library_source("builtin"))
         .file("/test/project/alpha_tags.py", library_source("alpha"))
         .file("/test/project/beta_tags.py", library_source("beta"))
@@ -1201,11 +1204,10 @@ fn find_references_resolves_extends_with_the_source_origin_skipped() {
     let child_path = "/test/project/first/base.html";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/first', '/test/project/second'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/first".into(), "/test/project/second".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file(
             "/test/project/first/include.html",
@@ -1255,11 +1257,14 @@ fn find_references_skips_the_source_file_across_template_name_aliases() {
     let source_path = "/test/project/templates/alias/base.html";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/templates/alias', '/test/project/fallback'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec![
+                "/test/project/templates".into(),
+                "/test/project/templates/alias".into(),
+                "/test/project/fallback".into(),
+            ],
+            ..ProjectSettings::default()
+        })
         .file(source_path, source)
         .file(
             "/test/project/templates/include.html",
@@ -1304,11 +1309,10 @@ fn find_references_reports_template_name_interior_range() {
     let child_path = "/test/project/templates/child.html";
 
     ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".into()],
+            ..ProjectSettings::default()
+        })
         .file(child_path, source)
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -18,6 +18,7 @@ use djls_source::InMemoryFileSystem;
 use djls_source::OsFileSystem;
 use djls_testing::OsTestDatabase;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
 use salsa::Database as _;
@@ -80,14 +81,13 @@ fn project_with_template_settings(
     db: &mut TestDatabase,
     root: &str,
     search_paths: SearchPaths,
-    settings_source: impl Into<String>,
+    settings: &ProjectSettings,
 ) -> Result<Project, Box<dyn std::error::Error>> {
     Ok(ProjectFixture::new(root)
         .search_paths(search_paths)
         .interpreter(Interpreter::Auto)
         .register_roots(false)
-        .django_settings_module("settings")
-        .file(format!("{root}/settings.py"), settings_source)
+        .settings(settings)
         .build(db)?)
 }
 
@@ -165,24 +165,6 @@ fn assert_no_will_execute_events(events: &[salsa::Event]) {
 fn set_project_search_paths(db: &mut TestDatabase, project: Project, search_paths: SearchPaths) {
     search_paths.register_roots(db);
     project.set_search_paths(db).to(search_paths);
-}
-
-fn django_template_settings(installed_apps: &[&str], builtins: &[&str]) -> String {
-    let installed_apps = installed_apps
-        .iter()
-        .map(|app| format!("'{app}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let builtins = builtins
-        .iter()
-        .map(|module| format!("'{module}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "INSTALLED_APPS = [{installed_apps}]\n\
-         TEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', \
-         'DIRS': [], 'APP_DIRS': True, 'OPTIONS': {{'builtins': [{builtins}]}}}}]\n"
-    )
 }
 
 #[test]
@@ -509,7 +491,11 @@ fn template_library_sources_tolerate_unregistered_search_paths() {
         &mut db,
         "/project",
         search_paths,
-        django_template_settings(&[], &[]),
+        &ProjectSettings {
+            dirs: Vec::new(),
+            app_dirs: true,
+            ..ProjectSettings::default()
+        },
     )
     .expect("template-settings project fixture should build");
 
@@ -548,7 +534,11 @@ fn template_library_source_resolution_uses_project_venv_site_packages_root() {
         &mut db,
         "/project",
         search_paths,
-        django_template_settings(&[], &[]),
+        &ProjectSettings {
+            dirs: Vec::new(),
+            app_dirs: true,
+            ..ProjectSettings::default()
+        },
     )
     .expect("template-settings project fixture should build");
 
@@ -601,7 +591,11 @@ fn template_library_source_resolution_prefers_first_party_module_shadowing_depen
         &mut db,
         "/project",
         search_paths,
-        django_template_settings(&[], &[]),
+        &ProjectSettings {
+            dirs: Vec::new(),
+            app_dirs: true,
+            ..ProjectSettings::default()
+        },
     )
     .expect("template-settings project fixture should build");
 
@@ -645,7 +639,15 @@ fn active_template_library_sources_preserve_builtin_order_across_roots() {
         &mut db,
         "/project",
         search_paths,
-        django_template_settings(&[], &["a.templatetags.tags", "z.templatetags.tags"]),
+        &ProjectSettings {
+            dirs: Vec::new(),
+            app_dirs: true,
+            builtins: vec![
+                "a.templatetags.tags".to_string(),
+                "z.templatetags.tags".to_string(),
+            ],
+            ..ProjectSettings::default()
+        },
     )
     .expect("template-settings project fixture should build");
 
@@ -686,8 +688,14 @@ fn active_template_library_sources_yield_loadable_before_builtins() {
         &mut db,
         "/project",
         search_paths,
-        "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'installed_tags'}, 'builtins': ['builtin_tags']}}]\n",
-    ).expect("template-settings project fixture should build");
+        &ProjectSettings {
+            dirs: Vec::new(),
+            builtins: vec!["builtin_tags".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "installed_tags".to_string())]),
+            ..ProjectSettings::default()
+        },
+    )
+    .expect("template-settings project fixture should build");
 
     let libraries = template_library_catalog(&db, project);
     let module_names: Vec<_> = ScopedTemplateLibraries::from_project_inventory(libraries)
@@ -739,7 +747,12 @@ def duplicate(value, arg):
         &mut db,
         "/project",
         search_paths,
-        django_template_settings(&[], &["z_first", "a_second"]),
+        &ProjectSettings {
+            dirs: Vec::new(),
+            app_dirs: true,
+            builtins: vec!["z_first".to_string(), "a_second".to_string()],
+            ..ProjectSettings::default()
+        },
     )
     .expect("template-settings project fixture should build");
 

--- a/crates/djls-project/tests/template_libraries.rs
+++ b/crates/djls-project/tests/template_libraries.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io;
 
 use djls_conf::TagDef;
@@ -28,6 +29,7 @@ use djls_project::testing::TemplateBackendLibrariesInput;
 use djls_project::testing::TemplateLibraryInput;
 use djls_source::Span;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
@@ -304,8 +306,14 @@ fn symbol_join_distinguishes_unanimous_and_partial_ambiguous_libraries() {
 fn symbol_lookup_keeps_known_providers_beside_open_loadable_libraries() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("settings")
-        .file("/proj/settings.py", "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'OPTIONS': {'libraries': {'known': 'known_tags', 'open': 'open_tags'}}}]\n")
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([
+                ("known".to_string(), "known_tags".to_string()),
+                ("open".to_string(), "open_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file("/proj/known_tags.py", "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known_tag(): pass\n")
         .file("/proj/open_tags.py", "from django import template\nregister = template.Library()\ndef other_tag(context): pass\nregister.simple_tag(takes_context=True)(globals()['other_tag'])\n")
         .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
@@ -458,7 +466,6 @@ fn effective_definition_preserves_absence_and_load_precedence_per_backend() {
 fn source_less_configured_library_keeps_keyed_structural_facts_without_origin() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
         .tag_specs(TagSpecDef {
             libraries: vec![TagLibraryDef {
                 module: "missing.panel_tags".to_string(),
@@ -475,10 +482,10 @@ fn source_less_configured_library_keeps_keyed_structural_facts_without_origin() 
             }],
             ..TagSpecDef::default()
         })
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'OPTIONS': {'libraries': {'panels': 'missing.panel_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            libraries: BTreeMap::from([("panels".to_string(), "missing.panel_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .build(&db)
         .expect("missing-library project fixture should build");
 
@@ -501,11 +508,13 @@ fn source_less_configured_library_keeps_keyed_structural_facts_without_origin() 
 fn source_less_alias_keeps_missing_same_named_available_in_app_symbols_inconclusive() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'OPTIONS': {'libraries': {'shared': 'missing.shared'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            libraries: BTreeMap::from([(
+                "shared".to_string(),
+                "missing.shared".to_string(),
+            )]),
+            ..ProjectSettings::default()
+        })
         .file("/project/available_in_app/__init__.py", "")
         .file("/project/available_in_app/templatetags/__init__.py", "")
         .file(
@@ -804,11 +813,15 @@ fn resolved_library_inventory_deduplicates_identical_builtin_identity() {
 fn imported_register_opens_only_its_symbol_inventory_and_keeps_known_symbols() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'OPTIONS': {'libraries': {'open': 'open_tags', 'closed': 'closed_tags', 'recovered': 'recovered_tags'}, 'builtins': ['open_builtin_tags']}}]\n",
-        )
+        .settings(&ProjectSettings {
+            builtins: vec!["open_builtin_tags".to_string()],
+            libraries: BTreeMap::from([
+                ("open".to_string(), "open_tags".to_string()),
+                ("closed".to_string(), "closed_tags".to_string()),
+                ("recovered".to_string(), "recovered_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file("/project/django/template/defaulttags.py", "from django import template\nregister = template.Library()\n")
         .file("/project/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
         .file("/project/django/template/loader_tags.py", "from django import template\nregister = template.Library()\n")

--- a/crates/djls-project/tests/templates.rs
+++ b/crates/djls-project/tests/templates.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::ptr;
 
@@ -6,6 +7,7 @@ use djls_project::*;
 use djls_source::ChangeEvent;
 use djls_source::SourceChanges;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
 use salsa::Database as _;
@@ -40,17 +42,11 @@ fn project_with_templates(
     template_dirs: Vec<&str>,
     templates: Vec<(&str, &str, &str)>,
 ) -> Result<Project, Box<dyn std::error::Error>> {
-    let dirs_literal = template_dirs
-        .into_iter()
-        .map(|dir| format!("'{dir}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let settings_source = format!(
-        "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [{dirs_literal}], 'APP_DIRS': False}}]\n"
-    );
-    let fixture = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings_source);
+    let settings = ProjectSettings {
+        dirs: template_dirs.into_iter().map(str::to_string).collect(),
+        ..ProjectSettings::default()
+    };
+    let fixture = ProjectFixture::new("/test/project").settings(&settings);
     Ok(templates
         .into_iter()
         .fold(fixture, |fixture, (_name, path, source)| {
@@ -170,10 +166,13 @@ fn project_inventory_preserves_backend_remainder_slot_order() {
 #[test]
 fn partial_known_backend_field_uncertainty_keeps_one_correlated_backend_alternative() {
     let db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [\n    {'BACKEND': 'django.template.backends.django.DjangoTemplates', unknown_key: 'maybe', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'alpha_tags'}}},\n]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("shared".to_string(), "alpha_tags".to_string())]),
+            partial: true,
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/alpha_tags.py",
             "from django import template\nregister = template.Library()\n",
@@ -202,11 +201,13 @@ fn partial_known_backend_field_uncertainty_keeps_one_correlated_backend_alternat
 fn scoped_template_libraries_backend_index_invalidates_with_settings_evidence() {
     let events = SalsaEventLog::default();
     let mut db = TestDatabase::with_event_log(events.clone());
-    let settings_path = "/test/project/testproject/settings.py";
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'alpha_tags'}}}]\n";
+    let settings_path = "/test/project/settings.py";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(settings_path, settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("shared".to_string(), "alpha_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/alpha_tags.py",
             "from django import template\nregister = template.Library()\n",
@@ -235,7 +236,12 @@ fn scoped_template_libraries_backend_index_invalidates_with_settings_evidence() 
 
     db.add_file(
         settings_path,
-        "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/other-templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'beta_tags'}}}]\n",
+        &ProjectSettings {
+            dirs: vec!["/test/project/other-templates".to_string()],
+            libraries: BTreeMap::from([("shared".to_string(), "beta_tags".to_string())]),
+            ..ProjectSettings::default()
+        }
+        .settings_py(),
     )
     .expect("updated settings fixture should be added to the test database");
     SourceChanges::new([ChangeEvent::ContentChanged(settings_path.into())]).apply(&mut db);
@@ -261,10 +267,12 @@ fn scoped_template_libraries_backend_index_invalidates_with_settings_evidence() 
 #[test]
 fn file_outside_template_roots_uses_open_project_inventory() {
     let db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'missing.shared_tags'}}}]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("shared".to_string(), "missing.shared_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file("/test/project/outside.html", "{% load shared %}")
         .build(&db)
         .expect("outside-template project fixture should build");
@@ -1241,11 +1249,12 @@ fn later_dynamic_directory_does_not_weaken_an_earlier_winner() {
 fn later_uncertainty_does_not_weaken_an_earlier_winner() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = ['missing']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': True}]\n",
-        )
+        .settings(&ProjectSettings {
+            installed_apps: vec!["missing".to_string()],
+            dirs: vec!["/test/project/templates".to_string()],
+            app_dirs: true,
+            ..ProjectSettings::default()
+        })
         .file("/test/project/templates/base.html", "base")
         .build(&db)
         .expect("later-uncertainty project fixture should build");

--- a/crates/djls-semantic/resources/mdtest/README.md
+++ b/crates/djls-semantic/resources/mdtest/README.md
@@ -32,11 +32,14 @@ A `toml` fence replaces the inherited settings as one value. Omitted keys take t
 
 | Key | Type | Default |
 |---|---|---|
+| `installed-apps` | list of module paths | `[]` |
 | `dirs` | list of strings | `["/templates"]` |
 | `app-dirs` | boolean | `false` |
 | `builtins` | list of module paths | `[]` |
 | `libraries` | table from load name to module path | `{}` |
 | `partial` | boolean | `false` |
+
+The default project installs no apps, so a scenario that needs a contrib library declares it with `installed-apps`.
 
 ## Inheritance
 

--- a/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
@@ -86,6 +86,10 @@ error[S111]: Unknown filter 'completelymadetupfilter'
 
 ## filter requires load when not configured as a builtin
 
+```toml
+installed-apps = ["django.contrib.humanize"]
+```
+
 ```htmldjango
 {{ value|intcomma }}
 ```

--- a/crates/djls-semantic/tests/corpus_inheritance.rs
+++ b/crates/djls-semantic/tests/corpus_inheritance.rs
@@ -8,6 +8,7 @@ use djls_semantic::template_inheritance;
 use djls_templates::parse_template;
 use djls_testing::Corpus;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 
 #[test]
@@ -32,18 +33,10 @@ fn corpus_template_inheritance_terminates() {
             continue;
         }
 
-        let settings_source = format!(
-            "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [{}], 'APP_DIRS': False}}]\n",
-            template_roots
-                .iter()
-                .map(|root| format!("'{root}'"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-        let settings_path = entry_dir.join("djls_corpus_settings.py");
-        let fixture = ProjectFixture::new(entry_dir.clone())
-            .django_settings_module("djls_corpus_settings")
-            .file(settings_path, settings_source);
+        let fixture = ProjectFixture::new(entry_dir.clone()).settings(&ProjectSettings {
+            dirs: template_roots.iter().map(ToString::to_string).collect(),
+            ..ProjectSettings::default()
+        });
         let db = TestDatabase::new();
 
         let mut fixture = fixture;

--- a/crates/djls-semantic/tests/inheritance.rs
+++ b/crates/djls-semantic/tests/inheritance.rs
@@ -24,6 +24,7 @@ use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_templates::parse_template;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use rustc_hash::FxHashMap;
 
@@ -32,17 +33,11 @@ fn project_with_templates(
     template_dirs: Vec<&str>,
     templates: Vec<(&str, &str)>,
 ) -> anyhow::Result<Project> {
-    let dirs_literal = template_dirs
-        .into_iter()
-        .map(|dir| format!("'{dir}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let settings_source = format!(
-        "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [{dirs_literal}], 'APP_DIRS': False}}]\n"
-    );
-    let fixture = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings_source)
+    let settings = ProjectSettings {
+        dirs: template_dirs.into_iter().map(str::to_string).collect(),
+        ..ProjectSettings::default()
+    };
+    let fixture = ProjectFixture::new("/test/project").settings(&settings)
         .file("/test/project/django/__init__.py", "")
         .file("/test/project/django/template/__init__.py", "")
         .file(
@@ -140,11 +135,10 @@ fn absent_effective_tag_does_not_fall_back_to_project_global_specs() {
     );
     let mut db = TestDatabase::new().with_projectless_tag_specs(specs);
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/templates/child.html",
             "{% overextends 'base.html' %}",
@@ -322,15 +316,11 @@ fn self_extends_skips_visited_origin_and_uses_shadowed_template() {
 fn originless_template_inheritance_resolves_absolute_extends_from_project_inventory() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
-        .file(
-            "/test/project/scratch.html",
-            "{% extends 'base.html' %}",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            ..ProjectSettings::default()
+        })
+        .file("/test/project/scratch.html", "{% extends 'base.html' %}")
         .file(
             "/test/project/templates/base.html",
             "{% block content %}Base{% endblock %}",
@@ -381,15 +371,11 @@ fn originless_template_inheritance_preserves_project_resolution_alternatives() {
 fn originless_template_inheritance_leaves_relative_extends_unresolved() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False}]\n",
-        )
-        .file(
-            "/test/project/scratch.html",
-            "{% extends './base.html' %}",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            ..ProjectSettings::default()
+        })
+        .file("/test/project/scratch.html", "{% extends './base.html' %}")
         .file("/test/project/templates/base.html", "base")
         .install(&mut db)
         .expect("project fixture should install into the test database");
@@ -439,10 +425,14 @@ fn template_inheritance_resolves_relative_sibling_extends() {
 #[test]
 fn template_inheritance_joins_relative_targets_for_every_source_name() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/templates/alias'], 'APP_DIRS': False}]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec![
+                "/test/project/templates".to_string(),
+                "/test/project/templates/alias".to_string(),
+            ],
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/templates/alias/child.html",
             "{% extends './parent.html' %}",
@@ -524,10 +514,14 @@ fn block_overrides_accepts_relative_winning_extends_target() {
 #[test]
 fn reverse_inheritance_starts_from_secondary_names_and_dedupes_physical_sites() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/templates/alias'], 'APP_DIRS': False}]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec![
+                "/test/project/templates".to_string(),
+                "/test/project/templates/alias".to_string(),
+            ],
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/templates/alias/base.html",
             "{% block content %}Base{% endblock %}",
@@ -554,10 +548,14 @@ fn reverse_inheritance_starts_from_secondary_names_and_dedupes_physical_sites() 
 #[test]
 fn originless_inheritance_keeps_the_exact_resolved_origin_for_relative_parents() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/templates/alias'], 'APP_DIRS': False}]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec![
+                "/test/project/templates".to_string(),
+                "/test/project/templates/alias".to_string(),
+            ],
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/scratch.html",
             "{% extends 'alias/dir/parent.html' %}",

--- a/crates/djls-semantic/tests/mdtest_inheritance.rs
+++ b/crates/djls-semantic/tests/mdtest_inheritance.rs
@@ -14,6 +14,7 @@ use djls_source::File;
 use djls_source::Span;
 use djls_templates::parse_template;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::Scenario;
 use djls_testing::ScenarioFileKind;
 use djls_testing::TestDatabase;
@@ -90,12 +91,10 @@ fn project_for_scenario(
     db: &TestDatabase,
     scenario: &Scenario,
 ) -> anyhow::Result<djls_project::Project> {
-    let settings_source = format!(
-        "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['{TEMPLATE_ROOT}'], 'APP_DIRS': False}}]\n"
-    );
-    let fixture = ProjectFixture::new(PROJECT_ROOT)
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings_source);
+    let fixture = ProjectFixture::new(PROJECT_ROOT).settings(&ProjectSettings {
+        dirs: vec![TEMPLATE_ROOT.to_string()],
+        ..ProjectSettings::default()
+    });
 
     scenario
         .files

--- a/crates/djls-semantic/tests/offset.rs
+++ b/crates/djls-semantic/tests/offset.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use camino::Utf8Path;
 use djls_project::TemplateName;
 use djls_semantic::SemanticOffsetContext;
@@ -5,6 +7,7 @@ use djls_semantic::TemplateReferenceKind;
 use djls_source::Offset;
 use djls_source::Span;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 
 fn offset_of(source: &str, needle: &str) -> Option<Offset> {
@@ -50,11 +53,11 @@ fn template_reference_context_follows_load_position() {
     let mut db = TestDatabase::new();
     let source = "{% include 'before.html' %}{% load custom %}{% include 'after.html' %}";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/test/project/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='include')\ndef custom_include(value):\n    pass\n",

--- a/crates/djls-semantic/tests/references.rs
+++ b/crates/djls-semantic/tests/references.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 use camino::Utf8Path;
 use djls_project::Project;
@@ -14,6 +15,7 @@ use djls_source::ChangeEvent;
 use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use rustc_hash::FxHashMap;
 
@@ -22,17 +24,11 @@ fn project_with_templates(
     template_dirs: Vec<&str>,
     templates: Vec<(&str, &str, &str)>,
 ) -> anyhow::Result<Project> {
-    let dirs_literal = template_dirs
-        .into_iter()
-        .map(|dir| format!("'{dir}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let settings_source = format!(
-        "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [{dirs_literal}], 'APP_DIRS': False}}]\n"
-    );
-    let fixture = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings_source);
+    let settings = ProjectSettings {
+        dirs: template_dirs.into_iter().map(str::to_string).collect(),
+        ..ProjectSettings::default()
+    };
+    let fixture = ProjectFixture::new("/test/project").settings(&settings);
     templates
         .into_iter()
         .fold(fixture, |fixture, (_name, path, source)| {
@@ -110,11 +106,11 @@ fn template_references_record_extends_and_include_kinds() {
 fn later_load_only_shadows_template_reference_occurrences_after_it() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='include')\ndef custom_include(value):\n    pass\n",
@@ -224,11 +220,11 @@ fn template_references_ignore_include_inside_verbatim() {
 fn extracted_verbatim_suppresses_references_while_custom_mixed_body_stays_active() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file(
-            "/test/project/testproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/django/template/defaulttags.py",
             include_str!(
@@ -376,10 +372,14 @@ fn template_references_are_omitted_when_target_exists_only_in_another_backend() 
 #[test]
 fn relative_references_normalize_for_every_name_of_the_source_file() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates', '/test/project/templates/alias'], 'APP_DIRS': False}]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec![
+                "/test/project/templates".to_string(),
+                "/test/project/templates/alias".to_string(),
+            ],
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/templates/alias/child.html",
             "{% include './parent.html' %}",
@@ -397,10 +397,13 @@ fn relative_references_normalize_for_every_name_of_the_source_file() {
 #[test]
 fn custom_shadowed_load_tag_creates_no_library_reference() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['custom_load'], 'libraries': {'custom': 'custom_tags'}}}]\n";
     let _project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            builtins: vec!["custom_load".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_load.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='load')\ndef custom_load(value): pass\n",
@@ -426,10 +429,13 @@ fn custom_shadowed_load_tag_creates_no_library_reference() {
 #[test]
 fn shadowed_load_does_not_bootstrap_loaded_opaque_grammar() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['custom_load'], 'libraries': {'custom': 'custom_tags'}}}]\n";
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("testproject.settings")
-        .file("/test/project/testproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            builtins: vec!["custom_load".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_load.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='load')\ndef custom_load(value): pass\n",

--- a/crates/djls-semantic/tests/structure_outline.rs
+++ b/crates/djls-semantic/tests/structure_outline.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 use camino::Utf8Path;
 use djls_semantic::EndTag;
@@ -12,6 +13,7 @@ use djls_semantic::builtin_tag_specs;
 use djls_source::Span;
 use djls_templates::parse_template;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::TestDatabase;
 use rustc_hash::FxHashMap;
 
@@ -87,11 +89,11 @@ fn header_tags_produce_outline_items() {
 fn outline_roles_follow_load_position() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/test/project/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/test/project/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/test/project/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='include')\ndef custom_include(value):\n    pass\n",

--- a/crates/djls-semantic/tests/structure_tree.rs
+++ b/crates/djls-semantic/tests/structure_tree.rs
@@ -22,6 +22,7 @@ use djls_templates::Node;
 use djls_templates::TagBit;
 use djls_templates::parse_template;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectSettings;
 use djls_testing::SalsaEventLog;
 use djls_testing::TestDatabase;
 use rustc_hash::FxHashMap;
@@ -357,11 +358,10 @@ fn project_backed_structure_queries_use_correlated_template_analysis() {
     let event_log = SalsaEventLog::default();
     let mut db = TestDatabase::with_event_log(event_log.clone());
     ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/project/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/project/templates".to_string()],
+            ..ProjectSettings::default()
+        })
         .file(
             "/project/templates/tree.html",
             "{% if value %}body{% endif %}",

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -169,11 +169,11 @@ fn for_reversed_forms_validate_dynamic_in_position() {
         ("invalid-too-short.html", "{% for x in %}{% endfor %}"),
     ];
     let mut fixture = ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['django.template.defaulttags']}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/project/templates".to_string()],
+            builtins: vec!["django.template.defaulttags".to_string()],
+            ..ProjectSettings::default()
+        })
         .file("/project/django/__init__.py", "")
         .file("/project/django/template/__init__.py", "")
         .file(
@@ -260,11 +260,11 @@ fn for_reversed_forms_validate_dynamic_in_position() {
 fn branch_specific_form_diagnostics_use_the_matching_execution_path() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['routed_tags']}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/project/templates".to_string()],
+            builtins: vec!["routed_tags".to_string()],
+            ..ProjectSettings::default()
+        })
         .file(
             "/project/routed_tags.py",
             r#"from django import template
@@ -319,11 +319,11 @@ def compile_routed(parser, token):
 fn token_contents_diagnostic_uses_registration_alias_and_normalized_bits() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/project")
-        .django_settings_module("project.settings")
-        .file(
-            "/project/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['loop_tags']}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/project/templates".to_string()],
+            builtins: vec!["loop_tags".to_string()],
+            ..ProjectSettings::default()
+        })
         .file(
             "/project/loop_tags.py",
             r#"from django import template
@@ -407,16 +407,16 @@ fn repeated_project_symbols_keep_occurrence_diagnostics_across_load_prefixes() {
         "{{ fourth|needs_arg }}\n",
     );
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
         .tag_specs(configured_tag_specs(&[(
             "custom_tags",
             "custom",
             TagTypeDef::Standalone,
         )]))
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'extras': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("extras".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef custom(value):\n    pass\n@register.filter\ndef needs_arg(value, arg):\n    return value\n",
@@ -605,10 +605,13 @@ fn dynamic_installed_apps_suppress_guidance_without_template_backends() {
 #[test]
 fn partial_django_backend_keeps_configured_library_validation_inconclusive() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}, unknown_key: 'maybe'}]\n";
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file("/proj/myproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            partial: true,
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef configured(value):\n    pass\n",
@@ -712,16 +715,16 @@ fn conflicting_backend_specs_do_not_produce_argument_arity_or_structure_diagnost
 fn source_less_configured_library_preserves_block_structure() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
         .tag_specs(configured_tag_specs(&[(
             "missing.panel_tags",
             "panel",
             TagTypeDef::Block,
         )]))
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'panels': 'missing.panel_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("panels".to_string(), "missing.panel_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/templates/page.html",
             "{% load panels %}{% panel %}body",
@@ -750,11 +753,11 @@ fn source_less_configured_library_preserves_block_structure() {
 fn loaded_source_less_alias_suppresses_same_named_available_in_app_guidance() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'shared': 'missing.shared'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("shared".to_string(), "missing.shared".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file("/proj/available_in_app/__init__.py", "")
         .file("/proj/available_in_app/templatetags/__init__.py", "")
         .file(
@@ -793,16 +796,16 @@ fn loaded_source_less_alias_suppresses_same_named_available_in_app_guidance() {
 fn source_less_default_builtins_keep_django_grammar_and_load_configured_library() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
         .tag_specs(configured_tag_specs(&[(
             "missing.panel_tags",
             "panel",
             TagTypeDef::Standalone,
         )]))
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'panels': 'missing.panel_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("panels".to_string(), "missing.panel_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/templates/page.html",
             "{% load panels %}{% panel %}{% if condition %}{% for item in items %}{% comment %}{% endfor %}{% endif %}{% endcomment %}{% empty %}empty{% endfor %}{% else %}fallback{% endif %}",
@@ -878,15 +881,18 @@ fn source_less_default_builtins_keep_django_grammar_and_load_configured_library(
 fn configured_same_name_specs_remain_keyed_by_library() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
         .tag_specs(configured_tag_specs(&[
             ("alpha_tags", "shared", TagTypeDef::Block),
             ("beta_tags", "shared", TagTypeDef::Standalone),
         ]))
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([
+                ("alpha".to_string(), "alpha_tags".to_string()),
+                ("beta".to_string(), "beta_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/alpha_tags.py",
             "from django import template\nregister = template.Library()\n",
@@ -931,16 +937,16 @@ fn configured_same_name_specs_remain_keyed_by_library() {
 fn configured_source_registration_is_available_through_its_library_catalog() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
         .tag_specs(configured_tag_specs(&[(
             "dynamic_tags",
             "dynamic_panel",
             TagTypeDef::Block,
         )]))
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'dynamic': 'dynamic_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("dynamic".to_string(), "dynamic_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/dynamic_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef sourced_tag():\n    return ''\ndef compile_panel(parser, token):\n    return Node()\ntag_name = 'dynamic_panel'\nregister.tag(tag_name, compile_panel)\n",
@@ -1010,12 +1016,12 @@ fn configured_arguments_fill_a_kwargs_only_simple_tag() {
     }))
     .expect("configured argument fixture should deserialize");
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
         .tag_specs(tag_specs)
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'dynamic': 'dynamic_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("dynamic".to_string(), "dynamic_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/dynamic_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef configured(**kwargs):\n    return ''\n",
@@ -1080,12 +1086,12 @@ fn configured_fallback_does_not_weaken_empty_trusted_signatures() {
     }))
     .expect("strict configured fallback fixture should deserialize");
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("project.settings")
         .tag_specs(tag_specs)
-        .file(
-            "/proj/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'strict': 'strict_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("strict".to_string(), "strict_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/strict_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef empty_helper(): return ''\n@register.simple_tag\ndef kwargs_helper(**options): return options\n",
@@ -1145,11 +1151,14 @@ fn configured_fallback_does_not_weaken_empty_trusted_signatures() {
 fn loaded_imported_signature_rebinds_after_source_invalidation() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("project.settings")
-        .file(
-            "/proj/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'authored': 'app.templatetags.authored'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([(
+                "authored".to_string(),
+                "app.templatetags.authored".to_string(),
+            )]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/app/templatetags/authored.py",
             "from django import template\nfrom app.implementation import imported\nregister = template.Library()\nregister.simple_tag(imported, name='loaded_imported')\n",
@@ -1237,11 +1246,11 @@ fn loaded_imported_signature_rebinds_after_source_invalidation() {
 fn semantic_grammar_vocabulary_indexes_definition_identities_and_openness() {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'panels': 'panel_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("panels".to_string(), "panel_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/django/template/defaultfilters.py",
             "from django import template\nregister = template.Library()\n@register.filter\ndef title(value): return value\n",
@@ -1275,10 +1284,15 @@ fn semantic_grammar_vocabulary_indexes_definition_identities_and_openness() {
 #[test]
 fn unloaded_custom_collision_does_not_override_builtin_if_grammar() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'collisions': 'collision_tags'}}}]\n";
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file("/proj/myproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([(
+                "collisions".to_string(),
+                "collision_tags".to_string(),
+            )]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/collision_tags.py",
             "from django import template\nregister = template.Library()\n@register.tag(name='if')\ndef custom_if(parser, token):\n    body = parser.parse(('endcustom',))\n    return Node(body)\n",
@@ -1318,11 +1332,11 @@ fn unloaded_custom_collision_does_not_override_builtin_if_grammar() {
 fn unloaded_custom_closer_still_reports_unknown_tag() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'panels': 'panel_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("panels".to_string(), "panel_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/panel_tags.py",
             "from django import template\nregister = template.Library()\n@register.tag(name='panel')\ndef panel(parser, token):\n    body = parser.parse(('endpanel',))\n    return Node(body)\n",
@@ -1391,11 +1405,10 @@ fn feasible_backend_builtin_if_collision_stays_semantically_inconclusive() {
 fn project_fixture_registers_builtin_for_structure() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/templates/valid.html",
             "{% for item in items %}{{ item }}{% empty %}empty{% endfor %}",
@@ -1431,10 +1444,15 @@ fn project_fixture_registers_builtin_for_structure() {
 #[test]
 fn loaded_library_contract_wins_over_conflicting_unloaded_library() {
     let mut db = TestDatabase::new();
-    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}}]\n";
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file("/proj/myproject/settings.py", settings)
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([
+                ("alpha".to_string(), "alpha_tags".to_string()),
+                ("beta".to_string(), "beta_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/alpha_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='shared_tag')\ndef alpha(value):\n    pass\n",
@@ -1496,11 +1514,11 @@ fn shadowed_template_file_keeps_its_origin_backend_environment() {
 fn later_load_does_not_change_an_open_block_contract() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='if')\ndef custom_if(value):\n    pass\n",
@@ -1538,11 +1556,11 @@ fn later_load_does_not_change_an_open_block_contract() {
 fn opening_contract_keeps_later_intermediate_valid_after_shadowing() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='if')\ndef custom_if(value): pass\n",
@@ -1681,11 +1699,15 @@ fn captured_intermediate_does_not_apply_a_colliding_standalone_contract() {
 fn load_discovery_rebuilds_structure_until_later_load_is_visible() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['opaque_tags'], 'libraries': {'first': 'first_tags', 'second': 'second_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            builtins: vec!["opaque_tags".to_string()],
+            libraries: BTreeMap::from([
+                ("first".to_string(), "first_tags".to_string()),
+                ("second".to_string(), "second_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/opaque_tags.py",
             "from django import template\nregister = template.Library()\n@register.tag(name='shadow')\ndef shadow(parser, token):\n    parser.skip_past('endshadow')\n    return Node()\n",
@@ -1722,11 +1744,14 @@ fn load_discovery_rebuilds_structure_until_later_load_is_visible() {
 fn newly_revealed_opaque_grammar_discards_hidden_loads_and_pass_diagnostics() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'gates': 'gate_tags', 'hidden': 'hidden_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([
+                ("gates".to_string(), "gate_tags".to_string()),
+                ("hidden".to_string(), "hidden_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/gate_tags.py",
             "from django import template\nregister = template.Library()\n@register.tag\ndef gate(parser, token):\n    parser.skip_past('endgate')\n    return Node()\n",
@@ -1764,11 +1789,11 @@ fn newly_revealed_opaque_grammar_discards_hidden_loads_and_pass_diagnostics() {
 fn structural_diagnostics_accumulate_once_after_load_fixed_point_converges() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.tag\ndef customblock(parser, token):\n    parser.parse(('endcustomblock',))\n    return Node()\n",
@@ -1802,18 +1827,14 @@ fn load_discovery_converges_through_more_than_eight_grammar_changes() {
         assert!(REVEAL_COUNT > 8);
     }
 
-    let mut settings_libraries = String::new();
+    let mut settings_libraries = BTreeMap::new();
     let mut opaque_tags =
         "from django import template\nregister = template.Library()\n".to_string();
     let mut template = "{% load chain_0 %}".to_string();
-    let mut fixture = ProjectFixture::new("/proj").django_settings_module("myproject.settings");
+    let mut fixture = ProjectFixture::new("/proj");
 
     for index in 0..REVEAL_COUNT {
-        if index > 0 {
-            settings_libraries.push_str(", ");
-        }
-        write!(settings_libraries, "'chain_{index}': 'chain_{index}_tags'")
-            .expect("writing a library entry to a String should succeed");
+        settings_libraries.insert(format!("chain_{index}"), format!("chain_{index}_tags"));
         write!(
             opaque_tags,
             "@register.tag(name='gate_{index}')\ndef gate_{index}(parser, token):\n    parser.skip_past('endgate_{index}')\n    return Node()\n"
@@ -1833,19 +1854,18 @@ fn load_discovery_converges_through_more_than_eight_grammar_changes() {
         );
     }
 
-    write!(
-        settings_libraries,
-        ", 'chain_{REVEAL_COUNT}': 'chain_{REVEAL_COUNT}_tags'"
-    )
-    .expect("writing the final library entry to a String should succeed");
+    settings_libraries.insert(
+        format!("chain_{REVEAL_COUNT}"),
+        format!("chain_{REVEAL_COUNT}_tags"),
+    );
     template.push_str("{% revealed %}");
     fixture = fixture
-        .file(
-            "/proj/myproject/settings.py",
-            format!(
-                "INSTALLED_APPS = []\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {{'builtins': ['opaque_tags'], 'libraries': {{{settings_libraries}}}}}}}]\n"
-            ),
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            builtins: vec!["opaque_tags".to_string()],
+            libraries: settings_libraries,
+            ..ProjectSettings::default()
+        })
         .file("/proj/opaque_tags.py", opaque_tags)
         .file(
             format!("/proj/chain_{REVEAL_COUNT}_tags.py"),
@@ -1874,11 +1894,11 @@ fn load_discovery_converges_through_more_than_eight_grammar_changes() {
 fn custom_tag_named_if_does_not_run_builtin_if_expression_validation() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag(name='if')\ndef custom_if(*args):\n    pass\n",
@@ -1997,7 +2017,12 @@ fn mixed_authoritative_alias_shadowing_makes_available_in_app_guidance_inconclus
 fn extracted_block_db(source: &str) -> anyhow::Result<TestDatabase> {
     let mut db = TestDatabase::new();
     let project = ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
+        .settings(&ProjectSettings {
+            installed_apps: vec!["blog".to_string()],
+            dirs: Vec::new(),
+            app_dirs: true,
+            ..ProjectSettings::default()
+        })
         .file("/proj/blog/__init__.py", "")
         .file("/proj/blog/templatetags/__init__.py", "")
         .file("/proj/blog/templatetags/ambiguous.py", source)
@@ -2010,10 +2035,6 @@ fn extracted_block_db(source: &str) -> anyhow::Result<TestDatabase> {
         .file(
             "/proj/django/template/loader_tags.py",
             "from django import template\nregister = template.Library()\n@register.tag\ndef block(parser, token): pass\n@register.tag\ndef extends(parser, token): pass\n@register.tag\ndef include(parser, token): pass\n",
-        )
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = ['blog']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': True}]\n",
         )
         .install(&mut db)?;
 
@@ -2678,11 +2699,11 @@ fn opaque_region_suppresses_all_validation() {
 fn extracted_verbatim_policy_stays_opaque_while_custom_mixed_body_is_analyzed() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("myproject.settings")
-        .file(
-            "/proj/myproject/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'custom_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/django/template/defaulttags.py",
             include_str!(
@@ -3351,11 +3372,14 @@ fn loaded_unreadable_library_reports_each_load_argument_without_changing_validat
     let selective_template = "{% load known_tag from open %}";
     let repeated_template = "{% load open open %}";
     ProjectFixture::new("/proj")
-        .django_settings_module("project.settings")
-        .file(
-            "/proj/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'known': 'known_tags', 'open': 'open_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([
+                ("known".to_string(), "known_tags".to_string()),
+                ("open".to_string(), "open_tags".to_string()),
+            ]),
+            ..ProjectSettings::default()
+        })
         .file(
             "/proj/known_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef known_tag(): pass\n",
@@ -3474,11 +3498,11 @@ fn loaded_unreadable_library_reports_each_load_argument_without_changing_validat
 fn imported_register_keeps_known_symbols_and_makes_only_symbol_misses_inconclusive() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("project.settings")
-        .file(
-            "/proj/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'open': 'open_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("open".to_string(), "open_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file("/proj/django/template/defaulttags.py", "from django import template\nregister = template.Library()\n@register.tag\ndef load(parser, token): pass\n")
         .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
         .file("/proj/django/template/loader_tags.py", "from django import template\nregister = template.Library()\n")
@@ -3539,11 +3563,11 @@ fn unloaded_tag_diagnostic_depends_on_whether_the_open_library_is_loaded() {
 fn closed_registration_source_still_produces_symbol_negatives() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .django_settings_module("project.settings")
-        .file(
-            "/proj/project/settings.py",
-            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'closed': 'closed_tags'}}}]\n",
-        )
+        .settings(&ProjectSettings {
+            dirs: vec!["/proj/templates".to_string()],
+            libraries: BTreeMap::from([("closed".to_string(), "closed_tags".to_string())]),
+            ..ProjectSettings::default()
+        })
         .file("/proj/django/template/defaulttags.py", "from django import template\nregister = template.Library()\n@register.tag\ndef load(parser, token): pass\n")
         .file("/proj/django/template/defaultfilters.py", "from django import template\nregister = template.Library()\n")
         .file("/proj/django/template/loader_tags.py", "from django import template\nregister = template.Library()\n")

--- a/crates/djls-testing/src/fixtures.rs
+++ b/crates/djls-testing/src/fixtures.rs
@@ -288,6 +288,13 @@ impl ProjectFixture {
         self
     }
 
+    #[must_use]
+    pub fn settings(self, settings: &ProjectSettings) -> Self {
+        let path = self.root.join("settings.py");
+        self.file(path, settings.settings_py())
+            .django_settings_module("settings")
+    }
+
     /// Set the fixture's Django settings module.
     #[must_use]
     pub fn django_settings_module(mut self, module: impl Into<String>) -> Self {
@@ -572,7 +579,7 @@ pub fn validation_db(settings: &ProjectSettings) -> anyhow::Result<OsTestDatabas
 
     let mut db = OsTestDatabase::with_disk_roots([django_source_root]);
     search_paths.register_roots(&db);
-    db.add_file("/fixture/settings.py", &settings.render_settings_py()?)?;
+    db.add_file("/fixture/settings.py", &settings.settings_py())?;
 
     let project = Project::new(
         &db,

--- a/crates/djls-testing/src/mdtest.rs
+++ b/crates/djls-testing/src/mdtest.rs
@@ -149,7 +149,7 @@ pub fn render_validation_scenario(
     if settings_overridden {
         db.add_file(
             VALIDATION_SETTINGS_PATH,
-            &scenario.project_settings.render_settings_py()?,
+            &scenario.project_settings.settings_py(),
         )?;
     }
 
@@ -169,10 +169,7 @@ pub fn render_validation_scenario(
         db.remove_file(path.as_str())?;
     }
     if settings_overridden {
-        db.add_file(
-            VALIDATION_SETTINGS_PATH,
-            &default_settings.render_settings_py()?,
-        )?;
+        db.add_file(VALIDATION_SETTINGS_PATH, &default_settings.settings_py())?;
     }
 
     let rendered = rendered?;

--- a/crates/djls-testing/src/settings.rs
+++ b/crates/djls-testing/src/settings.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ProjectSettings {
+    pub installed_apps: Vec<String>,
     pub dirs: Vec<String>,
     pub app_dirs: bool,
     pub builtins: Vec<String>,
@@ -16,6 +17,7 @@ pub struct ProjectSettings {
 impl Default for ProjectSettings {
     fn default() -> Self {
         Self {
+            installed_apps: Vec::new(),
             dirs: vec!["/templates".to_string()],
             app_dirs: false,
             builtins: Vec::new(),
@@ -26,10 +28,17 @@ impl Default for ProjectSettings {
 }
 
 impl ProjectSettings {
-    pub(crate) fn render_settings_py(&self) -> anyhow::Result<String> {
-        let dirs = serde_json::to_string(&self.dirs)?;
-        let builtins = serde_json::to_string(&self.builtins)?;
-        let libraries = serde_json::to_string(&self.libraries)?;
+    #[must_use]
+    pub fn settings_py(&self) -> String {
+        let installed_apps = python_list(&self.installed_apps);
+        let dirs = python_list(&self.dirs);
+        let builtins = python_list(&self.builtins);
+        let libraries = self
+            .libraries
+            .iter()
+            .map(|(name, module)| format!("{}: {}", python_string(name), python_string(module)))
+            .collect::<Vec<_>>()
+            .join(", ");
         let app_dirs = if self.app_dirs { "True" } else { "False" };
         let partial = if self.partial {
             ", UNKNOWN: 'maybe'"
@@ -37,10 +46,23 @@ impl ProjectSettings {
             ""
         };
 
-        Ok(format!(
-            "INSTALLED_APPS = ['django.contrib.humanize']\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': {dirs}, 'APP_DIRS': {app_dirs}, 'OPTIONS': {{'builtins': {builtins}, 'libraries': {libraries}}}{partial}}}]\n"
-        ))
+        format!(
+            "INSTALLED_APPS = {installed_apps}\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': {dirs}, 'APP_DIRS': {app_dirs}, 'OPTIONS': {{'builtins': {builtins}, 'libraries': {{{libraries}}}}}{partial}}}]\n"
+        )
     }
+}
+
+fn python_list(values: &[String]) -> String {
+    let values = values
+        .iter()
+        .map(|value| python_string(value))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{values}]")
+}
+
+fn python_string(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
 }
 
 #[cfg(test)]
@@ -49,7 +71,13 @@ mod tests {
 
     #[test]
     fn renders_settings_python() {
+        assert_eq!(
+            ProjectSettings::default().settings_py(),
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {}}}]\n"
+        );
+
         let settings = ProjectSettings {
+            installed_apps: vec!["django.contrib.admin".to_string()],
             dirs: vec!["/templates".to_string(), "/other".to_string()],
             app_dirs: true,
             builtins: vec!["custom_tags".to_string()],
@@ -58,10 +86,8 @@ mod tests {
         };
 
         assert_eq!(
-            settings
-                .render_settings_py()
-                .expect("settings should render as Python"),
-            "INSTALLED_APPS = ['django.contrib.humanize']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [\"/templates\",\"/other\"], 'APP_DIRS': True, 'OPTIONS': {'builtins': [\"custom_tags\"], 'libraries': {\"custom\":\"custom_tags\"}}, UNKNOWN: 'maybe'}]\n"
+            settings.settings_py(),
+            "INSTALLED_APPS = ['django.contrib.admin']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates', '/other'], 'APP_DIRS': True, 'OPTIONS': {'builtins': ['custom_tags'], 'libraries': {'custom': 'custom_tags'}}, UNKNOWN: 'maybe'}]\n"
         );
     }
 }


### PR DESCRIPTION
## Why

Test fixtures repeated a full Django `TEMPLATES` dictionary whenever they only needed a project to exist. That made ordinary setup hard to distinguish from tests whose subject is the Python settings syntax itself.

## What changed

- `ProjectSettings` now describes installed apps, template directories, app-directory discovery, builtins, libraries, and partial settings. `settings_py()` renders a complete file with stable single-quoted Python literals.
- `ProjectFixture::settings` writes `<root>/settings.py` and selects `settings` as the Django settings module.
- Literal, single-backend scaffolding now uses the typed value. Hand-written Python remains where branches, unknown values, multiple backend entries, missing keys, or expressions drive the assertion.
- The default project installs no apps. The mdtest and code-action cases that need `django.contrib.humanize` now declare it.
- The resolver helper and benchmark settings constant are gone.

No diagnostic snapshot fence or `.snap` file changed. No migrated site needed a package-scoped generated settings module.

## `TEMPLATES = [` census

Counts use `rg -c 'TEMPLATES = \[' crates --type rust` before and after this change.

| File | Before | After |
|---|---:|---:|
| `crates/djls-bench/src/specs.rs` | 1 | 0 |
| `crates/djls-ide/src/warmup.rs` | 2 | 2 |
| `crates/djls-ide/tests/code_actions.rs` | 1 | 0 |
| `crates/djls-ide/tests/completions.rs` | 11 | 7 |
| `crates/djls-ide/tests/diagnostics.rs` | 1 | 0 |
| `crates/djls-ide/tests/document_links.rs` | 9 | 3 |
| `crates/djls-ide/tests/hover.rs` | 7 | 3 |
| `crates/djls-ide/tests/navigation.rs` | 21 | 7 |
| `crates/djls-ide/tests/warmup.rs` | 1 | 1 |
| `crates/djls-project/tests/resolve.rs` | 2 | 0 |
| `crates/djls-project/tests/settings.rs` | 67 | 67 |
| `crates/djls-project/tests/settings_extraction.rs` | 52 | 52 |
| `crates/djls-project/tests/template_libraries.rs` | 7 | 3 |
| `crates/djls-project/tests/templates.rs` | 35 | 29 |
| `crates/djls-semantic/tests/corpus_inheritance.rs` | 1 | 0 |
| `crates/djls-semantic/tests/inheritance.rs` | 17 | 10 |
| `crates/djls-semantic/tests/mdtest_inheritance.rs` | 1 | 0 |
| `crates/djls-semantic/tests/offset.rs` | 1 | 0 |
| `crates/djls-semantic/tests/references.rs` | 9 | 3 |
| `crates/djls-semantic/tests/structure_outline.rs` | 1 | 0 |
| `crates/djls-semantic/tests/structure_tree.rs` | 1 | 0 |
| `crates/djls-semantic/tests/validation.rs` | 43 | 13 |
| `crates/djls-testing/src/settings.rs` | 2 | 3 |
| `crates/djls-db/src/db.rs` | 16 | 16 |
| `crates/djls/src/commands/common.rs` | 3 | 3 |
| `crates/djls/tests/check.rs` | 6 | 6 |

The settings extraction tests remain raw because their input Python is the subject. The database and CLI files remain raw because they do not build through `djls-testing`.

## Kept-raw scaffolding

Each line number identifies one hand-written settings site at this commit.

- `crates/djls-project/tests/templates.rs`
  - `multi-entry`: 61, 370, 1294, 1326, 1351
  - `unknown`: 136, 345, 721, 755, 772, 792, 812, 1236, 1275, 1413
  - `branch`: 303, 404, 895, 934, 974, 978, 1021, 1049, 1093, 1099, 1138, 1173, 1203
  - `expression`: 841
- `crates/djls-project/tests/template_libraries.rs`
  - `missing-key`: 341
  - `unknown`: 574, 602
- `crates/djls-semantic/tests/validation.rs`
  - `unknown`: 96, 484, 540, 572
  - `branch`: 512, 676, 1365, 1926, 1975, 1993
  - `multi-entry`: 639, 1484
  - `missing-key`: 3532
- `crates/djls-semantic/tests/inheritance.rs`
  - `branch`: 159, 346
  - `multi-entry`: 191, 636, 711, 738, 776
  - `unknown`: 666, 839, 870
- `crates/djls-semantic/tests/references.rs`
  - `branch`: 43
  - `unknown`: 340
  - `multi-entry`: 359
- `crates/djls-ide/tests/navigation.rs`
  - `multi-entry`: 63
  - `unknown`: 318, 381, 612
  - `missing-key`: 909
  - `branch`: 1017, 1049
- `crates/djls-ide/tests/completions.rs`
  - `multi-entry`: 228, 629
  - `branch`: 280, 341, 403, 447
  - `unknown`: 701
- `crates/djls-ide/tests/hover.rs`
  - `branch`: 197
  - `multi-entry`: 259
  - `unknown`: 379
- `crates/djls-ide/tests/document_links.rs`
  - `multi-entry`: 23
  - `unknown`: 178, 237
- `crates/djls-ide/tests/warmup.rs`
  - `missing-key`: 18
- `crates/djls-ide/src/warmup.rs`
  - `missing-key`: 266, 352

## Stack

This PR is stacked on #877: https://github.com/joshuadavidthomas/django-language-server/pull/877

## Local gates

- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`
- `just hawk` — 0 findings
- `cargo test -q -p djls-semantic --test mdtest` with snapshot updates disabled
