### PR TITLE
Mark optional synthesized tag arguments

### DIFF
--- a/crates/djls-ide/src/snippets.rs
+++ b/crates/djls-ide/src/snippets.rs
@@ -11,6 +11,9 @@ use djls_semantic::TagSpec;
 fn generate_snippet_from_args(args: &[TagArgument]) -> String {
     let mut parts = Vec::new();
     let mut placeholder_index = 1;
+    let has_required_argument = args
+        .iter()
+        .any(|argument| argument.requirement.is_required());
 
     for arg in args {
         // Skip optional literals entirely - they're usually flags like "reversed" or "only"
@@ -19,8 +22,8 @@ fn generate_snippet_from_args(args: &[TagArgument]) -> String {
             continue;
         }
 
-        // Skip other optional args if we haven't seen any required args yet
-        if !arg.requirement.is_required() && parts.is_empty() {
+        // Skip leading optional args when a required argument follows.
+        if !arg.requirement.is_required() && has_required_argument && parts.is_empty() {
             continue;
         }
 
@@ -412,6 +415,18 @@ mod tests {
 
         let snippet = generate_snippet_from_args(&args);
         assert_eq!(snippet, "");
+    }
+
+    #[test]
+    fn all_optional_arguments_keep_completion_placeholders() {
+        let args = vec![
+            make_var("arg1", false),
+            make_var("arg2", false),
+            make_var("arg3", false),
+        ];
+
+        let snippet = generate_snippet_from_args(&args);
+        assert_eq!(snippet, "${1:arg1} ${2:arg2} ${3:arg3}");
     }
 
     #[test]

--- a/crates/djls-project/src/templates/tags/analysis.rs
+++ b/crates/djls-project/src/templates/tags/analysis.rs
@@ -444,6 +444,7 @@ pub(super) fn extract_arg_names(
         .unwrap_or(0);
     let max_from_constraints = infer_max_position(arg_constraints);
 
+    let min_pos = infer_min_position(arg_constraints);
     let max_pos = max_from_env
         .max(max_from_keywords)
         .max(max_from_constraints);
@@ -455,6 +456,11 @@ pub(super) fn extract_arg_names(
     let mut args = Vec::new();
     for pos in 1..=max_pos {
         let pos_split = SplitPosition::Forward(pos);
+        let inferred_requirement = if min_pos.is_some_and(|min_pos| pos > min_pos) {
+            ParameterRequirement::Optional
+        } else {
+            ParameterRequirement::Required
+        };
 
         // Check if there's a required keyword or choice at this position.
         if let Some(rk) = required_keywords.iter().find(|rk| rk.position == pos_split) {
@@ -481,7 +487,7 @@ pub(super) fn extract_arg_names(
         if let Some((_, name)) = named_positions.iter().find(|(p, _)| *p == pos) {
             args.push(TagArgument {
                 name: name.clone(),
-                requirement: ParameterRequirement::Required,
+                requirement: inferred_requirement,
                 kind: TagArgumentKind::Variable,
             });
             continue;
@@ -490,7 +496,7 @@ pub(super) fn extract_arg_names(
         // Fallback: generic name
         args.push(TagArgument {
             name: format!("arg{pos}"),
-            requirement: ParameterRequirement::Required,
+            requirement: inferred_requirement,
             kind: TagArgumentKind::Variable,
         });
     }
@@ -515,6 +521,25 @@ fn infer_max_position(constraints: &[ArgumentCountConstraint]) -> usize {
         max = max.max(candidate);
     }
     max
+}
+
+/// Infer the minimum argument position from constraints.
+///
+/// Returns the known number of guaranteed argument positions (in `split_contents`
+/// coordinates, excluding the tag name), or `None` when no constraint has a lower bound.
+fn infer_min_position(constraints: &[ArgumentCountConstraint]) -> Option<usize> {
+    constraints
+        .iter()
+        .filter_map(|constraint| match constraint {
+            ArgumentCountConstraint::Exact(n) | ArgumentCountConstraint::Min(n) => {
+                Some(n.saturating_sub(1))
+            }
+            ArgumentCountConstraint::Max(_) => None,
+            ArgumentCountConstraint::OneOf(vals) => {
+                vals.iter().copied().min().map(|n| n.saturating_sub(1))
+            }
+        })
+        .max()
 }
 
 #[cfg(test)]
@@ -681,6 +706,163 @@ def do_tag(parser, token):
         assert_eq!(parameters(&rule)[0].name, "arg1");
         assert_eq!(parameters(&rule)[1].name, "arg2");
         assert_eq!(parameters(&rule)[2].name, "arg3");
+    }
+
+    #[test]
+    fn min_and_max_make_arguments_after_the_minimum_optional() {
+        let rule = analyze_source(
+            r#"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    if len(bits) < 3 or len(bits) > 6:
+        raise TemplateSyntaxError("err")
+    first = bits[1]
+    second = bits[2]
+"#,
+        );
+
+        assert_eq!(
+            parameters(&rule)
+                .iter()
+                .map(|argument| argument.requirement)
+                .collect::<Vec<_>>(),
+            vec![
+                ParameterRequirement::Required,
+                ParameterRequirement::Required,
+                ParameterRequirement::Optional,
+                ParameterRequirement::Optional,
+                ParameterRequirement::Optional,
+            ]
+        );
+    }
+
+    #[test]
+    fn named_position_after_the_minimum_is_optional() {
+        let mut env = state::Env::default();
+        env.set(
+            "third".to_string(),
+            state::AbstractValue::SplitElement {
+                index: SplitPosition::Forward(3),
+            },
+        );
+
+        let arguments = extract_arg_names(
+            &env,
+            &[],
+            &[],
+            &[
+                ArgumentCountConstraint::Min(3),
+                ArgumentCountConstraint::Max(4),
+            ],
+        );
+
+        assert_eq!(arguments[2].name, "third");
+        assert_eq!(arguments[2].requirement, ParameterRequirement::Optional);
+    }
+
+    #[test]
+    fn exact_count_requires_every_synthesized_argument() {
+        let rule = analyze_source(
+            r#"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    if len(bits) != 4:
+        raise TemplateSyntaxError("err")
+"#,
+        );
+
+        assert_eq!(
+            parameters(&rule)
+                .iter()
+                .map(|argument| argument.requirement)
+                .collect::<Vec<_>>(),
+            vec![
+                ParameterRequirement::Required,
+                ParameterRequirement::Required,
+                ParameterRequirement::Required,
+            ]
+        );
+    }
+
+    #[test]
+    fn one_of_makes_arguments_after_smallest_count_optional() {
+        let rule = analyze_source(
+            r#"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    if len(bits) not in (3, 5):
+        raise TemplateSyntaxError("err")
+"#,
+        );
+
+        assert_eq!(
+            parameters(&rule)
+                .iter()
+                .map(|argument| argument.requirement)
+                .collect::<Vec<_>>(),
+            vec![
+                ParameterRequirement::Required,
+                ParameterRequirement::Required,
+                ParameterRequirement::Optional,
+                ParameterRequirement::Optional,
+            ]
+        );
+    }
+
+    #[test]
+    fn max_only_keeps_every_synthesized_argument_required() {
+        let rule = analyze_source(
+            r#"
+def do_tag(parser, token):
+    bits = token.split_contents()
+    if len(bits) > 3:
+        raise TemplateSyntaxError("err")
+"#,
+        );
+
+        assert_eq!(
+            parameters(&rule)
+                .iter()
+                .map(|argument| argument.requirement)
+                .collect::<Vec<_>>(),
+            vec![
+                ParameterRequirement::Required,
+                ParameterRequirement::Required,
+            ]
+        );
+    }
+
+    #[test]
+    fn minimum_position_uses_the_strongest_conjunctive_lower_bound() {
+        assert_eq!(infer_min_position(&[]), None);
+        assert_eq!(infer_min_position(&[ArgumentCountConstraint::Max(6)]), None);
+        assert_eq!(
+            infer_min_position(&[ArgumentCountConstraint::OneOf(Vec::new())]),
+            None
+        );
+        assert_eq!(
+            infer_min_position(&[
+                ArgumentCountConstraint::Min(3),
+                ArgumentCountConstraint::Max(6),
+            ]),
+            Some(2)
+        );
+        assert_eq!(
+            infer_min_position(&[ArgumentCountConstraint::Exact(4)]),
+            Some(3)
+        );
+        assert_eq!(
+            infer_min_position(&[ArgumentCountConstraint::OneOf(vec![3, 5])]),
+            Some(2)
+        );
+        assert_eq!(
+            infer_min_position(&[
+                ArgumentCountConstraint::OneOf(Vec::new()),
+                ArgumentCountConstraint::Min(2),
+                ArgumentCountConstraint::Exact(4),
+            ]),
+            Some(3)
+        );
     }
 
     #[test]

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -30,13 +30,13 @@ tag_rules:
           requirement: required
           kind: Variable
         - name: arg3
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg4
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg5
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
 filter_arities: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-5.2__django__template__defaulttags.py.snap
@@ -262,13 +262,13 @@ tag_rules:
     argument_syntax:
       Parameters:
         - name: arg1
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg2
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg3
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
   "django.template.defaulttags::tag::now":

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -30,13 +30,13 @@ tag_rules:
           requirement: required
           kind: Variable
         - name: arg3
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg4
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg5
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
 filter_arities: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.0__django__template__defaulttags.py.snap
@@ -268,13 +268,13 @@ tag_rules:
     argument_syntax:
       Parameters:
         - name: arg1
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg2
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg3
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
   "django.template.defaulttags::tag::now":

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__flatpages__templatetags__flatpages.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__contrib__flatpages__templatetags__flatpages.py.snap
@@ -30,13 +30,13 @@ tag_rules:
           requirement: required
           kind: Variable
         - name: arg3
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg4
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg5
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
 filter_arities: {}

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-6.1__django__template__defaulttags.py.snap
@@ -285,13 +285,13 @@ tag_rules:
     argument_syntax:
       Parameters:
         - name: arg1
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg2
-          requirement: required
+          requirement: optional
           kind: Variable
         - name: arg3
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
   "django.template.defaulttags::tag::now":

--- a/crates/djls-project/tests/snapshots/corpus__repos__django-guardian__guardian__templatetags__guardian_tags.py.snap
+++ b/crates/djls-project/tests/snapshots/corpus__repos__django-guardian__guardian__templatetags__guardian_tags.py.snap
@@ -78,7 +78,7 @@ tag_rules:
           requirement: required
           kind: Variable
         - name: arg6
-          requirement: required
+          requirement: optional
           kind: Variable
     as_var: keep
 filter_arities: {}


### PR DESCRIPTION
## Summary

- infer a known lower argument bound separately from the upper bound when synthesizing parameters for hand-written template tags
- mark synthesized variable slots optional only when an `Exact`, `Min`, or nonempty `OneOf` constraint proves that the slot may be absent
- keep synthesized slots required when only an upper bound is known, and keep source-asserted keyword and choice positions required
- preserve completion placeholders when every synthesized parameter is optional while continuing to omit optional literal flags
- leave the `TagArgumentSyntax` variant unchanged

## Corpus snapshots

Seven snapshot files changed, each matching an optional suffix accepted by the tag source:

- Django 5.2 `get_flatpages`: arguments after the two-slot minimum are optional
- Django 5.2 `lorem`: all three arguments are optional because the bare tag is accepted
- Django 6.0 `get_flatpages`: arguments after the two-slot minimum are optional
- Django 6.0 `lorem`: all three arguments are optional because the bare tag is accepted
- Django 6.1 `get_flatpages`: arguments after the two-slot minimum are optional
- Django 6.1 `lorem`: all three arguments are optional because the bare tag is accepted
- django-guardian `get_obj_perms`: the trailing permission-checker argument is optional

Snapshots for tags with only a `Max` constraint remain unchanged. An upper bound alone says nothing about how few arguments a tag accepts, and several corpus tags check nothing but an upper bound while still requiring their first argument.

## Verification

- `cargo test -q`
- `just clippy`
- `just fmt`
- `just lint`
- `just hawk` (0 findings)
