### PR TITLE
Use Python settings files in markdown tests

### DIFF
--- a/crates/djls-ide/tests/code_actions.rs
+++ b/crates/djls-ide/tests/code_actions.rs
@@ -43,7 +43,7 @@ fn ambiguous_db_with_source(source: &str) -> TestResult<OsTestDatabase> {
         ]),
         ..ProjectSettings::default()
     };
-    let mut db = validation_db(&settings)?;
+    let mut db = validation_db(&settings.settings_py())?;
     let library = "from django import template\nregister = template.Library()\n@register.tag(name='ambiguous_tag')\ndef ambiguous_tag(parser, token): pass\n@register.filter(name='ambiguous_filter')\ndef ambiguous_filter(value): pass\n";
     db.add_file("/fixture/alpha_tags.py", library)?;
     db.add_file("/fixture/beta_tags.py", library)?;
@@ -198,14 +198,16 @@ fn unloaded_filter_action_inserts_required_library() {
         installed_apps: vec!["django.contrib.humanize".into()],
         ..ProjectSettings::default()
     };
-    let mut db = validation_db(&settings).expect("validation fixture should build");
+    let settings_py = settings.settings_py();
+    let mut db = validation_db(&settings_py).expect("validation fixture should build");
     db.add_file(TEMPLATE_PATH, source)
         .expect("template fixture should be added");
     let actions = collect_actions(&db, request_at(source, "intcomma"))
         .expect("unloaded filter should produce a code action response");
     let action = only_action(actions).expect("unloaded filter should produce one action");
     let edit = only_edit(&action).expect("unloaded filter action should contain one edit");
-    let mut edited_db = validation_db(&settings).expect("edited validation fixture should build");
+    let mut edited_db =
+        validation_db(&settings_py).expect("edited validation fixture should build");
     edited_db
         .add_file(TEMPLATE_PATH, &apply_edit(source, edit))
         .expect("edited template fixture should be added");

--- a/crates/djls-project/tests/templates.rs
+++ b/crates/djls-project/tests/templates.rs
@@ -167,12 +167,11 @@ fn project_inventory_preserves_backend_remainder_slot_order() {
 fn partial_known_backend_field_uncertainty_keeps_one_correlated_backend_alternative() {
     let db = TestDatabase::new();
     let project = ProjectFixture::new("/test/project")
-        .settings(&ProjectSettings {
-            dirs: vec!["/test/project/templates".to_string()],
-            libraries: BTreeMap::from([("shared".to_string(), "alpha_tags".to_string())]),
-            partial: true,
-            ..ProjectSettings::default()
-        })
+        .django_settings_module("settings")
+        .file(
+            "/test/project/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/test/project/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {'shared': 'alpha_tags'}}, UNKNOWN: 'maybe'}]\n",
+        )
         .file(
             "/test/project/alpha_tags.py",
             "from django import template\nregister = template.Library()\n",

--- a/crates/djls-semantic/resources/mdtest/README.md
+++ b/crates/djls-semantic/resources/mdtest/README.md
@@ -21,41 +21,41 @@ Each fenced block belongs to the heading above it:
 | Fence | Meaning |
 |---|---|
 | `htmldjango`, `django`, or `html` | A template. The unlabeled block is the file under test; labeled blocks are support templates. |
-| `py` | A Python module in the fixture project. A relative path label is required. |
-| `toml` | The project settings for that heading and its descendants. |
+| `py` | A Python module in the fixture project. A relative path label is required. A block labeled `settings.py` supplies the project settings and inherits through nested headings. |
 | `snapshot` | The expected rendered diagnostics. |
 | `ignore` | Content that the runner skips. |
 
-The runner rejects unknown fence languages. A section may contain at most one `toml` fence.
+The runner rejects unknown fence languages. A section may contain at most one `settings.py` block.
 
-A `toml` fence replaces the inherited settings as one value. Omitted keys take these defaults:
+A scenario with no `settings.py` in its heading ancestry uses this file:
 
-| Key | Type | Default |
-|---|---|---|
-| `installed-apps` | list of module paths | `[]` |
-| `dirs` | list of strings | `["/templates"]` |
-| `app-dirs` | boolean | `false` |
-| `builtins` | list of module paths | `[]` |
-| `libraries` | table from load name to module path | `{}` |
-| `partial` | boolean | `false` |
+`settings.py`:
 
-The default project installs no apps, so a scenario that needs a contrib library declares it with `installed-apps`.
+```py
+INSTALLED_APPS = []
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {}}}]
+```
+
+Copy that block into a scenario or grouping heading, then edit the Django settings the scenario needs.
 
 ## Inheritance
 
-A `toml` fence applies to its heading and every nested heading until a child supplies another `toml` fence. The child settings replace the inherited value rather than merging fields.
+A `settings.py` block applies to its heading and every nested heading until a child supplies another one. The child replaces the inherited file.
 
-Files stay in the section that declares them. Each scenario repeats the `py` files and templates it needs. A grouping heading may contain `toml`, but a `py` fence there is an error because child scenarios do not inherit it. Once a heading contains a template, it cannot have child headings.
+Other files stay in the section that declares them. Each scenario repeats the Python modules and templates it needs. A grouping heading may contain `settings.py`, but any other Python file there is an error because child scenarios do not inherit it. Once a heading contains a template, it cannot have child headings.
 
-A `libraries` or `builtins` entry naming a module that no `py` fence in that scenario provides makes the library unreadable and suppresses unknown-name diagnostics, so keep the `toml` fence beside the fences that supply its modules.
+A `libraries` or `builtins` entry naming a module that the scenario does not provide makes the library unreadable and suppresses unknown-name diagnostics. Keep each settings block beside the scenarios whose Python fences provide its modules.
 
-This example shares the settings from the title while keeping the Python module in the scenario that uses it:
+This example shares settings from the title while keeping the Python module in the scenario that uses it:
 
 ````markdown
 # Greeting tags
 
-```toml
-builtins = ["greeting_tags"]
+`settings.py`:
+
+```py
+INSTALLED_APPS = []
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['greeting_tags'], 'libraries': {}}}]
 ```
 
 ## accepts one name

--- a/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/scoping.md
@@ -30,10 +30,11 @@ error[S109]: Tag 'static' requires the 'static' tag library
 
 ## tag is available from multiple unloaded libraries
 
-```toml
-[libraries]
-alpha = "alpha_tags"
-beta = "beta_tags"
+`settings.py`:
+
+```py
+INSTALLED_APPS = []
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}}]
 ```
 
 `alpha_tags.py`:
@@ -86,8 +87,11 @@ error[S111]: Unknown filter 'completelymadetupfilter'
 
 ## filter requires load when not configured as a builtin
 
-```toml
-installed-apps = ["django.contrib.humanize"]
+`settings.py`:
+
+```py
+INSTALLED_APPS = ['django.contrib.humanize']
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {}}}]
 ```
 
 ```htmldjango
@@ -104,10 +108,11 @@ error[S112]: Filter 'intcomma' requires the 'humanize' tag library
 
 ## filter is available from multiple unloaded libraries
 
-```toml
-[libraries]
-alpha = "alpha_tags"
-beta = "beta_tags"
+`settings.py`:
+
+```py
+INSTALLED_APPS = []
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}}]
 ```
 
 `alpha_tags.py`:

--- a/crates/djls-semantic/resources/mdtest/diagnostics/tag-rules.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/tag-rules.md
@@ -1,7 +1,10 @@
 # Tag argument diagnostics
 
-```toml
-builtins = ["custom_tags"]
+`settings.py`:
+
+```py
+INSTALLED_APPS = []
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['custom_tags'], 'libraries': {}}}]
 ```
 
 ## tag requires an argument

--- a/crates/djls-semantic/resources/mdtest/diagnostics/unreadable-library.md
+++ b/crates/djls-semantic/resources/mdtest/diagnostics/unreadable-library.md
@@ -1,7 +1,10 @@
 # Unreadable Template Library loads
 
-```toml
-libraries = { open = "open_tags" }
+`settings.py`:
+
+```py
+INSTALLED_APPS = []
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {'open': 'open_tags'}}}]
 ```
 
 ## loaded library has a registration DJLS could not read

--- a/crates/djls-semantic/tests/validation.rs
+++ b/crates/djls-semantic/tests/validation.rs
@@ -72,15 +72,8 @@ fn configured_tag_specs(definitions: &[(&str, &str, TagTypeDef)]) -> TagSpecDef 
 }
 
 fn partial_ambiguous_db() -> anyhow::Result<OsTestDatabase> {
-    let settings = ProjectSettings {
-        libraries: BTreeMap::from([
-            ("alpha".to_string(), "alpha_tags".to_string()),
-            ("beta".to_string(), "beta_tags".to_string()),
-        ]),
-        partial: true,
-        ..ProjectSettings::default()
-    };
-    let mut db = validation_db(&settings)?;
+    let settings = "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {'alpha': 'alpha_tags', 'beta': 'beta_tags'}}, UNKNOWN: 'maybe'}]\n";
+    let mut db = validation_db(settings)?;
     let library = "from django import template\nregister = template.Library()\n@register.tag(name='shared')\ndef shared_tag(parser, token): pass\n@register.filter(name='shared')\ndef shared_filter(value): pass\n";
     db.add_file("/fixture/alpha_tags.py", library)?;
     db.add_file("/fixture/beta_tags.py", library)?;
@@ -606,12 +599,11 @@ fn dynamic_installed_apps_suppress_guidance_without_template_backends() {
 fn partial_django_backend_keeps_configured_library_validation_inconclusive() {
     let mut db = TestDatabase::new();
     ProjectFixture::new("/proj")
-        .settings(&ProjectSettings {
-            dirs: vec!["/proj/templates".to_string()],
-            libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
-            partial: true,
-            ..ProjectSettings::default()
-        })
+        .django_settings_module("settings")
+        .file(
+            "/proj/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/proj/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {'custom': 'custom_tags'}}, UNKNOWN: 'maybe'}]\n",
+        )
         .file(
             "/proj/custom_tags.py",
             "from django import template\nregister = template.Library()\n@register.simple_tag\ndef configured(value):\n    pass\n",
@@ -2407,10 +2399,13 @@ fn unknown_load_shadowed_tag_contract_exact_and_closed_loads_retain_contracts() 
         "an exact load must not suppress an unrelated opener contract: {exact_errors:?}"
     );
 
-    let mut closed = validation_db(&ProjectSettings {
-        builtins: vec!["one_arg_tags".into()],
-        ..ProjectSettings::default()
-    })
+    let mut closed = validation_db(
+        &ProjectSettings {
+            builtins: vec!["one_arg_tags".into()],
+            ..ProjectSettings::default()
+        }
+        .settings_py(),
+    )
     .expect("closed validation fixture should build");
     closed
         .add_file(

--- a/crates/djls-testing/src/fixtures.rs
+++ b/crates/djls-testing/src/fixtures.rs
@@ -551,17 +551,16 @@ pub fn snapshot_validate_files<'a>(
 
 /// Validation fixture for mdtest snapshots backed by the pinned Django corpus.
 pub fn standard_validation_db() -> anyhow::Result<OsTestDatabase> {
-    validation_db(&ProjectSettings::default())
+    validation_db(&ProjectSettings::default().settings_py())
 }
 
 pub fn partial_validation_db() -> anyhow::Result<OsTestDatabase> {
-    validation_db(&ProjectSettings {
-        partial: true,
-        ..ProjectSettings::default()
-    })
+    validation_db(
+        "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': [], 'libraries': {}}, UNKNOWN: 'maybe'}]\n",
+    )
 }
 
-pub fn validation_db(settings: &ProjectSettings) -> anyhow::Result<OsTestDatabase> {
+pub fn validation_db(settings_py: &str) -> anyhow::Result<OsTestDatabase> {
     let corpus = Corpus::require()?;
     let django_source_root = corpus.root().join("repos/django-5.2");
     anyhow::ensure!(
@@ -579,7 +578,7 @@ pub fn validation_db(settings: &ProjectSettings) -> anyhow::Result<OsTestDatabas
 
     let mut db = OsTestDatabase::with_disk_roots([django_source_root]);
     search_paths.register_roots(&db);
-    db.add_file("/fixture/settings.py", &settings.settings_py())?;
+    db.add_file("/fixture/settings.py", settings_py)?;
 
     let project = Project::new(
         &db,

--- a/crates/djls-testing/src/mdtest.rs
+++ b/crates/djls-testing/src/mdtest.rs
@@ -34,7 +34,7 @@ pub struct Scenario {
     snapshot_start: Option<usize>,
     snapshot_end: Option<usize>,
     snapshot_insert_at: usize,
-    project_settings: ProjectSettings,
+    settings_source: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -144,13 +144,8 @@ pub fn render_validation_scenario(
     for (path, source) in &python_files {
         db.add_file(path.as_str(), source)?;
     }
-    let default_settings = ProjectSettings::default();
-    let settings_overridden = scenario.project_settings != default_settings;
-    if settings_overridden {
-        db.add_file(
-            VALIDATION_SETTINGS_PATH,
-            &scenario.project_settings.settings_py(),
-        )?;
+    if let Some(settings_source) = &scenario.settings_source {
+        db.add_file(VALIDATION_SETTINGS_PATH, settings_source)?;
     }
 
     let rendered = snapshot_validate_files(
@@ -168,8 +163,11 @@ pub fn render_validation_scenario(
     for (path, _) in &python_files {
         db.remove_file(path.as_str())?;
     }
-    if settings_overridden {
-        db.add_file(VALIDATION_SETTINGS_PATH, &default_settings.settings_py())?;
+    if scenario.settings_source.is_some() {
+        db.add_file(
+            VALIDATION_SETTINGS_PATH,
+            &ProjectSettings::default().settings_py(),
+        )?;
     }
 
     let rendered = rendered?;
@@ -377,7 +375,7 @@ struct ScenarioCollector<'a> {
 struct Heading {
     level: usize,
     name: String,
-    settings: Option<ProjectSettings>,
+    settings: Option<String>,
 }
 
 #[derive(Debug)]
@@ -611,7 +609,7 @@ impl<'a> ScenarioCollector<'a> {
         }
         if !matches!(
             language.as_str(),
-            "htmldjango" | "django" | "html" | "py" | "toml" | "snapshot"
+            "htmldjango" | "django" | "html" | "py" | "snapshot"
         ) {
             let heading = self
                 .current
@@ -634,7 +632,6 @@ impl<'a> ScenarioCollector<'a> {
         match block.language.as_str() {
             "htmldjango" | "django" | "html" => self.set_template(block),
             "py" => self.set_python(block),
-            "toml" => self.set_settings(&block),
             "snapshot" => self.set_snapshot(block),
             _ => Ok(()),
         }
@@ -701,10 +698,18 @@ impl<'a> ScenarioCollector<'a> {
             ));
         }
         if file_path == "settings.py" {
-            return Err(format!(
-                "heading '{}' Python path 'settings.py' is reserved for generated project settings",
-                current.name
-            ));
+            let heading = self
+                .headings
+                .last_mut()
+                .ok_or_else(|| "settings.py must appear under a heading".to_string())?;
+            if heading.settings.is_some() {
+                return Err(format!(
+                    "heading '{}' has more than one py block for path 'settings.py'",
+                    current.name
+                ));
+            }
+            heading.settings = Some(block.content);
+            return Ok(());
         }
         if current
             .files
@@ -722,29 +727,6 @@ impl<'a> ScenarioCollector<'a> {
             path: file_path,
             source: block.content,
         });
-        Ok(())
-    }
-
-    fn set_settings(&mut self, block: &FencedBlock) -> Result<(), String> {
-        self.pending_file_path = None;
-        let current_name = self
-            .current
-            .as_ref()
-            .ok_or_else(|| "toml code block must appear under a heading".to_string())?
-            .name
-            .clone();
-        let heading = self
-            .headings
-            .last_mut()
-            .ok_or_else(|| "toml code block must appear under a heading".to_string())?;
-        if heading.settings.is_some() {
-            return Err(format!(
-                "heading '{current_name}' has more than one toml code block"
-            ));
-        }
-        let settings = toml::from_str(&block.content)
-            .map_err(|error| format!("heading '{current_name}' has invalid toml: {error}"))?;
-        heading.settings = Some(settings);
         Ok(())
     }
 
@@ -803,12 +785,11 @@ impl<'a> ScenarioCollector<'a> {
                     current.name
                 )
             })?;
-            let project_settings = self
+            let settings_source = self
                 .headings
                 .iter()
                 .rev()
-                .find_map(|heading| heading.settings.clone())
-                .unwrap_or_default();
+                .find_map(|heading| heading.settings.clone());
             self.scenarios.push(Scenario {
                 name: current.name,
                 files: current.files,
@@ -817,7 +798,7 @@ impl<'a> ScenarioCollector<'a> {
                 snapshot_start: current.snapshot_start,
                 snapshot_end: current.snapshot_end,
                 snapshot_insert_at,
-                project_settings,
+                settings_source,
             });
             Ok(())
         } else if current.snapshot.is_none() {
@@ -1110,23 +1091,30 @@ source
     }
 
     #[test]
-    fn rejects_two_toml_blocks_in_one_section() {
+    fn rejects_two_settings_python_blocks_in_one_section() {
         let markdown = r"# Shape
 
-```toml
-builtins = []
+`settings.py`:
+
+```py
+FIRST = 1
 ```
 
-```toml
-libraries = {}
+`settings.py`:
+
+```py
+SECOND = 2
 ```
 ";
 
         let error = ScenarioCollector::new(markdown)
             .collect()
-            .expect_err("two toml blocks should be rejected");
+            .expect_err("two settings.py blocks should be rejected");
 
-        assert_eq!(error, "heading 'Shape' has more than one toml code block");
+        assert_eq!(
+            error,
+            "heading 'Shape' has more than one py block for path 'settings.py'"
+        );
     }
 
     #[test]
@@ -1192,35 +1180,18 @@ SECOND = 2
     }
 
     #[test]
-    fn rejects_python_label_reserved_for_generated_settings() {
-        let markdown = r"# Shape
+    fn inherits_settings_python_from_an_ancestor_heading() {
+        let markdown = r#"# Shape
 
 `settings.py`:
 
 ```py
-VALUE = 1
-```
-";
-
-        let error = ScenarioCollector::new(markdown)
-            .collect()
-            .expect_err("settings.py should be reserved");
-
-        assert_eq!(
-            error,
-            "heading 'Shape' Python path 'settings.py' is reserved for generated project settings"
-        );
-    }
-
-    #[test]
-    fn inherits_toml_from_an_ancestor_heading() {
-        let markdown = r#"# Shape
-
-```toml
-builtins = ["local_tags"]
+BUILTINS = ["local_tags"]
 ```
 
-## scenario
+## Group
+
+### scenario
 
 `local_tags.py`:
 
@@ -1257,7 +1228,37 @@ snapshot
                 },
             ]
         );
-        assert_eq!(scenarios[0].project_settings.builtins, ["local_tags"]);
+        assert_eq!(
+            scenarios[0].settings_source.as_deref(),
+            Some("BUILTINS = [\"local_tags\"]")
+        );
+    }
+
+    #[test]
+    fn allows_settings_python_on_a_grouping_heading() {
+        let markdown = r"# Shape
+
+## Group
+
+`settings.py`:
+
+```py
+VALUE = 1
+```
+
+### scenario
+
+```htmldjango
+content
+```
+";
+
+        let scenarios = ScenarioCollector::new(markdown)
+            .collect()
+            .expect("settings.py on a grouping heading should parse");
+
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(scenarios[0].settings_source.as_deref(), Some("VALUE = 1"));
     }
 
     #[test]

--- a/crates/djls-testing/src/settings.rs
+++ b/crates/djls-testing/src/settings.rs
@@ -1,17 +1,13 @@
 use std::collections::BTreeMap;
 
-use serde::Deserialize;
-
-/// Django template backend settings used by validation fixtures and mdtests.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
+/// Django template backend settings used by Rust test fixtures.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProjectSettings {
     pub installed_apps: Vec<String>,
     pub dirs: Vec<String>,
     pub app_dirs: bool,
     pub builtins: Vec<String>,
     pub libraries: BTreeMap<String, String>,
-    pub partial: bool,
 }
 
 impl Default for ProjectSettings {
@@ -22,7 +18,6 @@ impl Default for ProjectSettings {
             app_dirs: false,
             builtins: Vec::new(),
             libraries: BTreeMap::new(),
-            partial: false,
         }
     }
 }
@@ -40,14 +35,9 @@ impl ProjectSettings {
             .collect::<Vec<_>>()
             .join(", ");
         let app_dirs = if self.app_dirs { "True" } else { "False" };
-        let partial = if self.partial {
-            ", UNKNOWN: 'maybe'"
-        } else {
-            ""
-        };
 
         format!(
-            "INSTALLED_APPS = {installed_apps}\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': {dirs}, 'APP_DIRS': {app_dirs}, 'OPTIONS': {{'builtins': {builtins}, 'libraries': {{{libraries}}}}}{partial}}}]\n"
+            "INSTALLED_APPS = {installed_apps}\nTEMPLATES = [{{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': {dirs}, 'APP_DIRS': {app_dirs}, 'OPTIONS': {{'builtins': {builtins}, 'libraries': {{{libraries}}}}}}}]\n"
         )
     }
 }
@@ -82,12 +72,11 @@ mod tests {
             app_dirs: true,
             builtins: vec!["custom_tags".to_string()],
             libraries: BTreeMap::from([("custom".to_string(), "custom_tags".to_string())]),
-            partial: true,
         };
 
         assert_eq!(
             settings.settings_py(),
-            "INSTALLED_APPS = ['django.contrib.admin']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates', '/other'], 'APP_DIRS': True, 'OPTIONS': {'builtins': ['custom_tags'], 'libraries': {'custom': 'custom_tags'}}, UNKNOWN: 'maybe'}]\n"
+            "INSTALLED_APPS = ['django.contrib.admin']\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates', '/other'], 'APP_DIRS': True, 'OPTIONS': {'builtins': ['custom_tags'], 'libraries': {'custom': 'custom_tags'}}}]\n"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Treat a `py` fence labeled `settings.py` as the scenario's full Django settings module.
- Inherit that settings file through nested headings while keeping templates and other Python modules local to each scenario.
- Keep `ProjectSettings` as the typed renderer for Rust fixtures; fixtures with unresolved Python expressions use source text.
- Rewrite the existing markdown settings without changing diagnostic snapshots.

## Example

Before:

```toml
builtins = ["custom_tags"]
```

After:

`settings.py`:

```py
INSTALLED_APPS = []
TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': ['/templates'], 'APP_DIRS': False, 'OPTIONS': {'builtins': ['custom_tags'], 'libraries': {}}}]
```

## Validation

- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`
- `just hawk`
- `cargo test -q -p djls-semantic --test mdtest`