### PR TITLE
Build all test projects through ProjectFixture

### DIFF
--- a/crates/djls-project/tests/corpus_settings.rs
+++ b/crates/djls-project/tests/corpus_settings.rs
@@ -16,20 +16,14 @@ use camino::Utf8Path;
 #[cfg(not(windows))]
 use djls_project::Interpreter;
 #[cfg(not(windows))]
-use djls_project::Project;
-#[cfg(not(windows))]
-use djls_project::PythonModuleName;
-#[cfg(not(windows))]
-use djls_project::SearchPaths;
-#[cfg(not(windows))]
 use djls_project::testing::django_settings;
 #[cfg(not(windows))]
 use djls_project::testing::settings_module_file;
-#[cfg(not(windows))]
-use djls_source::Db as _;
 use djls_testing::Corpus;
 #[cfg(not(windows))]
 use djls_testing::OsTestDatabase;
+#[cfg(not(windows))]
+use djls_testing::ProjectFixture;
 use serde_json::Value;
 
 #[cfg(not(windows))]
@@ -190,25 +184,10 @@ fn settings_extraction_snapshots() -> Result<(), Box<dyn std::error::Error>> {
         for settings_module in corpus_project.django_settings_modules {
             let mut db = OsTestDatabase::with_disk_roots([checkout_root.clone()]);
             let interpreter = Interpreter::VenvPath(corpus.root().join("hermetic-no-venv"));
-            let pythonpath = Vec::new();
-            let search_paths = SearchPaths::from_project_settings(
-                db.file_system(),
-                project_root.as_path(),
-                &interpreter,
-                &pythonpath,
-            );
-            search_paths.register_roots(&db);
-            let project = Project::new(
-                &db,
-                project_root.clone(),
-                search_paths,
-                interpreter,
-                Some(PythonModuleName::parse(&settings_module)?),
-                pythonpath,
-                Vec::new(),
-                djls_conf::Settings::default().tagspecs().clone(),
-            );
-            db.set_project(project);
+            let project = ProjectFixture::new(project_root.clone())
+                .django_settings_module(&settings_module)
+                .interpreter(interpreter)
+                .install(&mut db)?;
 
             settings_module_file(&db, project).ok_or_else(|| {
                 io::Error::other(format!(

--- a/crates/djls-project/tests/model_relations.rs
+++ b/crates/djls-project/tests/model_relations.rs
@@ -8,7 +8,6 @@ use djls_project::ModelGraph;
 use djls_project::ModelId;
 use djls_project::Project;
 use djls_project::PythonModuleName;
-use djls_project::SearchPaths;
 use djls_project::compute_model_graph;
 use djls_project::testing::ModelAncestryOutcomeView;
 use djls_project::testing::ModelBaseOutcomeView;
@@ -23,7 +22,6 @@ use djls_project::testing::model_relation_locations;
 use djls_project::testing::python_syntax_errors;
 use djls_project::testing::resolve_model_graph_from_modules;
 use djls_source::ChangeEvent;
-use djls_source::Db as _;
 use djls_source::SourceChanges;
 use djls_source::Span;
 use djls_testing::ProjectFixture;
@@ -1222,41 +1220,23 @@ fn computed_model_graph_does_not_expose_file_local_relation_resolution() {
 fn salsa_recomputes_relation_resolution_for_import_edits_only_where_needed() {
     let event_log = SalsaEventLog::default();
     let mut db = TestDatabase::with_event_log(event_log.clone());
-    db.add_file(
-        "/project/accounts/models.py",
-        include_str!("testdata/model_relations/salsa_recomputes_relation_resolution_for_import_edits_only_where_needed/accounts/models.py"),
-    )
-    .expect("accounts model fixture should be added to the test database");
-    db.add_file(
-        "/project/blog/models.py",
-        include_str!("testdata/model_relations/salsa_recomputes_relation_resolution_for_import_edits_only_where_needed/blog/models_initial.py"),
-    )
-    .expect("blog model fixture should be added to the test database");
-    db.add_file(
-        "/project/other/models.py",
-        include_str!("testdata/model_relations/salsa_recomputes_relation_resolution_for_import_edits_only_where_needed/other/models_initial.py"),
-    )
-    .expect("other model fixture should be added to the test database");
-
-    let interpreter = Interpreter::Auto;
-    let search_paths = SearchPaths::from_project_settings(
-        db.file_system(),
-        Utf8Path::new("/project"),
-        &interpreter,
-        &[],
-    );
-    search_paths.register_roots(&db);
-    let project = Project::new(
-        &db,
-        Utf8Path::new("/project").to_path_buf(),
-        search_paths,
-        interpreter,
-        None,
-        Vec::new(),
-        Vec::new(),
-        TagSpecDef::default(),
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new("/project")
+        .file(
+            "/project/accounts/models.py",
+            include_str!("testdata/model_relations/salsa_recomputes_relation_resolution_for_import_edits_only_where_needed/accounts/models.py"),
+        )
+        .file(
+            "/project/blog/models.py",
+            include_str!("testdata/model_relations/salsa_recomputes_relation_resolution_for_import_edits_only_where_needed/blog/models_initial.py"),
+        )
+        .file(
+            "/project/other/models.py",
+            include_str!("testdata/model_relations/salsa_recomputes_relation_resolution_for_import_edits_only_where_needed/other/models_initial.py"),
+        )
+        .interpreter(Interpreter::Auto)
+        .tag_specs(TagSpecDef::default())
+        .install(&mut db)
+        .expect("model project fixture should build");
 
     let graph = compute_model_graph(&db, project);
     let post = model_id(graph, "Post", "blog.models")

--- a/crates/djls-project/tests/resolve.rs
+++ b/crates/djls-project/tests/resolve.rs
@@ -3,7 +3,6 @@ use std::io;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_conf::Settings;
 use djls_project::testing::PythonImportOutcomeView;
 use djls_project::testing::PythonModuleEvaluationView;
 use djls_project::testing::compute_django_environment;
@@ -1345,18 +1344,11 @@ fn ty_symlink() {
         &Interpreter::Auto,
         &[],
     );
-    search_paths.register_roots(&db);
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        Interpreter::Auto,
-        None,
-        Vec::new(),
-        Vec::new(),
-        Settings::default().tagspecs().clone(),
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new(root)
+        .interpreter(Interpreter::Auto)
+        .search_paths(search_paths)
+        .install(&mut db)
+        .expect("resolver project fixture should build");
 
     let foo_module = PythonSourceModule::resolve(
         &db,
@@ -2354,18 +2346,11 @@ fn ty_case_sensitive_resolution_with_symlinked_directory() {
         &Interpreter::Auto,
         &[],
     );
-    search_paths.register_roots(&db);
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        Interpreter::Auto,
-        None,
-        Vec::new(),
-        Vec::new(),
-        Settings::default().tagspecs().clone(),
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new(root)
+        .interpreter(Interpreter::Auto)
+        .search_paths(search_paths)
+        .install(&mut db)
+        .expect("resolver project fixture should build");
 
     assert_eq!(
         PythonSourceModule::resolve(

--- a/crates/djls-project/tests/settings.rs
+++ b/crates/djls-project/tests/settings.rs
@@ -1,15 +1,12 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::io;
-use std::mem;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use djls_conf::Settings;
 use djls_project::Db as ProjectDb;
 use djls_project::testing::PythonSyntaxErrorClass;
 use djls_project::testing::compute_django_environment;
@@ -24,7 +21,6 @@ use djls_source::FileSystem;
 use djls_source::InMemoryFileSystem;
 use djls_source::RootWalk;
 use djls_source::SourceChanges;
-use djls_source::SourceFiles;
 use djls_source::WalkOptions;
 use djls_testing::DjangoFactsGolden;
 use djls_testing::GoldenTemplateSymbol;
@@ -36,7 +32,6 @@ use djls_testing::django_facts_project;
 use salsa::Database;
 use salsa::Event;
 use salsa::EventKind;
-use salsa::Storage;
 use serde_json::Value;
 use serde_json::to_value;
 
@@ -1052,39 +1047,9 @@ impl FileSystem for ToggleReadFileSystem {
     }
 }
 
-#[salsa::db]
-#[derive(Clone)]
-struct EventTestDatabase {
-    storage: Storage<Self>,
-    fs: Arc<dyn FileSystem>,
-    files: SourceFiles,
-    project: Option<Project>,
-}
-
-#[salsa::db]
-impl Database for EventTestDatabase {}
-
-#[salsa::db]
-impl SourceDb for EventTestDatabase {
-    fn files(&self) -> &SourceFiles {
-        &self.files
-    }
-
-    fn file_system(&self) -> &dyn FileSystem {
-        self.fs.as_ref()
-    }
-}
-
-#[salsa::db]
-impl ProjectDb for EventTestDatabase {
-    fn project(&self) -> Option<Project> {
-        self.project
-    }
-}
-
 #[test]
 fn readable_unreadable_rescans_recompute_ancestors_once_and_retain_dependency() {
-    let events = Arc::new(Mutex::new(Vec::new()));
+    let events = SalsaEventLog::default();
     let readable = Arc::new(AtomicBool::new(true));
     let leaf_path = Utf8PathBuf::from("/proj/myproject/leaf.py");
     let mut inner = InMemoryFileSystem::new();
@@ -1097,48 +1062,20 @@ fn readable_unreadable_rescans_recompute_ancestors_once_and_retain_dependency() 
         "from .leaf import *\nINSTALLED_APPS = ['local']\n".to_string(),
     );
     inner.add_file(leaf_path.clone(), "TEMPLATES = []\n".to_string());
-    let mut db = EventTestDatabase {
-        storage: Storage::new(Some(Box::new({
-            let events = Arc::clone(&events);
-            move |event| {
-                events
-                    .lock()
-                    .expect("test mutex should not be poisoned")
-                    .push(event);
-            }
-        }))),
-        fs: Arc::new(ToggleReadFileSystem {
+    let mut db = OsTestDatabase::with_file_system_and_event_log(
+        Arc::new(ToggleReadFileSystem {
             inner,
             toggled_path: leaf_path,
             readable: Arc::clone(&readable),
         }),
-        files: SourceFiles::default(),
-        project: None,
-    };
-    let root = Utf8PathBuf::from("/proj");
-    let interpreter = Interpreter::Auto;
-    let pythonpath = Vec::new();
-    let search_paths = SearchPaths::from_project_settings(
-        db.file_system(),
-        root.as_path(),
-        &interpreter,
-        &pythonpath,
+        [Utf8PathBuf::from("/proj")],
+        events.clone(),
     );
-    search_paths.register_roots(&db);
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        interpreter,
-        Some(
-            PythonModuleName::parse("myproject.settings")
-                .expect("test Python module name should be valid"),
-        ),
-        pythonpath,
-        Vec::new(),
-        Settings::default().tagspecs().clone(),
-    );
-    db.project = Some(project);
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .interpreter(Interpreter::Auto)
+        .install(&mut db)
+        .expect("settings project fixture should build");
 
     let _ = django_settings(&db, project);
     // settings.py loads `.leaf` and its distinct parent package
@@ -1148,9 +1085,8 @@ fn readable_unreadable_rescans_recompute_ancestors_once_and_retain_dependency() 
         3
     );
     events
-        .lock()
-        .expect("test mutex should not be poisoned")
-        .clear();
+        .take()
+        .expect("settings event log should be readable");
 
     for next_readable in [false, true] {
         readable.store(next_readable, Ordering::SeqCst);
@@ -1160,8 +1096,9 @@ fn readable_unreadable_rescans_recompute_ancestors_once_and_retain_dependency() 
             ProjectFactsPhase::SettingsSources.run(&db, project).count(),
             3
         );
-        let transition_events =
-            mem::take(&mut *events.lock().expect("test mutex should not be poisoned"));
+        let transition_events = events
+            .take()
+            .expect("settings event log should be readable");
 
         assert_eq!(
             execution_count(&db, &transition_events, "evaluate_python_module"),
@@ -1287,27 +1224,10 @@ fn project_with_file_system_failure(
         Arc::new(FailingFileSystem { inner: fs, failure }),
         [Utf8PathBuf::from("/proj")],
     );
-    let root = Utf8PathBuf::from("/proj");
-    let interpreter = Interpreter::Auto;
-    let pythonpath = Vec::new();
-    let search_paths = SearchPaths::from_project_settings(
-        db.file_system(),
-        root.as_path(),
-        &interpreter,
-        &pythonpath,
-    );
-    search_paths.register_roots(&db);
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        interpreter,
-        Some(PythonModuleName::parse("myproject.settings")?),
-        pythonpath,
-        Vec::new(),
-        djls_conf::Settings::default().tagspecs().clone(),
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .interpreter(Interpreter::Auto)
+        .install(&mut db)?;
 
     Ok((db, project))
 }
@@ -1331,28 +1251,22 @@ fn apply_project_discovery(db: &mut TestDatabase) -> Result<(), io::Error> {
 fn project_requiring_environment_application(
     db: &mut TestDatabase,
 ) -> Result<Project, Box<dyn std::error::Error>> {
-    db.add_file(
-        "/proj/settings.py",
-        "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'extras.tags'}}}]\n",
-    )?;
-    db.add_file("/vendor/extras/__init__.py", "")?;
-    db.add_file(
-        "/vendor/extras/tags.py",
-        "from django import template\nregister = template.Library()\n@register.simple_tag\ndef custom(): pass\n",
-    )?;
-
-    let project = Project::new(
-        db,
-        Utf8PathBuf::from("/proj"),
-        SearchPaths::default(),
-        Interpreter::Auto,
-        Some(PythonModuleName::parse("settings")?),
-        vec![Utf8PathBuf::from("/vendor")],
-        Vec::new(),
-        Settings::default().tagspecs().clone(),
-    );
-    db.set_project(project);
-    Ok(project)
+    Ok(ProjectFixture::new("/proj")
+        .file(
+            "/proj/settings.py",
+            "INSTALLED_APPS = []\nTEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'DIRS': [], 'APP_DIRS': False, 'OPTIONS': {'libraries': {'custom': 'extras.tags'}}}]\n",
+        )
+        .file("/vendor/extras/__init__.py", "")
+        .file(
+            "/vendor/extras/tags.py",
+            "from django import template\nregister = template.Library()\n@register.simple_tag\ndef custom(): pass\n",
+        )
+        .django_settings_module("settings")
+        .pythonpath("/vendor")
+        .interpreter(Interpreter::Auto)
+        .search_paths(SearchPaths::default())
+        .register_roots(false)
+        .install(db)?)
 }
 
 #[test]
@@ -1708,30 +1622,11 @@ fn unreadable_root_settings_are_dynamic_never_unset() {
         }),
         [Utf8PathBuf::from("/proj")],
     );
-    let root = Utf8PathBuf::from("/proj");
-    let interpreter = Interpreter::Auto;
-    let pythonpath = Vec::new();
-    let search_paths = SearchPaths::from_project_settings(
-        db.file_system(),
-        root.as_path(),
-        &interpreter,
-        &pythonpath,
-    );
-    search_paths.register_roots(&db);
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        interpreter,
-        Some(
-            PythonModuleName::parse("myproject.settings")
-                .expect("test Python module name should be valid"),
-        ),
-        pythonpath,
-        Vec::new(),
-        Settings::default().tagspecs().clone(),
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .interpreter(Interpreter::Auto)
+        .install(&mut db)
+        .expect("settings project fixture should build");
 
     let settings =
         to_value(django_settings(&db, project)).expect("test Python module name should be valid");
@@ -1766,31 +1661,11 @@ fn django_discovery_includes_deduped_unreadable_settings_source() {
         }),
         [Utf8PathBuf::from("/proj")],
     );
-    let root = Utf8PathBuf::from("/proj");
-    let interpreter = Interpreter::Auto;
-    let pythonpath = Vec::new();
-    let search_paths = SearchPaths::from_project_settings(
-        db.file_system(),
-        root.as_path(),
-        &interpreter,
-        &pythonpath,
-    );
-    search_paths.register_roots(&db);
-    let tag_specs = djls_conf::Settings::default().tagspecs().clone();
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        interpreter,
-        Some(
-            PythonModuleName::parse("myproject.settings")
-                .expect("test Python module name should be valid"),
-        ),
-        pythonpath,
-        Vec::new(),
-        tag_specs,
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .interpreter(Interpreter::Auto)
+        .install(&mut db)
+        .expect("settings project fixture should build");
 
     let settings_sources = ProjectFactsPhase::SettingsSources.run(&db, project);
     assert_eq!(settings_sources.count(), 3);
@@ -3200,31 +3075,11 @@ fn failed_available_candidate_walk_makes_missing_library_inconclusive() {
         }),
         [Utf8PathBuf::from("/proj")],
     );
-    let root = Utf8PathBuf::from("/proj");
-    let interpreter = Interpreter::Auto;
-    let pythonpath = Vec::new();
-    let search_paths = SearchPaths::from_project_settings(
-        db.file_system(),
-        root.as_path(),
-        &interpreter,
-        &pythonpath,
-    );
-    search_paths.register_roots(&db);
-    let tag_specs = djls_conf::Settings::default().tagspecs().clone();
-    let project = Project::new(
-        &db,
-        root,
-        search_paths,
-        interpreter,
-        Some(
-            PythonModuleName::parse("myproject.settings")
-                .expect("test Python module name should be valid"),
-        ),
-        pythonpath,
-        Vec::new(),
-        tag_specs,
-    );
-    db.set_project(project);
+    let project = ProjectFixture::new("/proj")
+        .django_settings_module("myproject.settings")
+        .interpreter(Interpreter::Auto)
+        .install(&mut db)
+        .expect("settings project fixture should build");
 
     let libraries = template_library_catalog(&db, project);
     assert!(matches!(

--- a/crates/djls-project/tests/settings_extraction.rs
+++ b/crates/djls-project/tests/settings_extraction.rs
@@ -8,7 +8,6 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use djls_conf::Settings;
 use djls_conf::TagSpecDef;
-use djls_project::Db;
 use djls_project::Interpreter;
 use djls_project::Project;
 use djls_project::PythonModuleName;
@@ -51,6 +50,7 @@ use djls_source::WalkOptions;
 use djls_source::path_to_file;
 use djls_testing::OsTestDatabase;
 use djls_testing::ProjectFixture;
+use djls_testing::ProjectFixtureDatabase;
 use djls_testing::TestDatabase;
 use serde_json::Value;
 use serde_json::json;
@@ -138,26 +138,24 @@ fn binding_unknown_origin(source: &str, name: &str) -> Result<Origin, Box<dyn st
     })?)
 }
 
-fn python_project(db: &dyn Db) -> Project {
+fn python_project(db: &impl ProjectFixtureDatabase) -> Project {
     python_project_with_paths(db, &[])
 }
 
-fn python_project_with_paths(db: &dyn Db, pythonpath: &[Utf8PathBuf]) -> Project {
+fn python_project_with_paths(
+    db: &impl ProjectFixtureDatabase,
+    pythonpath: &[Utf8PathBuf],
+) -> Project {
     let root = Utf8Path::new("/project");
     let interpreter = Interpreter::Auto;
     let search_paths =
         SearchPaths::from_project_settings(db.file_system(), root, &interpreter, pythonpath);
-    search_paths.register_roots(db);
-    Project::new(
-        db,
-        root.to_path_buf(),
-        search_paths,
-        interpreter,
-        None,
-        Vec::new(),
-        Vec::new(),
-        TagSpecDef::default(),
-    )
+    ProjectFixture::new(root)
+        .interpreter(interpreter)
+        .search_paths(search_paths)
+        .tag_specs(TagSpecDef::default())
+        .build(db)
+        .unwrap_or_else(|error| panic!("Python project fixture should build: {error:#}"))
 }
 
 fn expected_span(source: &str, needle: &str) -> Option<Span> {

--- a/crates/djls-testing/src/db.rs
+++ b/crates/djls-testing/src/db.rs
@@ -352,6 +352,28 @@ impl OsTestDatabase {
         disk: Arc<dyn FileSystem>,
         disk_roots: impl IntoIterator<Item = Utf8PathBuf>,
     ) -> Self {
+        Self::with_file_system_and_storage(disk, disk_roots, salsa::Storage::default())
+    }
+
+    /// Create a layered database that records Salsa events.
+    #[must_use]
+    pub fn with_file_system_and_event_log(
+        disk: Arc<dyn FileSystem>,
+        disk_roots: impl IntoIterator<Item = Utf8PathBuf>,
+        event_log: SalsaEventLog,
+    ) -> Self {
+        Self::with_file_system_and_storage(
+            disk,
+            disk_roots,
+            salsa::Storage::new(Some(Box::new(move |event| event_log.push(event)))),
+        )
+    }
+
+    fn with_file_system_and_storage(
+        disk: Arc<dyn FileSystem>,
+        disk_roots: impl IntoIterator<Item = Utf8PathBuf>,
+        storage: salsa::Storage<Self>,
+    ) -> Self {
         let memory = Arc::new(Mutex::new(InMemoryFileSystem::new()));
         let fs = Arc::new(LayeredFileSystem::new(
             Arc::clone(&memory),
@@ -359,7 +381,7 @@ impl OsTestDatabase {
             disk_roots,
         ));
         Self {
-            storage: salsa::Storage::default(),
+            storage,
             fs,
             memory,
             files: SourceFiles::default(),
@@ -382,6 +404,15 @@ impl OsTestDatabase {
     pub fn with_projectless_tag_specs(mut self, specs: TagSpecs) -> Self {
         self.projectless_tag_specs = specs;
         self
+    }
+
+    pub(crate) fn insert_fixture_file(&self, path: &str, content: &str) -> anyhow::Result<()> {
+        // Fixture setup precedes root registration and queries, so no change event is needed.
+        self.memory
+            .lock()
+            .map_err(|_error| anyhow::anyhow!("in-memory filesystem lock is poisoned"))?
+            .add_file(path.into(), content.to_string());
+        Ok(())
     }
 
     /// Add an in-memory file above the database's disk filesystem.
@@ -499,6 +530,7 @@ mod tests {
     use djls_source::Db as _;
 
     use super::*;
+    use crate::ProjectFixture;
 
     #[test]
     fn layered_filesystem_reads_disk_only_below_allowed_roots() {
@@ -568,6 +600,23 @@ mod tests {
         assert!(issues.is_empty());
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].path, Utf8Path::new("/blocked/memory.py"));
+    }
+
+    #[test]
+    fn project_fixture_installs_files_in_os_database() {
+        let mut db = OsTestDatabase::new();
+        let project = ProjectFixture::new("/project")
+            .file("/project/module.py", "VALUE = 1\n")
+            .install(&mut db)
+            .expect("OS-backed project fixture should install");
+
+        assert_eq!(db.project(), Some(project));
+        assert_eq!(
+            db.file_system()
+                .read_to_string(Utf8Path::new("/project/module.py"))
+                .expect("fixture file should be readable"),
+            "VALUE = 1\n"
+        );
     }
 
     #[test]

--- a/crates/djls-testing/src/fixtures.rs
+++ b/crates/djls-testing/src/fixtures.rs
@@ -29,7 +29,6 @@ use djls_semantic::ValidationError;
 use djls_semantic::ValidationErrorAccumulator;
 use djls_semantic::builtin_tag_specs;
 use djls_semantic::validate_template_file;
-use djls_source::Db as _;
 use djls_source::Diagnostic;
 use djls_source::DiagnosticRenderer;
 use djls_source::File;
@@ -254,6 +253,33 @@ fn add_loadable_symbol(
     Ok(())
 }
 
+/// Database operations used while building a project fixture.
+pub trait ProjectFixtureDatabase: ProjectDb {
+    fn add_fixture_file(&self, path: &str, source: &str) -> anyhow::Result<()>;
+
+    fn set_fixture_project(&mut self, project: Project);
+}
+
+impl ProjectFixtureDatabase for TestDatabase {
+    fn add_fixture_file(&self, path: &str, source: &str) -> anyhow::Result<()> {
+        self.add_file(path, source)
+    }
+
+    fn set_fixture_project(&mut self, project: Project) {
+        self.set_project(project);
+    }
+}
+
+impl ProjectFixtureDatabase for OsTestDatabase {
+    fn add_fixture_file(&self, path: &str, source: &str) -> anyhow::Result<()> {
+        self.insert_fixture_file(path, source)
+    }
+
+    fn set_fixture_project(&mut self, project: Project) {
+        self.set_project(project);
+    }
+}
+
 pub struct ProjectFixture {
     root: Utf8PathBuf,
     files: Vec<(Utf8PathBuf, String)>,
@@ -336,7 +362,7 @@ impl ProjectFixture {
         self
     }
 
-    pub fn build(self, db: &TestDatabase) -> anyhow::Result<Project> {
+    pub fn build<Db: ProjectFixtureDatabase>(self, db: &Db) -> anyhow::Result<Project> {
         let django_settings_module = self.django_settings_module?;
         let mut paths = BTreeSet::new();
         for (path, _) in &self.files {
@@ -346,7 +372,7 @@ impl ProjectFixture {
             );
         }
         for (path, source) in self.files {
-            db.add_file(path.as_str(), &source)
+            db.add_fixture_file(path.as_str(), &source)
                 .with_context(|| format!("failed to add fixture file `{path}`"))?;
         }
 
@@ -374,9 +400,9 @@ impl ProjectFixture {
         ))
     }
 
-    pub fn install(self, db: &mut TestDatabase) -> anyhow::Result<Project> {
+    pub fn install<Db: ProjectFixtureDatabase>(self, db: &mut Db) -> anyhow::Result<Project> {
         let project = self.build(db)?;
-        db.set_project(project);
+        db.set_fixture_project(project);
         Ok(project)
     }
 }

--- a/crates/djls-testing/src/lib.rs
+++ b/crates/djls-testing/src/lib.rs
@@ -33,6 +33,7 @@ pub use extraction::SortedExtractionResult;
 pub use extraction::extract_bundle;
 pub use extraction::sorted_snapshot;
 pub use fixtures::ProjectFixture;
+pub use fixtures::ProjectFixtureDatabase;
 pub use fixtures::build_entry_specs;
 pub use fixtures::build_specs_from_extraction;
 pub use fixtures::builtin_filter;


### PR DESCRIPTION
## Summary

ProjectFixture now builds projects on either test database through one shared construction path.

Settings, resolver, corpus, extraction, and model tests that constructed a Project by hand now go through the fixture.

## Sites moved

- `crates/djls-project/tests/settings.rs::readable_unreadable_rescans_recompute_ancestors_once_and_retain_dependency`
- `crates/djls-project/tests/settings.rs::project_with_file_system_failure`
- `crates/djls-project/tests/settings.rs::project_requiring_environment_application`
- `crates/djls-project/tests/settings.rs::unreadable_root_settings_are_dynamic_never_unset`
- `crates/djls-project/tests/settings.rs::django_discovery_includes_deduped_unreadable_settings_source`
- `crates/djls-project/tests/settings.rs::failed_available_candidate_walk_makes_missing_library_inconclusive`
- `crates/djls-project/tests/resolve.rs::ty_symlink`
- `crates/djls-project/tests/resolve.rs::ty_case_sensitive_resolution_with_symlinked_directory`
- `crates/djls-project/tests/corpus_settings.rs::settings_extraction_snapshots`
- `crates/djls-project/tests/settings_extraction.rs::python_project_with_paths`
- `crates/djls-project/tests/model_relations.rs::salsa_recomputes_relation_resolution_for_import_edits_only_where_needed`

## Local checks

- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`
- `just hawk` (0 findings)
