### PR TITLE
Make full-corpus benchmark checks opt in

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo run -q -p djls-testing --bin corpus -- sync
 
       - name: Verify benchmark workload snapshots
-        run: DJLS_REQUIRE_BENCH_CORPUS=1 cargo test -p djls-bench
+        run: DJLS_REQUIRE_BENCH_CORPUS=1 cargo test -p djls-bench -- --include-ignored
 
       - run: cargo install cargo-codspeed --locked
 

--- a/crates/djls-bench/src/check.rs
+++ b/crates/djls-bench/src/check.rs
@@ -898,6 +898,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "runs the full corpus check workload in the benchmark workflow"]
     fn full_corpus_check_workload_is_stable() {
         let corpus = full_corpus_templates().expect("full corpus templates should load");
         snapshot_corpus("check_workload_corpus_all", corpus);

--- a/crates/djls-bench/src/fixtures.rs
+++ b/crates/djls-bench/src/fixtures.rs
@@ -526,6 +526,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "loads the Django and full template corpora and checks discovered file counts in the benchmark workflow"]
     fn corpus_loader_synchronizes_every_discovered_template() {
         let required = bench_corpus_is_required();
         for (name, corpus) in [


### PR DESCRIPTION
## Summary

- mark the two checks that process the full template corpus as ignored during ordinary Cargo test runs
- run ignored checks explicitly in the benchmark workflow while requiring the synchronized corpus
- keep the existing corpus availability and skip behavior unchanged

## Timing

A warm `cargo test -q -p djls-bench` run changed from 16.04s with 27 tests run to 0.81s with 25 passed and 2 ignored.

## Verification

- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`
- `just hawk` (0 findings)
